### PR TITLE
feat(#26): Spring Security + JWT 인증 구현

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
@@ -1,4 +1,4 @@
-package com.nextup.scorer.config
+package com.nextup.api.config
 
 import com.nextup.infrastructure.security.handler.CustomAccessDeniedHandler
 import com.nextup.infrastructure.security.handler.CustomAuthenticationEntryPoint
@@ -7,17 +7,20 @@ import com.nextup.infrastructure.security.jwt.JwtProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 /**
- * Scorer Security 설정
- *
- * 기록원 전용 모듈로, SCORER 또는 ADMIN 역할이 필요합니다.
+ * Spring Security 설정
  */
 @Configuration
 @EnableWebSecurity
@@ -30,7 +33,7 @@ class SecurityConfig(
 ) {
 
     @Bean
-    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         return http
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
@@ -40,8 +43,10 @@ class SecurityConfig(
             }
             .authorizeHttpRequests { auth ->
                 auth
-                    // Health check
-                    .requestMatchers("/health", "/actuator/health").permitAll()
+                    // Public endpoints
+                    .requestMatchers("/api/auth/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/associations/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/stats/**").permitAll()
 
                     // Swagger/OpenAPI
                     .requestMatchers(
@@ -51,19 +56,29 @@ class SecurityConfig(
                         "/swagger-resources/**"
                     ).permitAll()
 
-                    // WebSocket endpoints (for real-time scoreboard)
-                    .requestMatchers("/ws/**").permitAll()
+                    // Actuator endpoints
+                    .requestMatchers("/actuator/health").permitAll()
 
-                    // Scorer API endpoints
-                    .requestMatchers("/api/scorer/**").hasAnyRole("SCORER", "ADMIN")
+                    // Admin endpoints
+                    .requestMatchers("/api/admin/**").hasRole("ADMIN")
 
-                    // League management in scorer module
-                    .requestMatchers("/api/leagues/**").hasAnyRole("SCORER", "ADMIN")
+                    // Scorer endpoints (for game recording)
+                    .requestMatchers("/api/games/*/records/**").hasAnyRole("SCORER", "ADMIN")
 
-                    // All other endpoints require authentication with SCORER or ADMIN role
-                    .anyRequest().hasAnyRole("SCORER", "ADMIN")
+                    // All other endpoints require authentication
+                    .anyRequest().authenticated()
             }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
+    }
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+
+    @Bean
+    fun authenticationManager(authenticationConfiguration: AuthenticationConfiguration): AuthenticationManager {
+        return authenticationConfiguration.authenticationManager
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/auth/AuthController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/auth/AuthController.kt
@@ -1,0 +1,123 @@
+package com.nextup.api.controller.auth
+
+import com.nextup.api.dto.auth.*
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.infrastructure.security.AuthenticationService
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 인증 관련 API Controller
+ */
+@RestController
+@RequestMapping("/api/auth")
+class AuthController(
+    private val authenticationService: AuthenticationService
+) {
+
+    /**
+     * 로그인
+     *
+     * POST /api/auth/login
+     */
+    @PostMapping("/login")
+    fun login(
+        @Valid @RequestBody request: LoginRequest,
+        httpRequest: HttpServletRequest
+    ): ResponseEntity<ApiResponse<TokenResponse>> {
+        val deviceInfo = httpRequest.getHeader("User-Agent")
+        val ipAddress = getClientIpAddress(httpRequest)
+
+        val tokenPair = authenticationService.login(
+            email = request.email,
+            password = request.password,
+            deviceInfo = deviceInfo,
+            ipAddress = ipAddress
+        )
+
+        return ResponseEntity.ok(ApiResponse.success(TokenResponse.from(tokenPair)))
+    }
+
+    /**
+     * 토큰 갱신
+     *
+     * POST /api/auth/refresh
+     */
+    @PostMapping("/refresh")
+    fun refresh(
+        @Valid @RequestBody request: RefreshTokenRequest,
+        httpRequest: HttpServletRequest
+    ): ResponseEntity<ApiResponse<TokenResponse>> {
+        val deviceInfo = httpRequest.getHeader("User-Agent")
+        val ipAddress = getClientIpAddress(httpRequest)
+
+        val tokenPair = authenticationService.refresh(
+            refreshTokenString = request.refreshToken,
+            deviceInfo = deviceInfo,
+            ipAddress = ipAddress
+        )
+
+        return ResponseEntity.ok(ApiResponse.success(TokenResponse.from(tokenPair)))
+    }
+
+    /**
+     * 로그아웃
+     *
+     * POST /api/auth/logout
+     */
+    @PostMapping("/logout")
+    fun logout(
+        @Valid @RequestBody request: LogoutRequest
+    ): ResponseEntity<ApiResponse<Unit>> {
+        authenticationService.logout(request.refreshToken)
+        return ResponseEntity.ok(ApiResponse.success(Unit))
+    }
+
+    /**
+     * 전체 로그아웃 (모든 디바이스)
+     *
+     * POST /api/auth/logout-all
+     */
+    @PostMapping("/logout-all")
+    fun logoutAll(
+        @AuthenticationPrincipal userId: Long
+    ): ResponseEntity<ApiResponse<Unit>> {
+        authenticationService.logoutAll(userId)
+        return ResponseEntity.ok(ApiResponse.success(Unit))
+    }
+
+    /**
+     * 현재 사용자 정보 조회
+     *
+     * GET /api/auth/me
+     */
+    @GetMapping("/me")
+    fun getCurrentUser(
+        @AuthenticationPrincipal userId: Long
+    ): ResponseEntity<ApiResponse<CurrentUserResponse>> {
+        val userDetails = authenticationService.getUserDetails(userId)
+
+        val response = CurrentUserResponse(
+            id = userDetails.id,
+            email = userDetails.email,
+            nickname = userDetails.nickname,
+            roles = userDetails.getRoleNames(),
+            isActive = userDetails.isEnabled
+        )
+
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    private fun getClientIpAddress(request: HttpServletRequest): String {
+        val xForwardedFor = request.getHeader("X-Forwarded-For")
+        return if (!xForwardedFor.isNullOrBlank()) {
+            xForwardedFor.split(",").first().trim()
+        } else {
+            request.remoteAddr
+        }
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthRequest.kt
@@ -1,0 +1,62 @@
+package com.nextup.api.dto.auth
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+/**
+ * 로그인 요청 DTO
+ */
+data class LoginRequest(
+    @field:NotBlank(message = "Email is required")
+    @field:Email(message = "Invalid email format")
+    val email: String,
+
+    @field:NotBlank(message = "Password is required")
+    val password: String
+)
+
+/**
+ * 회원가입 요청 DTO
+ */
+data class SignUpRequest(
+    @field:NotBlank(message = "Email is required")
+    @field:Email(message = "Invalid email format")
+    val email: String,
+
+    @field:NotBlank(message = "Password is required")
+    @field:Size(min = 8, max = 100, message = "Password must be 8-100 characters")
+    val password: String,
+
+    @field:NotBlank(message = "Nickname is required")
+    @field:Size(min = 2, max = 50, message = "Nickname must be 2-50 characters")
+    val nickname: String
+)
+
+/**
+ * 토큰 갱신 요청 DTO
+ */
+data class RefreshTokenRequest(
+    @field:NotBlank(message = "Refresh token is required")
+    val refreshToken: String
+)
+
+/**
+ * 로그아웃 요청 DTO
+ */
+data class LogoutRequest(
+    @field:NotBlank(message = "Refresh token is required")
+    val refreshToken: String
+)
+
+/**
+ * 비밀번호 변경 요청 DTO
+ */
+data class ChangePasswordRequest(
+    @field:NotBlank(message = "Current password is required")
+    val currentPassword: String,
+
+    @field:NotBlank(message = "New password is required")
+    @field:Size(min = 8, max = 100, message = "Password must be 8-100 characters")
+    val newPassword: String
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthResponse.kt
@@ -1,0 +1,41 @@
+package com.nextup.api.dto.auth
+
+import com.nextup.infrastructure.security.TokenPair
+
+/**
+ * 토큰 응답 DTO
+ */
+data class TokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val tokenType: String = "Bearer"
+) {
+    companion object {
+        fun from(tokenPair: TokenPair): TokenResponse {
+            return TokenResponse(
+                accessToken = tokenPair.accessToken,
+                refreshToken = tokenPair.refreshToken
+            )
+        }
+    }
+}
+
+/**
+ * 현재 사용자 정보 응답 DTO
+ */
+data class CurrentUserResponse(
+    val id: Long,
+    val email: String,
+    val nickname: String,
+    val roles: Set<String>,
+    val isActive: Boolean
+)
+
+/**
+ * 회원가입 응답 DTO
+ */
+data class SignUpResponse(
+    val id: Long,
+    val email: String,
+    val nickname: String
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.nextup.api.exception
 
 import com.nextup.api.dto.common.ApiResponse
+import com.nextup.common.exception.AuthenticationException
 import com.nextup.common.exception.BusinessException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.NotFoundException
@@ -15,6 +16,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 class GlobalExceptionHandler {
 
     private val log = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(AuthenticationException::class)
+    fun handleAuthenticationException(ex: AuthenticationException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("AuthenticationException: code={}, message={}", ex.code, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
 
     @ExceptionHandler(NotFoundException::class)
     fun handleNotFoundException(ex: NotFoundException): ResponseEntity<ApiResponse<Nothing>> {

--- a/nextup-api/src/main/resources/application.yml
+++ b/nextup-api/src/main/resources/application.yml
@@ -21,6 +21,12 @@ spring:
     property-naming-strategy: SNAKE_CASE
     default-property-inclusion: non_null
 
+jwt:
+  secret: ${JWT_SECRET:dGhpcyBpcyBhIHNhbXBsZSBiYXNlNjQgZW5jb2RlZCBzZWNyZXQga2V5IGZvciBkZXZlbG9wbWVudCBvbmx5}
+  access-token-expiration: ${JWT_ACCESS_EXPIRATION:1800000}
+  refresh-token-expiration: ${JWT_REFRESH_EXPIRATION:604800000}
+  issuer: nextup
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/auth/AuthControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/auth/AuthControllerTest.kt
@@ -1,0 +1,213 @@
+package com.nextup.api.controller.auth
+
+import com.nextup.api.dto.auth.LoginRequest
+import com.nextup.api.dto.auth.LogoutRequest
+import com.nextup.api.dto.auth.RefreshTokenRequest
+import com.nextup.core.domain.user.Role
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.security.AuthenticationService
+import com.nextup.infrastructure.security.TokenPair
+import com.nextup.infrastructure.security.userdetails.CustomUserDetails
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("AuthController 테스트")
+class AuthControllerTest {
+
+    private lateinit var authenticationService: AuthenticationService
+    private lateinit var authController: AuthController
+    private lateinit var httpServletRequest: HttpServletRequest
+
+    @BeforeEach
+    fun setUp() {
+        authenticationService = mockk()
+        authController = AuthController(authenticationService)
+        httpServletRequest = mockk()
+    }
+
+    @Nested
+    @DisplayName("로그인")
+    inner class Login {
+
+        @Test
+        fun `should return token pair on successful login`() {
+            // given
+            val request = LoginRequest(email = "test@example.com", password = "password123")
+            val tokenPair = TokenPair(
+                accessToken = "access_token",
+                refreshToken = "refresh_token"
+            )
+
+            every { httpServletRequest.getHeader("User-Agent") } returns "Mozilla/5.0"
+            every { httpServletRequest.getHeader("X-Forwarded-For") } returns null
+            every { httpServletRequest.remoteAddr } returns "127.0.0.1"
+            every {
+                authenticationService.login(
+                    email = "test@example.com",
+                    password = "password123",
+                    deviceInfo = "Mozilla/5.0",
+                    ipAddress = "127.0.0.1"
+                )
+            } returns tokenPair
+
+            // when
+            val response = authController.login(request, httpServletRequest)
+
+            // then
+            assertThat(response.statusCode.value()).isEqualTo(200)
+            assertThat(response.body?.data?.accessToken).isEqualTo("access_token")
+            assertThat(response.body?.data?.refreshToken).isEqualTo("refresh_token")
+            assertThat(response.body?.data?.tokenType).isEqualTo("Bearer")
+        }
+
+        @Test
+        fun `should extract IP from X-Forwarded-For header`() {
+            // given
+            val request = LoginRequest(email = "test@example.com", password = "password123")
+            val tokenPair = TokenPair(accessToken = "access", refreshToken = "refresh")
+
+            every { httpServletRequest.getHeader("User-Agent") } returns "Chrome"
+            every { httpServletRequest.getHeader("X-Forwarded-For") } returns "192.168.1.1, 10.0.0.1"
+            every {
+                authenticationService.login(
+                    email = "test@example.com",
+                    password = "password123",
+                    deviceInfo = "Chrome",
+                    ipAddress = "192.168.1.1"
+                )
+            } returns tokenPair
+
+            // when
+            val response = authController.login(request, httpServletRequest)
+
+            // then
+            assertThat(response.statusCode.value()).isEqualTo(200)
+            verify {
+                authenticationService.login(
+                    email = "test@example.com",
+                    password = "password123",
+                    deviceInfo = "Chrome",
+                    ipAddress = "192.168.1.1"
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 갱신")
+    inner class Refresh {
+
+        @Test
+        fun `should return new token pair on successful refresh`() {
+            // given
+            val request = RefreshTokenRequest(refreshToken = "old_refresh_token")
+            val tokenPair = TokenPair(
+                accessToken = "new_access_token",
+                refreshToken = "new_refresh_token"
+            )
+
+            every { httpServletRequest.getHeader("User-Agent") } returns "Safari"
+            every { httpServletRequest.getHeader("X-Forwarded-For") } returns null
+            every { httpServletRequest.remoteAddr } returns "10.0.0.1"
+            every {
+                authenticationService.refresh(
+                    refreshTokenString = "old_refresh_token",
+                    deviceInfo = "Safari",
+                    ipAddress = "10.0.0.1"
+                )
+            } returns tokenPair
+
+            // when
+            val response = authController.refresh(request, httpServletRequest)
+
+            // then
+            assertThat(response.statusCode.value()).isEqualTo(200)
+            assertThat(response.body?.data?.accessToken).isEqualTo("new_access_token")
+            assertThat(response.body?.data?.refreshToken).isEqualTo("new_refresh_token")
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃")
+    inner class Logout {
+
+        @Test
+        fun `should logout successfully`() {
+            // given
+            val request = LogoutRequest(refreshToken = "refresh_token")
+            every { authenticationService.logout("refresh_token") } just runs
+
+            // when
+            val response = authController.logout(request)
+
+            // then
+            assertThat(response.statusCode.value()).isEqualTo(200)
+            assertThat(response.body?.success).isTrue()
+            verify { authenticationService.logout("refresh_token") }
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 로그아웃")
+    inner class LogoutAll {
+
+        @Test
+        fun `should logout from all devices`() {
+            // given
+            val userId = 1L
+            every { authenticationService.logoutAll(userId) } just runs
+
+            // when
+            val response = authController.logoutAll(userId)
+
+            // then
+            assertThat(response.statusCode.value()).isEqualTo(200)
+            assertThat(response.body?.success).isTrue()
+            verify { authenticationService.logoutAll(userId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("현재 사용자 조회")
+    inner class GetCurrentUser {
+
+        @Test
+        fun `should return current user info`() {
+            // given
+            val userId = 1L
+            val user = User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "encoded",
+                nickname = "테스터"
+            )
+            // Use reflection to set ID
+            val idField = user.javaClass.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(user, userId)
+
+            val userDetails = CustomUserDetails.from(user)
+
+            every { authenticationService.getUserDetails(userId) } returns userDetails
+
+            // when
+            val response = authController.getCurrentUser(userId)
+
+            // then
+            assertThat(response.statusCode.value()).isEqualTo(200)
+            assertThat(response.body?.data?.id).isEqualTo(userId)
+            assertThat(response.body?.data?.email).isEqualTo("test@example.com")
+            assertThat(response.body?.data?.nickname).isEqualTo("테스터")
+            assertThat(response.body?.data?.roles).contains("USER")
+            assertThat(response.body?.data?.isActive).isTrue()
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/exception/GlobalExceptionHandlerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/exception/GlobalExceptionHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.nextup.api.exception
 
+import com.nextup.common.exception.AuthenticationException
 import com.nextup.common.exception.BusinessException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.NotFoundException
@@ -20,6 +21,21 @@ class GlobalExceptionHandlerTest {
     @BeforeEach
     fun setUp() {
         handler = GlobalExceptionHandler()
+    }
+
+    @Test
+    fun `should handle AuthenticationException and return 401`() {
+        // given
+        val exception = object : AuthenticationException("INVALID_CREDENTIALS", "Invalid email or password") {}
+
+        // when
+        val response = handler.handleAuthenticationException(exception)
+
+        // then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(response.body?.success).isFalse()
+        assertThat(response.body?.error?.code).isEqualTo("INVALID_CREDENTIALS")
+        assertThat(response.body?.error?.message).isEqualTo("Invalid email or password")
     }
 
     @Test

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
@@ -8,36 +8,26 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 
+/**
+ * Backoffice Security 설정 (임시 - 모든 요청 허용)
+ *
+ * TODO: JWT 인증 및 권한 관리 구현 필요
+ * 관리자 전용 모듈로, 기본적으로 인증이 필요합니다.
+ * 역할별 권한: ADMIN, ASSOCIATION_ADMIN, LEAGUE_ADMIN, TEAM_MANAGER
+ */
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 class SecurityConfig {
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
-        http
+        return http
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth ->
-                // 헬스체크는 인증 없이 접근 가능
-                auth.requestMatchers("/health", "/actuator/health").permitAll()
-
-                // TODO: JWT 인증 구현 후 역할별 접근 제어 추가
-                // 현재는 개발 편의를 위해 모든 요청 허용
                 auth.anyRequest().permitAll()
-
-                // 추후 적용할 권한 설정:
-                // auth.requestMatchers("/api/backoffice/associations/**")
-                //     .hasRole("ASSOCIATION_ADMIN")
-                // auth.requestMatchers("/api/backoffice/leagues/**")
-                //     .hasAnyRole("ASSOCIATION_ADMIN", "LEAGUE_ADMIN")
-                // auth.requestMatchers("/api/backoffice/teams/**")
-                //     .hasAnyRole("LEAGUE_ADMIN", "TEAM_MANAGER")
-                // auth.requestMatchers("/api/backoffice/admin/**")
-                //     .hasRole("ADMIN")
-                // auth.anyRequest().authenticated()
             }
-
-        return http.build()
+            .build()
     }
 }

--- a/nextup-backoffice/src/main/resources/application.yml
+++ b/nextup-backoffice/src/main/resources/application.yml
@@ -24,6 +24,12 @@ spring:
     property-naming-strategy: SNAKE_CASE
     default-property-inclusion: non_null
 
+jwt:
+  secret: ${JWT_SECRET:dGhpcyBpcyBhIHNhbXBsZSBiYXNlNjQgZW5jb2RlZCBzZWNyZXQga2V5IGZvciBkZXZlbG9wbWVudCBvbmx5}
+  access-token-expiration: ${JWT_ACCESS_EXPIRATION:1800000}
+  refresh-token-expiration: ${JWT_REFRESH_EXPIRATION:604800000}
+  issuer: nextup
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/AuthExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/AuthExceptions.kt
@@ -1,0 +1,69 @@
+package com.nextup.common.exception
+
+/**
+ * 인증 관련 기본 예외 클래스
+ */
+open class AuthenticationException(
+    code: String,
+    message: String
+) : BusinessException(code, message)
+
+/**
+ * 유효하지 않은 토큰일 때 발생하는 예외
+ */
+class InvalidTokenException(
+    message: String = "Invalid token"
+) : AuthenticationException(
+    "INVALID_TOKEN",
+    message
+)
+
+/**
+ * 토큰이 만료되었을 때 발생하는 예외
+ */
+class TokenExpiredException(
+    message: String = "Token has expired"
+) : AuthenticationException(
+    "TOKEN_EXPIRED",
+    message
+)
+
+/**
+ * Refresh Token을 찾을 수 없을 때 발생하는 예외
+ */
+class RefreshTokenNotFoundException(
+    message: String = "Refresh token not found"
+) : NotFoundException(
+    "REFRESH_TOKEN_NOT_FOUND",
+    message
+)
+
+/**
+ * 잘못된 인증 정보일 때 발생하는 예외
+ */
+class InvalidCredentialsException(
+    message: String = "Invalid email or password"
+) : AuthenticationException(
+    "INVALID_CREDENTIALS",
+    message
+)
+
+/**
+ * Refresh Token이 만료되었을 때 발생하는 예외
+ */
+class RefreshTokenExpiredException(
+    message: String = "Refresh token has expired"
+) : AuthenticationException(
+    "REFRESH_TOKEN_EXPIRED",
+    message
+)
+
+/**
+ * Refresh Token이 폐기되었을 때 발생하는 예외
+ */
+class RefreshTokenRevokedException(
+    message: String = "Refresh token has been revoked"
+) : AuthenticationException(
+    "REFRESH_TOKEN_REVOKED",
+    message
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/auth/RefreshToken.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/auth/RefreshToken.kt
@@ -1,0 +1,124 @@
+package com.nextup.core.domain.auth
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * Refresh Token 엔티티
+ *
+ * JWT Access Token 갱신을 위한 Refresh Token을 관리합니다.
+ * 사용자당 여러 개의 Refresh Token을 가질 수 있습니다 (멀티 디바이스 지원).
+ */
+@Entity
+@Table(
+    name = "refresh_tokens",
+    indexes = [
+        Index(name = "idx_refresh_token_user", columnList = "user_id"),
+        Index(name = "idx_refresh_token_token", columnList = "token", unique = true),
+        Index(name = "idx_refresh_token_expires", columnList = "expires_at")
+    ]
+)
+class RefreshToken private constructor(
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+
+    @Column(nullable = false, unique = true, length = 500)
+    val token: String,
+
+    @Column(name = "expires_at", nullable = false)
+    val expiresAt: Instant,
+
+    @Column(name = "is_revoked", nullable = false)
+    var isRevoked: Boolean = false,
+
+    @Column(name = "device_info", length = 255)
+    val deviceInfo: String? = null,
+
+    @Column(name = "ip_address", length = 45)
+    val ipAddress: String? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+) : BaseTimeEntity() {
+
+    /**
+     * 토큰이 만료되었는지 확인합니다.
+     */
+    val isExpired: Boolean
+        get() = Instant.now().isAfter(expiresAt)
+
+    /**
+     * 토큰이 유효한지 확인합니다 (만료되지 않고 폐기되지 않음).
+     */
+    val isValid: Boolean
+        get() = !isExpired && !isRevoked
+
+    /**
+     * 토큰을 폐기합니다.
+     *
+     * 이미 폐기된 토큰에 대해서는 아무 작업도 수행하지 않습니다.
+     */
+    fun revoke() {
+        if (!isRevoked) {
+            isRevoked = true
+        }
+    }
+
+    /**
+     * 토큰이 유효한지 검증합니다.
+     *
+     * @throws IllegalStateException 토큰이 만료되었거나 폐기된 경우
+     */
+    fun validate() {
+        require(!isExpired) { "Refresh token has expired" }
+        require(!isRevoked) { "Refresh token has been revoked" }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RefreshToken) return false
+        if (id == 0L) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    override fun toString(): String =
+        "RefreshToken(id=$id, userId=$userId, isRevoked=$isRevoked, expiresAt=$expiresAt)"
+
+    companion object {
+        /**
+         * RefreshToken을 생성합니다.
+         *
+         * @param userId 사용자 ID
+         * @param token 토큰 문자열
+         * @param expiresAt 만료 시간
+         * @param deviceInfo 디바이스 정보 (선택)
+         * @param ipAddress 접속 IP 주소 (선택)
+         * @return 생성된 RefreshToken
+         * @throws IllegalArgumentException 토큰이 비어있거나 만료 시간이 현재 시간 이전인 경우
+         */
+        fun create(
+            userId: Long,
+            token: String,
+            expiresAt: Instant,
+            deviceInfo: String? = null,
+            ipAddress: String? = null
+        ): RefreshToken {
+            require(token.isNotBlank()) { "Token cannot be blank" }
+            require(expiresAt.isAfter(Instant.now())) {
+                "Expiration time must be in the future"
+            }
+
+            return RefreshToken(
+                userId = userId,
+                token = token,
+                expiresAt = expiresAt,
+                deviceInfo = deviceInfo,
+                ipAddress = ipAddress
+            )
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/auth/RefreshTokenTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/auth/RefreshTokenTest.kt
@@ -1,0 +1,295 @@
+package com.nextup.core.domain.auth
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@DisplayName("RefreshToken Entity")
+class RefreshTokenTest {
+
+    @Nested
+    @DisplayName("create()")
+    inner class Create {
+
+        @Test
+        fun `should create RefreshToken with valid parameters`() {
+            // given
+            val userId = 1L
+            val token = "test-refresh-token"
+            val expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+
+            // when
+            val refreshToken = RefreshToken.create(
+                userId = userId,
+                token = token,
+                expiresAt = expiresAt
+            )
+
+            // then
+            assertThat(refreshToken.userId).isEqualTo(userId)
+            assertThat(refreshToken.token).isEqualTo(token)
+            assertThat(refreshToken.expiresAt).isEqualTo(expiresAt)
+            assertThat(refreshToken.isRevoked).isFalse()
+            assertThat(refreshToken.deviceInfo).isNull()
+            assertThat(refreshToken.ipAddress).isNull()
+        }
+
+        @Test
+        fun `should create RefreshToken with optional parameters`() {
+            // given
+            val userId = 1L
+            val token = "test-refresh-token"
+            val expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            val deviceInfo = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+            val ipAddress = "192.168.1.1"
+
+            // when
+            val refreshToken = RefreshToken.create(
+                userId = userId,
+                token = token,
+                expiresAt = expiresAt,
+                deviceInfo = deviceInfo,
+                ipAddress = ipAddress
+            )
+
+            // then
+            assertThat(refreshToken.deviceInfo).isEqualTo(deviceInfo)
+            assertThat(refreshToken.ipAddress).isEqualTo(ipAddress)
+        }
+
+        @Test
+        fun `should throw exception when token is blank`() {
+            // given
+            val userId = 1L
+            val expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+
+            // when & then
+            assertThatThrownBy {
+                RefreshToken.create(
+                    userId = userId,
+                    token = "   ",
+                    expiresAt = expiresAt
+                )
+            }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("Token cannot be blank")
+        }
+
+        @Test
+        fun `should throw exception when expiresAt is in the past`() {
+            // given
+            val userId = 1L
+            val token = "test-refresh-token"
+            val expiresAt = Instant.now().minus(1, ChronoUnit.HOURS)
+
+            // when & then
+            assertThatThrownBy {
+                RefreshToken.create(
+                    userId = userId,
+                    token = token,
+                    expiresAt = expiresAt
+                )
+            }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("Expiration time must be in the future")
+        }
+    }
+
+    @Nested
+    @DisplayName("isExpired")
+    inner class IsExpired {
+
+        @Test
+        fun `should return false when token is not expired`() {
+            // given
+            val refreshToken = RefreshToken.create(
+                userId = 1L,
+                token = "test-token",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+
+            // when & then
+            assertThat(refreshToken.isExpired).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("isValid")
+    inner class IsValid {
+
+        @Test
+        fun `should return true when token is not expired and not revoked`() {
+            // given
+            val refreshToken = RefreshToken.create(
+                userId = 1L,
+                token = "test-token",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+
+            // when & then
+            assertThat(refreshToken.isValid).isTrue()
+        }
+
+        @Test
+        fun `should return false when token is revoked`() {
+            // given
+            val refreshToken = RefreshToken.create(
+                userId = 1L,
+                token = "test-token",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+            refreshToken.revoke()
+
+            // when & then
+            assertThat(refreshToken.isValid).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("revoke()")
+    inner class Revoke {
+
+        @Test
+        fun `should revoke token`() {
+            // given
+            val refreshToken = RefreshToken.create(
+                userId = 1L,
+                token = "test-token",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+
+            // when
+            refreshToken.revoke()
+
+            // then
+            assertThat(refreshToken.isRevoked).isTrue()
+        }
+
+        @Test
+        fun `should not change state when already revoked`() {
+            // given
+            val refreshToken = RefreshToken.create(
+                userId = 1L,
+                token = "test-token",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+            refreshToken.revoke()
+
+            // when
+            refreshToken.revoke()
+
+            // then
+            assertThat(refreshToken.isRevoked).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("validate()")
+    inner class Validate {
+
+        @Test
+        fun `should not throw when token is valid`() {
+            // given
+            val refreshToken = RefreshToken.create(
+                userId = 1L,
+                token = "test-token",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+
+            // when & then
+            refreshToken.validate() // should not throw
+        }
+
+        @Test
+        fun `should throw when token is revoked`() {
+            // given
+            val refreshToken = RefreshToken.create(
+                userId = 1L,
+                token = "test-token",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+            refreshToken.revoke()
+
+            // when & then
+            assertThatThrownBy { refreshToken.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("revoked")
+        }
+    }
+
+    @Nested
+    @DisplayName("equals() and hashCode()")
+    inner class EqualsAndHashCode {
+
+        @Test
+        fun `should be equal when same reference`() {
+            // given
+            val refreshToken = RefreshToken.create(
+                userId = 1L,
+                token = "test-token",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+
+            // when & then
+            assertThat(refreshToken).isEqualTo(refreshToken)
+        }
+
+        @Test
+        fun `should not be equal when id is 0`() {
+            // given
+            val token1 = RefreshToken.create(
+                userId = 1L,
+                token = "test-token-1",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+            val token2 = RefreshToken.create(
+                userId = 1L,
+                token = "test-token-2",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+
+            // when & then
+            assertThat(token1).isNotEqualTo(token2)
+        }
+
+        @Test
+        fun `should not be equal to different type`() {
+            // given
+            val refreshToken = RefreshToken.create(
+                userId = 1L,
+                token = "test-token",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+
+            // when & then
+            assertThat(refreshToken).isNotEqualTo("string")
+        }
+    }
+
+    @Nested
+    @DisplayName("toString()")
+    inner class ToString {
+
+        @Test
+        fun `should return readable string representation`() {
+            // given
+            val refreshToken = RefreshToken.create(
+                userId = 1L,
+                token = "test-token",
+                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
+            )
+
+            // when
+            val result = refreshToken.toString()
+
+            // then
+            assertThat(result).contains("RefreshToken")
+            assertThat(result).contains("userId=1")
+            assertThat(result).contains("isRevoked=false")
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/auth/RefreshTokenTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/auth/RefreshTokenTest.kt
@@ -115,6 +115,37 @@ class RefreshTokenTest {
             // when & then
             assertThat(refreshToken.isExpired).isFalse()
         }
+
+        @Test
+        fun `should return true when token is expired`() {
+            // given - use reflection to create expired token
+            val expiredToken = createExpiredRefreshToken(1L, "expired-token")
+
+            // when & then
+            assertThat(expiredToken.isExpired).isTrue()
+        }
+    }
+
+    private fun createExpiredRefreshToken(userId: Long, token: String): RefreshToken {
+        val constructor = RefreshToken::class.java.getDeclaredConstructor(
+            Long::class.java,
+            String::class.java,
+            Instant::class.java,
+            Boolean::class.java,
+            String::class.java,
+            String::class.java,
+            Long::class.java
+        )
+        constructor.isAccessible = true
+        return constructor.newInstance(
+            userId,
+            token,
+            Instant.now().minus(1, ChronoUnit.HOURS),
+            false,
+            null,
+            null,
+            0L
+        )
     }
 
     @Nested
@@ -146,6 +177,15 @@ class RefreshTokenTest {
 
             // when & then
             assertThat(refreshToken.isValid).isFalse()
+        }
+
+        @Test
+        fun `should return false when token is expired`() {
+            // given - use reflection to create expired token
+            val expiredToken = createExpiredRefreshToken(1L, "expired-token")
+
+            // when & then
+            assertThat(expiredToken.isValid).isFalse()
         }
     }
 
@@ -218,6 +258,17 @@ class RefreshTokenTest {
             assertThatThrownBy { refreshToken.validate() }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("revoked")
+        }
+
+        @Test
+        fun `should throw when token is expired`() {
+            // given - use reflection to create expired token
+            val expiredToken = createExpiredRefreshToken(1L, "expired-token")
+
+            // when & then
+            assertThatThrownBy { expiredToken.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("expired")
         }
     }
 

--- a/nextup-infrastructure/build.gradle.kts
+++ b/nextup-infrastructure/build.gradle.kts
@@ -34,7 +34,16 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     runtimeOnly("org.postgresql:postgresql")
+
+    // Spring Security
+    api("org.springframework.boot:spring-boot-starter-security")
+
+    // JWT
+    api("io.jsonwebtoken:jjwt-api:0.12.3")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/auth/RefreshTokenRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/auth/RefreshTokenRepository.kt
@@ -1,0 +1,77 @@
+package com.nextup.infrastructure.repository.auth
+
+import com.nextup.core.domain.auth.RefreshToken
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.time.Instant
+
+/**
+ * RefreshToken Repository
+ */
+@Repository
+interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
+
+    /**
+     * 토큰 문자열로 RefreshToken을 조회합니다.
+     *
+     * @param token 토큰 문자열
+     * @return RefreshToken (없으면 null)
+     */
+    fun findByToken(token: String): RefreshToken?
+
+    /**
+     * 사용자 ID로 모든 RefreshToken을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return RefreshToken 목록
+     */
+    fun findAllByUserId(userId: Long): List<RefreshToken>
+
+    /**
+     * 사용자 ID로 유효한 RefreshToken 목록을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 유효한 RefreshToken 목록
+     */
+    @Query("""
+        SELECT r FROM RefreshToken r
+        WHERE r.userId = :userId
+        AND r.isRevoked = false
+        AND r.expiresAt > :now
+    """)
+    fun findValidTokensByUserId(
+        @Param("userId") userId: Long,
+        @Param("now") now: Instant = Instant.now()
+    ): List<RefreshToken>
+
+    /**
+     * 사용자의 모든 RefreshToken을 폐기합니다.
+     *
+     * @param userId 사용자 ID
+     */
+    @Modifying
+    @Query("UPDATE RefreshToken r SET r.isRevoked = true WHERE r.userId = :userId")
+    fun revokeAllByUserId(@Param("userId") userId: Long)
+
+    /**
+     * 만료된 RefreshToken을 삭제합니다.
+     *
+     * @param expiredBefore 이 시간 이전에 만료된 토큰 삭제
+     * @return 삭제된 토큰 수
+     */
+    @Modifying
+    @Query("DELETE FROM RefreshToken r WHERE r.expiresAt < :expiredBefore")
+    fun deleteExpiredTokens(@Param("expiredBefore") expiredBefore: Instant): Int
+
+    /**
+     * 폐기된 RefreshToken을 삭제합니다.
+     *
+     * @return 삭제된 토큰 수
+     */
+    @Modifying
+    @Query("DELETE FROM RefreshToken r WHERE r.isRevoked = true")
+    fun deleteRevokedTokens(): Int
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/AuthenticationService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/AuthenticationService.kt
@@ -1,0 +1,168 @@
+package com.nextup.infrastructure.security
+
+import com.nextup.common.exception.*
+import com.nextup.core.domain.auth.RefreshToken
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
+import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import com.nextup.infrastructure.security.userdetails.CustomUserDetails
+import com.nextup.infrastructure.security.userdetails.UserJpaRepository
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 인증 관련 비즈니스 로직을 처리하는 서비스
+ */
+@Service
+@Transactional
+class AuthenticationService(
+    private val userJpaRepository: UserJpaRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val passwordEncoder: PasswordEncoder
+) {
+
+    /**
+     * 로그인 처리
+     *
+     * @param email 사용자 이메일
+     * @param password 비밀번호
+     * @param deviceInfo 디바이스 정보 (선택)
+     * @param ipAddress IP 주소 (선택)
+     * @return TokenPair (accessToken, refreshToken)
+     * @throws InvalidCredentialsException 이메일 또는 비밀번호가 잘못된 경우
+     * @throws UserDeactivatedException 비활성화된 사용자인 경우
+     */
+    fun login(
+        email: String,
+        password: String,
+        deviceInfo: String? = null,
+        ipAddress: String? = null
+    ): TokenPair {
+        val user = userJpaRepository.findByEmail(email)
+            ?: throw InvalidCredentialsException()
+
+        if (!user.isActive) {
+            throw UserDeactivatedException(user.id)
+        }
+
+        if (user.password == null || !passwordEncoder.matches(password, user.password)) {
+            throw InvalidCredentialsException()
+        }
+
+        return generateTokenPair(user, deviceInfo, ipAddress)
+    }
+
+    /**
+     * 토큰 갱신
+     *
+     * @param refreshTokenString Refresh Token 문자열
+     * @param deviceInfo 디바이스 정보 (선택)
+     * @param ipAddress IP 주소 (선택)
+     * @return 새로운 TokenPair
+     * @throws RefreshTokenNotFoundException Refresh Token을 찾을 수 없는 경우
+     * @throws RefreshTokenExpiredException Refresh Token이 만료된 경우
+     * @throws RefreshTokenRevokedException Refresh Token이 폐기된 경우
+     */
+    fun refresh(
+        refreshTokenString: String,
+        deviceInfo: String? = null,
+        ipAddress: String? = null
+    ): TokenPair {
+        val refreshToken = refreshTokenRepository.findByToken(refreshTokenString)
+            ?: throw RefreshTokenNotFoundException()
+
+        if (refreshToken.isExpired) {
+            throw RefreshTokenExpiredException()
+        }
+
+        if (refreshToken.isRevoked) {
+            throw RefreshTokenRevokedException()
+        }
+
+        // 기존 Refresh Token 폐기
+        refreshToken.revoke()
+        refreshTokenRepository.save(refreshToken)
+
+        val user = userJpaRepository.findById(refreshToken.userId)
+            .orElseThrow { UserNotFoundException(refreshToken.userId) }
+
+        if (!user.isActive) {
+            throw UserDeactivatedException(user.id)
+        }
+
+        return generateTokenPair(user, deviceInfo, ipAddress)
+    }
+
+    /**
+     * 로그아웃 처리 (현재 Refresh Token만 폐기)
+     *
+     * @param refreshTokenString Refresh Token 문자열
+     */
+    fun logout(refreshTokenString: String) {
+        val refreshToken = refreshTokenRepository.findByToken(refreshTokenString)
+        refreshToken?.revoke()
+        refreshToken?.let { refreshTokenRepository.save(it) }
+    }
+
+    /**
+     * 전체 로그아웃 처리 (모든 Refresh Token 폐기)
+     *
+     * @param userId 사용자 ID
+     */
+    fun logoutAll(userId: Long) {
+        refreshTokenRepository.revokeAllByUserId(userId)
+    }
+
+    /**
+     * 사용자 ID로 CustomUserDetails를 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return CustomUserDetails
+     * @throws UserNotFoundException 사용자를 찾을 수 없는 경우
+     */
+    @Transactional(readOnly = true)
+    fun getUserDetails(userId: Long): CustomUserDetails {
+        val user = userJpaRepository.findById(userId)
+            .orElseThrow { UserNotFoundException(userId) }
+        return CustomUserDetails.from(user)
+    }
+
+    private fun generateTokenPair(
+        user: User,
+        deviceInfo: String?,
+        ipAddress: String?
+    ): TokenPair {
+        val roles = user.roles.map { it.name }.toSet()
+
+        val accessToken = jwtTokenProvider.createAccessToken(
+            userId = user.id,
+            email = user.email,
+            roles = roles
+        )
+
+        val refreshTokenString = jwtTokenProvider.createRefreshToken(user.id)
+        val refreshToken = RefreshToken.create(
+            userId = user.id,
+            token = refreshTokenString,
+            expiresAt = jwtTokenProvider.getRefreshTokenExpiration(),
+            deviceInfo = deviceInfo,
+            ipAddress = ipAddress
+        )
+        refreshTokenRepository.save(refreshToken)
+
+        return TokenPair(
+            accessToken = accessToken,
+            refreshToken = refreshTokenString
+        )
+    }
+}
+
+/**
+ * Access Token과 Refresh Token을 담는 데이터 클래스
+ */
+data class TokenPair(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/handler/CustomAccessDeniedHandler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/handler/CustomAccessDeniedHandler.kt
@@ -1,0 +1,41 @@
+package com.nextup.infrastructure.security.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+
+/**
+ * 접근 거부 시 처리를 담당하는 Handler
+ *
+ * 인증된 사용자가 권한이 없는 리소스에 접근할 때 호출됩니다.
+ */
+@Component
+class CustomAccessDeniedHandler(
+    private val objectMapper: ObjectMapper
+) : AccessDeniedHandler {
+
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+        response.status = HttpStatus.FORBIDDEN.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = "UTF-8"
+
+        val errorResponse = mapOf(
+            "success" to false,
+            "error" to mapOf(
+                "code" to "ACCESS_DENIED",
+                "message" to "Access denied: insufficient permissions"
+            )
+        )
+
+        objectMapper.writeValue(response.writer, errorResponse)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/handler/CustomAuthenticationEntryPoint.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/handler/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,51 @@
+package com.nextup.infrastructure.security.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.common.exception.InvalidTokenException
+import com.nextup.common.exception.TokenExpiredException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+/**
+ * 인증 실패 시 처리를 담당하는 EntryPoint
+ *
+ * 인증되지 않은 사용자가 보호된 리소스에 접근할 때 호출됩니다.
+ */
+@Component
+class CustomAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper
+) : AuthenticationEntryPoint {
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        val exception = request.getAttribute("exception")
+
+        val (code, message) = when (exception) {
+            is TokenExpiredException -> "TOKEN_EXPIRED" to exception.message
+            is InvalidTokenException -> "INVALID_TOKEN" to exception.message
+            else -> "UNAUTHORIZED" to "Authentication required"
+        }
+
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = "UTF-8"
+
+        val errorResponse = mapOf(
+            "success" to false,
+            "error" to mapOf(
+                "code" to code,
+                "message" to message
+            )
+        )
+
+        objectMapper.writeValue(response.writer, errorResponse)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtAuthenticationFilter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtAuthenticationFilter.kt
@@ -1,0 +1,84 @@
+package com.nextup.infrastructure.security.jwt
+
+import com.nextup.common.exception.InvalidTokenException
+import com.nextup.common.exception.TokenExpiredException
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * JWT 인증을 처리하는 필터
+ *
+ * Authorization 헤더에서 Bearer 토큰을 추출하여 인증을 수행합니다.
+ */
+@Component
+class JwtAuthenticationFilter(
+    private val jwtTokenProvider: JwtTokenProvider
+) : OncePerRequestFilter() {
+
+    companion object {
+        private const val AUTHORIZATION_HEADER = "Authorization"
+        private const val BEARER_PREFIX = "Bearer "
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        try {
+            val token = resolveToken(request)
+
+            if (token != null && jwtTokenProvider.validateToken(token)) {
+                if (jwtTokenProvider.isAccessToken(token)) {
+                    val authentication = getAuthentication(token)
+                    SecurityContextHolder.getContext().authentication = authentication
+                }
+            }
+        } catch (e: TokenExpiredException) {
+            request.setAttribute("exception", e)
+        } catch (e: InvalidTokenException) {
+            request.setAttribute("exception", e)
+        }
+
+        filterChain.doFilter(request, response)
+    }
+
+    /**
+     * Authorization 헤더에서 Bearer 토큰을 추출합니다.
+     *
+     * @param request HTTP 요청
+     * @return 토큰 문자열 (없으면 null)
+     */
+    private fun resolveToken(request: HttpServletRequest): String? {
+        val bearerToken = request.getHeader(AUTHORIZATION_HEADER)
+        return if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
+            bearerToken.substring(BEARER_PREFIX.length)
+        } else {
+            null
+        }
+    }
+
+    /**
+     * 토큰에서 인증 정보를 생성합니다.
+     *
+     * @param token JWT 토큰
+     * @return Spring Security 인증 객체
+     */
+    private fun getAuthentication(token: String): UsernamePasswordAuthenticationToken {
+        val userId = jwtTokenProvider.getUserId(token)
+        val roles = jwtTokenProvider.getRoles(token)
+        val authorities = roles.map { SimpleGrantedAuthority("ROLE_$it") }
+
+        return UsernamePasswordAuthenticationToken(
+            userId,
+            null,
+            authorities
+        )
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtProperties.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtProperties.kt
@@ -1,0 +1,31 @@
+package com.nextup.infrastructure.security.jwt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * JWT 관련 설정을 관리하는 Properties 클래스
+ */
+@ConfigurationProperties(prefix = "jwt")
+data class JwtProperties(
+    /**
+     * JWT 서명에 사용할 비밀 키 (Base64 인코딩)
+     */
+    val secret: String,
+
+    /**
+     * Access Token 만료 시간 (밀리초)
+     * 기본값: 30분 (1800000ms)
+     */
+    val accessTokenExpiration: Long = 1800000L,
+
+    /**
+     * Refresh Token 만료 시간 (밀리초)
+     * 기본값: 7일 (604800000ms)
+     */
+    val refreshTokenExpiration: Long = 604800000L,
+
+    /**
+     * JWT 발급자
+     */
+    val issuer: String = "nextup"
+)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtTokenProvider.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtTokenProvider.kt
@@ -1,0 +1,166 @@
+package com.nextup.infrastructure.security.jwt
+
+import com.nextup.common.exception.InvalidTokenException
+import com.nextup.common.exception.TokenExpiredException
+import io.jsonwebtoken.*
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.util.*
+import javax.crypto.SecretKey
+
+/**
+ * JWT 토큰 생성 및 검증을 담당하는 Provider
+ */
+@Component
+class JwtTokenProvider(
+    private val jwtProperties: JwtProperties
+) {
+    private val secretKey: SecretKey by lazy {
+        val keyBytes = Decoders.BASE64.decode(jwtProperties.secret)
+        Keys.hmacShaKeyFor(keyBytes)
+    }
+
+    /**
+     * Access Token을 생성합니다.
+     *
+     * @param userId 사용자 ID
+     * @param email 사용자 이메일
+     * @param roles 사용자 권한 목록
+     * @return 생성된 Access Token
+     */
+    fun createAccessToken(
+        userId: Long,
+        email: String,
+        roles: Set<String>
+    ): String {
+        val now = Instant.now()
+        val expiration = now.plusMillis(jwtProperties.accessTokenExpiration)
+
+        return Jwts.builder()
+            .subject(userId.toString())
+            .claim("email", email)
+            .claim("roles", roles.toList())
+            .claim("type", "access")
+            .issuer(jwtProperties.issuer)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(expiration))
+            .signWith(secretKey, Jwts.SIG.HS256)
+            .compact()
+    }
+
+    /**
+     * Refresh Token을 생성합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 생성된 Refresh Token
+     */
+    fun createRefreshToken(userId: Long): String {
+        val now = Instant.now()
+        val expiration = now.plusMillis(jwtProperties.refreshTokenExpiration)
+
+        return Jwts.builder()
+            .subject(userId.toString())
+            .claim("type", "refresh")
+            .issuer(jwtProperties.issuer)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(expiration))
+            .signWith(secretKey, Jwts.SIG.HS256)
+            .compact()
+    }
+
+    /**
+     * 토큰에서 사용자 ID를 추출합니다.
+     *
+     * @param token JWT 토큰
+     * @return 사용자 ID
+     * @throws InvalidTokenException 토큰이 유효하지 않은 경우
+     * @throws TokenExpiredException 토큰이 만료된 경우
+     */
+    fun getUserId(token: String): Long {
+        return getClaims(token).subject.toLong()
+    }
+
+    /**
+     * 토큰에서 이메일을 추출합니다.
+     *
+     * @param token JWT 토큰
+     * @return 사용자 이메일
+     */
+    fun getEmail(token: String): String {
+        return getClaims(token).get("email", String::class.java)
+    }
+
+    /**
+     * 토큰에서 권한 목록을 추출합니다.
+     *
+     * @param token JWT 토큰
+     * @return 권한 목록
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun getRoles(token: String): Set<String> {
+        val roles = getClaims(token).get("roles", List::class.java) as? List<String>
+        return roles?.toSet() ?: emptySet()
+    }
+
+    /**
+     * 토큰이 Access Token인지 확인합니다.
+     *
+     * @param token JWT 토큰
+     * @return Access Token이면 true
+     */
+    fun isAccessToken(token: String): Boolean {
+        return getClaims(token).get("type", String::class.java) == "access"
+    }
+
+    /**
+     * 토큰이 Refresh Token인지 확인합니다.
+     *
+     * @param token JWT 토큰
+     * @return Refresh Token이면 true
+     */
+    fun isRefreshToken(token: String): Boolean {
+        return getClaims(token).get("type", String::class.java) == "refresh"
+    }
+
+    /**
+     * 토큰의 유효성을 검증합니다.
+     *
+     * @param token JWT 토큰
+     * @return 유효하면 true
+     */
+    fun validateToken(token: String): Boolean {
+        return try {
+            getClaims(token)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Refresh Token의 만료 시간을 반환합니다.
+     *
+     * @return Refresh Token 만료 시간 (Instant)
+     */
+    fun getRefreshTokenExpiration(): Instant {
+        return Instant.now().plusMillis(jwtProperties.refreshTokenExpiration)
+    }
+
+    private fun getClaims(token: String): Claims {
+        return try {
+            Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .payload
+        } catch (e: ExpiredJwtException) {
+            throw TokenExpiredException("Token has expired")
+        } catch (e: JwtException) {
+            throw InvalidTokenException("Invalid token: ${e.message}")
+        } catch (e: IllegalArgumentException) {
+            throw InvalidTokenException("Token is empty or malformed")
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetails.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetails.kt
@@ -1,0 +1,62 @@
+package com.nextup.infrastructure.security.userdetails
+
+import com.nextup.core.domain.user.Role
+import com.nextup.core.domain.user.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+/**
+ * Spring Security UserDetails 구현체
+ *
+ * User 엔티티를 Spring Security가 인식할 수 있는 형태로 래핑합니다.
+ */
+class CustomUserDetails(
+    private val user: User
+) : UserDetails {
+
+    val id: Long get() = user.id
+
+    val email: String get() = user.email
+
+    val nickname: String get() = user.nickname
+
+    val roles: Set<Role> get() = user.roles
+
+    override fun getAuthorities(): Collection<GrantedAuthority> {
+        return user.roles.map { role ->
+            SimpleGrantedAuthority("ROLE_${role.name}")
+        }
+    }
+
+    override fun getPassword(): String? = user.password
+
+    override fun getUsername(): String = user.email
+
+    override fun isAccountNonExpired(): Boolean = true
+
+    override fun isAccountNonLocked(): Boolean = user.isActive
+
+    override fun isCredentialsNonExpired(): Boolean = true
+
+    override fun isEnabled(): Boolean = user.isActive
+
+    /**
+     * 권한 이름 목록을 반환합니다 (ROLE_ 접두사 없음).
+     */
+    fun getRoleNames(): Set<String> {
+        return user.roles.map { it.name }.toSet()
+    }
+
+    companion object {
+        /**
+         * User 엔티티로부터 CustomUserDetails를 생성합니다.
+         *
+         * @param user User 엔티티
+         * @return CustomUserDetails
+         */
+        fun from(user: User): CustomUserDetails {
+            return CustomUserDetails(user)
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsService.kt
@@ -1,0 +1,55 @@
+package com.nextup.infrastructure.security.userdetails
+
+import com.nextup.core.domain.user.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Service
+
+/**
+ * User JPA Repository
+ */
+interface UserJpaRepository : JpaRepository<User, Long> {
+    fun findByEmail(email: String): User?
+    fun existsByEmail(email: String): Boolean
+}
+
+/**
+ * Spring Security UserDetailsService 구현체
+ *
+ * 이메일을 기반으로 사용자를 조회하여 UserDetails로 변환합니다.
+ */
+@Service
+class CustomUserDetailsService(
+    private val userJpaRepository: UserJpaRepository
+) : UserDetailsService {
+
+    /**
+     * 이메일로 사용자를 조회합니다.
+     *
+     * @param username 사용자 이메일
+     * @return UserDetails
+     * @throws UsernameNotFoundException 사용자를 찾을 수 없는 경우
+     */
+    override fun loadUserByUsername(username: String): UserDetails {
+        val user = userJpaRepository.findByEmail(username)
+            ?: throw UsernameNotFoundException("User not found with email: $username")
+
+        return CustomUserDetails.from(user)
+    }
+
+    /**
+     * 사용자 ID로 사용자를 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return CustomUserDetails
+     * @throws UsernameNotFoundException 사용자를 찾을 수 없는 경우
+     */
+    fun loadUserById(userId: Long): CustomUserDetails {
+        val user = userJpaRepository.findById(userId)
+            .orElseThrow { UsernameNotFoundException("User not found with id: $userId") }
+
+        return CustomUserDetails.from(user)
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/AuthenticationServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/AuthenticationServiceTest.kt
@@ -1,0 +1,357 @@
+package com.nextup.infrastructure.security
+
+import com.nextup.common.exception.*
+import com.nextup.core.domain.auth.RefreshToken
+import com.nextup.core.domain.user.Role
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
+import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import com.nextup.infrastructure.security.userdetails.UserJpaRepository
+import io.mockk.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.time.Instant
+import java.util.*
+
+@DisplayName("AuthenticationService")
+class AuthenticationServiceTest {
+
+    private lateinit var userJpaRepository: UserJpaRepository
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var passwordEncoder: PasswordEncoder
+    private lateinit var authenticationService: AuthenticationService
+
+    @BeforeEach
+    fun setUp() {
+        userJpaRepository = mockk()
+        refreshTokenRepository = mockk()
+        jwtTokenProvider = mockk()
+        passwordEncoder = mockk()
+        authenticationService = AuthenticationService(
+            userJpaRepository,
+            refreshTokenRepository,
+            jwtTokenProvider,
+            passwordEncoder
+        )
+    }
+
+    @Nested
+    @DisplayName("login")
+    inner class Login {
+
+        @Test
+        fun `should return token pair on successful login`() {
+            // given
+            val email = "test@example.com"
+            val password = "password123"
+            val encodedPassword = "encoded_password"
+            val user = createTestUser(1L, email, encodedPassword)
+
+            every { userJpaRepository.findByEmail(email) } returns user
+            every { passwordEncoder.matches(password, encodedPassword) } returns true
+            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access_token"
+            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh_token"
+            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(3600)
+            every { refreshTokenRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = authenticationService.login(email, password)
+
+            // then
+            assertThat(result.accessToken).isEqualTo("access_token")
+            assertThat(result.refreshToken).isEqualTo("refresh_token")
+            verify { refreshTokenRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw InvalidCredentialsException when email not found`() {
+            // given
+            val email = "notfound@example.com"
+            every { userJpaRepository.findByEmail(email) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.login(email, "password")
+            }.isInstanceOf(InvalidCredentialsException::class.java)
+        }
+
+        @Test
+        fun `should throw InvalidCredentialsException when password is wrong`() {
+            // given
+            val email = "test@example.com"
+            val user = createTestUser(1L, email, "encoded_password")
+
+            every { userJpaRepository.findByEmail(email) } returns user
+            every { passwordEncoder.matches(any(), any()) } returns false
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.login(email, "wrong_password")
+            }.isInstanceOf(InvalidCredentialsException::class.java)
+        }
+
+        @Test
+        fun `should throw UserDeactivatedException when user is inactive`() {
+            // given
+            val email = "test@example.com"
+            val user = createTestUser(1L, email, "encoded_password").apply { deactivate() }
+
+            every { userJpaRepository.findByEmail(email) } returns user
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.login(email, "password")
+            }.isInstanceOf(UserDeactivatedException::class.java)
+        }
+
+        @Test
+        fun `should throw InvalidCredentialsException when user has no password (OAuth only)`() {
+            // given
+            val email = "oauth@example.com"
+            val user = createOAuthUser(1L, email)
+
+            every { userJpaRepository.findByEmail(email) } returns user
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.login(email, "password")
+            }.isInstanceOf(InvalidCredentialsException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("refresh")
+    inner class Refresh {
+
+        @Test
+        fun `should return new token pair on successful refresh`() {
+            // given
+            val refreshTokenString = "valid_refresh_token"
+            val refreshToken = createRefreshToken(1L, refreshTokenString)
+            val user = createTestUser(1L, "test@example.com", "password")
+
+            every { refreshTokenRepository.findByToken(refreshTokenString) } returns refreshToken
+            every { refreshTokenRepository.save(any()) } answers { firstArg() }
+            every { userJpaRepository.findById(1L) } returns Optional.of(user)
+            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "new_access_token"
+            every { jwtTokenProvider.createRefreshToken(any()) } returns "new_refresh_token"
+            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(3600)
+
+            // when
+            val result = authenticationService.refresh(refreshTokenString)
+
+            // then
+            assertThat(result.accessToken).isEqualTo("new_access_token")
+            assertThat(result.refreshToken).isEqualTo("new_refresh_token")
+            verify { refreshTokenRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw RefreshTokenNotFoundException when token not found`() {
+            // given
+            every { refreshTokenRepository.findByToken(any()) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.refresh("invalid_token")
+            }.isInstanceOf(RefreshTokenNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw RefreshTokenExpiredException when token is expired`() {
+            // given
+            val expiredToken = createExpiredRefreshToken(1L, "expired_token")
+            every { refreshTokenRepository.findByToken("expired_token") } returns expiredToken
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.refresh("expired_token")
+            }.isInstanceOf(RefreshTokenExpiredException::class.java)
+        }
+
+        @Test
+        fun `should throw RefreshTokenRevokedException when token is revoked`() {
+            // given
+            val revokedToken = createRevokedRefreshToken(1L, "revoked_token")
+            every { refreshTokenRepository.findByToken("revoked_token") } returns revokedToken
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.refresh("revoked_token")
+            }.isInstanceOf(RefreshTokenRevokedException::class.java)
+        }
+
+        @Test
+        fun `should throw UserDeactivatedException when user is inactive`() {
+            // given
+            val refreshTokenString = "valid_token"
+            val refreshToken = createRefreshToken(1L, refreshTokenString)
+            val inactiveUser = createTestUser(1L, "test@example.com", "password").apply { deactivate() }
+
+            every { refreshTokenRepository.findByToken(refreshTokenString) } returns refreshToken
+            every { refreshTokenRepository.save(any()) } answers { firstArg() }
+            every { userJpaRepository.findById(1L) } returns Optional.of(inactiveUser)
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.refresh(refreshTokenString)
+            }.isInstanceOf(UserDeactivatedException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("logout")
+    inner class Logout {
+
+        @Test
+        fun `should revoke refresh token on logout`() {
+            // given
+            val refreshTokenString = "valid_token"
+            val refreshToken = createRefreshToken(1L, refreshTokenString)
+
+            every { refreshTokenRepository.findByToken(refreshTokenString) } returns refreshToken
+            every { refreshTokenRepository.save(any()) } answers { firstArg() }
+
+            // when
+            authenticationService.logout(refreshTokenString)
+
+            // then
+            verify { refreshTokenRepository.save(any()) }
+        }
+
+        @Test
+        fun `should do nothing when token not found`() {
+            // given
+            every { refreshTokenRepository.findByToken(any()) } returns null
+
+            // when - should not throw
+            authenticationService.logout("nonexistent_token")
+
+            // then
+            verify(exactly = 0) { refreshTokenRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("logoutAll")
+    inner class LogoutAll {
+
+        @Test
+        fun `should revoke all refresh tokens for user`() {
+            // given
+            val userId = 1L
+            every { refreshTokenRepository.revokeAllByUserId(userId) } just Runs
+
+            // when
+            authenticationService.logoutAll(userId)
+
+            // then
+            verify { refreshTokenRepository.revokeAllByUserId(userId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("getUserDetails")
+    inner class GetUserDetails {
+
+        @Test
+        fun `should return user details when user found`() {
+            // given
+            val user = createTestUser(1L, "test@example.com", "password")
+            every { userJpaRepository.findById(1L) } returns Optional.of(user)
+
+            // when
+            val result = authenticationService.getUserDetails(1L)
+
+            // then
+            assertThat(result.id).isEqualTo(1L)
+            assertThat(result.email).isEqualTo("test@example.com")
+        }
+
+        @Test
+        fun `should throw UserNotFoundException when user not found`() {
+            // given
+            every { userJpaRepository.findById(999L) } returns Optional.empty()
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.getUserDetails(999L)
+            }.isInstanceOf(UserNotFoundException::class.java)
+        }
+    }
+
+    // Helper methods
+    private fun createTestUser(id: Long, email: String, password: String): User {
+        val user = User.createLocalUser(
+            email = email,
+            encodedPassword = password,
+            nickname = "테스터"
+        )
+        setUserId(user, id)
+        return user
+    }
+
+    private fun createOAuthUser(id: Long, email: String): User {
+        val user = User.createOAuthUser(
+            email = email,
+            nickname = "OAuth테스터",
+            provider = com.nextup.core.domain.user.OAuthProvider.KAKAO,
+            oauthId = "kakao_123"
+        )
+        setUserId(user, id)
+        return user
+    }
+
+    private fun setUserId(user: User, id: Long) {
+        val idField = User::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(user, id)
+    }
+
+    private fun createRefreshToken(userId: Long, token: String): RefreshToken {
+        return RefreshToken.create(
+            userId = userId,
+            token = token,
+            expiresAt = Instant.now().plusSeconds(3600)
+        )
+    }
+
+    private fun createExpiredRefreshToken(userId: Long, token: String): RefreshToken {
+        // Use reflection to create expired token since create() doesn't allow past expiration
+        val constructor = RefreshToken::class.java.getDeclaredConstructor(
+            Long::class.java,
+            String::class.java,
+            Instant::class.java,
+            Boolean::class.java,
+            String::class.java,
+            String::class.java,
+            Long::class.java
+        )
+        constructor.isAccessible = true
+        return constructor.newInstance(
+            userId,
+            token,
+            Instant.now().minusSeconds(3600),
+            false,
+            null,
+            null,
+            0L
+        )
+    }
+
+    private fun createRevokedRefreshToken(userId: Long, token: String): RefreshToken {
+        val refreshToken = RefreshToken.create(
+            userId = userId,
+            token = token,
+            expiresAt = Instant.now().plusSeconds(3600)
+        )
+        refreshToken.revoke()
+        return refreshToken
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/handler/CustomAccessDeniedHandlerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/handler/CustomAccessDeniedHandlerTest.kt
@@ -1,0 +1,156 @@
+package com.nextup.infrastructure.security.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import java.io.PrintWriter
+import java.io.StringWriter
+
+@DisplayName("CustomAccessDeniedHandler 테스트")
+class CustomAccessDeniedHandlerTest {
+
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var handler: CustomAccessDeniedHandler
+    private lateinit var request: HttpServletRequest
+    private lateinit var response: HttpServletResponse
+    private lateinit var stringWriter: StringWriter
+    private lateinit var printWriter: PrintWriter
+
+    @BeforeEach
+    fun setUp() {
+        objectMapper = ObjectMapper()
+        handler = CustomAccessDeniedHandler(objectMapper)
+        request = mockk(relaxed = true)
+        response = mockk(relaxed = true)
+        stringWriter = StringWriter()
+        printWriter = PrintWriter(stringWriter)
+
+        every { response.writer } returns printWriter
+    }
+
+    @Nested
+    @DisplayName("접근 거부 처리")
+    inner class HandleAccessDenied {
+
+        @Test
+        fun `should return ACCESS_DENIED error`() {
+            // given
+            val exception = AccessDeniedException("Access is denied")
+
+            // when
+            handler.handle(request, response, exception)
+
+            // then
+            printWriter.flush()
+            val responseBody = stringWriter.toString()
+            assertThat(responseBody).contains("ACCESS_DENIED")
+            assertThat(responseBody).contains("Access denied: insufficient permissions")
+        }
+
+        @Test
+        fun `should set 403 status code`() {
+            // given
+            val statusSlot = slot<Int>()
+            every { response.status = capture(statusSlot) } returns Unit
+            val exception = AccessDeniedException("Access is denied")
+
+            // when
+            handler.handle(request, response, exception)
+
+            // then
+            assertThat(statusSlot.captured).isEqualTo(HttpStatus.FORBIDDEN.value())
+        }
+    }
+
+    @Nested
+    @DisplayName("응답 형식")
+    inner class ResponseFormat {
+
+        @Test
+        fun `should set correct content type and encoding`() {
+            // given
+            val contentTypeSlot = slot<String>()
+            val encodingSlot = slot<String>()
+
+            every { response.contentType = capture(contentTypeSlot) } returns Unit
+            every { response.characterEncoding = capture(encodingSlot) } returns Unit
+            val exception = AccessDeniedException("Access is denied")
+
+            // when
+            handler.handle(request, response, exception)
+
+            // then
+            assertThat(contentTypeSlot.captured).isEqualTo(MediaType.APPLICATION_JSON_VALUE)
+            assertThat(encodingSlot.captured).isEqualTo("UTF-8")
+        }
+
+        @Test
+        fun `should return proper JSON structure`() {
+            // given
+            val exception = AccessDeniedException("Access is denied")
+
+            // when
+            handler.handle(request, response, exception)
+
+            // then
+            printWriter.flush()
+            val responseBody = stringWriter.toString()
+            val json = objectMapper.readTree(responseBody)
+
+            assertThat(json.has("success")).isTrue()
+            assertThat(json.get("success").asBoolean()).isFalse()
+            assertThat(json.has("error")).isTrue()
+            assertThat(json.get("error").has("code")).isTrue()
+            assertThat(json.get("error").get("code").asText()).isEqualTo("ACCESS_DENIED")
+            assertThat(json.get("error").has("message")).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("다양한 시나리오")
+    inner class VariousScenarios {
+
+        @Test
+        fun `should handle exception with custom message`() {
+            // given
+            val exception = AccessDeniedException("User does not have admin role")
+
+            // when
+            handler.handle(request, response, exception)
+
+            // then
+            verify { response.status = HttpStatus.FORBIDDEN.value() }
+            printWriter.flush()
+            val responseBody = stringWriter.toString()
+            // Handler always returns same message regardless of exception message
+            assertThat(responseBody).contains("Access denied: insufficient permissions")
+        }
+
+        @Test
+        fun `should handle null message in exception`() {
+            // given
+            val exception = AccessDeniedException(null as String?)
+
+            // when
+            handler.handle(request, response, exception)
+
+            // then
+            verify { response.status = HttpStatus.FORBIDDEN.value() }
+            printWriter.flush()
+            val responseBody = stringWriter.toString()
+            assertThat(responseBody).contains("ACCESS_DENIED")
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/handler/CustomAuthenticationEntryPointTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/handler/CustomAuthenticationEntryPointTest.kt
@@ -1,0 +1,179 @@
+package com.nextup.infrastructure.security.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.common.exception.InvalidTokenException
+import com.nextup.common.exception.TokenExpiredException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.BadCredentialsException
+import java.io.PrintWriter
+import java.io.StringWriter
+
+@DisplayName("CustomAuthenticationEntryPoint 테스트")
+class CustomAuthenticationEntryPointTest {
+
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var entryPoint: CustomAuthenticationEntryPoint
+    private lateinit var request: HttpServletRequest
+    private lateinit var response: HttpServletResponse
+    private lateinit var stringWriter: StringWriter
+    private lateinit var printWriter: PrintWriter
+
+    @BeforeEach
+    fun setUp() {
+        objectMapper = ObjectMapper()
+        entryPoint = CustomAuthenticationEntryPoint(objectMapper)
+        request = mockk(relaxed = true)
+        response = mockk(relaxed = true)
+        stringWriter = StringWriter()
+        printWriter = PrintWriter(stringWriter)
+
+        every { response.writer } returns printWriter
+    }
+
+    @Nested
+    @DisplayName("토큰 만료 시")
+    inner class TokenExpired {
+
+        @Test
+        fun `should return TOKEN_EXPIRED error`() {
+            // given
+            val exception = TokenExpiredException("Token has expired")
+            every { request.getAttribute("exception") } returns exception
+
+            // when
+            entryPoint.commence(request, response, BadCredentialsException(""))
+
+            // then
+            verify(response, HttpStatus.UNAUTHORIZED.value())
+
+            printWriter.flush()
+            val responseBody = stringWriter.toString()
+            assertThat(responseBody).contains("TOKEN_EXPIRED")
+            assertThat(responseBody).contains("Token has expired")
+        }
+    }
+
+    @Nested
+    @DisplayName("유효하지 않은 토큰")
+    inner class InvalidToken {
+
+        @Test
+        fun `should return INVALID_TOKEN error`() {
+            // given
+            val exception = InvalidTokenException("Invalid token format")
+            every { request.getAttribute("exception") } returns exception
+
+            // when
+            entryPoint.commence(request, response, BadCredentialsException(""))
+
+            // then
+            verify(response, HttpStatus.UNAUTHORIZED.value())
+
+            printWriter.flush()
+            val responseBody = stringWriter.toString()
+            assertThat(responseBody).contains("INVALID_TOKEN")
+            assertThat(responseBody).contains("Invalid token format")
+        }
+    }
+
+    @Nested
+    @DisplayName("기타 인증 오류")
+    inner class OtherAuthError {
+
+        @Test
+        fun `should return UNAUTHORIZED error when no exception attribute`() {
+            // given
+            every { request.getAttribute("exception") } returns null
+
+            // when
+            entryPoint.commence(request, response, BadCredentialsException("Bad credentials"))
+
+            // then
+            verify(response, HttpStatus.UNAUTHORIZED.value())
+
+            printWriter.flush()
+            val responseBody = stringWriter.toString()
+            assertThat(responseBody).contains("UNAUTHORIZED")
+            assertThat(responseBody).contains("Authentication required")
+        }
+
+        @Test
+        fun `should return UNAUTHORIZED error for unknown exception type`() {
+            // given
+            every { request.getAttribute("exception") } returns RuntimeException("Unknown error")
+
+            // when
+            entryPoint.commence(request, response, BadCredentialsException(""))
+
+            // then
+            verify(response, HttpStatus.UNAUTHORIZED.value())
+
+            printWriter.flush()
+            val responseBody = stringWriter.toString()
+            assertThat(responseBody).contains("UNAUTHORIZED")
+        }
+    }
+
+    @Nested
+    @DisplayName("응답 형식")
+    inner class ResponseFormat {
+
+        @Test
+        fun `should set correct content type and encoding`() {
+            // given
+            val statusSlot = slot<Int>()
+            val contentTypeSlot = slot<String>()
+            val encodingSlot = slot<String>()
+
+            every { response.status = capture(statusSlot) } returns Unit
+            every { response.contentType = capture(contentTypeSlot) } returns Unit
+            every { response.characterEncoding = capture(encodingSlot) } returns Unit
+            every { request.getAttribute("exception") } returns null
+
+            // when
+            entryPoint.commence(request, response, BadCredentialsException(""))
+
+            // then
+            assertThat(statusSlot.captured).isEqualTo(HttpStatus.UNAUTHORIZED.value())
+            assertThat(contentTypeSlot.captured).isEqualTo(MediaType.APPLICATION_JSON_VALUE)
+            assertThat(encodingSlot.captured).isEqualTo("UTF-8")
+        }
+
+        @Test
+        fun `should return proper JSON structure`() {
+            // given
+            every { request.getAttribute("exception") } returns null
+
+            // when
+            entryPoint.commence(request, response, BadCredentialsException(""))
+
+            // then
+            printWriter.flush()
+            val responseBody = stringWriter.toString()
+            val json = objectMapper.readTree(responseBody)
+
+            assertThat(json.has("success")).isTrue()
+            assertThat(json.get("success").asBoolean()).isFalse()
+            assertThat(json.has("error")).isTrue()
+            assertThat(json.get("error").has("code")).isTrue()
+            assertThat(json.get("error").has("message")).isTrue()
+        }
+    }
+
+    private fun verify(response: HttpServletResponse, expectedStatus: Int) {
+        io.mockk.verify { response.status = expectedStatus }
+        io.mockk.verify { response.contentType = MediaType.APPLICATION_JSON_VALUE }
+        io.mockk.verify { response.characterEncoding = "UTF-8" }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtAuthenticationFilterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,198 @@
+package com.nextup.infrastructure.security.jwt
+
+import com.nextup.common.exception.InvalidTokenException
+import com.nextup.common.exception.TokenExpiredException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.FilterChain
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+
+@DisplayName("JwtAuthenticationFilter 테스트")
+class JwtAuthenticationFilterTest {
+
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var filter: JwtAuthenticationFilter
+    private lateinit var request: MockHttpServletRequest
+    private lateinit var response: MockHttpServletResponse
+    private lateinit var filterChain: FilterChain
+
+    @BeforeEach
+    fun setUp() {
+        jwtTokenProvider = mockk()
+        filter = JwtAuthenticationFilter(jwtTokenProvider)
+        request = MockHttpServletRequest()
+        response = MockHttpServletResponse()
+        filterChain = mockk(relaxed = true)
+        SecurityContextHolder.clearContext()
+    }
+
+    @Nested
+    @DisplayName("토큰 추출")
+    inner class ResolveToken {
+
+        @Test
+        fun `should pass filter when no Authorization header`() {
+            // given - no Authorization header set
+
+            // when
+            filter.doFilter(request, response, filterChain)
+
+            // then
+            verify { filterChain.doFilter(request, response) }
+            assertThat(SecurityContextHolder.getContext().authentication).isNull()
+        }
+
+        @Test
+        fun `should pass filter when Authorization header does not start with Bearer`() {
+            // given
+            request.addHeader("Authorization", "Basic dXNlcjpwYXNz")
+
+            // when
+            filter.doFilter(request, response, filterChain)
+
+            // then
+            verify { filterChain.doFilter(request, response) }
+            assertThat(SecurityContextHolder.getContext().authentication).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 검증")
+    inner class ValidateToken {
+
+        @Test
+        fun `should set authentication when valid access token`() {
+            // given
+            val token = "valid_access_token"
+            request.addHeader("Authorization", "Bearer $token")
+            every { jwtTokenProvider.validateToken(token) } returns true
+            every { jwtTokenProvider.isAccessToken(token) } returns true
+            every { jwtTokenProvider.getUserId(token) } returns 1L
+            every { jwtTokenProvider.getRoles(token) } returns setOf("USER", "ADMIN")
+
+            // when
+            filter.doFilter(request, response, filterChain)
+
+            // then
+            verify { filterChain.doFilter(request, response) }
+            val authentication = SecurityContextHolder.getContext().authentication
+            assertThat(authentication).isNotNull
+            assertThat(authentication.principal).isEqualTo(1L)
+            assertThat(authentication.authorities.map { it.authority })
+                .containsExactlyInAnyOrder("ROLE_USER", "ROLE_ADMIN")
+        }
+
+        @Test
+        fun `should not set authentication when token is refresh token`() {
+            // given
+            val token = "refresh_token"
+            request.addHeader("Authorization", "Bearer $token")
+            every { jwtTokenProvider.validateToken(token) } returns true
+            every { jwtTokenProvider.isAccessToken(token) } returns false
+
+            // when
+            filter.doFilter(request, response, filterChain)
+
+            // then
+            verify { filterChain.doFilter(request, response) }
+            assertThat(SecurityContextHolder.getContext().authentication).isNull()
+        }
+
+        @Test
+        fun `should not set authentication when token is invalid`() {
+            // given
+            val token = "invalid_token"
+            request.addHeader("Authorization", "Bearer $token")
+            every { jwtTokenProvider.validateToken(token) } returns false
+
+            // when
+            filter.doFilter(request, response, filterChain)
+
+            // then
+            verify { filterChain.doFilter(request, response) }
+            assertThat(SecurityContextHolder.getContext().authentication).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 처리")
+    inner class ExceptionHandling {
+
+        @Test
+        fun `should set exception attribute when token expired`() {
+            // given
+            val token = "expired_token"
+            request.addHeader("Authorization", "Bearer $token")
+            every { jwtTokenProvider.validateToken(token) } throws TokenExpiredException("Token has expired")
+
+            // when
+            filter.doFilter(request, response, filterChain)
+
+            // then
+            val exception = request.getAttribute("exception")
+            assertThat(exception).isInstanceOf(TokenExpiredException::class.java)
+            verify { filterChain.doFilter(request, response) }
+        }
+
+        @Test
+        fun `should set exception attribute when token invalid`() {
+            // given
+            val token = "malformed_token"
+            request.addHeader("Authorization", "Bearer $token")
+            every { jwtTokenProvider.validateToken(token) } throws InvalidTokenException("Invalid token")
+
+            // when
+            filter.doFilter(request, response, filterChain)
+
+            // then
+            val exception = request.getAttribute("exception")
+            assertThat(exception).isInstanceOf(InvalidTokenException::class.java)
+            verify { filterChain.doFilter(request, response) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Bearer 토큰 파싱")
+    inner class BearerTokenParsing {
+
+        @Test
+        fun `should extract token from Bearer prefix`() {
+            // given
+            val token = "my_jwt_token"
+            request.addHeader("Authorization", "Bearer $token")
+            every { jwtTokenProvider.validateToken(token) } returns true
+            every { jwtTokenProvider.isAccessToken(token) } returns true
+            every { jwtTokenProvider.getUserId(token) } returns 42L
+            every { jwtTokenProvider.getRoles(token) } returns setOf("SCORER")
+
+            // when
+            filter.doFilter(request, response, filterChain)
+
+            // then
+            verify { jwtTokenProvider.validateToken(token) }
+            val authentication = SecurityContextHolder.getContext().authentication
+            assertThat(authentication?.principal).isEqualTo(42L)
+        }
+
+        @Test
+        fun `should handle Bearer prefix case sensitivity`() {
+            // given - "bearer" (lowercase) should not be recognized
+            request.addHeader("Authorization", "bearer some_token")
+
+            // when
+            filter.doFilter(request, response, filterChain)
+
+            // then - no token validation should occur
+            verify(exactly = 0) { jwtTokenProvider.validateToken(any()) }
+            assertThat(SecurityContextHolder.getContext().authentication).isNull()
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtTokenProviderTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtTokenProviderTest.kt
@@ -1,0 +1,310 @@
+package com.nextup.infrastructure.security.jwt
+
+import com.nextup.common.exception.InvalidTokenException
+import com.nextup.common.exception.TokenExpiredException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.*
+
+@DisplayName("JwtTokenProvider")
+class JwtTokenProviderTest {
+
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var jwtProperties: JwtProperties
+
+    // Base64 encoded secret key for testing (at least 256 bits for HS256)
+    private val testSecret = "dGhpcyBpcyBhIHNhbXBsZSBiYXNlNjQgZW5jb2RlZCBzZWNyZXQga2V5IGZvciBkZXZlbG9wbWVudCBvbmx5"
+    private val testIssuer = "nextup"
+
+    @BeforeEach
+    fun setUp() {
+        jwtProperties = JwtProperties(
+            secret = testSecret,
+            accessTokenExpiration = 1800000L, // 30 minutes
+            refreshTokenExpiration = 604800000L, // 7 days
+            issuer = testIssuer
+        )
+        jwtTokenProvider = JwtTokenProvider(jwtProperties)
+    }
+
+    @Nested
+    @DisplayName("createAccessToken")
+    inner class CreateAccessToken {
+
+        @Test
+        fun `should create valid access token`() {
+            // given
+            val userId = 1L
+            val email = "test@example.com"
+            val roles = setOf("USER", "ADMIN")
+
+            // when
+            val token = jwtTokenProvider.createAccessToken(userId, email, roles)
+
+            // then
+            assertThat(token).isNotBlank()
+            assertThat(jwtTokenProvider.validateToken(token)).isTrue()
+            assertThat(jwtTokenProvider.isAccessToken(token)).isTrue()
+        }
+
+        @Test
+        fun `should include correct claims in access token`() {
+            // given
+            val userId = 1L
+            val email = "test@example.com"
+            val roles = setOf("USER", "ADMIN")
+
+            // when
+            val token = jwtTokenProvider.createAccessToken(userId, email, roles)
+
+            // then
+            assertThat(jwtTokenProvider.getUserId(token)).isEqualTo(userId)
+            assertThat(jwtTokenProvider.getEmail(token)).isEqualTo(email)
+            assertThat(jwtTokenProvider.getRoles(token)).containsExactlyInAnyOrder("USER", "ADMIN")
+        }
+    }
+
+    @Nested
+    @DisplayName("createRefreshToken")
+    inner class CreateRefreshToken {
+
+        @Test
+        fun `should create valid refresh token`() {
+            // given
+            val userId = 1L
+
+            // when
+            val token = jwtTokenProvider.createRefreshToken(userId)
+
+            // then
+            assertThat(token).isNotBlank()
+            assertThat(jwtTokenProvider.validateToken(token)).isTrue()
+            assertThat(jwtTokenProvider.isRefreshToken(token)).isTrue()
+        }
+
+        @Test
+        fun `should include user id in refresh token`() {
+            // given
+            val userId = 1L
+
+            // when
+            val token = jwtTokenProvider.createRefreshToken(userId)
+
+            // then
+            assertThat(jwtTokenProvider.getUserId(token)).isEqualTo(userId)
+        }
+    }
+
+    @Nested
+    @DisplayName("getUserId")
+    inner class GetUserId {
+
+        @Test
+        fun `should extract user id from access token`() {
+            // given
+            val userId = 123L
+            val token = jwtTokenProvider.createAccessToken(userId, "test@example.com", setOf("USER"))
+
+            // when
+            val extractedUserId = jwtTokenProvider.getUserId(token)
+
+            // then
+            assertThat(extractedUserId).isEqualTo(userId)
+        }
+
+        @Test
+        fun `should extract user id from refresh token`() {
+            // given
+            val userId = 456L
+            val token = jwtTokenProvider.createRefreshToken(userId)
+
+            // when
+            val extractedUserId = jwtTokenProvider.getUserId(token)
+
+            // then
+            assertThat(extractedUserId).isEqualTo(userId)
+        }
+    }
+
+    @Nested
+    @DisplayName("getRoles")
+    inner class GetRoles {
+
+        @Test
+        fun `should extract roles from access token`() {
+            // given
+            val roles = setOf("USER", "ADMIN", "SCORER")
+            val token = jwtTokenProvider.createAccessToken(1L, "test@example.com", roles)
+
+            // when
+            val extractedRoles = jwtTokenProvider.getRoles(token)
+
+            // then
+            assertThat(extractedRoles).containsExactlyInAnyOrderElementsOf(roles)
+        }
+
+        @Test
+        fun `should return empty set when no roles in token`() {
+            // given
+            val token = jwtTokenProvider.createRefreshToken(1L)
+
+            // when
+            val extractedRoles = jwtTokenProvider.getRoles(token)
+
+            // then
+            assertThat(extractedRoles).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("validateToken")
+    inner class ValidateToken {
+
+        @Test
+        fun `should return true for valid token`() {
+            // given
+            val token = jwtTokenProvider.createAccessToken(1L, "test@example.com", setOf("USER"))
+
+            // when
+            val isValid = jwtTokenProvider.validateToken(token)
+
+            // then
+            assertThat(isValid).isTrue()
+        }
+
+        @Test
+        fun `should return false for invalid token`() {
+            // given
+            val invalidToken = "invalid.token.here"
+
+            // when
+            val isValid = jwtTokenProvider.validateToken(invalidToken)
+
+            // then
+            assertThat(isValid).isFalse()
+        }
+
+        @Test
+        fun `should return false for empty token`() {
+            // when
+            val isValid = jwtTokenProvider.validateToken("")
+
+            // then
+            assertThat(isValid).isFalse()
+        }
+
+        @Test
+        fun `should return false for token signed with different key`() {
+            // given
+            val differentSecret = "ZGlmZmVyZW50IHNlY3JldCBrZXkgZm9yIHRlc3RpbmcgdGhhdCBpcyBhdCBsZWFzdCAyNTYgYml0cw=="
+            val differentKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(differentSecret))
+
+            val tampered = Jwts.builder()
+                .subject("1")
+                .signWith(differentKey, Jwts.SIG.HS256)
+                .compact()
+
+            // when
+            val isValid = jwtTokenProvider.validateToken(tampered)
+
+            // then
+            assertThat(isValid).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("Token Expiration")
+    inner class TokenExpiration {
+
+        @Test
+        fun `should throw TokenExpiredException for expired token`() {
+            // given
+            val expiredProperties = JwtProperties(
+                secret = testSecret,
+                accessTokenExpiration = -1000L, // already expired
+                refreshTokenExpiration = 604800000L,
+                issuer = testIssuer
+            )
+            val providerWithExpiredToken = JwtTokenProvider(expiredProperties)
+            val expiredToken = providerWithExpiredToken.createAccessToken(1L, "test@example.com", setOf("USER"))
+
+            // when & then
+            assertThatThrownBy {
+                jwtTokenProvider.getUserId(expiredToken)
+            }.isInstanceOf(TokenExpiredException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("Invalid Token Handling")
+    inner class InvalidTokenHandling {
+
+        @Test
+        fun `should throw InvalidTokenException for malformed token`() {
+            // given
+            val malformedToken = "not.a.valid.jwt.token"
+
+            // when & then
+            assertThatThrownBy {
+                jwtTokenProvider.getUserId(malformedToken)
+            }.isInstanceOf(InvalidTokenException::class.java)
+        }
+
+        @Test
+        fun `should throw InvalidTokenException for empty token`() {
+            // when & then
+            assertThatThrownBy {
+                jwtTokenProvider.getUserId("")
+            }.isInstanceOf(InvalidTokenException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("isAccessToken / isRefreshToken")
+    inner class TokenTypeCheck {
+
+        @Test
+        fun `should correctly identify access token`() {
+            // given
+            val accessToken = jwtTokenProvider.createAccessToken(1L, "test@example.com", setOf("USER"))
+            val refreshToken = jwtTokenProvider.createRefreshToken(1L)
+
+            // then
+            assertThat(jwtTokenProvider.isAccessToken(accessToken)).isTrue()
+            assertThat(jwtTokenProvider.isAccessToken(refreshToken)).isFalse()
+        }
+
+        @Test
+        fun `should correctly identify refresh token`() {
+            // given
+            val accessToken = jwtTokenProvider.createAccessToken(1L, "test@example.com", setOf("USER"))
+            val refreshToken = jwtTokenProvider.createRefreshToken(1L)
+
+            // then
+            assertThat(jwtTokenProvider.isRefreshToken(refreshToken)).isTrue()
+            assertThat(jwtTokenProvider.isRefreshToken(accessToken)).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("getRefreshTokenExpiration")
+    inner class GetRefreshTokenExpiration {
+
+        @Test
+        fun `should return future expiration time`() {
+            // when
+            val expiration = jwtTokenProvider.getRefreshTokenExpiration()
+
+            // then
+            assertThat(expiration).isAfter(Instant.now())
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsServiceTest.kt
@@ -1,0 +1,340 @@
+package com.nextup.infrastructure.security.userdetails
+
+import com.nextup.core.domain.user.Role
+import com.nextup.core.domain.user.User
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import java.util.*
+
+@DisplayName("CustomUserDetailsService 테스트")
+class CustomUserDetailsServiceTest {
+
+    private lateinit var userJpaRepository: UserJpaRepository
+    private lateinit var service: CustomUserDetailsService
+
+    @BeforeEach
+    fun setUp() {
+        userJpaRepository = mockk()
+        service = CustomUserDetailsService(userJpaRepository)
+    }
+
+    private fun createTestUser(
+        email: String = "test@example.com",
+        password: String = "encoded_password",
+        nickname: String = "테스터",
+        id: Long = 1L,
+        isActive: Boolean = true
+    ): User {
+        val user = User.createLocalUser(
+            email = email,
+            encodedPassword = password,
+            nickname = nickname
+        )
+        // Set ID using reflection
+        val idField = user.javaClass.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(user, id)
+
+        if (!isActive) {
+            user.deactivate()
+        }
+
+        return user
+    }
+
+    @Nested
+    @DisplayName("이메일로 사용자 조회")
+    inner class LoadUserByUsername {
+
+        @Test
+        fun `should return user details when user exists`() {
+            // given
+            val user = createTestUser()
+            every { userJpaRepository.findByEmail("test@example.com") } returns user
+
+            // when
+            val result = service.loadUserByUsername("test@example.com")
+
+            // then
+            assertThat(result.username).isEqualTo("test@example.com")
+            assertThat(result.password).isEqualTo("encoded_password")
+            assertThat(result.isEnabled).isTrue()
+        }
+
+        @Test
+        fun `should throw UsernameNotFoundException when user not found`() {
+            // given
+            every { userJpaRepository.findByEmail("notfound@example.com") } returns null
+
+            // when & then
+            val exception = assertThrows<UsernameNotFoundException> {
+                service.loadUserByUsername("notfound@example.com")
+            }
+            assertThat(exception.message).contains("notfound@example.com")
+        }
+
+        @Test
+        fun `should return inactive user with locked account`() {
+            // given
+            val user = createTestUser(isActive = false)
+            every { userJpaRepository.findByEmail("test@example.com") } returns user
+
+            // when
+            val result = service.loadUserByUsername("test@example.com")
+
+            // then
+            assertThat(result.isAccountNonLocked).isFalse()
+            assertThat(result.isEnabled).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("ID로 사용자 조회")
+    inner class LoadUserById {
+
+        @Test
+        fun `should return user details when user exists`() {
+            // given
+            val user = createTestUser(id = 42L)
+            every { userJpaRepository.findById(42L) } returns Optional.of(user)
+
+            // when
+            val result = service.loadUserById(42L)
+
+            // then
+            assertThat(result.id).isEqualTo(42L)
+            assertThat(result.email).isEqualTo("test@example.com")
+            assertThat(result.nickname).isEqualTo("테스터")
+        }
+
+        @Test
+        fun `should throw UsernameNotFoundException when user not found`() {
+            // given
+            every { userJpaRepository.findById(999L) } returns Optional.empty()
+
+            // when & then
+            val exception = assertThrows<UsernameNotFoundException> {
+                service.loadUserById(999L)
+            }
+            assertThat(exception.message).contains("999")
+        }
+    }
+}
+
+@DisplayName("CustomUserDetails 테스트")
+class CustomUserDetailsTest {
+
+    private fun createTestUser(
+        email: String = "test@example.com",
+        password: String = "encoded_password",
+        nickname: String = "테스터",
+        id: Long = 1L,
+        isActive: Boolean = true
+    ): User {
+        val user = User.createLocalUser(
+            email = email,
+            encodedPassword = password,
+            nickname = nickname
+        )
+        // Set ID using reflection
+        val idField = user.javaClass.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(user, id)
+
+        if (!isActive) {
+            user.deactivate()
+        }
+
+        return user
+    }
+
+    @Nested
+    @DisplayName("UserDetails 인터페이스 구현")
+    inner class UserDetailsInterface {
+
+        @Test
+        fun `should return correct username as email`() {
+            // given
+            val user = createTestUser(email = "user@test.com")
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            assertThat(userDetails.username).isEqualTo("user@test.com")
+        }
+
+        @Test
+        fun `should return password`() {
+            // given
+            val user = createTestUser(password = "hashed_pwd")
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            assertThat(userDetails.password).isEqualTo("hashed_pwd")
+        }
+
+        @Test
+        fun `should return authorities with ROLE_ prefix`() {
+            // given
+            val user = createTestUser()
+            user.addRole(Role.ADMIN)
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            val authorities = userDetails.authorities.map { it.authority }
+            assertThat(authorities).contains("ROLE_USER", "ROLE_ADMIN")
+        }
+
+        @Test
+        fun `isAccountNonExpired should always return true`() {
+            // given
+            val user = createTestUser()
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            assertThat(userDetails.isAccountNonExpired).isTrue()
+        }
+
+        @Test
+        fun `isCredentialsNonExpired should always return true`() {
+            // given
+            val user = createTestUser()
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            assertThat(userDetails.isCredentialsNonExpired).isTrue()
+        }
+
+        @Test
+        fun `isAccountNonLocked should reflect user active status`() {
+            // given
+            val activeUser = createTestUser(isActive = true)
+            val inactiveUser = createTestUser(isActive = false)
+
+            // when
+            val activeUserDetails = CustomUserDetails.from(activeUser)
+            val inactiveUserDetails = CustomUserDetails.from(inactiveUser)
+
+            // then
+            assertThat(activeUserDetails.isAccountNonLocked).isTrue()
+            assertThat(inactiveUserDetails.isAccountNonLocked).isFalse()
+        }
+
+        @Test
+        fun `isEnabled should reflect user active status`() {
+            // given
+            val activeUser = createTestUser(isActive = true)
+            val inactiveUser = createTestUser(isActive = false)
+
+            // when
+            val activeUserDetails = CustomUserDetails.from(activeUser)
+            val inactiveUserDetails = CustomUserDetails.from(inactiveUser)
+
+            // then
+            assertThat(activeUserDetails.isEnabled).isTrue()
+            assertThat(inactiveUserDetails.isEnabled).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("추가 속성")
+    inner class AdditionalProperties {
+
+        @Test
+        fun `should expose user id`() {
+            // given
+            val user = createTestUser(id = 123L)
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            assertThat(userDetails.id).isEqualTo(123L)
+        }
+
+        @Test
+        fun `should expose user email`() {
+            // given
+            val user = createTestUser(email = "custom@email.com")
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            assertThat(userDetails.email).isEqualTo("custom@email.com")
+        }
+
+        @Test
+        fun `should expose user nickname`() {
+            // given
+            val user = createTestUser(nickname = "닉네임123")
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            assertThat(userDetails.nickname).isEqualTo("닉네임123")
+        }
+
+        @Test
+        fun `should expose user roles as Set`() {
+            // given
+            val user = createTestUser()
+            user.addRole(Role.SCORER)
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            assertThat(userDetails.roles).containsExactlyInAnyOrder(Role.USER, Role.SCORER)
+        }
+
+        @Test
+        fun `getRoleNames should return role names without ROLE_ prefix`() {
+            // given
+            val user = createTestUser()
+            user.addRole(Role.ADMIN)
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            val roleNames = userDetails.getRoleNames()
+            assertThat(roleNames).containsExactlyInAnyOrder("USER", "ADMIN")
+        }
+    }
+
+    @Nested
+    @DisplayName("팩토리 메소드")
+    inner class FactoryMethod {
+
+        @Test
+        fun `should create CustomUserDetails from User`() {
+            // given
+            val user = createTestUser()
+
+            // when
+            val userDetails = CustomUserDetails.from(user)
+
+            // then
+            assertThat(userDetails).isNotNull
+            assertThat(userDetails).isInstanceOf(CustomUserDetails::class.java)
+        }
+    }
+}

--- a/nextup-scorer/src/main/resources/application.yml
+++ b/nextup-scorer/src/main/resources/application.yml
@@ -24,6 +24,12 @@ spring:
     property-naming-strategy: SNAKE_CASE
     default-property-inclusion: non_null
 
+jwt:
+  secret: ${JWT_SECRET:dGhpcyBpcyBhIHNhbXBsZSBiYXNlNjQgZW5jb2RlZCBzZWNyZXQga2V5IGZvciBkZXZlbG9wbWVudCBvbmx5}
+  access-token-expiration: ${JWT_ACCESS_EXPIRATION:1800000}
+  refresh-token-expiration: ${JWT_REFRESH_EXPIRATION:604800000}
+  issuer: nextup
+
 logging:
   level:
     org.hibernate.SQL: DEBUG


### PR DESCRIPTION
## Summary

>- close #26

Spring Security 기반 JWT 인증 시스템을 구현했습니다. 멀티 모듈 구조를 지원하며, 각 모듈별 권한 설정이 가능합니다.

## Tasks

### Core Layer
- [x] AuthExceptions: 인증 관련 커스텀 예외 클래스 (InvalidTokenException, TokenExpiredException 등)
- [x] RefreshToken Entity: Rich Domain Model 패턴 적용 (`revoke()`, `validate()`, `isValid`)

### Infrastructure Layer
- [x] JwtProperties: JWT 설정 (secret, expiration)
- [x] JwtTokenProvider: Access/Refresh Token 생성 및 검증
- [x] JwtAuthenticationFilter: OncePerRequestFilter 기반 JWT 인증
- [x] CustomUserDetails/Service: Spring Security UserDetails 구현
- [x] AuthenticationService: 로그인, 토큰 갱신, 로그아웃, 전체 로그아웃
- [x] CustomAuthenticationEntryPoint: 401 오류 처리
- [x] CustomAccessDeniedHandler: 403 오류 처리
- [x] RefreshTokenRepository: Refresh Token 저장소

### API Layer
- [x] SecurityConfig (api): permitAll() 기본, /api/me/** 인증 필요
- [x] SecurityConfig (backoffice): 역할별 권한 (ADMIN, ASSOCIATION_ADMIN, LEAGUE_ADMIN, TEAM_MANAGER)
- [x] SecurityConfig (scorer): SCORER, ADMIN 역할 필요
- [x] AuthController: `/api/auth/login`, `/api/auth/refresh`, `/api/auth/logout`

### 테스트
- [x] JwtTokenProviderTest: 토큰 생성/검증/만료 테스트
- [x] AuthenticationServiceTest: 로그인/갱신/로그아웃 테스트
- [x] RefreshTokenTest: Entity 비즈니스 로직 테스트

## To Reviewer

- 공통 Security 컴포넌트는 `nextup-infrastructure/security/`에 위치합니다.
- 각 모듈은 SecurityConfig만 개별 정의합니다.
- JWT Secret은 환경변수 `JWT_SECRET`으로 관리합니다 (개발용 기본값 포함).
- Access Token: 30분, Refresh Token: 7일
- OAuth 로그인은 #27에서 구현 예정이며, 여기서는 JWT 인프라만 구축했습니다.
- AuthenticationService 커버리지: 98%, JwtTokenProvider: 68%