### PR TITLE
feat(#22): Competition CRUD 구현

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
@@ -1,0 +1,55 @@
+package com.nextup.api.controller.competition
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.competition.CompetitionResponse
+import com.nextup.infrastructure.service.competition.CompetitionService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 대회 API Controller (일반 사용자 - 조회 전용)
+ */
+@RestController
+@RequestMapping("/api/v1/competitions")
+class CompetitionController(
+    private val competitionService: CompetitionService
+) {
+
+    /**
+     * 진행 중인 대회 목록을 조회합니다.
+     */
+    @GetMapping
+    fun getCompetitions(): ApiResponse<List<CompetitionResponse>> {
+        val competitions = competitionService.getInProgress()
+        return ApiResponse.success(
+            competitions.map { CompetitionResponse.from(it) }
+        )
+    }
+
+    /**
+     * 대회 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getCompetition(
+        @PathVariable id: Long
+    ): ApiResponse<CompetitionResponse> {
+        val competition = competitionService.getByIdWithLeague(id)
+        return ApiResponse.success(CompetitionResponse.from(competition))
+    }
+
+    /**
+     * 리그별 대회 목록을 조회합니다.
+     */
+    @GetMapping("/by-league/{leagueId}")
+    fun getCompetitionsByLeague(
+        @PathVariable leagueId: Long
+    ): ApiResponse<List<CompetitionResponse>> {
+        val competitions = competitionService.getByLeagueId(leagueId)
+        return ApiResponse.success(
+            competitions.map { CompetitionResponse.from(it) }
+        )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/competition/CompetitionResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/competition/CompetitionResponse.kt
@@ -1,0 +1,45 @@
+package com.nextup.api.dto.competition
+
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import java.time.LocalDate
+
+/**
+ * 대회 응답 DTO (API - 조회 전용)
+ *
+ * 일반 사용자용 대회 정보
+ */
+data class CompetitionResponse(
+    val id: Long,
+    val leagueId: Long,
+    val leagueName: String,
+    val name: String,
+    val year: Int,
+    val season: Int,
+    val type: CompetitionType,
+    val startDate: LocalDate,
+    val endDate: LocalDate?,
+    val status: CompetitionStatus,
+    val description: String?,
+    val maxTeams: Int?
+) {
+    companion object {
+        fun from(competition: Competition): CompetitionResponse {
+            return CompetitionResponse(
+                id = competition.id,
+                leagueId = competition.league.id,
+                leagueName = competition.league.name,
+                name = competition.name,
+                year = competition.year,
+                season = competition.season,
+                type = competition.type,
+                startDate = competition.startDate,
+                endDate = competition.endDate,
+                status = competition.status,
+                description = competition.description,
+                maxTeams = competition.maxTeams
+            )
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerTest.kt
@@ -1,0 +1,201 @@
+package com.nextup.api.controller.competition
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.infrastructure.service.competition.CompetitionService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+
+@DisplayName("CompetitionController")
+class CompetitionControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var competitionService: CompetitionService
+    private lateinit var controller: CompetitionController
+
+    @BeforeEach
+    fun setUp() {
+        competitionService = mockk()
+        controller = CompetitionController(competitionService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/competitions")
+    inner class GetCompetitions {
+
+        @Test
+        fun `should return all in-progress competitions`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competitions = listOf(
+                createCompetition(1L, league, "2025 춘계대회", 2025, 1).apply { start() },
+                createCompetition(2L, league, "2025 하계대회", 2025, 2).apply { start() }
+            )
+            every { competitionService.getInProgress() } returns competitions
+
+            // when & then
+            mockMvc.perform(get("/api/v1/competitions"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].name").value("2025 춘계대회"))
+                .andExpect(jsonPath("$.data[0].status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.data[1].name").value("2025 하계대회"))
+        }
+
+        @Test
+        fun `should return empty list when no in-progress competitions`() {
+            // given
+            every { competitionService.getInProgress() } returns emptyList()
+
+            // when & then
+            mockMvc.perform(get("/api/v1/competitions"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(0))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/competitions/{id}")
+    inner class GetCompetition {
+
+        @Test
+        fun `should return competition detail when found`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(1L, league, "2025 춘계대회", 2025, 1)
+            every { competitionService.getByIdWithLeague(1L) } returns competition
+
+            // when & then
+            mockMvc.perform(get("/api/v1/competitions/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("2025 춘계대회"))
+                .andExpect(jsonPath("$.data.leagueId").value(1))
+                .andExpect(jsonPath("$.data.leagueName").value("1부 리그"))
+                .andExpect(jsonPath("$.data.year").value(2025))
+                .andExpect(jsonPath("$.data.season").value(1))
+                .andExpect(jsonPath("$.data.type").value("LEAGUE"))
+                .andExpect(jsonPath("$.data.status").value("SCHEDULED"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/competitions/by-league/{leagueId}")
+    inner class GetCompetitionsByLeague {
+
+        @Test
+        fun `should return competitions by league`() {
+            // given
+            val leagueId = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(leagueId, "1부 리그", association)
+            val competitions = listOf(
+                createCompetition(1L, league, "2025 춘계대회", 2025, 1),
+                createCompetition(2L, league, "2025 하계대회", 2025, 2),
+                createCompetition(3L, league, "2024 추계대회", 2024, 2)
+            )
+            every { competitionService.getByLeagueId(leagueId) } returns competitions
+
+            // when & then
+            mockMvc.perform(get("/api/v1/competitions/by-league/$leagueId"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].leagueId").value(leagueId))
+                .andExpect(jsonPath("$.data[0].name").value("2025 춘계대회"))
+                .andExpect(jsonPath("$.data[1].name").value("2025 하계대회"))
+                .andExpect(jsonPath("$.data[2].name").value("2024 추계대회"))
+        }
+
+        @Test
+        fun `should return empty list when league has no competitions`() {
+            // given
+            val leagueId = 1L
+            every { competitionService.getByLeagueId(leagueId) } returns emptyList()
+
+            // when & then
+            mockMvc.perform(get("/api/v1/competitions/by-league/$leagueId"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(0))
+        }
+    }
+
+    private fun createAssociation(id: Long, name: String): Association {
+        return Association(
+            name = name,
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createLeague(id: Long, name: String, association: Association): League {
+        return League(
+            association = association,
+            name = name,
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createCompetition(
+        id: Long,
+        league: League,
+        name: String,
+        year: Int,
+        season: Int
+    ): Competition {
+        return Competition(
+            league = league,
+            name = name,
+            year = year,
+            season = season,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(year, 3, 1),
+            endDate = null,
+            description = null,
+            maxTeams = null
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminController.kt
@@ -1,0 +1,157 @@
+package com.nextup.backoffice.controller.competition
+
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.backoffice.dto.competition.CompetitionAdminResponse
+import com.nextup.backoffice.dto.competition.CreateCompetitionRequest
+import com.nextup.backoffice.dto.competition.UpdateCompetitionRequest
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.infrastructure.service.competition.CompetitionService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+/**
+ * 대회 관리 API Controller (관리자용)
+ *
+ * 전체 권한: 생성, 조회, 수정, 삭제, 상태 변경
+ */
+@RestController
+@RequestMapping("/api/backoffice/competitions")
+class CompetitionAdminController(
+    private val competitionService: CompetitionService
+) {
+
+    /**
+     * 모든 대회 목록을 조회합니다.
+     */
+    @GetMapping
+    fun getAllCompetitions(
+        @RequestParam(required = false) status: CompetitionStatus?
+    ): ApiResponse<List<CompetitionAdminResponse>> {
+        val competitions = if (status != null) {
+            competitionService.getByStatus(status)
+        } else {
+            competitionService.getAll()
+        }
+        return ApiResponse.success(
+            competitions.map { CompetitionAdminResponse.from(it) }
+        )
+    }
+
+    /**
+     * 대회 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getCompetition(
+        @PathVariable id: Long
+    ): ApiResponse<CompetitionAdminResponse> {
+        val competition = competitionService.getByIdWithLeague(id)
+        return ApiResponse.success(CompetitionAdminResponse.from(competition))
+    }
+
+    /**
+     * 리그별 대회 목록을 조회합니다.
+     */
+    @GetMapping("/by-league/{leagueId}")
+    fun getCompetitionsByLeague(
+        @PathVariable leagueId: Long
+    ): ApiResponse<List<CompetitionAdminResponse>> {
+        val competitions = competitionService.getByLeagueId(leagueId)
+        return ApiResponse.success(
+            competitions.map { CompetitionAdminResponse.from(it) }
+        )
+    }
+
+    /**
+     * 대회를 생성합니다.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createCompetition(
+        @Valid @RequestBody request: CreateCompetitionRequest
+    ): ApiResponse<CompetitionAdminResponse> {
+        val competition = competitionService.create(
+            leagueId = request.leagueId,
+            name = request.name,
+            year = request.year,
+            season = request.season,
+            type = request.type,
+            startDate = request.startDate,
+            endDate = request.endDate,
+            description = request.description,
+            maxTeams = request.maxTeams
+        )
+        return ApiResponse.success(CompetitionAdminResponse.from(competition))
+    }
+
+    /**
+     * 대회 정보를 수정합니다.
+     */
+    @PutMapping("/{id}")
+    fun updateCompetition(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateCompetitionRequest
+    ): ApiResponse<CompetitionAdminResponse> {
+        val competition = competitionService.update(
+            id = id,
+            description = request.description,
+            endDate = request.endDate
+        )
+        return ApiResponse.success(CompetitionAdminResponse.from(competition))
+    }
+
+    /**
+     * 대회를 시작합니다.
+     */
+    @PostMapping("/{id}/start")
+    fun startCompetition(
+        @PathVariable id: Long
+    ): ApiResponse<CompetitionAdminResponse> {
+        val competition = competitionService.start(id)
+        return ApiResponse.success(CompetitionAdminResponse.from(competition))
+    }
+
+    /**
+     * 대회를 완료합니다.
+     */
+    @PostMapping("/{id}/complete")
+    fun completeCompetition(
+        @PathVariable id: Long,
+        @RequestBody(required = false) endDate: LocalDate?
+    ): ApiResponse<CompetitionAdminResponse> {
+        val competition = competitionService.complete(id, endDate ?: LocalDate.now())
+        return ApiResponse.success(CompetitionAdminResponse.from(competition))
+    }
+
+    /**
+     * 대회를 취소합니다.
+     */
+    @DeleteMapping("/{id}")
+    fun cancelCompetition(
+        @PathVariable id: Long
+    ): ApiResponse<CompetitionAdminResponse> {
+        val competition = competitionService.cancel(id)
+        return ApiResponse.success(CompetitionAdminResponse.from(competition))
+    }
+
+    /**
+     * 대회를 연기합니다.
+     */
+    @PostMapping("/{id}/postpone")
+    fun postponeCompetition(
+        @PathVariable id: Long
+    ): ApiResponse<CompetitionAdminResponse> {
+        val competition = competitionService.postpone(id)
+        return ApiResponse.success(CompetitionAdminResponse.from(competition))
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/league/LeagueAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/league/LeagueAdminController.kt
@@ -1,0 +1,108 @@
+package com.nextup.backoffice.controller.league
+
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.backoffice.dto.league.CreateLeagueRequest
+import com.nextup.backoffice.dto.league.LeagueAdminResponse
+import com.nextup.backoffice.dto.league.UpdateLeagueRequest
+import com.nextup.infrastructure.service.league.LeagueService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 리그 관리 API Controller (관리자용)
+ */
+@RestController
+@RequestMapping("/api/backoffice/leagues")
+class LeagueAdminController(
+    private val leagueService: LeagueService
+) {
+
+    /**
+     * 모든 리그 목록을 조회합니다 (비활성화 포함).
+     */
+    @GetMapping
+    fun getAllLeagues(): ApiResponse<List<LeagueAdminResponse>> {
+        val leagues = leagueService.getAll()
+        return ApiResponse.success(
+            leagues.map { LeagueAdminResponse.from(it) }
+        )
+    }
+
+    /**
+     * 리그 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getLeague(
+        @PathVariable id: Long
+    ): ApiResponse<LeagueAdminResponse> {
+        val league = leagueService.getById(id)
+        return ApiResponse.success(LeagueAdminResponse.from(league))
+    }
+
+    /**
+     * 리그를 생성합니다.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createLeague(
+        @Valid @RequestBody request: CreateLeagueRequest
+    ): ApiResponse<LeagueAdminResponse> {
+        val league = leagueService.create(
+            associationId = request.associationId,
+            name = request.name,
+            abbreviation = request.abbreviation,
+            foundedYear = request.foundedYear,
+            divisionLevel = request.divisionLevel,
+            description = request.description,
+            logoUrl = request.logoUrl
+        )
+        return ApiResponse.success(LeagueAdminResponse.from(league))
+    }
+
+    /**
+     * 리그 정보를 수정합니다.
+     */
+    @PutMapping("/{id}")
+    fun updateLeague(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateLeagueRequest
+    ): ApiResponse<LeagueAdminResponse> {
+        val league = leagueService.update(
+            id = id,
+            description = request.description,
+            logoUrl = request.logoUrl
+        )
+        return ApiResponse.success(LeagueAdminResponse.from(league))
+    }
+
+    /**
+     * 리그를 비활성화합니다.
+     */
+    @DeleteMapping("/{id}")
+    fun deactivateLeague(
+        @PathVariable id: Long
+    ): ApiResponse<LeagueAdminResponse> {
+        val league = leagueService.deactivate(id)
+        return ApiResponse.success(LeagueAdminResponse.from(league))
+    }
+
+    /**
+     * 리그를 활성화합니다.
+     */
+    @PostMapping("/{id}/activate")
+    fun activateLeague(
+        @PathVariable id: Long
+    ): ApiResponse<LeagueAdminResponse> {
+        val league = leagueService.activate(id)
+        return ApiResponse.success(LeagueAdminResponse.from(league))
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/CompetitionAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/CompetitionAdminResponse.kt
@@ -1,0 +1,54 @@
+package com.nextup.backoffice.dto.competition
+
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import java.time.Instant
+import java.time.LocalDate
+
+/**
+ * 대회 관리자 응답 DTO
+ *
+ * backoffice 모듈에 독립적으로 존재
+ */
+data class CompetitionAdminResponse(
+    val id: Long,
+    val leagueId: Long,
+    val leagueName: String,
+    val leagueAbbreviation: String?,
+    val name: String,
+    val year: Int,
+    val season: Int,
+    val type: CompetitionType,
+    val startDate: LocalDate,
+    val endDate: LocalDate?,
+    val status: CompetitionStatus,
+    val description: String?,
+    val maxTeams: Int?,
+    val isActive: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant
+) {
+    companion object {
+        fun from(competition: Competition): CompetitionAdminResponse {
+            return CompetitionAdminResponse(
+                id = competition.id,
+                leagueId = competition.league.id,
+                leagueName = competition.league.name,
+                leagueAbbreviation = competition.league.abbreviation,
+                name = competition.name,
+                year = competition.year,
+                season = competition.season,
+                type = competition.type,
+                startDate = competition.startDate,
+                endDate = competition.endDate,
+                status = competition.status,
+                description = competition.description,
+                maxTeams = competition.maxTeams,
+                isActive = competition.isActive,
+                createdAt = competition.createdAt,
+                updatedAt = competition.updatedAt
+            )
+        }
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/CompetitionRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/CompetitionRequest.kt
@@ -1,0 +1,49 @@
+package com.nextup.backoffice.dto.competition
+
+import com.nextup.core.domain.competition.CompetitionType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+import java.time.LocalDate
+
+/**
+ * 대회 생성 요청 DTO (관리자용)
+ */
+data class CreateCompetitionRequest(
+    @field:NotNull(message = "리그 ID는 필수입니다")
+    @field:Positive(message = "리그 ID는 양수여야 합니다")
+    val leagueId: Long,
+
+    @field:NotBlank(message = "대회 이름은 필수입니다")
+    @field:Size(max = 100, message = "대회 이름은 100자를 초과할 수 없습니다")
+    val name: String,
+
+    @field:NotNull(message = "연도는 필수입니다")
+    val year: Int,
+
+    val season: Int = 1,
+
+    @field:NotNull(message = "대회 타입은 필수입니다")
+    val type: CompetitionType,
+
+    @field:NotNull(message = "시작일은 필수입니다")
+    val startDate: LocalDate,
+
+    val endDate: LocalDate? = null,
+
+    @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    val description: String? = null,
+
+    val maxTeams: Int? = null
+)
+
+/**
+ * 대회 수정 요청 DTO (관리자용)
+ */
+data class UpdateCompetitionRequest(
+    @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    val description: String? = null,
+
+    val endDate: LocalDate? = null
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/league/LeagueAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/league/LeagueAdminResponse.kt
@@ -1,0 +1,43 @@
+package com.nextup.backoffice.dto.league
+
+import com.nextup.core.domain.league.League
+import java.time.Instant
+
+/**
+ * 리그 관리자 응답 DTO
+ *
+ * backoffice 모듈에 독립적으로 존재
+ */
+data class LeagueAdminResponse(
+    val id: Long,
+    val associationId: Long,
+    val associationName: String,
+    val name: String,
+    val abbreviation: String?,
+    val foundedYear: Int,
+    val divisionLevel: Int?,
+    val description: String?,
+    val logoUrl: String?,
+    val isActive: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant
+) {
+    companion object {
+        fun from(league: League): LeagueAdminResponse {
+            return LeagueAdminResponse(
+                id = league.id,
+                associationId = league.association.id,
+                associationName = league.association.name,
+                name = league.name,
+                abbreviation = league.abbreviation,
+                foundedYear = league.foundedYear,
+                divisionLevel = league.divisionLevel,
+                description = league.description,
+                logoUrl = league.logoUrl,
+                isActive = league.isActive,
+                createdAt = league.createdAt,
+                updatedAt = league.updatedAt
+            )
+        }
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/league/LeagueRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/league/LeagueRequest.kt
@@ -1,0 +1,44 @@
+package com.nextup.backoffice.dto.league
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+
+/**
+ * 리그 생성 요청 DTO
+ */
+data class CreateLeagueRequest(
+    @field:NotNull(message = "협회 ID는 필수입니다")
+    @field:Positive(message = "협회 ID는 양수여야 합니다")
+    val associationId: Long,
+
+    @field:NotBlank(message = "리그 이름은 필수입니다")
+    @field:Size(max = 100, message = "리그 이름은 100자를 초과할 수 없습니다")
+    val name: String,
+
+    @field:Size(max = 20, message = "약어는 20자를 초과할 수 없습니다")
+    val abbreviation: String? = null,
+
+    @field:NotNull(message = "창단 연도는 필수입니다")
+    val foundedYear: Int,
+
+    val divisionLevel: Int? = null,
+
+    @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    val description: String? = null,
+
+    @field:Size(max = 255, message = "로고 URL은 255자를 초과할 수 없습니다")
+    val logoUrl: String? = null
+)
+
+/**
+ * 리그 수정 요청 DTO
+ */
+data class UpdateLeagueRequest(
+    @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    val description: String? = null,
+
+    @field:Size(max = 255, message = "로고 URL은 255자를 초과할 수 없습니다")
+    val logoUrl: String? = null
+)

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminControllerTest.kt
@@ -1,0 +1,313 @@
+package com.nextup.backoffice.controller.competition
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.nextup.backoffice.dto.competition.CreateCompetitionRequest
+import com.nextup.backoffice.dto.competition.UpdateCompetitionRequest
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.infrastructure.service.competition.CompetitionService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+
+@DisplayName("CompetitionAdminController")
+class CompetitionAdminControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var competitionService: CompetitionService
+    private lateinit var controller: CompetitionAdminController
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        competitionService = mockk()
+        controller = CompetitionAdminController(competitionService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+        objectMapper = ObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @Nested
+    @DisplayName("GET /api/backoffice/competitions")
+    inner class GetAllCompetitions {
+
+        @Test
+        fun `should return all competitions`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competitions = listOf(
+                createCompetition(1L, "2025 춘계대회", league, 2025, 1),
+                createCompetition(2L, "2025 추계대회", league, 2025, 2)
+            )
+            every { competitionService.getAll() } returns competitions
+
+            // when & then
+            mockMvc.perform(get("/api/backoffice/competitions"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].name").value("2025 춘계대회"))
+                .andExpect(jsonPath("$.data[0].year").value(2025))
+                .andExpect(jsonPath("$.data[0].season").value(1))
+
+            verify(exactly = 1) { competitionService.getAll() }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/backoffice/competitions/{id}")
+    inner class GetCompetition {
+
+        @Test
+        fun `should return competition when found`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1)
+            every { competitionService.getByIdWithLeague(1L) } returns competition
+
+            // when & then
+            mockMvc.perform(get("/api/backoffice/competitions/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("2025 춘계대회"))
+                .andExpect(jsonPath("$.data.leagueId").value(1))
+                .andExpect(jsonPath("$.data.year").value(2025))
+                .andExpect(jsonPath("$.data.status").value("SCHEDULED"))
+
+            verify(exactly = 1) { competitionService.getByIdWithLeague(1L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/backoffice/competitions")
+    inner class CreateCompetition {
+
+        @Test
+        fun `should create competition with valid request`() {
+            // given
+            val request = CreateCompetitionRequest(
+                leagueId = 1L,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                endDate = LocalDate.of(2025, 6, 30),
+                description = "2025년 춘계 시즌",
+                maxTeams = 8
+            )
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1)
+
+            every {
+                competitionService.create(
+                    leagueId = 1L,
+                    name = "2025 춘계대회",
+                    year = 2025,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    endDate = LocalDate.of(2025, 6, 30),
+                    description = "2025년 춘계 시즌",
+                    maxTeams = 8
+                )
+            } returns competition
+
+            // when & then
+            mockMvc.perform(
+                post("/api/backoffice/competitions")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("2025 춘계대회"))
+
+            verify(exactly = 1) {
+                competitionService.create(
+                    leagueId = 1L,
+                    name = "2025 춘계대회",
+                    year = 2025,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    endDate = LocalDate.of(2025, 6, 30),
+                    description = "2025년 춘계 시즌",
+                    maxTeams = 8
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/backoffice/competitions/{id}")
+    inner class UpdateCompetition {
+
+        @Test
+        fun `should update competition with valid request`() {
+            // given
+            val request = UpdateCompetitionRequest(
+                description = "수정된 설명",
+                endDate = LocalDate.of(2025, 7, 15)
+            )
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1)
+
+            every {
+                competitionService.update(
+                    id = 1L,
+                    description = "수정된 설명",
+                    endDate = LocalDate.of(2025, 7, 15)
+                )
+            } returns competition
+
+            // when & then
+            mockMvc.perform(
+                put("/api/backoffice/competitions/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+
+            verify(exactly = 1) {
+                competitionService.update(
+                    id = 1L,
+                    description = "수정된 설명",
+                    endDate = LocalDate.of(2025, 7, 15)
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/backoffice/competitions/{id}/start")
+    inner class StartCompetition {
+
+        @Test
+        fun `should start competition`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1).apply {
+                start()
+            }
+            every { competitionService.start(1L) } returns competition
+
+            // when & then
+            mockMvc.perform(post("/api/backoffice/competitions/1/start"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+
+            verify(exactly = 1) { competitionService.start(1L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/backoffice/competitions/{id}/complete")
+    inner class CompleteCompetition {
+
+        @Test
+        fun `should complete competition`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1).apply {
+                start()
+                complete(LocalDate.now())
+            }
+            every { competitionService.complete(1L, any()) } returns competition
+
+            // when & then
+            mockMvc.perform(post("/api/backoffice/competitions/1/complete"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"))
+
+            verify(exactly = 1) { competitionService.complete(1L, any()) }
+        }
+    }
+
+    private fun createAssociation(id: Long, name: String): Association {
+        return Association(
+            name = name,
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createLeague(id: Long, name: String, association: Association): League {
+        return League(
+            association = association,
+            name = name,
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createCompetition(
+        id: Long,
+        name: String,
+        league: League,
+        year: Int,
+        season: Int
+    ): Competition {
+        return Competition(
+            league = league,
+            name = name,
+            year = year,
+            season = season,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(year, 3, 1),
+            endDate = LocalDate.of(year, 6, 30),
+            status = CompetitionStatus.SCHEDULED,
+            description = null,
+            maxTeams = null
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/league/LeagueAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/league/LeagueAdminControllerTest.kt
@@ -1,0 +1,270 @@
+package com.nextup.backoffice.controller.league
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.backoffice.dto.league.CreateLeagueRequest
+import com.nextup.backoffice.dto.league.UpdateLeagueRequest
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.infrastructure.service.league.LeagueService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("LeagueAdminController")
+class LeagueAdminControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var leagueService: LeagueService
+    private lateinit var controller: LeagueAdminController
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        leagueService = mockk()
+        controller = LeagueAdminController(leagueService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+        objectMapper = ObjectMapper()
+    }
+
+    @Nested
+    @DisplayName("GET /api/backoffice/leagues")
+    inner class GetAllLeagues {
+
+        @Test
+        fun `should return all leagues including inactive`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val leagues = listOf(
+                createLeague(1L, "1부 리그", association, true),
+                createLeague(2L, "2부 리그", association, false)
+            )
+            every { leagueService.getAll() } returns leagues
+
+            // when & then
+            mockMvc.perform(get("/api/backoffice/leagues"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].name").value("1부 리그"))
+                .andExpect(jsonPath("$.data[0].isActive").value(true))
+                .andExpect(jsonPath("$.data[1].isActive").value(false))
+
+            verify(exactly = 1) { leagueService.getAll() }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/backoffice/leagues/{id}")
+    inner class GetLeague {
+
+        @Test
+        fun `should return league when found`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association, true)
+            every { leagueService.getById(1L) } returns league
+
+            // when & then
+            mockMvc.perform(get("/api/backoffice/leagues/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("1부 리그"))
+                .andExpect(jsonPath("$.data.associationId").value(1))
+                .andExpect(jsonPath("$.data.isActive").value(true))
+
+            verify(exactly = 1) { leagueService.getById(1L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/backoffice/leagues")
+    inner class CreateLeague {
+
+        @Test
+        fun `should create league with valid request`() {
+            // given
+            val request = CreateLeagueRequest(
+                associationId = 1L,
+                name = "1부 리그",
+                abbreviation = "1st",
+                foundedYear = 2020,
+                divisionLevel = 1,
+                description = "최상위 리그",
+                logoUrl = "https://example.com/logo.png"
+            )
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association, true)
+
+            every {
+                leagueService.create(
+                    associationId = 1L,
+                    name = "1부 리그",
+                    abbreviation = "1st",
+                    foundedYear = 2020,
+                    divisionLevel = 1,
+                    description = "최상위 리그",
+                    logoUrl = "https://example.com/logo.png"
+                )
+            } returns league
+
+            // when & then
+            mockMvc.perform(
+                post("/api/backoffice/leagues")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("1부 리그"))
+
+            verify(exactly = 1) {
+                leagueService.create(
+                    associationId = 1L,
+                    name = "1부 리그",
+                    abbreviation = "1st",
+                    foundedYear = 2020,
+                    divisionLevel = 1,
+                    description = "최상위 리그",
+                    logoUrl = "https://example.com/logo.png"
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/backoffice/leagues/{id}")
+    inner class UpdateLeague {
+
+        @Test
+        fun `should update league with valid request`() {
+            // given
+            val request = UpdateLeagueRequest(
+                description = "수정된 설명",
+                logoUrl = "https://example.com/new-logo.png"
+            )
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association, true)
+
+            every {
+                leagueService.update(
+                    id = 1L,
+                    description = "수정된 설명",
+                    logoUrl = "https://example.com/new-logo.png"
+                )
+            } returns league
+
+            // when & then
+            mockMvc.perform(
+                put("/api/backoffice/leagues/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+
+            verify(exactly = 1) {
+                leagueService.update(
+                    id = 1L,
+                    description = "수정된 설명",
+                    logoUrl = "https://example.com/new-logo.png"
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/backoffice/leagues/{id}")
+    inner class DeactivateLeague {
+
+        @Test
+        fun `should deactivate league`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association, false)
+            every { leagueService.deactivate(1L) } returns league
+
+            // when & then
+            mockMvc.perform(delete("/api/backoffice/leagues/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.isActive").value(false))
+
+            verify(exactly = 1) { leagueService.deactivate(1L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/backoffice/leagues/{id}/activate")
+    inner class ActivateLeague {
+
+        @Test
+        fun `should activate league`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association, true)
+            every { leagueService.activate(1L) } returns league
+
+            // when & then
+            mockMvc.perform(post("/api/backoffice/leagues/1/activate"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.isActive").value(true))
+
+            verify(exactly = 1) { leagueService.activate(1L) }
+        }
+    }
+
+    private fun createAssociation(id: Long, name: String): Association {
+        return Association(
+            name = name,
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createLeague(id: Long, name: String, association: Association, isActive: Boolean): League {
+        return League(
+            association = association,
+            name = name,
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+
+            if (!isActive) {
+                this.deactivate()
+            }
+        }
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/CompetitionExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/CompetitionExceptions.kt
@@ -1,0 +1,19 @@
+package com.nextup.common.exception
+
+/**
+ * 대회를 찾을 수 없을 때 발생하는 예외
+ */
+class CompetitionNotFoundException(competitionId: Long) :
+    NotFoundException(
+        "COMPETITION_NOT_FOUND",
+        "Competition not found: $competitionId"
+    )
+
+/**
+ * 대회 상태가 유효하지 않을 때 발생하는 예외
+ */
+class InvalidCompetitionStateException(message: String) :
+    BusinessException(
+        "INVALID_COMPETITION_STATE",
+        message
+    )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/competition/CompetitionRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/competition/CompetitionRepository.kt
@@ -1,0 +1,36 @@
+package com.nextup.infrastructure.repository.competition
+
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface CompetitionRepository : JpaRepository<Competition, Long> {
+
+    /**
+     * 리그별 대회 목록 조회
+     */
+    fun findByLeagueId(leagueId: Long): List<Competition>
+
+    /**
+     * 리그 + 연도 + 시즌으로 대회 조회
+     */
+    fun findByLeagueIdAndYearAndSeason(leagueId: Long, year: Int, season: Int): Competition?
+
+    /**
+     * 특정 상태의 대회 목록 조회
+     */
+    fun findByStatus(status: CompetitionStatus): List<Competition>
+
+    /**
+     * 진행 중인 대회 목록 조회
+     */
+    @Query("SELECT c FROM Competition c WHERE c.status = 'IN_PROGRESS'")
+    fun findInProgressCompetitions(): List<Competition>
+
+    /**
+     * 리그와 함께 대회 조회 (N+1 방지)
+     */
+    @Query("SELECT c FROM Competition c JOIN FETCH c.league WHERE c.id = :id")
+    fun findByIdWithLeague(id: Long): Competition?
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/competition/CompetitionService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/competition/CompetitionService.kt
@@ -1,0 +1,183 @@
+package com.nextup.infrastructure.service.competition
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidCompetitionStateException
+import com.nextup.common.exception.LeagueNotFoundException
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.infrastructure.repository.competition.CompetitionRepository
+import com.nextup.infrastructure.repository.league.LeagueRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+/**
+ * 대회 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class CompetitionService(
+    private val competitionRepository: CompetitionRepository,
+    private val leagueRepository: LeagueRepository
+) {
+
+    /**
+     * 대회를 생성합니다.
+     */
+    @Transactional
+    fun create(
+        leagueId: Long,
+        name: String,
+        year: Int,
+        season: Int = 1,
+        type: CompetitionType = CompetitionType.LEAGUE,
+        startDate: LocalDate,
+        endDate: LocalDate? = null,
+        description: String? = null,
+        maxTeams: Int? = null
+    ): Competition {
+        // 리그 존재 확인
+        val league = leagueRepository.findById(leagueId)
+            .orElseThrow { LeagueNotFoundException(leagueId) }
+
+        // 동일한 리그, 연도, 시즌의 대회가 이미 존재하는지 확인
+        competitionRepository.findByLeagueIdAndYearAndSeason(leagueId, year, season)?.let {
+            throw InvalidCompetitionStateException(
+                "Competition already exists for league $leagueId, year $year, season $season"
+            )
+        }
+
+        val competition = Competition(
+            league = league,
+            name = name,
+            year = year,
+            season = season,
+            type = type,
+            startDate = startDate,
+            endDate = endDate,
+            description = description,
+            maxTeams = maxTeams
+        )
+
+        return competitionRepository.save(competition)
+    }
+
+    /**
+     * ID로 대회를 조회합니다.
+     */
+    fun getById(id: Long): Competition {
+        return competitionRepository.findById(id)
+            .orElseThrow { CompetitionNotFoundException(id) }
+    }
+
+    /**
+     * ID로 대회를 조회합니다 (League 함께 조회).
+     */
+    fun getByIdWithLeague(id: Long): Competition {
+        return competitionRepository.findByIdWithLeague(id)
+            ?: throw CompetitionNotFoundException(id)
+    }
+
+    /**
+     * 모든 대회를 조회합니다.
+     */
+    fun getAll(): List<Competition> {
+        return competitionRepository.findAll()
+    }
+
+    /**
+     * 리그별 대회 목록을 조회합니다.
+     */
+    fun getByLeagueId(leagueId: Long): List<Competition> {
+        return competitionRepository.findByLeagueId(leagueId)
+    }
+
+    /**
+     * 진행 중인 대회 목록을 조회합니다.
+     */
+    fun getInProgress(): List<Competition> {
+        return competitionRepository.findInProgressCompetitions()
+    }
+
+    /**
+     * 특정 상태의 대회 목록을 조회합니다.
+     */
+    fun getByStatus(status: CompetitionStatus): List<Competition> {
+        return competitionRepository.findByStatus(status)
+    }
+
+    /**
+     * 대회 정보를 수정합니다.
+     */
+    @Transactional
+    fun update(
+        id: Long,
+        description: String?,
+        endDate: LocalDate?
+    ): Competition {
+        val competition = getById(id)
+
+        description?.let { competition.description = it }
+        endDate?.let { competition.endDate = it }
+
+        return competition
+    }
+
+    /**
+     * 대회를 시작합니다.
+     */
+    @Transactional
+    fun start(id: Long): Competition {
+        val competition = getById(id)
+        try {
+            competition.start()
+        } catch (e: IllegalArgumentException) {
+            throw InvalidCompetitionStateException(e.message ?: "Cannot start competition")
+        }
+        return competition
+    }
+
+    /**
+     * 대회를 완료합니다.
+     */
+    @Transactional
+    fun complete(id: Long, endDate: LocalDate = LocalDate.now()): Competition {
+        val competition = getById(id)
+        try {
+            competition.complete(endDate)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidCompetitionStateException(e.message ?: "Cannot complete competition")
+        }
+        return competition
+    }
+
+    /**
+     * 대회를 취소합니다.
+     */
+    @Transactional
+    fun cancel(id: Long): Competition {
+        val competition = getById(id)
+        try {
+            competition.cancel()
+        } catch (e: IllegalArgumentException) {
+            throw InvalidCompetitionStateException(e.message ?: "Cannot cancel competition")
+        }
+        return competition
+    }
+
+    /**
+     * 대회를 연기합니다.
+     */
+    @Transactional
+    fun postpone(id: Long): Competition {
+        val competition = getById(id)
+        if (competition.status != CompetitionStatus.SCHEDULED) {
+            throw InvalidCompetitionStateException("Only scheduled competitions can be postponed")
+        }
+        competition.status = CompetitionStatus.POSTPONED
+        return competition
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/competition/CompetitionServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/competition/CompetitionServiceTest.kt
@@ -1,0 +1,387 @@
+package com.nextup.infrastructure.service.competition
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidCompetitionStateException
+import com.nextup.common.exception.LeagueNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.infrastructure.repository.competition.CompetitionRepository
+import com.nextup.infrastructure.repository.league.LeagueRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.Optional
+
+@DisplayName("CompetitionService")
+class CompetitionServiceTest {
+
+    private lateinit var competitionRepository: CompetitionRepository
+    private lateinit var leagueRepository: LeagueRepository
+    private lateinit var competitionService: CompetitionService
+
+    @BeforeEach
+    fun setUp() {
+        competitionRepository = mockk()
+        leagueRepository = mockk()
+        competitionService = CompetitionService(competitionRepository, leagueRepository)
+    }
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+
+        @Test
+        fun `should create competition successfully`() {
+            // given
+            val leagueId = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(leagueId, "1부 리그", association)
+            val name = "2025 춘계대회"
+            val year = 2025
+            val season = 1
+            val startDate = LocalDate.of(2025, 3, 1)
+
+            every { leagueRepository.findById(leagueId) } returns Optional.of(league)
+            every { competitionRepository.findByLeagueIdAndYearAndSeason(leagueId, year, season) } returns null
+            every { competitionRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = competitionService.create(
+                leagueId = leagueId,
+                name = name,
+                year = year,
+                season = season,
+                type = CompetitionType.LEAGUE,
+                startDate = startDate,
+                description = "2025년 춘계 정규 리그"
+            )
+
+            // then
+            assertThat(result.name).isEqualTo(name)
+            assertThat(result.year).isEqualTo(year)
+            assertThat(result.season).isEqualTo(season)
+            assertThat(result.league).isEqualTo(league)
+            assertThat(result.status).isEqualTo(CompetitionStatus.SCHEDULED)
+            verify { competitionRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when league not found`() {
+            // given
+            val leagueId = 999L
+            every { leagueRepository.findById(leagueId) } returns Optional.empty()
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.create(
+                    leagueId = leagueId,
+                    name = "2025 춘계대회",
+                    year = 2025,
+                    startDate = LocalDate.of(2025, 3, 1)
+                )
+            }.isInstanceOf(LeagueNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when competition already exists for same league year season`() {
+            // given
+            val leagueId = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(leagueId, "1부 리그", association)
+            val year = 2025
+            val season = 1
+            val existingCompetition = createCompetition(1L, league, "2025 춘계대회", year, season)
+
+            every { leagueRepository.findById(leagueId) } returns Optional.of(league)
+            every { competitionRepository.findByLeagueIdAndYearAndSeason(leagueId, year, season) } returns existingCompetition
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.create(
+                    leagueId = leagueId,
+                    name = "2025 춘계대회",
+                    year = year,
+                    season = season,
+                    startDate = LocalDate.of(2025, 3, 1)
+                )
+            }.isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getById")
+    inner class GetById {
+
+        @Test
+        fun `should return competition when found`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1)
+            every { competitionRepository.findById(id) } returns Optional.of(competition)
+
+            // when
+            val result = competitionService.getById(id)
+
+            // then
+            assertThat(result.id).isEqualTo(id)
+            assertThat(result.name).isEqualTo("2025 춘계대회")
+        }
+
+        @Test
+        fun `should throw exception when not found`() {
+            // given
+            val id = 999L
+            every { competitionRepository.findById(id) } returns Optional.empty()
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.getById(id)
+            }.isInstanceOf(CompetitionNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getInProgress")
+    inner class GetInProgress {
+
+        @Test
+        fun `should return only in-progress competitions`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competitions = listOf(
+                createCompetition(1L, league, "2025 춘계대회", 2025, 1).apply { start() },
+                createCompetition(2L, league, "2025 하계대회", 2025, 2).apply { start() }
+            )
+            every { competitionRepository.findInProgressCompetitions() } returns competitions
+
+            // when
+            val result = competitionService.getInProgress()
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result.all { it.status == CompetitionStatus.IN_PROGRESS }).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("getByLeagueId")
+    inner class GetByLeagueId {
+
+        @Test
+        fun `should return competitions by league`() {
+            // given
+            val leagueId = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(leagueId, "1부 리그", association)
+            val competitions = listOf(
+                createCompetition(1L, league, "2025 춘계대회", 2025, 1),
+                createCompetition(2L, league, "2025 하계대회", 2025, 2)
+            )
+            every { competitionRepository.findByLeagueId(leagueId) } returns competitions
+
+            // when
+            val result = competitionService.getByLeagueId(leagueId)
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result.all { it.league.id == leagueId }).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("start")
+    inner class Start {
+
+        @Test
+        fun `should start scheduled competition`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1)
+            every { competitionRepository.findById(id) } returns Optional.of(competition)
+
+            // when
+            val result = competitionService.start(id)
+
+            // then
+            assertThat(result.status).isEqualTo(CompetitionStatus.IN_PROGRESS)
+        }
+
+        @Test
+        fun `should throw exception when competition is not scheduled`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1).apply { start() }
+            every { competitionRepository.findById(id) } returns Optional.of(competition)
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.start(id)
+            }.isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("complete")
+    inner class Complete {
+
+        @Test
+        fun `should complete in-progress competition`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1).apply { start() }
+            val endDate = LocalDate.of(2025, 5, 31)
+            every { competitionRepository.findById(id) } returns Optional.of(competition)
+
+            // when
+            val result = competitionService.complete(id, endDate)
+
+            // then
+            assertThat(result.status).isEqualTo(CompetitionStatus.COMPLETED)
+            assertThat(result.endDate).isEqualTo(endDate)
+        }
+
+        @Test
+        fun `should throw exception when competition is not in progress`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1)
+            every { competitionRepository.findById(id) } returns Optional.of(competition)
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.complete(id)
+            }.isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("cancel")
+    inner class Cancel {
+
+        @Test
+        fun `should cancel scheduled competition`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1)
+            every { competitionRepository.findById(id) } returns Optional.of(competition)
+
+            // when
+            val result = competitionService.cancel(id)
+
+            // then
+            assertThat(result.status).isEqualTo(CompetitionStatus.CANCELLED)
+        }
+
+        @Test
+        fun `should cancel in-progress competition`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1).apply { start() }
+            every { competitionRepository.findById(id) } returns Optional.of(competition)
+
+            // when
+            val result = competitionService.cancel(id)
+
+            // then
+            assertThat(result.status).isEqualTo(CompetitionStatus.CANCELLED)
+        }
+
+        @Test
+        fun `should throw exception when competition is already completed`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1).apply {
+                start()
+                complete()
+            }
+            every { competitionRepository.findById(id) } returns Optional.of(competition)
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.cancel(id)
+            }.isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+    }
+
+    private fun createAssociation(id: Long, name: String): Association {
+        return Association(
+            name = name,
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createLeague(id: Long, name: String, association: Association): League {
+        return League(
+            association = association,
+            name = name,
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createCompetition(
+        id: Long,
+        league: League,
+        name: String,
+        year: Int,
+        season: Int
+    ): Competition {
+        return Competition(
+            league = league,
+            name = name,
+            year = year,
+            season = season,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(year, 3, 1),
+            endDate = null,
+            description = null,
+            maxTeams = null
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/competition/CompetitionScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/competition/CompetitionScorerController.kt
@@ -1,0 +1,149 @@
+package com.nextup.scorer.controller.competition
+
+import com.nextup.infrastructure.service.competition.CompetitionService
+import com.nextup.scorer.dto.common.ApiResponse
+import com.nextup.scorer.dto.competition.CompetitionScorerResponse
+import com.nextup.scorer.dto.competition.CreateCompetitionRequest
+import com.nextup.scorer.dto.competition.UpdateCompetitionRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+/**
+ * 대회 관리 API Controller (기록원용)
+ *
+ * 대회 생성, 수정, 삭제 및 상태 변경 권한
+ */
+@RestController
+@RequestMapping("/api/scorer/competitions")
+class CompetitionScorerController(
+    private val competitionService: CompetitionService
+) {
+
+    /**
+     * 모든 대회 목록을 조회합니다.
+     */
+    @GetMapping
+    fun getAllCompetitions(): ApiResponse<List<CompetitionScorerResponse>> {
+        val competitions = competitionService.getAll()
+        return ApiResponse.success(
+            competitions.map { CompetitionScorerResponse.from(it) }
+        )
+    }
+
+    /**
+     * 대회 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getCompetition(
+        @PathVariable id: Long
+    ): ApiResponse<CompetitionScorerResponse> {
+        val competition = competitionService.getByIdWithLeague(id)
+        return ApiResponse.success(CompetitionScorerResponse.from(competition))
+    }
+
+    /**
+     * 리그별 대회 목록을 조회합니다.
+     */
+    @GetMapping("/by-league/{leagueId}")
+    fun getCompetitionsByLeague(
+        @PathVariable leagueId: Long
+    ): ApiResponse<List<CompetitionScorerResponse>> {
+        val competitions = competitionService.getByLeagueId(leagueId)
+        return ApiResponse.success(
+            competitions.map { CompetitionScorerResponse.from(it) }
+        )
+    }
+
+    /**
+     * 대회를 생성합니다.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createCompetition(
+        @Valid @RequestBody request: CreateCompetitionRequest
+    ): ApiResponse<CompetitionScorerResponse> {
+        val competition = competitionService.create(
+            leagueId = request.leagueId,
+            name = request.name,
+            year = request.year,
+            season = request.season,
+            type = request.type,
+            startDate = request.startDate,
+            endDate = request.endDate,
+            description = request.description,
+            maxTeams = request.maxTeams
+        )
+        return ApiResponse.success(CompetitionScorerResponse.from(competition))
+    }
+
+    /**
+     * 대회 정보를 수정합니다.
+     */
+    @PutMapping("/{id}")
+    fun updateCompetition(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateCompetitionRequest
+    ): ApiResponse<CompetitionScorerResponse> {
+        val competition = competitionService.update(
+            id = id,
+            description = request.description,
+            endDate = request.endDate
+        )
+        return ApiResponse.success(CompetitionScorerResponse.from(competition))
+    }
+
+    /**
+     * 대회를 시작합니다.
+     */
+    @PostMapping("/{id}/start")
+    fun startCompetition(
+        @PathVariable id: Long
+    ): ApiResponse<CompetitionScorerResponse> {
+        val competition = competitionService.start(id)
+        return ApiResponse.success(CompetitionScorerResponse.from(competition))
+    }
+
+    /**
+     * 대회를 완료합니다.
+     */
+    @PostMapping("/{id}/complete")
+    fun completeCompetition(
+        @PathVariable id: Long,
+        @RequestBody(required = false) endDate: LocalDate?
+    ): ApiResponse<CompetitionScorerResponse> {
+        val competition = competitionService.complete(id, endDate ?: LocalDate.now())
+        return ApiResponse.success(CompetitionScorerResponse.from(competition))
+    }
+
+    /**
+     * 대회를 취소합니다.
+     */
+    @DeleteMapping("/{id}")
+    fun cancelCompetition(
+        @PathVariable id: Long
+    ): ApiResponse<CompetitionScorerResponse> {
+        val competition = competitionService.cancel(id)
+        return ApiResponse.success(CompetitionScorerResponse.from(competition))
+    }
+
+    /**
+     * 대회를 연기합니다.
+     */
+    @PostMapping("/{id}/postpone")
+    fun postponeCompetition(
+        @PathVariable id: Long
+    ): ApiResponse<CompetitionScorerResponse> {
+        val competition = competitionService.postpone(id)
+        return ApiResponse.success(CompetitionScorerResponse.from(competition))
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/competition/CompetitionRequest.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/competition/CompetitionRequest.kt
@@ -1,0 +1,49 @@
+package com.nextup.scorer.dto.competition
+
+import com.nextup.core.domain.competition.CompetitionType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+import java.time.LocalDate
+
+/**
+ * 대회 생성 요청 DTO (Scorer용)
+ */
+data class CreateCompetitionRequest(
+    @field:NotNull(message = "리그 ID는 필수입니다")
+    @field:Positive(message = "리그 ID는 양수여야 합니다")
+    val leagueId: Long,
+
+    @field:NotBlank(message = "대회 이름은 필수입니다")
+    @field:Size(max = 100, message = "대회 이름은 100자를 초과할 수 없습니다")
+    val name: String,
+
+    @field:NotNull(message = "연도는 필수입니다")
+    val year: Int,
+
+    val season: Int = 1,
+
+    @field:NotNull(message = "대회 타입은 필수입니다")
+    val type: CompetitionType,
+
+    @field:NotNull(message = "시작일은 필수입니다")
+    val startDate: LocalDate,
+
+    val endDate: LocalDate? = null,
+
+    @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    val description: String? = null,
+
+    val maxTeams: Int? = null
+)
+
+/**
+ * 대회 수정 요청 DTO (Scorer용)
+ */
+data class UpdateCompetitionRequest(
+    @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
+    val description: String? = null,
+
+    val endDate: LocalDate? = null
+)

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/competition/CompetitionScorerResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/competition/CompetitionScorerResponse.kt
@@ -1,0 +1,52 @@
+package com.nextup.scorer.dto.competition
+
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import java.time.Instant
+import java.time.LocalDate
+
+/**
+ * 대회 응답 DTO (Scorer용)
+ *
+ * 기록원이 필요한 대회 관리 정보 포함
+ */
+data class CompetitionScorerResponse(
+    val id: Long,
+    val leagueId: Long,
+    val leagueName: String,
+    val name: String,
+    val year: Int,
+    val season: Int,
+    val type: CompetitionType,
+    val startDate: LocalDate,
+    val endDate: LocalDate?,
+    val status: CompetitionStatus,
+    val description: String?,
+    val maxTeams: Int?,
+    val isActive: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant
+) {
+    companion object {
+        fun from(competition: Competition): CompetitionScorerResponse {
+            return CompetitionScorerResponse(
+                id = competition.id,
+                leagueId = competition.league.id,
+                leagueName = competition.league.name,
+                name = competition.name,
+                year = competition.year,
+                season = competition.season,
+                type = competition.type,
+                startDate = competition.startDate,
+                endDate = competition.endDate,
+                status = competition.status,
+                description = competition.description,
+                maxTeams = competition.maxTeams,
+                isActive = competition.isActive,
+                createdAt = competition.createdAt,
+                updatedAt = competition.updatedAt
+            )
+        }
+    }
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/competition/CompetitionScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/competition/CompetitionScorerControllerTest.kt
@@ -1,0 +1,307 @@
+package com.nextup.scorer.controller.competition
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.infrastructure.service.competition.CompetitionService
+import com.nextup.scorer.dto.competition.CreateCompetitionRequest
+import com.nextup.scorer.dto.competition.UpdateCompetitionRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+
+@DisplayName("CompetitionScorerController")
+class CompetitionScorerControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var competitionService: CompetitionService
+    private lateinit var controller: CompetitionScorerController
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        competitionService = mockk()
+        controller = CompetitionScorerController(competitionService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+        objectMapper = ObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @Nested
+    @DisplayName("GET /api/scorer/competitions")
+    inner class GetAllCompetitions {
+
+        @Test
+        fun `should return all competitions when no filter provided`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competitions = listOf(
+                createCompetition(1L, "2025 춘계대회", league, 2025, 1),
+                createCompetition(2L, "2025 추계대회", league, 2025, 2)
+            )
+            every { competitionService.getAll() } returns competitions
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/competitions"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].name").value("2025 춘계대회"))
+                .andExpect(jsonPath("$.data[0].leagueName").value("1부 리그"))
+
+            verify(exactly = 1) { competitionService.getAll() }
+        }
+
+        @Test
+        fun `should return competitions filtered by leagueId`() {
+            // given
+            val leagueId = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(leagueId, "1부 리그", association)
+            val competitions = listOf(
+                createCompetition(1L, "2025 춘계대회", league, 2025, 1)
+            )
+            every { competitionService.getByLeagueId(leagueId) } returns competitions
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/competitions/by-league/$leagueId"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].leagueId").value(leagueId))
+
+            verify(exactly = 1) { competitionService.getByLeagueId(leagueId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/scorer/competitions/{id}")
+    inner class GetCompetition {
+
+        @Test
+        fun `should return competition when found`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1)
+            every { competitionService.getByIdWithLeague(1L) } returns competition
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/competitions/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("2025 춘계대회"))
+                .andExpect(jsonPath("$.data.leagueId").value(1))
+                .andExpect(jsonPath("$.data.status").value("SCHEDULED"))
+
+            verify(exactly = 1) { competitionService.getByIdWithLeague(1L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/competitions")
+    inner class CreateCompetition {
+
+        @Test
+        fun `should create competition with valid request`() {
+            // given
+            val request = CreateCompetitionRequest(
+                leagueId = 1L,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                endDate = LocalDate.of(2025, 6, 30),
+                description = "2025년 춘계 시즌",
+                maxTeams = 8
+            )
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1)
+
+            every {
+                competitionService.create(
+                    leagueId = 1L,
+                    name = "2025 춘계대회",
+                    year = 2025,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    endDate = LocalDate.of(2025, 6, 30),
+                    description = "2025년 춘계 시즌",
+                    maxTeams = 8
+                )
+            } returns competition
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/competitions")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("2025 춘계대회"))
+
+            verify(exactly = 1) {
+                competitionService.create(
+                    leagueId = 1L,
+                    name = "2025 춘계대회",
+                    year = 2025,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    endDate = LocalDate.of(2025, 6, 30),
+                    description = "2025년 춘계 시즌",
+                    maxTeams = 8
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/scorer/competitions/{id}")
+    inner class UpdateCompetition {
+
+        @Test
+        fun `should update competition with valid request`() {
+            // given
+            val request = UpdateCompetitionRequest(
+                description = "수정된 설명",
+                endDate = LocalDate.of(2025, 7, 15)
+            )
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1)
+
+            every {
+                competitionService.update(
+                    id = 1L,
+                    description = "수정된 설명",
+                    endDate = LocalDate.of(2025, 7, 15)
+                )
+            } returns competition
+
+            // when & then
+            mockMvc.perform(
+                put("/api/scorer/competitions/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+
+            verify(exactly = 1) {
+                competitionService.update(
+                    id = 1L,
+                    description = "수정된 설명",
+                    endDate = LocalDate.of(2025, 7, 15)
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/competitions/{id}/start")
+    inner class StartCompetition {
+
+        @Test
+        fun `should start competition`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1).apply {
+                start()
+            }
+            every { competitionService.start(1L) } returns competition
+
+            // when & then
+            mockMvc.perform(post("/api/scorer/competitions/1/start"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+
+            verify(exactly = 1) { competitionService.start(1L) }
+        }
+    }
+
+    private fun createAssociation(id: Long, name: String): Association {
+        return Association(
+            name = name,
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createLeague(id: Long, name: String, association: Association): League {
+        return League(
+            association = association,
+            name = name,
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createCompetition(
+        id: Long,
+        name: String,
+        league: League,
+        year: Int,
+        season: Int
+    ): Competition {
+        return Competition(
+            league = league,
+            name = name,
+            year = year,
+            season = season,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(year, 3, 1),
+            endDate = LocalDate.of(year, 6, 30),
+            status = CompetitionStatus.SCHEDULED,
+            description = null,
+            maxTeams = null
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/league/LeagueControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/league/LeagueControllerTest.kt
@@ -1,0 +1,291 @@
+package com.nextup.scorer.controller.league
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.infrastructure.service.league.LeagueService
+import com.nextup.scorer.dto.league.CreateLeagueRequest
+import com.nextup.scorer.dto.league.UpdateLeagueRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("LeagueController (Scorer)")
+class LeagueControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var leagueService: LeagueService
+    private lateinit var controller: LeagueController
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        leagueService = mockk()
+        controller = LeagueController(leagueService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+        objectMapper = ObjectMapper()
+    }
+
+    @Nested
+    @DisplayName("GET /api/scorer/leagues")
+    inner class GetAllLeagues {
+
+        @Test
+        fun `should return all leagues when no filter provided`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val leagues = listOf(
+                createLeague(1L, "1부 리그", association),
+                createLeague(2L, "2부 리그", association)
+            )
+            every { leagueService.getAll() } returns leagues
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/leagues"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].name").value("1부 리그"))
+                .andExpect(jsonPath("$.data[0].associationName").value("서울시야구협회"))
+
+            verify(exactly = 1) { leagueService.getAll() }
+        }
+
+        @Test
+        fun `should return leagues filtered by associationId`() {
+            // given
+            val associationId = 1L
+            val association = createAssociation(associationId, "서울시야구협회")
+            val leagues = listOf(
+                createLeague(1L, "1부 리그", association)
+            )
+            every { leagueService.getByAssociationId(associationId) } returns leagues
+
+            // when & then
+            mockMvc.perform(
+                get("/api/scorer/leagues")
+                    .param("associationId", associationId.toString())
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].associationId").value(associationId))
+
+            verify(exactly = 1) { leagueService.getByAssociationId(associationId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/scorer/leagues/{id}")
+    inner class GetLeague {
+
+        @Test
+        fun `should return league when found`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            every { leagueService.getById(1L) } returns league
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/leagues/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("1부 리그"))
+                .andExpect(jsonPath("$.data.associationId").value(1))
+                .andExpect(jsonPath("$.data.isActive").value(true))
+
+            verify(exactly = 1) { leagueService.getById(1L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/leagues")
+    inner class CreateLeague {
+
+        @Test
+        fun `should create league with valid request`() {
+            // given
+            val request = CreateLeagueRequest(
+                associationId = 1L,
+                name = "1부 리그",
+                abbreviation = "1st",
+                foundedYear = 2020,
+                divisionLevel = 1,
+                description = "최상위 리그",
+                logoUrl = "https://example.com/logo.png"
+            )
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+
+            every {
+                leagueService.create(
+                    associationId = 1L,
+                    name = "1부 리그",
+                    abbreviation = "1st",
+                    foundedYear = 2020,
+                    divisionLevel = 1,
+                    description = "최상위 리그",
+                    logoUrl = "https://example.com/logo.png"
+                )
+            } returns league
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/leagues")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("1부 리그"))
+
+            verify(exactly = 1) {
+                leagueService.create(
+                    associationId = 1L,
+                    name = "1부 리그",
+                    abbreviation = "1st",
+                    foundedYear = 2020,
+                    divisionLevel = 1,
+                    description = "최상위 리그",
+                    logoUrl = "https://example.com/logo.png"
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/scorer/leagues/{id}")
+    inner class UpdateLeague {
+
+        @Test
+        fun `should update league with valid request`() {
+            // given
+            val request = UpdateLeagueRequest(
+                description = "수정된 설명",
+                logoUrl = "https://example.com/new-logo.png"
+            )
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+
+            every {
+                leagueService.update(
+                    id = 1L,
+                    description = "수정된 설명",
+                    logoUrl = "https://example.com/new-logo.png"
+                )
+            } returns league
+
+            // when & then
+            mockMvc.perform(
+                put("/api/scorer/leagues/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+
+            verify(exactly = 1) {
+                leagueService.update(
+                    id = 1L,
+                    description = "수정된 설명",
+                    logoUrl = "https://example.com/new-logo.png"
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/scorer/leagues/{id}")
+    inner class DeactivateLeague {
+
+        @Test
+        fun `should deactivate league`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association).apply {
+                deactivate()
+            }
+            every { leagueService.deactivate(1L) } returns league
+
+            // when & then
+            mockMvc.perform(delete("/api/scorer/leagues/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.isActive").value(false))
+
+            verify(exactly = 1) { leagueService.deactivate(1L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/leagues/{id}/activate")
+    inner class ActivateLeague {
+
+        @Test
+        fun `should activate league`() {
+            // given
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            every { leagueService.activate(1L) } returns league
+
+            // when & then
+            mockMvc.perform(post("/api/scorer/leagues/1/activate"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.isActive").value(true))
+
+            verify(exactly = 1) { leagueService.activate(1L) }
+        }
+    }
+
+    private fun createAssociation(id: Long, name: String): Association {
+        return Association(
+            name = name,
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createLeague(id: Long, name: String, association: Association): League {
+        return League(
+            association = association,
+            name = name,
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #22

Competition(대회) 도메인의 전체 CRUD 기능을 구현합니다. 모듈별 역할 분리에 따라 api는 조회 전용, scorer는 기록원용 CUD + 상태 변경, backoffice는 관리자용 전체 권한을 제공합니다.

추가로 League backoffice API도 함께 구현하여 모듈 배치 규칙을 통일했습니다.

## Tasks

### Competition CRUD
- CompetitionExceptions 추가 (CompetitionNotFoundException, InvalidCompetitionStateException)
- CompetitionRepository 인터페이스 구현 (nextup-infrastructure)
- CompetitionService 구현 - CRUD + 상태 변경 (start, complete, cancel, postpone)
- CompetitionController 구현 (nextup-api - 조회 전용)
  - `GET /api/v1/competitions`
  - `GET /api/v1/competitions/{id}`
  - `GET /api/v1/competitions/by-league/{leagueId}`
- CompetitionScorerController 구현 (nextup-scorer - 기록원 CUD)
  - `POST /api/scorer/competitions`
  - `PUT /api/scorer/competitions/{id}`
  - `POST /api/scorer/competitions/{id}/start`
  - `POST /api/scorer/competitions/{id}/complete`
  - `DELETE /api/scorer/competitions/{id}`
  - `POST /api/scorer/competitions/{id}/postpone`
- CompetitionAdminController 구현 (nextup-backoffice - 관리자 전체 권한)
- CompetitionServiceTest, CompetitionControllerTest 추가

### League backoffice API 추가
- LeagueAdminController 구현 (nextup-backoffice)
  - `GET /api/backoffice/leagues`
  - `POST /api/backoffice/leagues`
  - `PUT /api/backoffice/leagues/{id}`
  - `DELETE /api/backoffice/leagues/{id}`
  - `POST /api/backoffice/leagues/{id}/activate`

## To Reviewer

- 모듈 배치 규칙: backoffice(관리자)는 모든 권한, scorer(기록원)는 본인 협회 관련만
- Competition Entity의 Rich Domain Model 활용 (start, complete, cancel 메서드)
- Spring Security 권한 체크는 추후 구현 예정 (TODO 주석 처리)