### PR TITLE
feat(#25): User CRUD 구현

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/user/ProfileController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/user/ProfileController.kt
@@ -1,0 +1,102 @@
+package com.nextup.api.controller.user
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.user.*
+import com.nextup.infrastructure.service.user.UserService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 사용자 프로필 API Controller
+ *
+ * 로그인한 사용자가 본인 정보를 조회/수정하는 API를 제공합니다.
+ *
+ * TODO: Spring Security 구현 후 @AuthenticationPrincipal로 현재 사용자 주입
+ */
+@RestController
+@RequestMapping("/api/v1/me")
+class ProfileController(
+    private val userService: UserService
+) {
+
+    /**
+     * 내 프로필을 조회합니다.
+     *
+     * TODO: 인증 구현 후 userId를 @AuthenticationPrincipal에서 추출
+     */
+    @GetMapping
+    fun getMyProfile(
+        @RequestHeader("X-User-Id") userId: Long // 임시: 인증 구현 전까지 헤더로 전달
+    ): ApiResponse<ProfileResponse> {
+        val user = userService.getActiveById(userId)
+        return ApiResponse.success(ProfileResponse.from(user))
+    }
+
+    /**
+     * 내 프로필을 수정합니다.
+     */
+    @PutMapping
+    fun updateMyProfile(
+        @RequestHeader("X-User-Id") userId: Long,
+        @Valid @RequestBody request: UpdateProfileRequest
+    ): ApiResponse<ProfileResponse> {
+        val user = userService.updateProfile(
+            userId = userId,
+            nickname = request.nickname,
+            profileImageUrl = request.profileImageUrl
+        )
+        return ApiResponse.success(ProfileResponse.from(user))
+    }
+
+    /**
+     * 연동된 OAuth 계정 목록을 조회합니다.
+     */
+    @GetMapping("/oauth-accounts")
+    fun getLinkedOAuthAccounts(
+        @RequestHeader("X-User-Id") userId: Long
+    ): ApiResponse<List<LinkedOAuthProvider>> {
+        val user = userService.getActiveById(userId)
+        val providers = user.oauthAccounts.map {
+            LinkedOAuthProvider(
+                provider = it.provider.name,
+                displayName = it.provider.displayName,
+                connectedAt = it.connectedAt
+            )
+        }
+        return ApiResponse.success(providers)
+    }
+
+    /**
+     * 회원 탈퇴합니다 (계정 비활성화).
+     */
+    @DeleteMapping
+    fun deactivateMyAccount(
+        @RequestHeader("X-User-Id") userId: Long
+    ): ApiResponse<Unit> {
+        userService.deactivate(userId)
+        return ApiResponse.success(Unit)
+    }
+}
+
+/**
+ * 공개 프로필 API Controller
+ *
+ * 다른 사용자의 공개 프로필을 조회하는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/users")
+class PublicProfileController(
+    private val userService: UserService
+) {
+
+    /**
+     * 사용자의 공개 프로필을 조회합니다.
+     */
+    @GetMapping("/{userId}")
+    fun getPublicProfile(
+        @PathVariable userId: Long
+    ): ApiResponse<PublicProfileResponse> {
+        val user = userService.getActiveById(userId)
+        return ApiResponse.success(PublicProfileResponse.from(user))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/user/ProfileRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/user/ProfileRequest.kt
@@ -1,0 +1,23 @@
+package com.nextup.api.dto.user
+
+import jakarta.validation.constraints.Size
+
+/**
+ * 프로필 수정 요청 DTO
+ */
+data class UpdateProfileRequest(
+    @field:Size(min = 2, max = 50, message = "닉네임은 2~50자 사이여야 합니다")
+    val nickname: String? = null,
+
+    val profileImageUrl: String? = null
+)
+
+/**
+ * 비밀번호 변경 요청 DTO
+ */
+data class ChangePasswordRequest(
+    val currentPassword: String,
+
+    @field:Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
+    val newPassword: String
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/user/ProfileResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/user/ProfileResponse.kt
@@ -1,0 +1,77 @@
+package com.nextup.api.dto.user
+
+import com.nextup.core.domain.user.User
+import java.time.Instant
+
+/**
+ * 사용자 프로필 응답 DTO
+ *
+ * 로그인한 사용자가 본인 정보를 조회할 때 사용합니다.
+ */
+data class ProfileResponse(
+    val id: Long,
+    val email: String,
+    val nickname: String,
+    val profileImageUrl: String?,
+    val roles: Set<String>,
+    val isLocalUser: Boolean,
+    val linkedOAuthProviders: List<LinkedOAuthProvider>,
+    val hasLinkedPlayer: Boolean,
+    val playerId: Long?,
+    val createdAt: Instant
+) {
+    companion object {
+        fun from(user: User): ProfileResponse {
+            return ProfileResponse(
+                id = user.id,
+                email = user.email,
+                nickname = user.nickname,
+                profileImageUrl = user.profileImageUrl,
+                roles = user.roles.map { it.name }.toSet(),
+                isLocalUser = user.isLocalUser,
+                linkedOAuthProviders = user.oauthAccounts.map {
+                    LinkedOAuthProvider(
+                        provider = it.provider.name,
+                        displayName = it.provider.displayName,
+                        connectedAt = it.connectedAt
+                    )
+                },
+                hasLinkedPlayer = user.hasLinkedPlayer,
+                playerId = user.player?.id,
+                createdAt = user.createdAt
+            )
+        }
+    }
+}
+
+/**
+ * 연동된 OAuth Provider 정보
+ */
+data class LinkedOAuthProvider(
+    val provider: String,
+    val displayName: String,
+    val connectedAt: Instant
+)
+
+/**
+ * 프로필 간략 정보 (공개용)
+ */
+data class PublicProfileResponse(
+    val id: Long,
+    val nickname: String,
+    val profileImageUrl: String?,
+    val hasLinkedPlayer: Boolean,
+    val playerId: Long?
+) {
+    companion object {
+        fun from(user: User): PublicProfileResponse {
+            return PublicProfileResponse(
+                id = user.id,
+                nickname = user.nickname,
+                profileImageUrl = user.profileImageUrl,
+                hasLinkedPlayer = user.hasLinkedPlayer,
+                playerId = user.player?.id
+            )
+        }
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/user/UserAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/user/UserAdminController.kt
@@ -1,0 +1,180 @@
+package com.nextup.backoffice.controller.user
+
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.backoffice.dto.user.*
+import com.nextup.core.domain.user.Role
+import com.nextup.infrastructure.service.user.UserService
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 사용자 관리 API Controller (관리자용)
+ *
+ * 관리자가 사용자를 관리하는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/backoffice/users")
+class UserAdminController(
+    private val userService: UserService
+) {
+
+    /**
+     * 모든 사용자 목록을 페이징으로 조회합니다.
+     */
+    @GetMapping
+    fun getAllUsers(
+        @PageableDefault(size = 20) pageable: Pageable,
+        @RequestParam(required = false) isActive: Boolean?
+    ): ApiResponse<Page<UserListResponse>> {
+        val users = if (isActive != null) {
+            userService.getAllByStatus(isActive, pageable)
+        } else {
+            userService.getAll(pageable)
+        }
+        return ApiResponse.success(users.map { UserListResponse.from(it) })
+    }
+
+    /**
+     * 사용자를 검색합니다.
+     */
+    @GetMapping("/search")
+    fun searchUsers(
+        @RequestParam keyword: String,
+        @PageableDefault(size = 20) pageable: Pageable
+    ): ApiResponse<Page<UserListResponse>> {
+        val users = userService.search(keyword, pageable)
+        return ApiResponse.success(users.map { UserListResponse.from(it) })
+    }
+
+    /**
+     * 역할별 사용자를 조회합니다.
+     */
+    @GetMapping("/by-role/{role}")
+    fun getUsersByRole(
+        @PathVariable role: String,
+        @PageableDefault(size = 20) pageable: Pageable
+    ): ApiResponse<Page<UserListResponse>> {
+        val roleEnum = Role.valueOf(role.uppercase())
+        val users = userService.getAllByRole(roleEnum, pageable)
+        return ApiResponse.success(users.map { UserListResponse.from(it) })
+    }
+
+    /**
+     * 사용자 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getUser(@PathVariable id: Long): ApiResponse<UserAdminResponse> {
+        val user = userService.getById(id)
+        return ApiResponse.success(UserAdminResponse.from(user))
+    }
+
+    /**
+     * 사용자를 생성합니다 (관리자용 - 비밀번호 직접 설정).
+     *
+     * 주의: 실제 운영에서는 PasswordEncoder를 사용해야 합니다.
+     * Security 모듈 구현 후 수정 필요.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createUser(
+        @Valid @RequestBody request: CreateUserRequest
+    ): ApiResponse<UserAdminResponse> {
+        // TODO: PasswordEncoder 적용 필요 (Issue #26)
+        val user = userService.createLocalUser(
+            email = request.email,
+            encodedPassword = request.password, // 임시: 실제로는 인코딩 필요
+            nickname = request.nickname
+        )
+
+        // 추가 역할 부여
+        request.roles.forEach { roleName ->
+            val role = Role.valueOf(roleName.uppercase())
+            if (role != Role.USER) {
+                userService.addRole(user.id, role)
+            }
+        }
+
+        return ApiResponse.success(UserAdminResponse.from(userService.getById(user.id)))
+    }
+
+    /**
+     * 사용자 정보를 수정합니다.
+     */
+    @PutMapping("/{id}")
+    fun updateUser(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateUserRequest
+    ): ApiResponse<UserAdminResponse> {
+        var user = userService.updateProfile(
+            userId = id,
+            nickname = request.nickname,
+            profileImageUrl = request.profileImageUrl
+        )
+
+        // 역할 변경 처리
+        request.roles?.let { newRoles ->
+            val currentRoles = user.roles.map { it.name }.toSet()
+            val targetRoles = newRoles.map { it.uppercase() }.toSet()
+
+            // 제거할 역할
+            currentRoles.filter { it !in targetRoles && it != "USER" }.forEach { roleName ->
+                userService.removeRole(id, Role.valueOf(roleName))
+            }
+
+            // 추가할 역할
+            targetRoles.filter { it !in currentRoles && it != "USER" }.forEach { roleName ->
+                userService.addRole(id, Role.valueOf(roleName))
+            }
+        }
+
+        return ApiResponse.success(UserAdminResponse.from(userService.getById(id)))
+    }
+
+    /**
+     * 사용자에게 역할을 추가합니다.
+     */
+    @PostMapping("/{id}/roles")
+    fun addRole(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: RoleChangeRequest
+    ): ApiResponse<UserAdminResponse> {
+        val role = Role.valueOf(request.role.uppercase())
+        val user = userService.addRole(id, role)
+        return ApiResponse.success(UserAdminResponse.from(user))
+    }
+
+    /**
+     * 사용자에게서 역할을 제거합니다.
+     */
+    @DeleteMapping("/{id}/roles/{role}")
+    fun removeRole(
+        @PathVariable id: Long,
+        @PathVariable role: String
+    ): ApiResponse<UserAdminResponse> {
+        val roleEnum = Role.valueOf(role.uppercase())
+        val user = userService.removeRole(id, roleEnum)
+        return ApiResponse.success(UserAdminResponse.from(user))
+    }
+
+    /**
+     * 사용자를 비활성화합니다.
+     */
+    @DeleteMapping("/{id}")
+    fun deactivateUser(@PathVariable id: Long): ApiResponse<UserAdminResponse> {
+        val user = userService.deactivate(id)
+        return ApiResponse.success(UserAdminResponse.from(user))
+    }
+
+    /**
+     * 사용자를 활성화합니다.
+     */
+    @PostMapping("/{id}/activate")
+    fun activateUser(@PathVariable id: Long): ApiResponse<UserAdminResponse> {
+        val user = userService.activate(id)
+        return ApiResponse.success(UserAdminResponse.from(user))
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/user/UserAdminRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/user/UserAdminRequest.kt
@@ -1,0 +1,53 @@
+package com.nextup.backoffice.dto.user
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+/**
+ * 사용자 생성 요청 DTO (관리자용)
+ */
+data class CreateUserRequest(
+    @field:NotBlank(message = "이메일은 필수입니다")
+    @field:Email(message = "올바른 이메일 형식이 아닙니다")
+    val email: String,
+
+    @field:NotBlank(message = "비밀번호는 필수입니다")
+    @field:Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
+    val password: String,
+
+    @field:NotBlank(message = "닉네임은 필수입니다")
+    @field:Size(min = 2, max = 50, message = "닉네임은 2~50자 사이여야 합니다")
+    val nickname: String,
+
+    val roles: Set<String> = emptySet()
+)
+
+/**
+ * 사용자 정보 수정 요청 DTO (관리자용)
+ */
+data class UpdateUserRequest(
+    @field:Size(min = 2, max = 50, message = "닉네임은 2~50자 사이여야 합니다")
+    val nickname: String? = null,
+
+    val profileImageUrl: String? = null,
+
+    val roles: Set<String>? = null
+)
+
+/**
+ * 역할 변경 요청 DTO
+ */
+data class RoleChangeRequest(
+    @field:NotBlank(message = "역할은 필수입니다")
+    val role: String
+)
+
+/**
+ * 사용자 검색 필터
+ */
+data class UserSearchFilter(
+    val keyword: String? = null,
+    val role: String? = null,
+    val isActive: Boolean? = null
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/user/UserAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/user/UserAdminResponse.kt
@@ -1,0 +1,80 @@
+package com.nextup.backoffice.dto.user
+
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.core.domain.user.Role
+import com.nextup.core.domain.user.User
+import java.time.Instant
+
+/**
+ * 사용자 관리자 응답 DTO
+ *
+ * 관리자가 사용자 정보를 조회할 때 사용합니다.
+ */
+data class UserAdminResponse(
+    val id: Long,
+    val email: String,
+    val nickname: String,
+    val profileImageUrl: String?,
+    val roles: Set<String>,
+    val isLocalUser: Boolean,
+    val linkedOAuthProviders: List<String>,
+    val hasLinkedPlayer: Boolean,
+    val playerId: Long?,
+    val isActive: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant
+) {
+    companion object {
+        fun from(user: User): UserAdminResponse {
+            return UserAdminResponse(
+                id = user.id,
+                email = user.email,
+                nickname = user.nickname,
+                profileImageUrl = user.profileImageUrl,
+                roles = user.roles.map { it.name }.toSet(),
+                isLocalUser = user.isLocalUser,
+                linkedOAuthProviders = user.oauthAccounts.map { it.provider.name },
+                hasLinkedPlayer = user.hasLinkedPlayer,
+                playerId = user.player?.id,
+                isActive = user.isActive,
+                createdAt = user.createdAt,
+                updatedAt = user.updatedAt
+            )
+        }
+    }
+}
+
+/**
+ * 사용자 목록 응답 DTO (간략 정보)
+ */
+data class UserListResponse(
+    val id: Long,
+    val email: String,
+    val nickname: String,
+    val roles: Set<String>,
+    val isActive: Boolean,
+    val createdAt: Instant
+) {
+    companion object {
+        fun from(user: User): UserListResponse {
+            return UserListResponse(
+                id = user.id,
+                email = user.email,
+                nickname = user.nickname,
+                roles = user.roles.map { it.name }.toSet(),
+                isActive = user.isActive,
+                createdAt = user.createdAt
+            )
+        }
+    }
+}
+
+/**
+ * OAuth 계정 정보 응답 DTO
+ */
+data class OAuthAccountResponse(
+    val provider: String,
+    val providerDisplayName: String,
+    val email: String?,
+    val connectedAt: Instant
+)

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/UserExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/UserExceptions.kt
@@ -1,0 +1,64 @@
+package com.nextup.common.exception
+
+/**
+ * 사용자를 찾을 수 없을 때 발생하는 예외
+ */
+class UserNotFoundException(userId: Long) :
+    NotFoundException(
+        "USER_NOT_FOUND",
+        "User not found: $userId"
+    )
+
+/**
+ * 이메일로 사용자를 찾을 수 없을 때 발생하는 예외
+ */
+class UserNotFoundByEmailException(email: String) :
+    NotFoundException(
+        "USER_NOT_FOUND",
+        "User not found with email: $email"
+    )
+
+/**
+ * 이메일이 중복될 때 발생하는 예외
+ */
+class EmailDuplicateException(email: String) :
+    BusinessException(
+        "EMAIL_DUPLICATE",
+        "Email already exists: $email"
+    )
+
+/**
+ * OAuth 계정이 이미 연결되어 있을 때 발생하는 예외
+ */
+class OAuthAccountAlreadyLinkedException(provider: String) :
+    BusinessException(
+        "OAUTH_ALREADY_LINKED",
+        "OAuth account already linked: $provider"
+    )
+
+/**
+ * OAuth 계정을 찾을 수 없을 때 발생하는 예외
+ */
+class OAuthAccountNotFoundException(provider: String, oauthId: String) :
+    NotFoundException(
+        "OAUTH_ACCOUNT_NOT_FOUND",
+        "OAuth account not found: $provider, $oauthId"
+    )
+
+/**
+ * 인증 수단이 부족할 때 발생하는 예외
+ */
+class InsufficientAuthMethodException :
+    BusinessException(
+        "INSUFFICIENT_AUTH_METHOD",
+        "At least one authentication method is required"
+    )
+
+/**
+ * 비활성화된 사용자일 때 발생하는 예외
+ */
+class UserDeactivatedException(userId: Long) :
+    InvalidStateException(
+        "USER_DEACTIVATED",
+        "User is deactivated: $userId"
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/user/OAuthAccount.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/user/OAuthAccount.kt
@@ -1,0 +1,93 @@
+package com.nextup.core.domain.user
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * OAuth 계정 엔티티
+ *
+ * 사용자의 소셜 로그인 연동 정보를 관리합니다.
+ * 한 User가 여러 OAuthAccount를 가질 수 있습니다 (1:N).
+ */
+@Entity
+@Table(
+    name = "oauth_accounts",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_oauth_provider_id",
+            columnNames = ["provider", "oauth_id"]
+        )
+    ],
+    indexes = [
+        Index(name = "idx_oauth_user", columnList = "user_id"),
+        Index(name = "idx_oauth_provider", columnList = "provider")
+    ]
+)
+class OAuthAccount private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    val provider: OAuthProvider,
+
+    @Column(name = "oauth_id", nullable = false, length = 100)
+    val oauthId: String,
+
+    @Column(length = 100)
+    val email: String? = null,
+
+    @Column(name = "connected_at", nullable = false)
+    val connectedAt: Instant = Instant.now(),
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+) : BaseTimeEntity() {
+
+    companion object {
+        /**
+         * OAuthAccount를 생성합니다.
+         *
+         * @param user 연결할 사용자
+         * @param provider OAuth 제공자 (LOCAL은 허용되지 않음)
+         * @param oauthId OAuth 제공자에서 발급한 사용자 ID
+         * @param email OAuth 제공자에서 제공하는 이메일 (선택)
+         * @return 생성된 OAuthAccount
+         * @throws IllegalArgumentException LOCAL provider인 경우
+         */
+        fun create(
+            user: User,
+            provider: OAuthProvider,
+            oauthId: String,
+            email: String? = null
+        ): OAuthAccount {
+            require(provider != OAuthProvider.LOCAL) {
+                "LOCAL은 OAuthAccount로 관리하지 않습니다."
+            }
+            require(oauthId.isNotBlank()) {
+                "OAuth ID는 비어있을 수 없습니다."
+            }
+            return OAuthAccount(
+                user = user,
+                provider = provider,
+                oauthId = oauthId,
+                email = email
+            )
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OAuthAccount) return false
+        if (id == 0L) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    override fun toString(): String =
+        "OAuthAccount(id=$id, provider=$provider, oauthId=$oauthId, userId=${user.id})"
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/user/User.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/user/User.kt
@@ -9,17 +9,17 @@ import jakarta.persistence.*
  *
  * 서비스 인증/인가를 담당하는 엔티티입니다.
  * Player와는 선택적 1:1 관계를 가집니다.
+ * 여러 OAuth 계정을 연동할 수 있습니다 (1:N).
  */
 @Entity
 @Table(
     name = "users",
     indexes = [
         Index(name = "idx_users_email", columnList = "email", unique = true),
-        Index(name = "idx_users_oauth", columnList = "oauth_provider, oauth_id"),
         Index(name = "idx_users_player", columnList = "player_id")
     ]
 )
-class User(
+class User private constructor(
     @Column(nullable = false, unique = true, length = 100)
     val email: String,
 
@@ -28,13 +28,6 @@ class User(
 
     @Column(nullable = false, length = 50)
     var nickname: String,
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "oauth_provider", nullable = false, length = 20)
-    val oauthProvider: OAuthProvider = OAuthProvider.LOCAL,
-
-    @Column(name = "oauth_id", length = 100)
-    val oauthId: String? = null,
 
     @Column(name = "profile_image_url", length = 255)
     var profileImageUrl: String? = null,
@@ -60,13 +53,29 @@ class User(
     @Column(name = "role", nullable = false, length = 30)
     private val _roles: MutableSet<Role> = mutableSetOf(Role.USER)
 
+    @OneToMany(
+        mappedBy = "user",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY
+    )
+    private val _oauthAccounts: MutableList<OAuthAccount> = mutableListOf()
+
     val roles: Set<Role> get() = _roles.toSet()
 
+    val oauthAccounts: List<OAuthAccount> get() = _oauthAccounts.toList()
+
     /**
-     * OAuth 사용자인지 확인합니다.
+     * LOCAL 사용자인지 확인합니다 (password 기반 인증).
      */
-    val isOAuthUser: Boolean
-        get() = oauthProvider != OAuthProvider.LOCAL
+    val isLocalUser: Boolean
+        get() = password != null
+
+    /**
+     * OAuth 계정이 연동되어 있는지 확인합니다.
+     */
+    val hasOAuthAccount: Boolean
+        get() = _oauthAccounts.isNotEmpty()
 
     /**
      * Player와 연결되어 있는지 확인합니다.
@@ -93,6 +102,62 @@ class User(
      * 특정 권한을 가지고 있는지 확인합니다.
      */
     fun hasRole(role: Role): Boolean = _roles.contains(role)
+
+    /**
+     * OAuth 계정을 연동합니다.
+     *
+     * @param provider OAuth 제공자
+     * @param oauthId OAuth 제공자에서 발급한 사용자 ID
+     * @param email OAuth 제공자에서 제공하는 이메일 (선택)
+     * @return 생성된 OAuthAccount
+     * @throws IllegalArgumentException 이미 연동된 Provider인 경우
+     */
+    fun addOAuthAccount(
+        provider: OAuthProvider,
+        oauthId: String,
+        email: String? = null
+    ): OAuthAccount {
+        require(!hasOAuthProvider(provider)) {
+            "이미 ${provider.displayName} 계정이 연결되어 있습니다."
+        }
+        val account = OAuthAccount.create(this, provider, oauthId, email)
+        _oauthAccounts.add(account)
+        return account
+    }
+
+    /**
+     * OAuth 계정 연동을 해제합니다.
+     *
+     * @param provider 해제할 OAuth 제공자
+     * @throws IllegalStateException 최소 1개의 인증 수단이 없는 경우
+     */
+    fun removeOAuthAccount(provider: OAuthProvider) {
+        require(canRemoveAuthMethod()) {
+            "최소 1개의 인증 수단이 필요합니다. 비밀번호를 설정하거나 다른 소셜 계정을 연동해주세요."
+        }
+        _oauthAccounts.removeIf { it.provider == provider }
+    }
+
+    /**
+     * 특정 OAuth 제공자가 연동되어 있는지 확인합니다.
+     */
+    fun hasOAuthProvider(provider: OAuthProvider): Boolean =
+        _oauthAccounts.any { it.provider == provider }
+
+    /**
+     * 특정 OAuth 제공자의 연동 정보를 조회합니다.
+     */
+    fun getOAuthAccount(provider: OAuthProvider): OAuthAccount? =
+        _oauthAccounts.find { it.provider == provider }
+
+    /**
+     * 인증 수단을 제거할 수 있는지 확인합니다.
+     * (최소 1개의 인증 수단 유지 필요)
+     */
+    fun canRemoveAuthMethod(): Boolean {
+        val authMethodCount = (if (isLocalUser) 1 else 0) + _oauthAccounts.size
+        return authMethodCount > 1
+    }
 
     /**
      * Player 프로필을 연결합니다.
@@ -123,11 +188,23 @@ class User(
     }
 
     /**
-     * 비밀번호를 변경합니다 (LOCAL 사용자만).
+     * 비밀번호를 변경합니다.
      */
     fun changePassword(encodedPassword: String) {
-        require(!isOAuthUser) { "OAuth 사용자는 비밀번호를 변경할 수 없습니다." }
+        require(encodedPassword.isNotBlank()) { "비밀번호는 비어있을 수 없습니다." }
         this.password = encodedPassword
+    }
+
+    /**
+     * 비밀번호를 제거합니다 (OAuth 전용 계정으로 전환).
+     *
+     * @throws IllegalStateException OAuth 계정이 없는 경우
+     */
+    fun removePassword() {
+        require(hasOAuthAccount) {
+            "비밀번호를 제거하려면 최소 1개의 소셜 계정이 연동되어 있어야 합니다."
+        }
+        this.password = null
     }
 
     /**
@@ -144,6 +221,18 @@ class User(
         this.isActive = true
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is User) return false
+        if (id == 0L) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    override fun toString(): String =
+        "User(id=$id, email=$email, nickname=$nickname, isActive=$isActive)"
+
     companion object {
         /**
          * 일반 회원가입으로 User를 생성합니다.
@@ -152,15 +241,27 @@ class User(
             email: String,
             encodedPassword: String,
             nickname: String
-        ): User = User(
-            email = email,
-            password = encodedPassword,
-            nickname = nickname,
-            oauthProvider = OAuthProvider.LOCAL
-        )
+        ): User {
+            require(email.isNotBlank()) { "이메일은 비어있을 수 없습니다." }
+            require(encodedPassword.isNotBlank()) { "비밀번호는 비어있을 수 없습니다." }
+            require(nickname.isNotBlank()) { "닉네임은 비어있을 수 없습니다." }
+
+            return User(
+                email = email,
+                password = encodedPassword,
+                nickname = nickname
+            )
+        }
 
         /**
          * OAuth로 User를 생성합니다.
+         *
+         * @param email 사용자 이메일
+         * @param nickname 사용자 닉네임
+         * @param provider OAuth 제공자
+         * @param oauthId OAuth 제공자에서 발급한 사용자 ID
+         * @param profileImageUrl 프로필 이미지 URL (선택)
+         * @return 생성된 User (OAuthAccount가 자동으로 추가됨)
          */
         fun createOAuthUser(
             email: String,
@@ -168,12 +269,18 @@ class User(
             provider: OAuthProvider,
             oauthId: String,
             profileImageUrl: String? = null
-        ): User = User(
-            email = email,
-            nickname = nickname,
-            oauthProvider = provider,
-            oauthId = oauthId,
-            profileImageUrl = profileImageUrl
-        )
+        ): User {
+            require(email.isNotBlank()) { "이메일은 비어있을 수 없습니다." }
+            require(nickname.isNotBlank()) { "닉네임은 비어있을 수 없습니다." }
+            require(provider != OAuthProvider.LOCAL) { "OAuth 사용자는 LOCAL provider를 사용할 수 없습니다." }
+
+            return User(
+                email = email,
+                nickname = nickname,
+                profileImageUrl = profileImageUrl
+            ).apply {
+                addOAuthAccount(provider, oauthId, email)
+            }
+        }
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/user/OAuthAccountTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/user/OAuthAccountTest.kt
@@ -1,0 +1,143 @@
+package com.nextup.core.domain.user
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("OAuthAccount 테스트")
+class OAuthAccountTest {
+
+    private fun createTestUser(): User {
+        return User.createLocalUser(
+            email = "test@example.com",
+            encodedPassword = "password",
+            nickname = "테스터"
+        )
+    }
+
+    @Nested
+    @DisplayName("OAuth 계정 생성")
+    inner class Create {
+
+        @Test
+        fun `should create oauth account successfully`() {
+            // given
+            val user = createTestUser()
+
+            // when
+            val account = OAuthAccount.create(
+                user = user,
+                provider = OAuthProvider.KAKAO,
+                oauthId = "kakao_12345",
+                email = "kakao@example.com"
+            )
+
+            // then
+            assertThat(account.user).isEqualTo(user)
+            assertThat(account.provider).isEqualTo(OAuthProvider.KAKAO)
+            assertThat(account.oauthId).isEqualTo("kakao_12345")
+            assertThat(account.email).isEqualTo("kakao@example.com")
+            assertThat(account.connectedAt).isNotNull()
+        }
+
+        @Test
+        fun `should create oauth account without email`() {
+            // given
+            val user = createTestUser()
+
+            // when
+            val account = OAuthAccount.create(
+                user = user,
+                provider = OAuthProvider.GOOGLE,
+                oauthId = "google_12345"
+            )
+
+            // then
+            assertThat(account.email).isNull()
+        }
+
+        @Test
+        fun `should throw exception when provider is LOCAL`() {
+            // given
+            val user = createTestUser()
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                OAuthAccount.create(
+                    user = user,
+                    provider = OAuthProvider.LOCAL,
+                    oauthId = "local_123"
+                )
+            }
+        }
+
+        @Test
+        fun `should throw exception when oauthId is blank`() {
+            // given
+            val user = createTestUser()
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                OAuthAccount.create(
+                    user = user,
+                    provider = OAuthProvider.KAKAO,
+                    oauthId = ""
+                )
+            }
+        }
+
+        @Test
+        fun `should throw exception when oauthId is whitespace only`() {
+            // given
+            val user = createTestUser()
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                OAuthAccount.create(
+                    user = user,
+                    provider = OAuthProvider.NAVER,
+                    oauthId = "   "
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("OAuth Provider 종류")
+    inner class ProviderTypes {
+
+        @Test
+        fun `should create account for each provider`() {
+            // given
+            val user = createTestUser()
+            val providers = listOf(
+                OAuthProvider.KAKAO,
+                OAuthProvider.GOOGLE,
+                OAuthProvider.NAVER,
+                OAuthProvider.APPLE
+            )
+
+            // when & then
+            providers.forEach { provider ->
+                val account = OAuthAccount.create(
+                    user = user,
+                    provider = provider,
+                    oauthId = "${provider.name.lowercase()}_123"
+                )
+                assertThat(account.provider).isEqualTo(provider)
+            }
+        }
+
+        @Test
+        fun `should have correct display names for providers`() {
+            // then
+            assertThat(OAuthProvider.KAKAO.displayName).isEqualTo("카카오")
+            assertThat(OAuthProvider.GOOGLE.displayName).isEqualTo("구글")
+            assertThat(OAuthProvider.NAVER.displayName).isEqualTo("네이버")
+            assertThat(OAuthProvider.APPLE.displayName).isEqualTo("애플")
+            assertThat(OAuthProvider.LOCAL.displayName).isEqualTo("일반")
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/user/UserTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/user/UserTest.kt
@@ -1,0 +1,403 @@
+package com.nextup.core.domain.user
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("User 테스트")
+class UserTest {
+
+    @Nested
+    @DisplayName("LOCAL 사용자 생성")
+    inner class CreateLocalUser {
+
+        @Test
+        fun `should create local user successfully`() {
+            // when
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "encoded_password",
+                nickname = "테스터"
+            )
+
+            // then
+            assertThat(user.email).isEqualTo("test@example.com")
+            assertThat(user.password).isEqualTo("encoded_password")
+            assertThat(user.nickname).isEqualTo("테스터")
+            assertThat(user.isLocalUser).isTrue()
+            assertThat(user.hasOAuthAccount).isFalse()
+            assertThat(user.roles).contains(Role.USER)
+            assertThat(user.isActive).isTrue()
+        }
+
+        @Test
+        fun `should throw exception when email is blank`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                User.createLocalUser(
+                    email = "",
+                    encodedPassword = "password",
+                    nickname = "테스터"
+                )
+            }
+        }
+
+        @Test
+        fun `should throw exception when password is blank`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "",
+                    nickname = "테스터"
+                )
+            }
+        }
+
+        @Test
+        fun `should throw exception when nickname is blank`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = ""
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("OAuth 사용자 생성")
+    inner class CreateOAuthUser {
+
+        @Test
+        fun `should create oauth user successfully`() {
+            // when
+            val user = User.createOAuthUser(
+                email = "oauth@example.com",
+                nickname = "OAuth테스터",
+                provider = OAuthProvider.KAKAO,
+                oauthId = "kakao_12345",
+                profileImageUrl = "http://example.com/profile.jpg"
+            )
+
+            // then
+            assertThat(user.email).isEqualTo("oauth@example.com")
+            assertThat(user.password).isNull()
+            assertThat(user.nickname).isEqualTo("OAuth테스터")
+            assertThat(user.isLocalUser).isFalse()
+            assertThat(user.hasOAuthAccount).isTrue()
+            assertThat(user.oauthAccounts).hasSize(1)
+            assertThat(user.hasOAuthProvider(OAuthProvider.KAKAO)).isTrue()
+            assertThat(user.profileImageUrl).isEqualTo("http://example.com/profile.jpg")
+        }
+
+        @Test
+        fun `should throw exception when provider is LOCAL`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                User.createOAuthUser(
+                    email = "test@example.com",
+                    nickname = "테스터",
+                    provider = OAuthProvider.LOCAL,
+                    oauthId = "local_123"
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("OAuth 계정 연동")
+    inner class OAuthAccountLink {
+
+        @Test
+        fun `should add oauth account to local user`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+
+            // when
+            user.addOAuthAccount(OAuthProvider.GOOGLE, "google_123", "google@example.com")
+
+            // then
+            assertThat(user.hasOAuthAccount).isTrue()
+            assertThat(user.hasOAuthProvider(OAuthProvider.GOOGLE)).isTrue()
+            assertThat(user.oauthAccounts).hasSize(1)
+        }
+
+        @Test
+        fun `should add multiple oauth accounts`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+
+            // when
+            user.addOAuthAccount(OAuthProvider.KAKAO, "kakao_123")
+            user.addOAuthAccount(OAuthProvider.GOOGLE, "google_123")
+
+            // then
+            assertThat(user.oauthAccounts).hasSize(2)
+            assertThat(user.hasOAuthProvider(OAuthProvider.KAKAO)).isTrue()
+            assertThat(user.hasOAuthProvider(OAuthProvider.GOOGLE)).isTrue()
+        }
+
+        @Test
+        fun `should throw exception when adding duplicate provider`() {
+            // given
+            val user = User.createOAuthUser(
+                email = "test@example.com",
+                nickname = "테스터",
+                provider = OAuthProvider.KAKAO,
+                oauthId = "kakao_123"
+            )
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                user.addOAuthAccount(OAuthProvider.KAKAO, "kakao_456")
+            }
+        }
+
+        @Test
+        fun `should remove oauth account when multiple auth methods exist`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+            user.addOAuthAccount(OAuthProvider.KAKAO, "kakao_123")
+            user.addOAuthAccount(OAuthProvider.GOOGLE, "google_123")
+
+            // when
+            user.removeOAuthAccount(OAuthProvider.KAKAO)
+
+            // then
+            assertThat(user.hasOAuthProvider(OAuthProvider.KAKAO)).isFalse()
+            assertThat(user.hasOAuthProvider(OAuthProvider.GOOGLE)).isTrue()
+            assertThat(user.oauthAccounts).hasSize(1)
+        }
+
+        @Test
+        fun `should throw exception when removing last auth method`() {
+            // given
+            val user = User.createOAuthUser(
+                email = "test@example.com",
+                nickname = "테스터",
+                provider = OAuthProvider.KAKAO,
+                oauthId = "kakao_123"
+            )
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                user.removeOAuthAccount(OAuthProvider.KAKAO)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 수단 관리")
+    inner class AuthMethodManagement {
+
+        @Test
+        fun `should allow removing auth method when multiple exist`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+            user.addOAuthAccount(OAuthProvider.KAKAO, "kakao_123")
+
+            // when & then
+            assertThat(user.canRemoveAuthMethod()).isTrue()
+        }
+
+        @Test
+        fun `should not allow removing last auth method`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+
+            // when & then
+            assertThat(user.canRemoveAuthMethod()).isFalse()
+        }
+
+        @Test
+        fun `should remove password when oauth account exists`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+            user.addOAuthAccount(OAuthProvider.KAKAO, "kakao_123")
+
+            // when
+            user.removePassword()
+
+            // then
+            assertThat(user.password).isNull()
+            assertThat(user.isLocalUser).isFalse()
+        }
+
+        @Test
+        fun `should throw exception when removing password without oauth`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                user.removePassword()
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("역할 관리")
+    inner class RoleManagement {
+
+        @Test
+        fun `should add role successfully`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+
+            // when
+            user.addRole(Role.ADMIN)
+
+            // then
+            assertThat(user.hasRole(Role.ADMIN)).isTrue()
+            assertThat(user.hasRole(Role.USER)).isTrue()
+        }
+
+        @Test
+        fun `should remove role successfully`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+            user.addRole(Role.SCORER)
+
+            // when
+            user.removeRole(Role.SCORER)
+
+            // then
+            assertThat(user.hasRole(Role.SCORER)).isFalse()
+        }
+
+        @Test
+        fun `should throw exception when removing USER role`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                user.removeRole(Role.USER)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 업데이트")
+    inner class ProfileUpdate {
+
+        @Test
+        fun `should update profile successfully`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "원래닉네임"
+            )
+
+            // when
+            user.updateProfile(
+                nickname = "새닉네임",
+                profileImageUrl = "http://example.com/new-profile.jpg"
+            )
+
+            // then
+            assertThat(user.nickname).isEqualTo("새닉네임")
+            assertThat(user.profileImageUrl).isEqualTo("http://example.com/new-profile.jpg")
+        }
+
+        @Test
+        fun `should change password successfully`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "old_password",
+                nickname = "테스터"
+            )
+
+            // when
+            user.changePassword("new_password")
+
+            // then
+            assertThat(user.password).isEqualTo("new_password")
+        }
+    }
+
+    @Nested
+    @DisplayName("계정 상태 관리")
+    inner class AccountStatus {
+
+        @Test
+        fun `should deactivate account`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+
+            // when
+            user.deactivate()
+
+            // then
+            assertThat(user.isActive).isFalse()
+        }
+
+        @Test
+        fun `should activate account`() {
+            // given
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "password",
+                nickname = "테스터"
+            )
+            user.deactivate()
+
+            // when
+            user.activate()
+
+            // then
+            assertThat(user.isActive).isTrue()
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/OAuthAccountRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/OAuthAccountRepository.kt
@@ -1,0 +1,22 @@
+package com.nextup.infrastructure.repository.user
+
+import com.nextup.core.domain.user.OAuthAccount
+import com.nextup.core.domain.user.OAuthProvider
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface OAuthAccountRepository : JpaRepository<OAuthAccount, Long> {
+
+    fun findByProviderAndOauthId(provider: OAuthProvider, oauthId: String): OAuthAccount?
+
+    fun existsByProviderAndOauthId(provider: OAuthProvider, oauthId: String): Boolean
+
+    @Query("SELECT o FROM OAuthAccount o WHERE o.user.id = :userId")
+    fun findAllByUserId(userId: Long): List<OAuthAccount>
+
+    @Query("SELECT o FROM OAuthAccount o WHERE o.user.id = :userId AND o.provider = :provider")
+    fun findByUserIdAndProvider(userId: Long, provider: OAuthProvider): OAuthAccount?
+
+    @Query("SELECT o.provider FROM OAuthAccount o WHERE o.user.id = :userId")
+    fun findProvidersByUserId(userId: Long): List<OAuthProvider>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/UserRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/UserRepository.kt
@@ -1,0 +1,45 @@
+package com.nextup.infrastructure.repository.user
+
+import com.nextup.core.domain.user.Role
+import com.nextup.core.domain.user.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface UserRepository : JpaRepository<User, Long> {
+
+    fun findByEmail(email: String): User?
+
+    fun existsByEmail(email: String): Boolean
+
+    @Query("SELECT u FROM User u WHERE u.isActive = true")
+    fun findAllActive(pageable: Pageable): Page<User>
+
+    @Query("SELECT u FROM User u WHERE u.isActive = :isActive")
+    fun findAllByIsActive(isActive: Boolean, pageable: Pageable): Page<User>
+
+    @Query("""
+        SELECT u FROM User u
+        WHERE u.nickname LIKE %:keyword%
+        OR u.email LIKE %:keyword%
+    """)
+    fun searchByKeyword(keyword: String, pageable: Pageable): Page<User>
+
+    @Query("""
+        SELECT u FROM User u
+        JOIN u._roles r
+        WHERE r = :role
+    """)
+    fun findAllByRole(role: Role, pageable: Pageable): Page<User>
+
+    @Query("""
+        SELECT u FROM User u
+        JOIN u._roles r
+        WHERE r IN :roles
+    """)
+    fun findAllByRolesIn(roles: Set<Role>, pageable: Pageable): Page<User>
+
+    @Query("SELECT u FROM User u WHERE u.player.id = :playerId")
+    fun findByPlayerId(playerId: Long): User?
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/user/UserService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/user/UserService.kt
@@ -1,0 +1,304 @@
+package com.nextup.infrastructure.service.user
+
+import com.nextup.common.exception.*
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.core.domain.user.Role
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.user.OAuthAccountRepository
+import com.nextup.infrastructure.repository.user.UserRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 사용자 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class UserService(
+    private val userRepository: UserRepository,
+    private val oauthAccountRepository: OAuthAccountRepository
+) {
+
+    // ========== CREATE ==========
+
+    /**
+     * 일반 회원가입으로 사용자를 생성합니다.
+     */
+    @Transactional
+    fun createLocalUser(
+        email: String,
+        encodedPassword: String,
+        nickname: String
+    ): User {
+        validateEmailNotDuplicate(email)
+
+        val user = User.createLocalUser(
+            email = email,
+            encodedPassword = encodedPassword,
+            nickname = nickname
+        )
+
+        return userRepository.save(user)
+    }
+
+    /**
+     * OAuth로 사용자를 생성하거나, 기존 사용자에 OAuth를 연동합니다.
+     *
+     * @return Pair<User, Boolean> - (사용자, 신규생성여부)
+     */
+    @Transactional
+    fun createOrLinkOAuthUser(
+        email: String,
+        nickname: String,
+        provider: OAuthProvider,
+        oauthId: String,
+        profileImageUrl: String? = null
+    ): Pair<User, Boolean> {
+        // 이미 연동된 OAuth 계정이 있는지 확인
+        val existingOAuth = oauthAccountRepository.findByProviderAndOauthId(provider, oauthId)
+        if (existingOAuth != null) {
+            return Pair(existingOAuth.user, false)
+        }
+
+        // 같은 이메일의 기존 사용자가 있는지 확인
+        val existingUser = userRepository.findByEmail(email)
+        if (existingUser != null) {
+            // 기존 사용자에 OAuth 계정 연동
+            existingUser.addOAuthAccount(provider, oauthId, email)
+            if (profileImageUrl != null && existingUser.profileImageUrl == null) {
+                existingUser.updateProfile(profileImageUrl = profileImageUrl)
+            }
+            return Pair(existingUser, false)
+        }
+
+        // 신규 사용자 생성
+        val newUser = User.createOAuthUser(
+            email = email,
+            nickname = nickname,
+            provider = provider,
+            oauthId = oauthId,
+            profileImageUrl = profileImageUrl
+        )
+
+        return Pair(userRepository.save(newUser), true)
+    }
+
+    // ========== READ ==========
+
+    /**
+     * ID로 사용자를 조회합니다.
+     */
+    fun getById(id: Long): User {
+        return userRepository.findById(id)
+            .orElseThrow { UserNotFoundException(id) }
+    }
+
+    /**
+     * 활성 사용자를 ID로 조회합니다.
+     */
+    fun getActiveById(id: Long): User {
+        val user = getById(id)
+        if (!user.isActive) {
+            throw UserDeactivatedException(id)
+        }
+        return user
+    }
+
+    /**
+     * 이메일로 사용자를 조회합니다.
+     */
+    fun getByEmail(email: String): User {
+        return userRepository.findByEmail(email)
+            ?: throw UserNotFoundByEmailException(email)
+    }
+
+    /**
+     * 이메일로 사용자를 조회합니다 (없으면 null).
+     */
+    fun findByEmail(email: String): User? {
+        return userRepository.findByEmail(email)
+    }
+
+    /**
+     * OAuth 정보로 사용자를 조회합니다.
+     */
+    fun findByOAuth(provider: OAuthProvider, oauthId: String): User? {
+        return oauthAccountRepository.findByProviderAndOauthId(provider, oauthId)?.user
+    }
+
+    /**
+     * 활성화된 모든 사용자를 페이징으로 조회합니다.
+     */
+    fun getAllActive(pageable: Pageable): Page<User> {
+        return userRepository.findAllActive(pageable)
+    }
+
+    /**
+     * 모든 사용자를 페이징으로 조회합니다 (관리자용).
+     */
+    fun getAll(pageable: Pageable): Page<User> {
+        return userRepository.findAll(pageable)
+    }
+
+    /**
+     * 활성 상태별로 사용자를 조회합니다 (관리자용).
+     */
+    fun getAllByStatus(isActive: Boolean, pageable: Pageable): Page<User> {
+        return userRepository.findAllByIsActive(isActive, pageable)
+    }
+
+    /**
+     * 키워드로 사용자를 검색합니다 (관리자용).
+     */
+    fun search(keyword: String, pageable: Pageable): Page<User> {
+        return userRepository.searchByKeyword(keyword, pageable)
+    }
+
+    /**
+     * 역할별로 사용자를 조회합니다 (관리자용).
+     */
+    fun getAllByRole(role: Role, pageable: Pageable): Page<User> {
+        return userRepository.findAllByRole(role, pageable)
+    }
+
+    // ========== UPDATE ==========
+
+    /**
+     * 프로필 정보를 업데이트합니다.
+     */
+    @Transactional
+    fun updateProfile(
+        userId: Long,
+        nickname: String? = null,
+        profileImageUrl: String? = null
+    ): User {
+        val user = getActiveById(userId)
+
+        user.updateProfile(
+            nickname = nickname ?: user.nickname,
+            profileImageUrl = profileImageUrl
+        )
+
+        return user
+    }
+
+    /**
+     * 비밀번호를 변경합니다.
+     */
+    @Transactional
+    fun changePassword(userId: Long, encodedPassword: String): User {
+        val user = getActiveById(userId)
+        user.changePassword(encodedPassword)
+        return user
+    }
+
+    /**
+     * 역할을 추가합니다 (관리자용).
+     */
+    @Transactional
+    fun addRole(userId: Long, role: Role): User {
+        val user = getById(userId)
+        user.addRole(role)
+        return user
+    }
+
+    /**
+     * 역할을 제거합니다 (관리자용).
+     */
+    @Transactional
+    fun removeRole(userId: Long, role: Role): User {
+        val user = getById(userId)
+        user.removeRole(role)
+        return user
+    }
+
+    // ========== OAuth 관련 ==========
+
+    /**
+     * 기존 사용자에 OAuth 계정을 연동합니다.
+     */
+    @Transactional
+    fun linkOAuthAccount(
+        userId: Long,
+        provider: OAuthProvider,
+        oauthId: String,
+        email: String? = null
+    ): User {
+        val user = getActiveById(userId)
+
+        // 이미 다른 사용자에게 연동된 OAuth인지 확인
+        val existingOAuth = oauthAccountRepository.findByProviderAndOauthId(provider, oauthId)
+        if (existingOAuth != null && existingOAuth.user.id != userId) {
+            throw OAuthAccountAlreadyLinkedException(provider.displayName)
+        }
+
+        user.addOAuthAccount(provider, oauthId, email)
+        return user
+    }
+
+    /**
+     * OAuth 계정 연동을 해제합니다.
+     */
+    @Transactional
+    fun unlinkOAuthAccount(userId: Long, provider: OAuthProvider): User {
+        val user = getActiveById(userId)
+
+        if (!user.canRemoveAuthMethod()) {
+            throw InsufficientAuthMethodException()
+        }
+
+        user.removeOAuthAccount(provider)
+        return user
+    }
+
+    /**
+     * 사용자의 연동된 OAuth Provider 목록을 조회합니다.
+     */
+    fun getLinkedProviders(userId: Long): List<OAuthProvider> {
+        return oauthAccountRepository.findProvidersByUserId(userId)
+    }
+
+    // ========== 상태 변경 ==========
+
+    /**
+     * 사용자를 비활성화합니다 (관리자용 또는 회원탈퇴).
+     */
+    @Transactional
+    fun deactivate(userId: Long): User {
+        val user = getById(userId)
+        user.deactivate()
+        return user
+    }
+
+    /**
+     * 사용자를 활성화합니다 (관리자용).
+     */
+    @Transactional
+    fun activate(userId: Long): User {
+        val user = getById(userId)
+        user.activate()
+        return user
+    }
+
+    // ========== 유틸리티 ==========
+
+    /**
+     * 이메일 중복을 검사합니다.
+     */
+    fun validateEmailNotDuplicate(email: String) {
+        if (userRepository.existsByEmail(email)) {
+            throw EmailDuplicateException(email)
+        }
+    }
+
+    /**
+     * 이메일 존재 여부를 확인합니다.
+     */
+    fun existsByEmail(email: String): Boolean {
+        return userRepository.existsByEmail(email)
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/user/UserServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/user/UserServiceTest.kt
@@ -1,0 +1,753 @@
+package com.nextup.infrastructure.service.user
+
+import com.nextup.common.exception.*
+import com.nextup.core.domain.user.OAuthAccount
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.core.domain.user.Role
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.user.OAuthAccountRepository
+import com.nextup.infrastructure.repository.user.UserRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.util.*
+
+@DisplayName("UserService")
+class UserServiceTest {
+
+    private lateinit var userRepository: UserRepository
+    private lateinit var oauthAccountRepository: OAuthAccountRepository
+    private lateinit var userService: UserService
+
+    @BeforeEach
+    fun setUp() {
+        userRepository = mockk()
+        oauthAccountRepository = mockk()
+        userService = UserService(userRepository, oauthAccountRepository)
+    }
+
+    @Nested
+    @DisplayName("createLocalUser")
+    inner class CreateLocalUser {
+
+        @Test
+        fun `should create local user successfully`() {
+            // given
+            val email = "test@example.com"
+            val password = "encoded_password"
+            val nickname = "테스터"
+
+            every { userRepository.existsByEmail(email) } returns false
+            every { userRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = userService.createLocalUser(email, password, nickname)
+
+            // then
+            assertThat(result.email).isEqualTo(email)
+            assertThat(result.nickname).isEqualTo(nickname)
+            assertThat(result.isLocalUser).isTrue()
+            verify { userRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when email is duplicated`() {
+            // given
+            val email = "duplicate@example.com"
+            every { userRepository.existsByEmail(email) } returns true
+
+            // when & then
+            assertThatThrownBy {
+                userService.createLocalUser(email, "password", "테스터")
+            }.isInstanceOf(EmailDuplicateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("createOrLinkOAuthUser")
+    inner class CreateOrLinkOAuthUser {
+
+        @Test
+        fun `should return existing user when oauth account exists`() {
+            // given
+            val user = createTestUser(1L, "existing@example.com")
+            val oauthAccount = mockk<OAuthAccount>()
+            every { oauthAccount.user } returns user
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_123") } returns oauthAccount
+
+            // when
+            val (resultUser, isNew) = userService.createOrLinkOAuthUser(
+                email = "new@example.com",
+                nickname = "새사용자",
+                provider = OAuthProvider.KAKAO,
+                oauthId = "kakao_123"
+            )
+
+            // then
+            assertThat(resultUser.id).isEqualTo(1L)
+            assertThat(isNew).isFalse()
+        }
+
+        @Test
+        fun `should link oauth to existing user with same email`() {
+            // given
+            val existingUser = createTestUser(1L, "existing@example.com")
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.GOOGLE, "google_123") } returns null
+            every { userRepository.findByEmail("existing@example.com") } returns existingUser
+
+            // when
+            val (resultUser, isNew) = userService.createOrLinkOAuthUser(
+                email = "existing@example.com",
+                nickname = "새닉네임",
+                provider = OAuthProvider.GOOGLE,
+                oauthId = "google_123"
+            )
+
+            // then
+            assertThat(resultUser.id).isEqualTo(1L)
+            assertThat(resultUser.hasOAuthProvider(OAuthProvider.GOOGLE)).isTrue()
+            assertThat(isNew).isFalse()
+        }
+
+        @Test
+        fun `should create new user when no existing user found`() {
+            // given
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.NAVER, "naver_123") } returns null
+            every { userRepository.findByEmail("new@example.com") } returns null
+            every { userRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val (resultUser, isNew) = userService.createOrLinkOAuthUser(
+                email = "new@example.com",
+                nickname = "새사용자",
+                provider = OAuthProvider.NAVER,
+                oauthId = "naver_123"
+            )
+
+            // then
+            assertThat(resultUser.email).isEqualTo("new@example.com")
+            assertThat(resultUser.hasOAuthProvider(OAuthProvider.NAVER)).isTrue()
+            assertThat(isNew).isTrue()
+            verify { userRepository.save(any()) }
+        }
+
+        @Test
+        fun `should update profile image when linking oauth to existing user without profile image`() {
+            // given
+            val existingUser = createTestUser(1L, "existing@example.com")
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.GOOGLE, "google_123") } returns null
+            every { userRepository.findByEmail("existing@example.com") } returns existingUser
+
+            // when
+            val (resultUser, isNew) = userService.createOrLinkOAuthUser(
+                email = "existing@example.com",
+                nickname = "새닉네임",
+                provider = OAuthProvider.GOOGLE,
+                oauthId = "google_123",
+                profileImageUrl = "http://example.com/profile.jpg"
+            )
+
+            // then
+            assertThat(resultUser.profileImageUrl).isEqualTo("http://example.com/profile.jpg")
+            assertThat(isNew).isFalse()
+        }
+
+        @Test
+        fun `should not update profile image when existing user already has one`() {
+            // given
+            val existingUser = createTestUser(1L, "existing@example.com").apply {
+                updateProfile(profileImageUrl = "http://example.com/existing.jpg")
+            }
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.GOOGLE, "google_123") } returns null
+            every { userRepository.findByEmail("existing@example.com") } returns existingUser
+
+            // when
+            val (resultUser, isNew) = userService.createOrLinkOAuthUser(
+                email = "existing@example.com",
+                nickname = "새닉네임",
+                provider = OAuthProvider.GOOGLE,
+                oauthId = "google_123",
+                profileImageUrl = "http://example.com/new.jpg"
+            )
+
+            // then
+            assertThat(resultUser.profileImageUrl).isEqualTo("http://example.com/existing.jpg")
+            assertThat(isNew).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("getById")
+    inner class GetById {
+
+        @Test
+        fun `should return user when found`() {
+            // given
+            val user = createTestUser(1L, "test@example.com")
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = userService.getById(1L)
+
+            // then
+            assertThat(result.id).isEqualTo(1L)
+            assertThat(result.email).isEqualTo("test@example.com")
+        }
+
+        @Test
+        fun `should throw exception when not found`() {
+            // given
+            every { userRepository.findById(999L) } returns Optional.empty()
+
+            // when & then
+            assertThatThrownBy {
+                userService.getById(999L)
+            }.isInstanceOf(UserNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getActiveById")
+    inner class GetActiveById {
+
+        @Test
+        fun `should return active user`() {
+            // given
+            val user = createTestUser(1L, "active@example.com")
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = userService.getActiveById(1L)
+
+            // then
+            assertThat(result.isActive).isTrue()
+        }
+
+        @Test
+        fun `should throw exception when user is deactivated`() {
+            // given
+            val user = createTestUser(1L, "inactive@example.com").apply { deactivate() }
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when & then
+            assertThatThrownBy {
+                userService.getActiveById(1L)
+            }.isInstanceOf(UserDeactivatedException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getByEmail")
+    inner class GetByEmail {
+
+        @Test
+        fun `should return user when found by email`() {
+            // given
+            val user = createTestUser(1L, "found@example.com")
+            every { userRepository.findByEmail("found@example.com") } returns user
+
+            // when
+            val result = userService.getByEmail("found@example.com")
+
+            // then
+            assertThat(result.email).isEqualTo("found@example.com")
+        }
+
+        @Test
+        fun `should throw exception when not found by email`() {
+            // given
+            every { userRepository.findByEmail("notfound@example.com") } returns null
+
+            // when & then
+            assertThatThrownBy {
+                userService.getByEmail("notfound@example.com")
+            }.isInstanceOf(UserNotFoundByEmailException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("findByEmail")
+    inner class FindByEmail {
+
+        @Test
+        fun `should return user when found`() {
+            // given
+            val user = createTestUser(1L, "test@example.com")
+            every { userRepository.findByEmail("test@example.com") } returns user
+
+            // when
+            val result = userService.findByEmail("test@example.com")
+
+            // then
+            assertThat(result).isNotNull
+            assertThat(result?.email).isEqualTo("test@example.com")
+        }
+
+        @Test
+        fun `should return null when not found`() {
+            // given
+            every { userRepository.findByEmail("notexists@example.com") } returns null
+
+            // when
+            val result = userService.findByEmail("notexists@example.com")
+
+            // then
+            assertThat(result).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("findByOAuth")
+    inner class FindByOAuth {
+
+        @Test
+        fun `should return user when oauth account found`() {
+            // given
+            val user = createTestUser(1L, "oauth@example.com")
+            val oauthAccount = mockk<OAuthAccount>()
+            every { oauthAccount.user } returns user
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_123") } returns oauthAccount
+
+            // when
+            val result = userService.findByOAuth(OAuthProvider.KAKAO, "kakao_123")
+
+            // then
+            assertThat(result).isNotNull
+            assertThat(result?.id).isEqualTo(1L)
+        }
+
+        @Test
+        fun `should return null when oauth account not found`() {
+            // given
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.GOOGLE, "google_999") } returns null
+
+            // when
+            val result = userService.findByOAuth(OAuthProvider.GOOGLE, "google_999")
+
+            // then
+            assertThat(result).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllActive")
+    inner class GetAllActive {
+
+        @Test
+        fun `should return paginated active users`() {
+            // given
+            val users = listOf(
+                createTestUser(1L, "user1@example.com"),
+                createTestUser(2L, "user2@example.com")
+            )
+            val pageable = PageRequest.of(0, 10)
+            every { userRepository.findAllActive(pageable) } returns PageImpl(users)
+
+            // when
+            val result = userService.getAllActive(pageable)
+
+            // then
+            assertThat(result.content).hasSize(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("getAll")
+    inner class GetAll {
+
+        @Test
+        fun `should return all users paginated`() {
+            // given
+            val users = listOf(
+                createTestUser(1L, "user1@example.com"),
+                createTestUser(2L, "user2@example.com"),
+                createTestUser(3L, "user3@example.com")
+            )
+            val pageable = PageRequest.of(0, 10)
+            every { userRepository.findAll(pageable) } returns PageImpl(users)
+
+            // when
+            val result = userService.getAll(pageable)
+
+            // then
+            assertThat(result.content).hasSize(3)
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllByStatus")
+    inner class GetAllByStatus {
+
+        @Test
+        fun `should return active users only`() {
+            // given
+            val activeUsers = listOf(createTestUser(1L, "active@example.com"))
+            val pageable = PageRequest.of(0, 10)
+            every { userRepository.findAllByIsActive(true, pageable) } returns PageImpl(activeUsers)
+
+            // when
+            val result = userService.getAllByStatus(true, pageable)
+
+            // then
+            assertThat(result.content).hasSize(1)
+        }
+
+        @Test
+        fun `should return inactive users only`() {
+            // given
+            val inactiveUsers = listOf(
+                createTestUser(1L, "inactive@example.com").apply { deactivate() }
+            )
+            val pageable = PageRequest.of(0, 10)
+            every { userRepository.findAllByIsActive(false, pageable) } returns PageImpl(inactiveUsers)
+
+            // when
+            val result = userService.getAllByStatus(false, pageable)
+
+            // then
+            assertThat(result.content).hasSize(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("search")
+    inner class Search {
+
+        @Test
+        fun `should search users by keyword`() {
+            // given
+            val users = listOf(createTestUser(1L, "test@example.com"))
+            val pageable = PageRequest.of(0, 10)
+            every { userRepository.searchByKeyword("test", pageable) } returns PageImpl(users)
+
+            // when
+            val result = userService.search("test", pageable)
+
+            // then
+            assertThat(result.content).hasSize(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllByRole")
+    inner class GetAllByRole {
+
+        @Test
+        fun `should return users with specific role`() {
+            // given
+            val admins = listOf(
+                createTestUser(1L, "admin@example.com").apply { addRole(Role.ADMIN) }
+            )
+            val pageable = PageRequest.of(0, 10)
+            every { userRepository.findAllByRole(Role.ADMIN, pageable) } returns PageImpl(admins)
+
+            // when
+            val result = userService.getAllByRole(Role.ADMIN, pageable)
+
+            // then
+            assertThat(result.content).hasSize(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateProfile")
+    inner class UpdateProfile {
+
+        @Test
+        fun `should update profile successfully`() {
+            // given
+            val user = createTestUser(1L, "test@example.com")
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = userService.updateProfile(
+                userId = 1L,
+                nickname = "새닉네임",
+                profileImageUrl = "http://example.com/new.jpg"
+            )
+
+            // then
+            assertThat(result.nickname).isEqualTo("새닉네임")
+            assertThat(result.profileImageUrl).isEqualTo("http://example.com/new.jpg")
+        }
+
+        @Test
+        fun `should keep existing nickname when null provided`() {
+            // given
+            val user = createTestUser(1L, "test@example.com")
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = userService.updateProfile(
+                userId = 1L,
+                nickname = null,
+                profileImageUrl = "http://example.com/new.jpg"
+            )
+
+            // then
+            assertThat(result.nickname).isEqualTo("테스터")
+            assertThat(result.profileImageUrl).isEqualTo("http://example.com/new.jpg")
+        }
+    }
+
+    @Nested
+    @DisplayName("changePassword")
+    inner class ChangePassword {
+
+        @Test
+        fun `should change password successfully`() {
+            // given
+            val user = createTestUser(1L, "test@example.com")
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = userService.changePassword(1L, "new_encoded_password")
+
+            // then
+            assertThat(result.password).isEqualTo("new_encoded_password")
+        }
+    }
+
+    @Nested
+    @DisplayName("addRole / removeRole")
+    inner class RoleManagement {
+
+        @Test
+        fun `should add role to user`() {
+            // given
+            val user = createTestUser(1L, "test@example.com")
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = userService.addRole(1L, Role.ADMIN)
+
+            // then
+            assertThat(result.hasRole(Role.ADMIN)).isTrue()
+        }
+
+        @Test
+        fun `should remove role from user`() {
+            // given
+            val user = createTestUser(1L, "test@example.com").apply { addRole(Role.SCORER) }
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = userService.removeRole(1L, Role.SCORER)
+
+            // then
+            assertThat(result.hasRole(Role.SCORER)).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("linkOAuthAccount")
+    inner class LinkOAuthAccount {
+
+        @Test
+        fun `should link oauth account successfully`() {
+            // given
+            val user = createTestUser(1L, "test@example.com")
+            every { userRepository.findById(1L) } returns Optional.of(user)
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_new") } returns null
+
+            // when
+            val result = userService.linkOAuthAccount(1L, OAuthProvider.KAKAO, "kakao_new")
+
+            // then
+            assertThat(result.hasOAuthProvider(OAuthProvider.KAKAO)).isTrue()
+        }
+
+        @Test
+        fun `should throw exception when oauth already linked to another user`() {
+            // given
+            val user = createTestUser(1L, "test@example.com")
+            val anotherUser = createTestUser(2L, "another@example.com")
+            val existingOAuth = mockk<OAuthAccount>()
+            every { existingOAuth.user } returns anotherUser
+
+            every { userRepository.findById(1L) } returns Optional.of(user)
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_used") } returns existingOAuth
+
+            // when & then
+            assertThatThrownBy {
+                userService.linkOAuthAccount(1L, OAuthProvider.KAKAO, "kakao_used")
+            }.isInstanceOf(OAuthAccountAlreadyLinkedException::class.java)
+        }
+
+        @Test
+        fun `should allow linking oauth account already linked to same user`() {
+            // given
+            val user = createTestUser(1L, "test@example.com")
+            val existingOAuth = mockk<OAuthAccount>()
+            every { existingOAuth.user } returns user
+
+            every { userRepository.findById(1L) } returns Optional.of(user)
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_123") } returns existingOAuth
+
+            // when - no exception should be thrown
+            val result = userService.linkOAuthAccount(1L, OAuthProvider.KAKAO, "kakao_123")
+
+            // then
+            assertThat(result.id).isEqualTo(1L)
+        }
+    }
+
+    @Nested
+    @DisplayName("unlinkOAuthAccount")
+    inner class UnlinkOAuthAccount {
+
+        @Test
+        fun `should unlink oauth account when multiple auth methods exist`() {
+            // given
+            val user = createTestUser(1L, "test@example.com") // local user with password
+            user.addOAuthAccount(OAuthProvider.KAKAO, "kakao_123")
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = userService.unlinkOAuthAccount(1L, OAuthProvider.KAKAO)
+
+            // then
+            assertThat(result.hasOAuthProvider(OAuthProvider.KAKAO)).isFalse()
+        }
+
+        @Test
+        fun `should throw exception when trying to remove last auth method`() {
+            // given - OAuth only user (no password)
+            val user = User.createOAuthUser(
+                email = "oauth@example.com",
+                nickname = "OAuth사용자",
+                provider = OAuthProvider.KAKAO,
+                oauthId = "kakao_only"
+            )
+            setUserId(user, 1L)
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when & then
+            assertThatThrownBy {
+                userService.unlinkOAuthAccount(1L, OAuthProvider.KAKAO)
+            }.isInstanceOf(InsufficientAuthMethodException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getLinkedProviders")
+    inner class GetLinkedProviders {
+
+        @Test
+        fun `should return list of linked providers`() {
+            // given
+            val providers = listOf(OAuthProvider.KAKAO, OAuthProvider.GOOGLE)
+            every { oauthAccountRepository.findProvidersByUserId(1L) } returns providers
+
+            // when
+            val result = userService.getLinkedProviders(1L)
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result).containsExactly(OAuthProvider.KAKAO, OAuthProvider.GOOGLE)
+        }
+
+        @Test
+        fun `should return empty list when no providers linked`() {
+            // given
+            every { oauthAccountRepository.findProvidersByUserId(1L) } returns emptyList()
+
+            // when
+            val result = userService.getLinkedProviders(1L)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("deactivate / activate")
+    inner class DeactivateActivate {
+
+        @Test
+        fun `should deactivate user`() {
+            // given
+            val user = createTestUser(1L, "test@example.com")
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = userService.deactivate(1L)
+
+            // then
+            assertThat(result.isActive).isFalse()
+        }
+
+        @Test
+        fun `should activate user`() {
+            // given
+            val user = createTestUser(1L, "test@example.com").apply { deactivate() }
+            every { userRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = userService.activate(1L)
+
+            // then
+            assertThat(result.isActive).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("utility methods")
+    inner class UtilityMethods {
+
+        @Test
+        fun `should validate email not duplicate`() {
+            // given
+            every { userRepository.existsByEmail("unique@example.com") } returns false
+
+            // when & then (no exception)
+            userService.validateEmailNotDuplicate("unique@example.com")
+        }
+
+        @Test
+        fun `should throw exception when email is duplicate`() {
+            // given
+            every { userRepository.existsByEmail("duplicate@example.com") } returns true
+
+            // when & then
+            assertThatThrownBy {
+                userService.validateEmailNotDuplicate("duplicate@example.com")
+            }.isInstanceOf(EmailDuplicateException::class.java)
+        }
+
+        @Test
+        fun `should check if email exists`() {
+            // given
+            every { userRepository.existsByEmail("exists@example.com") } returns true
+            every { userRepository.existsByEmail("notexists@example.com") } returns false
+
+            // when & then
+            assertThat(userService.existsByEmail("exists@example.com")).isTrue()
+            assertThat(userService.existsByEmail("notexists@example.com")).isFalse()
+        }
+    }
+
+    private fun createTestUser(id: Long, email: String): User {
+        val user = User.createLocalUser(
+            email = email,
+            encodedPassword = "encoded_password",
+            nickname = "테스터"
+        )
+        setUserId(user, id)
+        return user
+    }
+
+    private fun setUserId(user: User, id: Long) {
+        val idField = User::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(user, id)
+    }
+}


### PR DESCRIPTION
## Summary

>- close #25

사용자 CRUD 기능을 구현했습니다. OAuth 계정 분리 (1:N 관계)와 Multi-Role 패턴을 적용하여 확장성 있는 사용자 관리 시스템을 구축했습니다.

## Tasks

- [x] User Entity: OAuth 계정 분리 (1:N 관계), Multi-Role 지원
- [x] OAuthAccount Entity: 독립된 OAuth 계정 관리
- [x] UserService: 회원가입/조회/수정/삭제, OAuth 연동/해제
- [x] ProfileController: 사용자 프로필 API (`/api/v1/me`)
- [x] UserAdminController: 관리자용 사용자 관리 API (`/api/backoffice/users`)
- [x] UserRepository/OAuthAccountRepository: JPA Repository
- [x] Custom Exceptions: UserNotFoundException, EmailDuplicateException 등
- [x] User/OAuthAccount Entity 테스트
- [x] UserService 테스트 (커버리지 96%)

## To Reviewer

- OAuth 계정을 별도 Entity로 분리하여 1 User : N OAuthAccount 관계로 구현했습니다.
- 인증 수단 관리 로직이 Entity 내부에 캡슐화되어 있어, 최소 1개의 인증 수단이 항상 유지됩니다.
- Spring Security 구현 전까지 임시로 X-User-Id 헤더를 사용합니다.
- 테스트 커버리지: UserService 96%, Infrastructure 모듈 전체 93%