### PR TITLE
feat(#13): 경기 기록 API 엔드포인트 구현

### DIFF
--- a/nextup-api/build.gradle.kts
+++ b/nextup-api/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BattingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BattingRecordController.kt
@@ -1,0 +1,47 @@
+package com.nextup.api.controller.game
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.game.BattingRecordResponse
+import com.nextup.api.dto.game.CreateBattingRecordRequest
+import com.nextup.api.mapper.game.toResponse
+import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
+import com.nextup.infrastructure.repository.game.GamePlayerRepository
+import com.nextup.infrastructure.service.game.BattingRecordService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/games/{gameId}/batting-records")
+class BattingRecordController(
+    private val battingRecordService: BattingRecordService,
+    private val gamePlayerRepository: GamePlayerRepository
+) {
+
+    @GetMapping
+    fun getBattingRecordsByGame(
+        @PathVariable gameId: Long
+    ): ApiResponse<List<BattingRecordResponse>> {
+        val records = battingRecordService.getAllByGameId(gameId)
+        return ApiResponse.success(records.toResponse())
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createBattingRecord(
+        @PathVariable gameId: Long,
+        @Valid @RequestBody request: CreateBattingRecordRequest
+    ): ApiResponse<BattingRecordResponse> {
+        val gamePlayer = gamePlayerRepository.findByGameIdAndPlayerId(gameId, request.playerId)
+            ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, request.playerId)
+
+        val record = battingRecordService.createRecord(gamePlayer.id)
+        return ApiResponse.success(record.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/PitchingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/PitchingRecordController.kt
@@ -1,0 +1,47 @@
+package com.nextup.api.controller.game
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.game.CreatePitchingRecordRequest
+import com.nextup.api.dto.game.PitchingRecordResponse
+import com.nextup.api.mapper.game.toResponse
+import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
+import com.nextup.infrastructure.repository.game.GamePlayerRepository
+import com.nextup.infrastructure.service.game.PitchingRecordService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/games/{gameId}/pitching-records")
+class PitchingRecordController(
+    private val pitchingRecordService: PitchingRecordService,
+    private val gamePlayerRepository: GamePlayerRepository
+) {
+
+    @GetMapping
+    fun getPitchingRecordsByGame(
+        @PathVariable gameId: Long
+    ): ApiResponse<List<PitchingRecordResponse>> {
+        val records = pitchingRecordService.getAllByGameId(gameId)
+        return ApiResponse.success(records.toResponse())
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createPitchingRecord(
+        @PathVariable gameId: Long,
+        @Valid @RequestBody request: CreatePitchingRecordRequest
+    ): ApiResponse<PitchingRecordResponse> {
+        val gamePlayer = gamePlayerRepository.findByGameIdAndPlayerId(gameId, request.playerId)
+            ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, request.playerId)
+
+        val record = pitchingRecordService.createRecord(gamePlayer.id, request.isStartingPitcher)
+        return ApiResponse.success(record.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/CreateBattingRecordRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/CreateBattingRecordRequest.kt
@@ -1,0 +1,13 @@
+package com.nextup.api.dto.game
+
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 타격 기록 생성 요청 DTO
+ *
+ * @property playerId 선수 ID (Game ID는 PathVariable로 받음)
+ */
+data class CreateBattingRecordRequest(
+    @field:NotNull(message = "playerId is required")
+    val playerId: Long
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/CreatePitchingRecordRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/CreatePitchingRecordRequest.kt
@@ -1,0 +1,15 @@
+package com.nextup.api.dto.game
+
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 투수 기록 생성 요청 DTO
+ *
+ * @property playerId 선수 ID (Game ID는 PathVariable로 받음)
+ * @property isStartingPitcher 선발 투수 여부 (기본값: false)
+ */
+data class CreatePitchingRecordRequest(
+    @field:NotNull(message = "playerId is required")
+    val playerId: Long,
+    val isStartingPitcher: Boolean = false
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,60 @@
+package com.nextup.api.exception
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.common.exception.NotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(NotFoundException::class)
+    fun handleNotFoundException(ex: NotFoundException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("NotFoundException: code={}, message={}", ex.code, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    @ExceptionHandler(InvalidStateException::class)
+    fun handleInvalidStateException(ex: InvalidStateException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("InvalidStateException: code={}, message={}", ex.code, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    @ExceptionHandler(BusinessException::class)
+    fun handleBusinessException(ex: BusinessException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("BusinessException: code={}, message={}", ex.code, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
+        val errors = ex.bindingResult.fieldErrors
+            .joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
+        log.warn("ValidationException: {}", errors)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("VALIDATION_ERROR", errors))
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(ex: Exception): ResponseEntity<ApiResponse<Nothing>> {
+        log.error("UnexpectedException: {}", ex.message, ex)
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.error("INTERNAL_ERROR", "An unexpected error occurred"))
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BattingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BattingRecordControllerTest.kt
@@ -1,0 +1,221 @@
+package com.nextup.api.controller.game
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.game.CreateBattingRecordRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
+import com.nextup.common.exception.RecordAlreadyExistsException
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.infrastructure.repository.game.GamePlayerRepository
+import com.nextup.infrastructure.service.game.BattingRecordService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("BattingRecordController 테스트")
+class BattingRecordControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var battingRecordService: BattingRecordService
+    private lateinit var gamePlayerRepository: GamePlayerRepository
+    private lateinit var objectMapper: ObjectMapper
+
+    private val gameId = 1L
+    private val playerId = 100L
+    private val gamePlayerId = 10L
+
+    @BeforeEach
+    fun setUp() {
+        battingRecordService = mockk()
+        gamePlayerRepository = mockk()
+        objectMapper = jacksonObjectMapper()
+
+        val controller = BattingRecordController(battingRecordService, gamePlayerRepository)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/games/{gameId}/batting-records")
+    inner class GetBattingRecords {
+
+        @Test
+        fun `should return batting records for game`() {
+            // given
+            val gamePlayer = mockk<GamePlayer> {
+                every { id } returns gamePlayerId
+            }
+            val record = mockk<BattingRecord> {
+                every { id } returns 1L
+                every { this@mockk.gamePlayer } returns gamePlayer
+                every { createdAt } returns java.time.Instant.now()
+                every { updatedAt } returns java.time.Instant.now()
+                every { plateAppearances } returns 4
+                every { atBats } returns 3
+                every { hits } returns 1
+                every { doubles } returns 0
+                every { triples } returns 0
+                every { homeRuns } returns 0
+                every { runs } returns 1
+                every { runsBattedIn } returns 0
+                every { walks } returns 1
+                every { intentionalWalks } returns 0
+                every { hitByPitch } returns 0
+                every { strikeouts } returns 1
+                every { sacrificeBunts } returns 0
+                every { sacrificeFlies } returns 0
+                every { stolenBases } returns 0
+                every { caughtStealing } returns 0
+                every { groundedIntoDoublePlays } returns 0
+                every { singles } returns 1
+                every { totalBases } returns 1
+                every { extraBaseHits } returns 0
+                every { sacrifices } returns 0
+                every { totalWalks } returns 1
+                every { battingAverage } returns java.math.BigDecimal("0.333")
+                every { onBasePercentage } returns java.math.BigDecimal("0.500")
+                every { sluggingPercentage } returns java.math.BigDecimal("0.333")
+                every { ops } returns java.math.BigDecimal("0.833")
+                every { stolenBasePercentage } returns java.math.BigDecimal("0.000")
+            }
+
+            every { battingRecordService.getAllByGameId(gameId) } returns listOf(record)
+
+            // when & then
+            mockMvc.perform(get("/api/games/$gameId/batting-records"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].hits").value(1))
+        }
+
+        @Test
+        fun `should return empty list when no records exist`() {
+            // given
+            every { battingRecordService.getAllByGameId(gameId) } returns emptyList()
+
+            // when & then
+            mockMvc.perform(get("/api/games/$gameId/batting-records"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/games/{gameId}/batting-records")
+    inner class CreateBattingRecord {
+
+        @Test
+        fun `should create batting record successfully`() {
+            // given
+            val request = CreateBattingRecordRequest(playerId = playerId)
+            val gamePlayer = mockk<GamePlayer> {
+                every { id } returns gamePlayerId
+            }
+            val record = mockk<BattingRecord> {
+                every { id } returns 1L
+                every { this@mockk.gamePlayer } returns gamePlayer
+                every { createdAt } returns java.time.Instant.now()
+                every { updatedAt } returns java.time.Instant.now()
+                every { plateAppearances } returns 0
+                every { atBats } returns 0
+                every { hits } returns 0
+                every { doubles } returns 0
+                every { triples } returns 0
+                every { homeRuns } returns 0
+                every { runs } returns 0
+                every { runsBattedIn } returns 0
+                every { walks } returns 0
+                every { intentionalWalks } returns 0
+                every { hitByPitch } returns 0
+                every { strikeouts } returns 0
+                every { sacrificeBunts } returns 0
+                every { sacrificeFlies } returns 0
+                every { stolenBases } returns 0
+                every { caughtStealing } returns 0
+                every { groundedIntoDoublePlays } returns 0
+                every { singles } returns 0
+                every { totalBases } returns 0
+                every { extraBaseHits } returns 0
+                every { sacrifices } returns 0
+                every { totalWalks } returns 0
+                every { battingAverage } returns java.math.BigDecimal("0.000")
+                every { onBasePercentage } returns java.math.BigDecimal("0.000")
+                every { sluggingPercentage } returns java.math.BigDecimal("0.000")
+                every { ops } returns java.math.BigDecimal("0.000")
+                every { stolenBasePercentage } returns java.math.BigDecimal("0.000")
+            }
+
+            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
+            every { battingRecordService.createRecord(gamePlayerId) } returns record
+
+            // when & then
+            mockMvc.perform(
+                post("/api/games/$gameId/batting-records")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.gamePlayerId").value(gamePlayerId))
+        }
+
+        @Test
+        fun `should return 404 when game player not found`() {
+            // given
+            val request = CreateBattingRecordRequest(playerId = playerId)
+            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns null
+
+            // when & then
+            mockMvc.perform(
+                post("/api/games/$gameId/batting-records")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("GAME_PLAYER_NOT_FOUND"))
+        }
+
+        @Test
+        fun `should return 400 when record already exists`() {
+            // given
+            val request = CreateBattingRecordRequest(playerId = playerId)
+            val gamePlayer = mockk<GamePlayer> {
+                every { id } returns gamePlayerId
+            }
+
+            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
+            every { battingRecordService.createRecord(gamePlayerId) } throws
+                RecordAlreadyExistsException(gamePlayerId, "Batting")
+
+            // when & then
+            mockMvc.perform(
+                post("/api/games/$gameId/batting-records")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("RECORD_ALREADY_EXISTS"))
+        }
+
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
@@ -1,0 +1,248 @@
+package com.nextup.api.controller.game
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.game.CreatePitchingRecordRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.RecordAlreadyExistsException
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.PitchingDecision
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.infrastructure.repository.game.GamePlayerRepository
+import com.nextup.infrastructure.service.game.PitchingRecordService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("PitchingRecordController 테스트")
+class PitchingRecordControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var pitchingRecordService: PitchingRecordService
+    private lateinit var gamePlayerRepository: GamePlayerRepository
+    private lateinit var objectMapper: ObjectMapper
+
+    private val gameId = 1L
+    private val playerId = 100L
+    private val gamePlayerId = 10L
+
+    @BeforeEach
+    fun setUp() {
+        pitchingRecordService = mockk()
+        gamePlayerRepository = mockk()
+        objectMapper = jacksonObjectMapper()
+
+        val controller = PitchingRecordController(pitchingRecordService, gamePlayerRepository)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/games/{gameId}/pitching-records")
+    inner class GetPitchingRecords {
+
+        @Test
+        fun `should return pitching records for game`() {
+            // given
+            val gamePlayer = mockk<GamePlayer> {
+                every { id } returns gamePlayerId
+            }
+            val record = mockk<PitchingRecord> {
+                every { id } returns 1L
+                every { this@mockk.gamePlayer } returns gamePlayer
+                every { createdAt } returns java.time.Instant.now()
+                every { updatedAt } returns java.time.Instant.now()
+                every { inningsPitchedOuts } returns 15
+                every { earnedRuns } returns 2
+                every { runsAllowed } returns 3
+                every { hitsAllowed } returns 5
+                every { walksAllowed } returns 2
+                every { strikeouts } returns 6
+                every { homeRunsAllowed } returns 1
+                every { hitBatsmen } returns 0
+                every { wildPitches } returns 1
+                every { balks } returns 0
+                every { battersFaced } returns 22
+                every { decision } returns PitchingDecision.WIN
+                every { isStartingPitcher } returns true
+                every { pitchesThrown } returns 85
+                every { strikesThrown } returns 55
+                every { completeInnings } returns 5
+                every { remainingOuts } returns 0
+                every { inningsPitched } returns java.math.BigDecimal("5.00")
+                every { inningsPitchedDisplay } returns "5.0"
+                every { earnedRunAverage } returns java.math.BigDecimal("3.60")
+                every { whip } returns java.math.BigDecimal("1.40")
+                every { strikeoutsPer9 } returns java.math.BigDecimal("10.80")
+                every { walksPer9 } returns java.math.BigDecimal("3.60")
+                every { strikeoutToWalkRatio } returns java.math.BigDecimal("3.00")
+                every { strikePercentage } returns java.math.BigDecimal("0.647")
+                every { unearnedRuns } returns 1
+                every { isQualifiedForWin } returns true
+            }
+
+            every { pitchingRecordService.getAllByGameId(gameId) } returns listOf(record)
+
+            // when & then
+            mockMvc.perform(get("/api/games/$gameId/pitching-records"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].isStartingPitcher").value(true))
+                .andExpect(jsonPath("$.data[0].decision").value("WIN"))
+        }
+
+        @Test
+        fun `should return empty list when no records exist`() {
+            // given
+            every { pitchingRecordService.getAllByGameId(gameId) } returns emptyList()
+
+            // when & then
+            mockMvc.perform(get("/api/games/$gameId/pitching-records"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/games/{gameId}/pitching-records")
+    inner class CreatePitchingRecord {
+
+        @Test
+        fun `should create starting pitcher record successfully`() {
+            // given
+            val request = CreatePitchingRecordRequest(playerId = playerId, isStartingPitcher = true)
+            val gamePlayer = mockk<GamePlayer> {
+                every { id } returns gamePlayerId
+            }
+            val record = createMockPitchingRecord(gamePlayer, isStartingPitcher = true)
+
+            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
+            every { pitchingRecordService.createRecord(gamePlayerId, true) } returns record
+
+            // when & then
+            mockMvc.perform(
+                post("/api/games/$gameId/pitching-records")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.isStartingPitcher").value(true))
+        }
+
+        @Test
+        fun `should create relief pitcher record successfully`() {
+            // given
+            val request = CreatePitchingRecordRequest(playerId = playerId, isStartingPitcher = false)
+            val gamePlayer = mockk<GamePlayer> {
+                every { id } returns gamePlayerId
+            }
+            val record = createMockPitchingRecord(gamePlayer, isStartingPitcher = false)
+
+            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
+            every { pitchingRecordService.createRecord(gamePlayerId, false) } returns record
+
+            // when & then
+            mockMvc.perform(
+                post("/api/games/$gameId/pitching-records")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.isStartingPitcher").value(false))
+        }
+
+        @Test
+        fun `should return 404 when game player not found`() {
+            // given
+            val request = CreatePitchingRecordRequest(playerId = playerId)
+            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns null
+
+            // when & then
+            mockMvc.perform(
+                post("/api/games/$gameId/pitching-records")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("GAME_PLAYER_NOT_FOUND"))
+        }
+
+        @Test
+        fun `should return 400 when record already exists`() {
+            // given
+            val request = CreatePitchingRecordRequest(playerId = playerId)
+            val gamePlayer = mockk<GamePlayer> {
+                every { id } returns gamePlayerId
+            }
+
+            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
+            every { pitchingRecordService.createRecord(gamePlayerId, false) } throws
+                RecordAlreadyExistsException(gamePlayerId, "Pitching")
+
+            // when & then
+            mockMvc.perform(
+                post("/api/games/$gameId/pitching-records")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("RECORD_ALREADY_EXISTS"))
+        }
+    }
+
+    private fun createMockPitchingRecord(gamePlayer: GamePlayer, isStartingPitcher: Boolean): PitchingRecord {
+        return mockk {
+            every { id } returns 1L
+            every { this@mockk.gamePlayer } returns gamePlayer
+            every { createdAt } returns java.time.Instant.now()
+            every { updatedAt } returns java.time.Instant.now()
+            every { inningsPitchedOuts } returns 0
+            every { earnedRuns } returns 0
+            every { runsAllowed } returns 0
+            every { hitsAllowed } returns 0
+            every { walksAllowed } returns 0
+            every { strikeouts } returns 0
+            every { homeRunsAllowed } returns 0
+            every { hitBatsmen } returns 0
+            every { wildPitches } returns 0
+            every { balks } returns 0
+            every { battersFaced } returns 0
+            every { decision } returns PitchingDecision.NONE
+            every { this@mockk.isStartingPitcher } returns isStartingPitcher
+            every { pitchesThrown } returns null
+            every { strikesThrown } returns null
+            every { completeInnings } returns 0
+            every { remainingOuts } returns 0
+            every { inningsPitched } returns java.math.BigDecimal("0.00")
+            every { inningsPitchedDisplay } returns "0.0"
+            every { earnedRunAverage } returns java.math.BigDecimal("0.00")
+            every { whip } returns java.math.BigDecimal("0.00")
+            every { strikeoutsPer9 } returns java.math.BigDecimal("0.00")
+            every { walksPer9 } returns java.math.BigDecimal("0.00")
+            every { strikeoutToWalkRatio } returns java.math.BigDecimal("0.00")
+            every { strikePercentage } returns null
+            every { unearnedRuns } returns 0
+            every { isQualifiedForWin } returns false
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/exception/GlobalExceptionHandlerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/exception/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,109 @@
+package com.nextup.api.exception
+
+import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.common.exception.NotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+
+@DisplayName("GlobalExceptionHandler 테스트")
+class GlobalExceptionHandlerTest {
+
+    private lateinit var handler: GlobalExceptionHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler = GlobalExceptionHandler()
+    }
+
+    @Test
+    fun `should handle NotFoundException and return 404`() {
+        // given
+        val exception = object : NotFoundException("ENTITY_NOT_FOUND", "Entity not found") {}
+
+        // when
+        val response = handler.handleNotFoundException(exception)
+
+        // then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.body?.success).isFalse()
+        assertThat(response.body?.error?.code).isEqualTo("ENTITY_NOT_FOUND")
+        assertThat(response.body?.error?.message).isEqualTo("Entity not found")
+    }
+
+    @Test
+    fun `should handle InvalidStateException and return 400`() {
+        // given
+        val exception = object : InvalidStateException("INVALID_STATE", "Invalid operation") {}
+
+        // when
+        val response = handler.handleInvalidStateException(exception)
+
+        // then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.body?.success).isFalse()
+        assertThat(response.body?.error?.code).isEqualTo("INVALID_STATE")
+        assertThat(response.body?.error?.message).isEqualTo("Invalid operation")
+    }
+
+    @Test
+    fun `should handle BusinessException and return 400`() {
+        // given
+        val exception = object : BusinessException("BUSINESS_ERROR", "Business rule violated") {}
+
+        // when
+        val response = handler.handleBusinessException(exception)
+
+        // then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.body?.success).isFalse()
+        assertThat(response.body?.error?.code).isEqualTo("BUSINESS_ERROR")
+        assertThat(response.body?.error?.message).isEqualTo("Business rule violated")
+    }
+
+    @Test
+    fun `should handle MethodArgumentNotValidException and return 400`() {
+        // given
+        data class TestRequest(val name: String?)
+        val target = TestRequest(null)
+        val bindingResult = BeanPropertyBindingResult(target, "testRequest")
+        bindingResult.addError(FieldError("testRequest", "name", "must not be null"))
+
+        val exception = MethodArgumentNotValidException(
+            org.springframework.core.MethodParameter(
+                TestRequest::class.java.constructors.first(), -1
+            ),
+            bindingResult
+        )
+
+        // when
+        val response = handler.handleValidationException(exception)
+
+        // then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(response.body?.success).isFalse()
+        assertThat(response.body?.error?.code).isEqualTo("VALIDATION_ERROR")
+        assertThat(response.body?.error?.message).contains("name")
+    }
+
+    @Test
+    fun `should handle generic Exception and return 500`() {
+        // given
+        val exception = RuntimeException("Unexpected error")
+
+        // when
+        val response = handler.handleException(exception)
+
+        // then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(response.body?.success).isFalse()
+        assertThat(response.body?.error?.code).isEqualTo("INTERNAL_ERROR")
+        assertThat(response.body?.error?.message).isEqualTo("An unexpected error occurred")
+    }
+}


### PR DESCRIPTION
## Summary

>- close #13

경기별 타격/투수 기록의 REST API 엔드포인트를 구현했습니다.

## Tasks

- BattingRecordController: GET/POST `/api/games/{gameId}/batting-records`
- PitchingRecordController: GET/POST `/api/games/{gameId}/pitching-records`
- GlobalExceptionHandler: 전역 예외 처리 (NotFoundException → 404, InvalidStateException → 400)
- CreateBattingRecordRequest, CreatePitchingRecordRequest DTO
- Controller 테스트 코드 작성 (커버리지 100%)

## To Reviewer

- Zero Entity Leak 준수: 모든 Response는 DTO 사용
- ApiResponse 래핑 적용
- CustomException 처리 적용
- `./gradlew build` 성공, 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)