### PR TITLE
feat(#24): nextup-backoffice 모듈 초기 설정

### DIFF
--- a/.claude/rules/dependency.md
+++ b/.claude/rules/dependency.md
@@ -4,31 +4,78 @@
 
 ```
 Outside → Inside (ONLY this direction allowed)
-Core NEVER knows about Infra or API
+Core NEVER knows about Infra or API layers
 ```
 
 ## Module Hierarchy (IMMUTABLE)
 
 ```
-nextup-api → nextup-infrastructure → nextup-core → nextup-common
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│   nextup-api    │    │nextup-backoffice│    │  nextup-scorer  │
+│  (일반 사용자)   │    │   (관리자 CRUD) │    │ (실시간 기록)    │
+│    port:8080    │    │    port:8081    │    │    port:8082    │
+└────────┬────────┘    └────────┬────────┘    └────────┬────────┘
+         │                      │                      │
+         └──────────────────────┼──────────────────────┘
+                                │
+                    ┌───────────▼───────────┐
+                    │ nextup-infrastructure │
+                    │   (Repository, 외부)   │
+                    └───────────┬───────────┘
+                                │
+                    ┌───────────▼───────────┐
+                    │     nextup-core       │
+                    │   (도메인, 비즈니스)    │
+                    └───────────┬───────────┘
+                                │
+                    ┌───────────▼───────────┐
+                    │    nextup-common      │
+                    │      (공통 유틸)       │
+                    └───────────────────────┘
 ```
+
+## Module Roles
+
+| Module | Role | Port |
+|--------|------|------|
+| `nextup-api` | 일반 사용자용 공개 API (조회 위주) | 8080 |
+| `nextup-backoffice` | 관리자 CRUD (협회/리그/팀/시스템 관리) | 8081 |
+| `nextup-scorer` | 실시간 경기 기록 (기록원 전용, WebSocket) | 8082 |
+| `nextup-infrastructure` | Repository, 외부 연동, 공통 Security | - |
+| `nextup-core` | 도메인 엔티티, 비즈니스 로직 | - |
+| `nextup-common` | 공통 유틸리티, Exception | - |
 
 ## Dependency Matrix
 
 | Module | Allowed Dependencies | FORBIDDEN |
 |--------|---------------------|-----------|
-| `nextup-api` | infra, core, common | - |
-| `nextup-core` | **common ONLY** | infra, api (NEVER) |
-| `nextup-infrastructure` | core, common | api (NEVER) |
+| `nextup-api` | infra, core, common | backoffice, scorer |
+| `nextup-backoffice` | infra, core, common | api, scorer |
+| `nextup-scorer` | infra, core, common | api, backoffice |
+| `nextup-infrastructure` | core, common | api, backoffice, scorer |
+| `nextup-core` | **common ONLY** | infra, api, backoffice, scorer (NEVER) |
 | `nextup-common` | **NONE** (leaf module) | ALL dependencies |
 
 ## Critical Rules
 
 Before ANY commit:
 - [ ] No circular dependencies
-- [ ] Core does not import from Infra/API
+- [ ] Core does not import from Infra/API layers
 - [ ] Common has zero dependencies
 - [ ] No business logic in Common
+- [ ] **API layer modules (api, backoffice, scorer) do NOT depend on each other**
+
+## API Layer Isolation
+
+```
+⚠️ IMPORTANT: API 계층 모듈간 상호 의존 금지
+
+nextup-api ←✗→ nextup-backoffice ←✗→ nextup-scorer
+```
+
+- 공통 로직은 반드시 `nextup-infrastructure`에 위치
+- Controller, DTO는 각 모듈에 독립적으로 존재
+- Security 설정은 각 모듈에서 개별 구성
 
 ## Violation Response
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,17 +37,35 @@ Core가 Infra를 알면 절대 안 됨
 ## 🏗️ Multi-Module Dependency Rules (불변)
 
 ```
-nextup-api → nextup-infrastructure → nextup-core → nextup-common
+nextup-api        ─┐
+nextup-backoffice ─┼→ nextup-infrastructure → nextup-core → nextup-common
+nextup-scorer     ─┘
 ```
+
+### 모듈별 역할
+
+| 모듈 | 역할 | 포트 |
+|------|------|------|
+| `nextup-api` | 일반 사용자용 공개 API (조회 위주) | 8080 |
+| `nextup-backoffice` | 관리자 CRUD (협회/리그/팀/시스템 관리) | 8081 |
+| `nextup-scorer` | 실시간 경기 기록 (기록원 전용, WebSocket) | 8082 |
+| `nextup-infrastructure` | Repository, 외부 연동, 공통 Security | - |
+| `nextup-core` | 도메인 엔티티, 비즈니스 로직 | - |
+| `nextup-common` | 공통 유틸리티, Exception | - |
+
+### 의존성 매트릭스
 
 | 모듈 | 허용된 의존성 | 금지 |
 |------|---------------|------|
-| `nextup-api` | `infra`, `core`, `common` | - |
-| `nextup-core` | `common` **ONLY** | infra, api 절대 금지 |
-| `nextup-infrastructure` | `core`, `common` | api 금지 |
+| `nextup-api` | `infra`, `core`, `common` | backoffice, scorer |
+| `nextup-backoffice` | `infra`, `core`, `common` | api, scorer |
+| `nextup-scorer` | `infra`, `core`, `common` | api, backoffice |
+| `nextup-infrastructure` | `core`, `common` | api, backoffice, scorer |
+| `nextup-core` | `common` **ONLY** | infra, api, backoffice, scorer 절대 금지 |
 | `nextup-common` | **NONE** (리프 모듈) | 모든 의존성 금지 |
 
 > ⚠️ **순환 참조 절대 금지** / **Common에 비즈니스 로직 금지**
+> ⚠️ **API 계층 모듈(api, backoffice, scorer)간 상호 의존 금지**
 
 ---
 
@@ -166,6 +184,7 @@ outputs/
 
 | 날짜 | 변경 내용 |
 |------|-----------|
+| 2026-02-01 | 모듈 구조 확장 (4개→6개): backoffice, scorer 모듈 추가 |
 | 2026-01-23 | Agent/Skill 구조 개선 (13개→5개 Agent, 4개→6개 Skill) |
 | 2026-01-23 | Rules, Commands 추가 |
 | 2026-01-23 | Jacoco + Codecov 설정 추가 |

--- a/nextup-backoffice/build.gradle.kts
+++ b/nextup-backoffice/build.gradle.kts
@@ -1,0 +1,59 @@
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.spring")
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
+}
+
+dependencies {
+    implementation(project(":nextup-infrastructure"))
+
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation("io.mockk:mockk:1.13.14")
+    testImplementation("org.assertj:assertj-core:3.27.3")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+tasks.jacocoTestReport {
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) {
+                exclude(
+                    "**/dto/**",
+                    "**/BackofficeApplication*"
+                )
+            }
+        })
+    )
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/BackofficeApplication.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/BackofficeApplication.kt
@@ -1,0 +1,11 @@
+package com.nextup.backoffice
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication(scanBasePackages = ["com.nextup"])
+class BackofficeApplication
+
+fun main(args: Array<String>) {
+    runApplication<BackofficeApplication>(*args)
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
@@ -1,0 +1,43 @@
+package com.nextup.backoffice.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+class SecurityConfig {
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth ->
+                // 헬스체크는 인증 없이 접근 가능
+                auth.requestMatchers("/health", "/actuator/health").permitAll()
+
+                // TODO: JWT 인증 구현 후 역할별 접근 제어 추가
+                // 현재는 개발 편의를 위해 모든 요청 허용
+                auth.anyRequest().permitAll()
+
+                // 추후 적용할 권한 설정:
+                // auth.requestMatchers("/api/backoffice/associations/**")
+                //     .hasRole("ASSOCIATION_ADMIN")
+                // auth.requestMatchers("/api/backoffice/leagues/**")
+                //     .hasAnyRole("ASSOCIATION_ADMIN", "LEAGUE_ADMIN")
+                // auth.requestMatchers("/api/backoffice/teams/**")
+                //     .hasAnyRole("LEAGUE_ADMIN", "TEAM_MANAGER")
+                // auth.requestMatchers("/api/backoffice/admin/**")
+                //     .hasRole("ADMIN")
+                // auth.anyRequest().authenticated()
+            }
+
+        return http.build()
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/HealthController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/HealthController.kt
@@ -1,0 +1,27 @@
+package com.nextup.backoffice.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+@RestController
+class HealthController {
+
+    @GetMapping("/health")
+    fun health(): ResponseEntity<HealthResponse> {
+        return ResponseEntity.ok(
+            HealthResponse(
+                status = "UP",
+                service = "next-up-backoffice",
+                timestamp = Instant.now().toString()
+            )
+        )
+    }
+
+    data class HealthResponse(
+        val status: String,
+        val service: String,
+        val timestamp: String
+    )
+}

--- a/nextup-backoffice/src/main/resources/application.yml
+++ b/nextup-backoffice/src/main/resources/application.yml
@@ -1,0 +1,42 @@
+server:
+  port: 8081
+
+spring:
+  application:
+    name: next-up-backoffice
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/nextup
+    username: ${DB_USERNAME:nextup}
+    password: ${DB_PASSWORD:nextup}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
+
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+    default-property-inclusion: non_null
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.springframework.security: DEBUG
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,5 +4,6 @@ include(
     "nextup-common",
     "nextup-core",
     "nextup-infrastructure",
-    "nextup-api"
+    "nextup-api",
+    "nextup-backoffice"
 )


### PR DESCRIPTION
## Summary
- 관리자 CRUD용 백오피스 모듈 `nextup-backoffice` 생성
- 협회/리그/팀 관리자 및 시스템 관리 기능을 위한 별도 모듈

## Changes
- `nextup-backoffice` 모듈 생성
- `settings.gradle.kts`에 모듈 추가
- Spring Security 기본 설정 (JWT 인증 준비)
- 헬스체크 엔드포인트 (`/health`)
- 포트 8081로 분리 설정

## 모듈 구조
```
nextup-backoffice/
├── src/main/kotlin/com/nextup/backoffice/
│   ├── BackofficeApplication.kt
│   ├── config/
│   │   └── SecurityConfig.kt
│   └── controller/
│       └── HealthController.kt
└── build.gradle.kts
```

## 아키텍처 결정
- 기록원(실시간)과 관리자(CRUD)의 특성이 다르므로 별도 모듈로 분리
- `nextup-scorer`(기록원 전용)는 #29에서 별도 진행

## Test plan
- [x] `./gradlew :nextup-backoffice:build` 성공
- [x] `./gradlew build` 전체 빌드 성공

## Related Issue
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)