### PR TITLE
feat(#29): nextup-scorer 모듈 초기 설정

### DIFF
--- a/nextup-scorer/build.gradle.kts
+++ b/nextup-scorer/build.gradle.kts
@@ -1,0 +1,60 @@
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.spring")
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
+}
+
+dependencies {
+    implementation(project(":nextup-infrastructure"))
+
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation("io.mockk:mockk:1.13.14")
+    testImplementation("org.assertj:assertj-core:3.27.3")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+tasks.jacocoTestReport {
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) {
+                exclude(
+                    "**/dto/**",
+                    "**/ScorerApplication*"
+                )
+            }
+        })
+    )
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/ScorerApplication.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/ScorerApplication.kt
@@ -1,0 +1,11 @@
+package com.nextup.scorer
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication(scanBasePackages = ["com.nextup"])
+class ScorerApplication
+
+fun main(args: Array<String>) {
+    runApplication<ScorerApplication>(*args)
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/SecurityConfig.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/SecurityConfig.kt
@@ -1,0 +1,40 @@
+package com.nextup.scorer.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+class SecurityConfig {
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth ->
+                // 헬스체크는 인증 없이 접근 가능
+                auth.requestMatchers("/health", "/actuator/health").permitAll()
+
+                // WebSocket 엔드포인트
+                auth.requestMatchers("/ws/**").permitAll()
+
+                // TODO: JWT 인증 구현 후 SCORER 역할 필수로 변경
+                // 현재는 개발 편의를 위해 모든 요청 허용
+                auth.anyRequest().permitAll()
+
+                // 추후 적용할 권한 설정:
+                // auth.requestMatchers("/api/scorer/**").hasRole("SCORER")
+                // auth.requestMatchers("/ws/scoreboard/**").hasRole("SCORER")
+                // auth.anyRequest().authenticated()
+            }
+
+        return http.build()
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketConfig.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketConfig.kt
@@ -1,0 +1,38 @@
+package com.nextup.scorer.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+/**
+ * WebSocket 설정
+ *
+ * 실시간 스코어보드 브로드캐스트를 위한 STOMP over WebSocket 설정
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+
+    override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+        // 클라이언트가 구독할 수 있는 prefix
+        // /topic/games/{gameId}/scoreboard - 특정 경기 스코어보드
+        // /topic/games/{gameId}/events - 특정 경기 이벤트
+        registry.enableSimpleBroker("/topic")
+
+        // 클라이언트가 서버로 메시지를 보낼 때 사용할 prefix
+        registry.setApplicationDestinationPrefixes("/app")
+    }
+
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        // WebSocket 연결 엔드포인트
+        registry.addEndpoint("/ws/scoreboard")
+            .setAllowedOriginPatterns("*")
+            .withSockJS()
+
+        // SockJS 없이 순수 WebSocket 연결
+        registry.addEndpoint("/ws/scoreboard")
+            .setAllowedOriginPatterns("*")
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/HealthController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/HealthController.kt
@@ -1,0 +1,29 @@
+package com.nextup.scorer.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+@RestController
+class HealthController {
+
+    @GetMapping("/health")
+    fun health(): ResponseEntity<HealthResponse> {
+        return ResponseEntity.ok(
+            HealthResponse(
+                status = "UP",
+                service = "next-up-scorer",
+                timestamp = Instant.now().toString(),
+                features = listOf("websocket", "real-time-scoring")
+            )
+        )
+    }
+
+    data class HealthResponse(
+        val status: String,
+        val service: String,
+        val timestamp: String,
+        val features: List<String>
+    )
+}

--- a/nextup-scorer/src/main/resources/application.yml
+++ b/nextup-scorer/src/main/resources/application.yml
@@ -1,0 +1,43 @@
+server:
+  port: 8082
+
+spring:
+  application:
+    name: next-up-scorer
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/nextup
+    username: ${DB_USERNAME:nextup}
+    password: ${DB_PASSWORD:nextup}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
+
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+    default-property-inclusion: non_null
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.springframework.security: DEBUG
+    org.springframework.websocket: DEBUG
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,5 +5,6 @@ include(
     "nextup-core",
     "nextup-infrastructure",
     "nextup-api",
-    "nextup-backoffice"
+    "nextup-backoffice",
+    "nextup-scorer"
 )


### PR DESCRIPTION
## Summary
- 실시간 경기 기록을 위한 기록원 전용 모듈 `nextup-scorer` 생성
- WebSocket 기반 실시간 스코어보드 브로드캐스트 지원

## 모듈 역할
| 역할 | 설명 |
|------|------|
| **SCORER** | 실시간 경기 기록 입력 |
| **WebSocket** | 스코어보드 실시간 브로드캐스트 |

## 기술 스택
- Spring WebSocket (STOMP over WebSocket)
- SockJS 폴백 지원
- Port: 8082

## WebSocket 엔드포인트
| 엔드포인트 | 설명 |
|-----------|------|
| `/ws/scoreboard` | WebSocket 연결 엔드포인트 |
| `/topic/games/{gameId}/scoreboard` | 경기별 스코어보드 구독 |
| `/topic/games/{gameId}/events` | 경기별 이벤트 구독 |
| `/app/*` | 클라이언트→서버 메시지 prefix |

## 모듈 구조
```
nextup-scorer/
├── src/main/kotlin/com/nextup/scorer/
│   ├── ScorerApplication.kt
│   ├── config/
│   │   ├── SecurityConfig.kt
│   │   └── WebSocketConfig.kt
│   └── controller/
│       └── HealthController.kt
└── build.gradle.kts
```

## 전체 모듈 구조
```
nextup-api        (8080) ─┐
nextup-backoffice (8081) ─┼→ infrastructure → core → common
nextup-scorer     (8082) ─┘
```

## Test plan
- [x] `./gradlew :nextup-scorer:build` 성공
- [x] `./gradlew build` 전체 빌드 성공

## Related Issue
>- close #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)