### PR TITLE
feat(#20): Association CRUD 구현

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/association/AssociationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/association/AssociationController.kt
@@ -1,0 +1,50 @@
+package com.nextup.api.controller.association
+
+import com.nextup.api.dto.association.AssociationResponse
+import com.nextup.api.dto.association.AssociationSummaryResponse
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.infrastructure.service.association.AssociationService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 협회 조회 API Controller (일반 사용자용)
+ */
+@RestController
+@RequestMapping("/api/associations")
+class AssociationController(
+    private val associationService: AssociationService
+) {
+
+    /**
+     * 활성화된 협회 목록을 조회합니다.
+     */
+    @GetMapping
+    fun getAssociations(
+        @RequestParam(required = false) region: String?
+    ): ApiResponse<List<AssociationSummaryResponse>> {
+        val associations = if (region != null) {
+            associationService.getActiveByRegion(region)
+        } else {
+            associationService.getAllActive()
+        }
+
+        return ApiResponse.success(
+            associations.map { AssociationSummaryResponse.from(it) }
+        )
+    }
+
+    /**
+     * 협회 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getAssociation(
+        @PathVariable id: Long
+    ): ApiResponse<AssociationResponse> {
+        val association = associationService.getById(id)
+        return ApiResponse.success(AssociationResponse.from(association))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/association/AssociationResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/association/AssociationResponse.kt
@@ -1,0 +1,60 @@
+package com.nextup.api.dto.association
+
+import com.nextup.core.domain.association.Association
+import java.time.Instant
+
+/**
+ * 협회 응답 DTO
+ */
+data class AssociationResponse(
+    val id: Long,
+    val name: String,
+    val abbreviation: String?,
+    val region: String?,
+    val description: String?,
+    val logoUrl: String?,
+    val websiteUrl: String?,
+    val isActive: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant
+) {
+    companion object {
+        fun from(association: Association): AssociationResponse {
+            return AssociationResponse(
+                id = association.id,
+                name = association.name,
+                abbreviation = association.abbreviation,
+                region = association.region,
+                description = association.description,
+                logoUrl = association.logoUrl,
+                websiteUrl = association.websiteUrl,
+                isActive = association.isActive,
+                createdAt = association.createdAt,
+                updatedAt = association.updatedAt
+            )
+        }
+    }
+}
+
+/**
+ * 협회 목록 응답 DTO (간략 정보)
+ */
+data class AssociationSummaryResponse(
+    val id: Long,
+    val name: String,
+    val abbreviation: String?,
+    val region: String?,
+    val logoUrl: String?
+) {
+    companion object {
+        fun from(association: Association): AssociationSummaryResponse {
+            return AssociationSummaryResponse(
+                id = association.id,
+                name = association.name,
+                abbreviation = association.abbreviation,
+                region = association.region,
+                logoUrl = association.logoUrl
+            )
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/association/AssociationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/association/AssociationControllerTest.kt
@@ -1,0 +1,106 @@
+package com.nextup.api.controller.association
+
+import com.nextup.common.exception.AssociationNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.infrastructure.service.association.AssociationService
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("AssociationController")
+class AssociationControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var associationService: AssociationService
+    private lateinit var controller: AssociationController
+
+    @BeforeEach
+    fun setUp() {
+        associationService = mockk()
+        controller = AssociationController(associationService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/associations")
+    inner class GetAssociations {
+
+        @Test
+        fun `should return all active associations`() {
+            // given
+            val associations = listOf(
+                createAssociation(1L, "서울시야구협회", "서울"),
+                createAssociation(2L, "경기도야구협회", "경기")
+            )
+            every { associationService.getAllActive() } returns associations
+
+            // when & then
+            mockMvc.perform(get("/api/associations"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].name").value("서울시야구협회"))
+        }
+
+        @Test
+        fun `should filter by region when region parameter is provided`() {
+            // given
+            val associations = listOf(
+                createAssociation(1L, "서울시야구협회", "서울")
+            )
+            every { associationService.getActiveByRegion("서울") } returns associations
+
+            // when & then
+            mockMvc.perform(get("/api/associations").param("region", "서울"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].region").value("서울"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/associations/{id}")
+    inner class GetAssociation {
+
+        @Test
+        fun `should return association when found`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회", "서울")
+            every { associationService.getById(1L) } returns association
+
+            // when & then
+            mockMvc.perform(get("/api/associations/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("서울시야구협회"))
+                .andExpect(jsonPath("$.data.region").value("서울"))
+        }
+    }
+
+    private fun createAssociation(id: Long, name: String, region: String): Association {
+        return Association(
+            name = name,
+            abbreviation = null,
+            region = region,
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/association/AssociationAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/association/AssociationAdminController.kt
@@ -1,0 +1,108 @@
+package com.nextup.backoffice.controller.association
+
+import com.nextup.backoffice.dto.association.AssociationAdminResponse
+import com.nextup.backoffice.dto.association.CreateAssociationRequest
+import com.nextup.backoffice.dto.association.UpdateAssociationRequest
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.infrastructure.service.association.AssociationService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 협회 관리 API Controller (관리자용)
+ */
+@RestController
+@RequestMapping("/api/backoffice/associations")
+class AssociationAdminController(
+    private val associationService: AssociationService
+) {
+
+    /**
+     * 모든 협회 목록을 조회합니다 (비활성화 포함).
+     */
+    @GetMapping
+    fun getAllAssociations(): ApiResponse<List<AssociationAdminResponse>> {
+        val associations = associationService.getAll()
+        return ApiResponse.success(
+            associations.map { AssociationAdminResponse.from(it) }
+        )
+    }
+
+    /**
+     * 협회 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getAssociation(
+        @PathVariable id: Long
+    ): ApiResponse<AssociationAdminResponse> {
+        val association = associationService.getById(id)
+        return ApiResponse.success(AssociationAdminResponse.from(association))
+    }
+
+    /**
+     * 협회를 생성합니다.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createAssociation(
+        @Valid @RequestBody request: CreateAssociationRequest
+    ): ApiResponse<AssociationAdminResponse> {
+        val association = associationService.create(
+            name = request.name,
+            abbreviation = request.abbreviation,
+            region = request.region,
+            description = request.description,
+            logoUrl = request.logoUrl,
+            websiteUrl = request.websiteUrl
+        )
+        return ApiResponse.success(AssociationAdminResponse.from(association))
+    }
+
+    /**
+     * 협회 정보를 수정합니다.
+     */
+    @PutMapping("/{id}")
+    fun updateAssociation(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateAssociationRequest
+    ): ApiResponse<AssociationAdminResponse> {
+        val association = associationService.update(
+            id = id,
+            description = request.description,
+            logoUrl = request.logoUrl,
+            websiteUrl = request.websiteUrl
+        )
+        return ApiResponse.success(AssociationAdminResponse.from(association))
+    }
+
+    /**
+     * 협회를 비활성화합니다.
+     */
+    @DeleteMapping("/{id}")
+    fun deactivateAssociation(
+        @PathVariable id: Long
+    ): ApiResponse<AssociationAdminResponse> {
+        val association = associationService.deactivate(id)
+        return ApiResponse.success(AssociationAdminResponse.from(association))
+    }
+
+    /**
+     * 협회를 활성화합니다.
+     */
+    @PostMapping("/{id}/activate")
+    fun activateAssociation(
+        @PathVariable id: Long
+    ): ApiResponse<AssociationAdminResponse> {
+        val association = associationService.activate(id)
+        return ApiResponse.success(AssociationAdminResponse.from(association))
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/association/AssociationAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/association/AssociationAdminResponse.kt
@@ -1,0 +1,39 @@
+package com.nextup.backoffice.dto.association
+
+import com.nextup.core.domain.association.Association
+import java.time.Instant
+
+/**
+ * 협회 관리자 응답 DTO
+ *
+ * 일반 사용자 응답과 동일하지만 backoffice 모듈에 독립적으로 존재
+ */
+data class AssociationAdminResponse(
+    val id: Long,
+    val name: String,
+    val abbreviation: String?,
+    val region: String?,
+    val description: String?,
+    val logoUrl: String?,
+    val websiteUrl: String?,
+    val isActive: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant
+) {
+    companion object {
+        fun from(association: Association): AssociationAdminResponse {
+            return AssociationAdminResponse(
+                id = association.id,
+                name = association.name,
+                abbreviation = association.abbreviation,
+                region = association.region,
+                description = association.description,
+                logoUrl = association.logoUrl,
+                websiteUrl = association.websiteUrl,
+                isActive = association.isActive,
+                createdAt = association.createdAt,
+                updatedAt = association.updatedAt
+            )
+        }
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/association/AssociationRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/association/AssociationRequest.kt
@@ -1,0 +1,42 @@
+package com.nextup.backoffice.dto.association
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+/**
+ * 협회 생성 요청 DTO
+ */
+data class CreateAssociationRequest(
+    @field:NotBlank(message = "협회 이름은 필수입니다")
+    @field:Size(max = 100, message = "협회 이름은 100자를 초과할 수 없습니다")
+    val name: String,
+
+    @field:Size(max = 20, message = "약어는 20자를 초과할 수 없습니다")
+    val abbreviation: String? = null,
+
+    @field:Size(max = 50, message = "지역은 50자를 초과할 수 없습니다")
+    val region: String? = null,
+
+    @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    val description: String? = null,
+
+    @field:Size(max = 255, message = "로고 URL은 255자를 초과할 수 없습니다")
+    val logoUrl: String? = null,
+
+    @field:Size(max = 255, message = "웹사이트 URL은 255자를 초과할 수 없습니다")
+    val websiteUrl: String? = null
+)
+
+/**
+ * 협회 수정 요청 DTO
+ */
+data class UpdateAssociationRequest(
+    @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    val description: String? = null,
+
+    @field:Size(max = 255, message = "로고 URL은 255자를 초과할 수 없습니다")
+    val logoUrl: String? = null,
+
+    @field:Size(max = 255, message = "웹사이트 URL은 255자를 초과할 수 없습니다")
+    val websiteUrl: String? = null
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/common/ApiResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/common/ApiResponse.kt
@@ -1,0 +1,31 @@
+package com.nextup.backoffice.dto.common
+
+/**
+ * API 응답 래퍼
+ *
+ * 모든 API 응답을 일관된 형태로 제공합니다.
+ */
+data class ApiResponse<T>(
+    val success: Boolean,
+    val data: T?,
+    val error: ErrorDetails?
+) {
+    companion object {
+        fun <T> success(data: T): ApiResponse<T> {
+            return ApiResponse(success = true, data = data, error = null)
+        }
+
+        fun <T> error(code: String, message: String): ApiResponse<T> {
+            return ApiResponse(
+                success = false,
+                data = null,
+                error = ErrorDetails(code, message)
+            )
+        }
+    }
+}
+
+data class ErrorDetails(
+    val code: String,
+    val message: String
+)

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/AssociationExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/AssociationExceptions.kt
@@ -1,0 +1,19 @@
+package com.nextup.common.exception
+
+/**
+ * 협회를 찾을 수 없을 때 발생하는 예외
+ */
+class AssociationNotFoundException(associationId: Long) :
+    NotFoundException(
+        "ASSOCIATION_NOT_FOUND",
+        "Association not found: $associationId"
+    )
+
+/**
+ * 협회 이름이 중복될 때 발생하는 예외
+ */
+class AssociationNameDuplicateException(name: String) :
+    BusinessException(
+        "ASSOCIATION_NAME_DUPLICATE",
+        "Association name already exists: $name"
+    )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/association/AssociationRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/association/AssociationRepository.kt
@@ -1,0 +1,35 @@
+package com.nextup.infrastructure.repository.association
+
+import com.nextup.core.domain.association.Association
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface AssociationRepository : JpaRepository<Association, Long> {
+
+    /**
+     * 협회 이름으로 조회합니다.
+     */
+    fun findByName(name: String): Association?
+
+    /**
+     * 협회 이름 존재 여부를 확인합니다.
+     */
+    fun existsByName(name: String): Boolean
+
+    /**
+     * 활성화된 협회 목록을 조회합니다.
+     */
+    @Query("SELECT a FROM Association a WHERE a.isActive = true ORDER BY a.name")
+    fun findAllActive(): List<Association>
+
+    /**
+     * 지역별 협회 목록을 조회합니다.
+     */
+    fun findByRegion(region: String): List<Association>
+
+    /**
+     * 지역별 활성화된 협회 목록을 조회합니다.
+     */
+    @Query("SELECT a FROM Association a WHERE a.region = :region AND a.isActive = true ORDER BY a.name")
+    fun findActiveByRegion(region: String): List<Association>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/association/AssociationService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/association/AssociationService.kt
@@ -1,0 +1,117 @@
+package com.nextup.infrastructure.service.association
+
+import com.nextup.common.exception.AssociationNameDuplicateException
+import com.nextup.common.exception.AssociationNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.infrastructure.repository.association.AssociationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 협회 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class AssociationService(
+    private val associationRepository: AssociationRepository
+) {
+
+    /**
+     * 협회를 생성합니다.
+     */
+    @Transactional
+    fun create(
+        name: String,
+        abbreviation: String? = null,
+        region: String? = null,
+        description: String? = null,
+        logoUrl: String? = null,
+        websiteUrl: String? = null
+    ): Association {
+        // 이름 중복 체크
+        if (associationRepository.existsByName(name)) {
+            throw AssociationNameDuplicateException(name)
+        }
+
+        val association = Association(
+            name = name,
+            abbreviation = abbreviation,
+            region = region,
+            description = description,
+            logoUrl = logoUrl,
+            websiteUrl = websiteUrl
+        )
+
+        return associationRepository.save(association)
+    }
+
+    /**
+     * ID로 협회를 조회합니다.
+     */
+    fun getById(id: Long): Association {
+        return associationRepository.findById(id)
+            .orElseThrow { AssociationNotFoundException(id) }
+    }
+
+    /**
+     * 활성화된 모든 협회를 조회합니다.
+     */
+    fun getAllActive(): List<Association> {
+        return associationRepository.findAllActive()
+    }
+
+    /**
+     * 모든 협회를 조회합니다 (관리자용).
+     */
+    fun getAll(): List<Association> {
+        return associationRepository.findAll()
+    }
+
+    /**
+     * 지역별 활성화된 협회를 조회합니다.
+     */
+    fun getActiveByRegion(region: String): List<Association> {
+        return associationRepository.findActiveByRegion(region)
+    }
+
+    /**
+     * 협회 정보를 수정합니다.
+     */
+    @Transactional
+    fun update(
+        id: Long,
+        description: String? = null,
+        logoUrl: String? = null,
+        websiteUrl: String? = null
+    ): Association {
+        val association = getById(id)
+        association.updateInfo(
+            description = description,
+            logoUrl = logoUrl,
+            websiteUrl = websiteUrl
+        )
+        return association
+    }
+
+    /**
+     * 협회를 비활성화합니다.
+     */
+    @Transactional
+    fun deactivate(id: Long): Association {
+        val association = getById(id)
+        association.deactivate()
+        return association
+    }
+
+    /**
+     * 협회를 활성화합니다.
+     */
+    @Transactional
+    fun activate(id: Long): Association {
+        val association = getById(id)
+        association.activate()
+        return association
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/association/AssociationServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/association/AssociationServiceTest.kt
@@ -1,0 +1,195 @@
+package com.nextup.infrastructure.service.association
+
+import com.nextup.common.exception.AssociationNameDuplicateException
+import com.nextup.common.exception.AssociationNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.infrastructure.repository.association.AssociationRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+@DisplayName("AssociationService")
+class AssociationServiceTest {
+
+    private lateinit var associationRepository: AssociationRepository
+    private lateinit var associationService: AssociationService
+
+    @BeforeEach
+    fun setUp() {
+        associationRepository = mockk()
+        associationService = AssociationService(associationRepository)
+    }
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+
+        @Test
+        fun `should create association successfully`() {
+            // given
+            val name = "서울시야구협회"
+            val region = "서울"
+            every { associationRepository.existsByName(name) } returns false
+            every { associationRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = associationService.create(
+                name = name,
+                abbreviation = "서야협",
+                region = region,
+                description = "서울시 사회인 야구 협회"
+            )
+
+            // then
+            assertThat(result.name).isEqualTo(name)
+            assertThat(result.region).isEqualTo(region)
+            assertThat(result.isActive).isTrue()
+            verify { associationRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when name is duplicated`() {
+            // given
+            val name = "서울시야구협회"
+            every { associationRepository.existsByName(name) } returns true
+
+            // when & then
+            assertThatThrownBy {
+                associationService.create(name = name)
+            }.isInstanceOf(AssociationNameDuplicateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getById")
+    inner class GetById {
+
+        @Test
+        fun `should return association when found`() {
+            // given
+            val id = 1L
+            val association = createAssociation(id, "서울시야구협회")
+            every { associationRepository.findById(id) } returns Optional.of(association)
+
+            // when
+            val result = associationService.getById(id)
+
+            // then
+            assertThat(result.id).isEqualTo(id)
+            assertThat(result.name).isEqualTo("서울시야구협회")
+        }
+
+        @Test
+        fun `should throw exception when not found`() {
+            // given
+            val id = 999L
+            every { associationRepository.findById(id) } returns Optional.empty()
+
+            // when & then
+            assertThatThrownBy {
+                associationService.getById(id)
+            }.isInstanceOf(AssociationNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllActive")
+    inner class GetAllActive {
+
+        @Test
+        fun `should return only active associations`() {
+            // given
+            val associations = listOf(
+                createAssociation(1L, "서울시야구협회"),
+                createAssociation(2L, "경기도야구협회")
+            )
+            every { associationRepository.findAllActive() } returns associations
+
+            // when
+            val result = associationService.getAllActive()
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    inner class Update {
+
+        @Test
+        fun `should update association info`() {
+            // given
+            val id = 1L
+            val association = createAssociation(id, "서울시야구협회")
+            every { associationRepository.findById(id) } returns Optional.of(association)
+
+            // when
+            val result = associationService.update(
+                id = id,
+                description = "새로운 설명",
+                logoUrl = "https://example.com/logo.png"
+            )
+
+            // then
+            assertThat(result.description).isEqualTo("새로운 설명")
+            assertThat(result.logoUrl).isEqualTo("https://example.com/logo.png")
+        }
+    }
+
+    @Nested
+    @DisplayName("deactivate/activate")
+    inner class DeactivateActivate {
+
+        @Test
+        fun `should deactivate association`() {
+            // given
+            val id = 1L
+            val association = createAssociation(id, "서울시야구협회")
+            every { associationRepository.findById(id) } returns Optional.of(association)
+
+            // when
+            val result = associationService.deactivate(id)
+
+            // then
+            assertThat(result.isActive).isFalse()
+        }
+
+        @Test
+        fun `should activate association`() {
+            // given
+            val id = 1L
+            val association = createAssociation(id, "서울시야구협회").apply { deactivate() }
+            every { associationRepository.findById(id) } returns Optional.of(association)
+
+            // when
+            val result = associationService.activate(id)
+
+            // then
+            assertThat(result.isActive).isTrue()
+        }
+    }
+
+    private fun createAssociation(id: Long, name: String): Association {
+        return Association(
+            name = name,
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            // 테스트용으로 ID를 설정하기 위해 리플렉션 사용
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 협회(Association) 도메인의 전체 CRUD 기능 구현
- 모듈별 역할에 맞게 기능 배치

## 모듈별 기능 배치

### nextup-api (일반 사용자용 - 조회)
| 엔드포인트 | 설명 |
|-----------|------|
| `GET /api/associations` | 협회 목록 조회 (region 필터 지원) |
| `GET /api/associations/{id}` | 협회 상세 조회 |

### nextup-backoffice (관리자용 - CUD)
| 엔드포인트 | 설명 |
|-----------|------|
| `GET /api/backoffice/associations` | 전체 협회 목록 (비활성화 포함) |
| `POST /api/backoffice/associations` | 협회 생성 |
| `PUT /api/backoffice/associations/{id}` | 협회 수정 |
| `DELETE /api/backoffice/associations/{id}` | 협회 비활성화 |
| `POST /api/backoffice/associations/{id}/activate` | 협회 활성화 |

## 구현 내용

### Infrastructure Layer
- `AssociationRepository`: 협회 조회 쿼리 (활성화/지역별)
- `AssociationService`: 협회 CRUD 비즈니스 로직

### API Layer
- `AssociationController`: 일반 사용자용 조회 API
- `AssociationResponse`: 협회 응답 DTO

### Backoffice Layer
- `AssociationAdminController`: 관리자용 CUD API
- `AssociationRequest`: 협회 생성/수정 요청 DTO
- `AssociationAdminResponse`: 관리자용 응답 DTO

### Common
- `AssociationExceptions`: 협회 관련 예외 클래스

## Test plan
- [x] `AssociationServiceTest`: Service 단위 테스트 (생성, 조회, 수정, 비활성화)
- [x] `AssociationControllerTest`: Controller 단위 테스트
- [x] `./gradlew build` 성공

## Related Issue
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)