### PR TITLE
feat(#28): 조직 관리자 매핑 시스템 구현

### DIFF
--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/admin/OrganizationAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/admin/OrganizationAdminController.kt
@@ -1,0 +1,145 @@
+package com.nextup.backoffice.controller.admin
+
+import com.nextup.backoffice.dto.admin.AssignAdminRequest
+import com.nextup.backoffice.dto.admin.ChangeRoleRequest
+import com.nextup.backoffice.dto.admin.OrganizationAdminResponse
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.core.domain.admin.OrganizationType
+import com.nextup.infrastructure.service.admin.OrganizationAdminService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 조직 관리자 API Controller (관리자용)
+ *
+ * 조직-관리자 매핑을 관리하는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/backoffice/organizations")
+class OrganizationAdminController(
+    private val organizationAdminService: OrganizationAdminService
+) {
+
+    /**
+     * 관리자를 할당합니다.
+     *
+     * @param type 조직 유형 (ASSOCIATION, LEAGUE, TEAM)
+     * @param id 조직 ID
+     * @param request 할당 요청 (userId, role)
+     * @return 생성된 관리자 정보
+     */
+    @PostMapping("/{type}/{id}/admins")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun assignAdmin(
+        @PathVariable type: String,
+        @PathVariable id: Long,
+        @Valid @RequestBody request: AssignAdminRequest
+    ): ApiResponse<OrganizationAdminResponse> {
+        val organizationType = OrganizationType.fromValue(type)
+
+        val admin = organizationAdminService.assignAdmin(
+            userId = request.userId,
+            organizationType = organizationType,
+            organizationId = id,
+            role = request.role,
+            assignedBy = null // TODO: 인증된 사용자 ID로 변경
+        )
+
+        return ApiResponse.success(OrganizationAdminResponse.from(admin))
+    }
+
+    /**
+     * 관리자 권한을 해제합니다.
+     *
+     * @param type 조직 유형
+     * @param id 조직 ID
+     * @param userId 사용자 ID
+     * @return 성공 응답
+     */
+    @DeleteMapping("/{type}/{id}/admins/{userId}")
+    fun removeAdmin(
+        @PathVariable type: String,
+        @PathVariable id: Long,
+        @PathVariable userId: Long
+    ): ApiResponse<Unit> {
+        val organizationType = OrganizationType.fromValue(type)
+
+        organizationAdminService.removeAdmin(
+            userId = userId,
+            organizationType = organizationType,
+            organizationId = id
+        )
+
+        return ApiResponse.success(Unit)
+    }
+
+    /**
+     * 특정 조직의 관리자 목록을 조회합니다.
+     *
+     * @param type 조직 유형
+     * @param id 조직 ID
+     * @return 관리자 목록
+     */
+    @GetMapping("/{type}/{id}/admins")
+    fun getAdminsByOrganization(
+        @PathVariable type: String,
+        @PathVariable id: Long
+    ): ApiResponse<List<OrganizationAdminResponse>> {
+        val organizationType = OrganizationType.fromValue(type)
+
+        val admins = organizationAdminService.getAdminsByOrganization(
+            organizationType = organizationType,
+            organizationId = id
+        )
+
+        return ApiResponse.success(
+            admins.map { OrganizationAdminResponse.from(it) }
+        )
+    }
+
+    /**
+     * 특정 사용자가 관리하는 모든 조직을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 관리하는 조직 목록
+     */
+    @GetMapping("/by-user/{userId}")
+    fun getOrganizationsByUser(
+        @PathVariable userId: Long
+    ): ApiResponse<List<OrganizationAdminResponse>> {
+        val admins = organizationAdminService.getOrganizationsByUser(userId)
+
+        return ApiResponse.success(
+            admins.map { OrganizationAdminResponse.from(it) }
+        )
+    }
+
+    /**
+     * 관리자의 역할을 변경합니다.
+     *
+     * @param type 조직 유형
+     * @param id 조직 ID
+     * @param userId 사용자 ID
+     * @param request 역할 변경 요청
+     * @return 수정된 관리자 정보
+     */
+    @PutMapping("/{type}/{id}/admins/{userId}/role")
+    fun changeRole(
+        @PathVariable type: String,
+        @PathVariable id: Long,
+        @PathVariable userId: Long,
+        @Valid @RequestBody request: ChangeRoleRequest
+    ): ApiResponse<OrganizationAdminResponse> {
+        val organizationType = OrganizationType.fromValue(type)
+
+        val admin = organizationAdminService.changeRole(
+            userId = userId,
+            organizationType = organizationType,
+            organizationId = id,
+            newRole = request.role
+        )
+
+        return ApiResponse.success(OrganizationAdminResponse.from(admin))
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/admin/OrganizationAdminRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/admin/OrganizationAdminRequest.kt
@@ -1,0 +1,25 @@
+package com.nextup.backoffice.dto.admin
+
+import com.nextup.core.domain.admin.OrganizationRole
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+
+/**
+ * 관리자 할당 요청 DTO
+ */
+data class AssignAdminRequest(
+    @field:NotNull(message = "사용자 ID는 필수입니다")
+    @field:Positive(message = "사용자 ID는 양수여야 합니다")
+    val userId: Long,
+
+    @field:NotNull(message = "역할은 필수입니다")
+    val role: OrganizationRole
+)
+
+/**
+ * 관리자 역할 변경 요청 DTO
+ */
+data class ChangeRoleRequest(
+    @field:NotNull(message = "역할은 필수입니다")
+    val role: OrganizationRole
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/admin/OrganizationAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/admin/OrganizationAdminResponse.kt
@@ -1,0 +1,74 @@
+package com.nextup.backoffice.dto.admin
+
+import com.nextup.core.domain.admin.OrganizationAdmin
+import com.nextup.core.domain.admin.OrganizationRole
+import com.nextup.core.domain.admin.OrganizationType
+import java.time.Instant
+
+/**
+ * 조직 관리자 응답 DTO
+ *
+ * backoffice 모듈에 독립적으로 존재
+ */
+data class OrganizationAdminResponse(
+    val id: Long,
+    val userId: Long,
+    val userName: String?,
+    val userEmail: String?,
+    val organizationType: OrganizationType,
+    val organizationId: Long,
+    val organizationName: String?,
+    val role: OrganizationRole,
+    val assignedAt: Instant,
+    val assignedBy: Long?,
+    val isActive: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant
+) {
+    companion object {
+        /**
+         * OrganizationAdmin Entity로부터 응답 DTO를 생성합니다.
+         *
+         * organizationName은 별도 조회가 필요하므로 null로 설정됩니다.
+         * 필요한 경우 Service 레이어에서 추가 조회하여 설정해야 합니다.
+         */
+        fun from(admin: OrganizationAdmin): OrganizationAdminResponse {
+            return OrganizationAdminResponse(
+                id = admin.id,
+                userId = admin.user.id,
+                userName = admin.user.nickname,
+                userEmail = admin.user.email,
+                organizationType = admin.organizationType,
+                organizationId = admin.organizationId,
+                organizationName = null, // 별도 조회 필요
+                role = admin.role,
+                assignedAt = admin.assignedAt,
+                assignedBy = admin.assignedBy,
+                isActive = admin.isActive,
+                createdAt = admin.createdAt,
+                updatedAt = admin.updatedAt
+            )
+        }
+
+        /**
+         * OrganizationAdmin Entity와 조직 이름으로부터 응답 DTO를 생성합니다.
+         */
+        fun from(admin: OrganizationAdmin, organizationName: String?): OrganizationAdminResponse {
+            return OrganizationAdminResponse(
+                id = admin.id,
+                userId = admin.user.id,
+                userName = admin.user.nickname,
+                userEmail = admin.user.email,
+                organizationType = admin.organizationType,
+                organizationId = admin.organizationId,
+                organizationName = organizationName,
+                role = admin.role,
+                assignedAt = admin.assignedAt,
+                assignedBy = admin.assignedBy,
+                isActive = admin.isActive,
+                createdAt = admin.createdAt,
+                updatedAt = admin.updatedAt
+            )
+        }
+    }
+}

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/admin/OrganizationAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/admin/OrganizationAdminControllerTest.kt
@@ -1,0 +1,268 @@
+package com.nextup.backoffice.controller.admin
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.backoffice.dto.admin.AssignAdminRequest
+import com.nextup.backoffice.dto.admin.ChangeRoleRequest
+import com.nextup.core.domain.admin.OrganizationAdmin
+import com.nextup.core.domain.admin.OrganizationRole
+import com.nextup.core.domain.admin.OrganizationType
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.service.admin.OrganizationAdminService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("OrganizationAdminController")
+class OrganizationAdminControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var organizationAdminService: OrganizationAdminService
+    private lateinit var controller: OrganizationAdminController
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        organizationAdminService = mockk()
+        controller = OrganizationAdminController(organizationAdminService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+        objectMapper = ObjectMapper()
+    }
+
+    @Nested
+    @DisplayName("POST /api/backoffice/organizations/{type}/{id}/admins")
+    inner class AssignAdmin {
+
+        @Test
+        fun `관리자를 할당할 수 있다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val organizationType = OrganizationType.ASSOCIATION
+            val organizationId = 1L
+            val role = OrganizationRole.ADMIN
+            val admin = createOrganizationAdmin(1L, user, organizationType, organizationId, role)
+
+            val request = AssignAdminRequest(userId = userId, role = role)
+
+            every {
+                organizationAdminService.assignAdmin(
+                    userId = userId,
+                    organizationType = organizationType,
+                    organizationId = organizationId,
+                    role = role,
+                    assignedBy = null
+                )
+            } returns admin
+
+            // when & then
+            mockMvc.perform(
+                post("/api/backoffice/organizations/ASSOCIATION/1/admins")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.userId").value(userId))
+                .andExpect(jsonPath("$.data.organizationType").value("ASSOCIATION"))
+                .andExpect(jsonPath("$.data.organizationId").value(organizationId))
+                .andExpect(jsonPath("$.data.role").value("ADMIN"))
+                .andExpect(jsonPath("$.data.isActive").value(true))
+
+            verify(exactly = 1) {
+                organizationAdminService.assignAdmin(
+                    userId = userId,
+                    organizationType = organizationType,
+                    organizationId = organizationId,
+                    role = role,
+                    assignedBy = null
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/backoffice/organizations/{type}/{id}/admins/{userId}")
+    inner class RemoveAdmin {
+
+        @Test
+        fun `관리자 권한을 해제할 수 있다`() {
+            // given
+            val userId = 1L
+            val organizationType = OrganizationType.ASSOCIATION
+            val organizationId = 1L
+
+            every {
+                organizationAdminService.removeAdmin(
+                    userId = userId,
+                    organizationType = organizationType,
+                    organizationId = organizationId
+                )
+            } returns Unit
+
+            // when & then
+            mockMvc.perform(
+                delete("/api/backoffice/organizations/ASSOCIATION/1/admins/$userId")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+
+            verify(exactly = 1) {
+                organizationAdminService.removeAdmin(
+                    userId = userId,
+                    organizationType = organizationType,
+                    organizationId = organizationId
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/backoffice/organizations/{type}/{id}/admins")
+    inner class GetAdminsByOrganization {
+
+        @Test
+        fun `특정 조직의 관리자 목록을 조회할 수 있다`() {
+            // given
+            val organizationType = OrganizationType.ASSOCIATION
+            val organizationId = 1L
+            val user1 = createUser(1L, "user1@example.com")
+            val user2 = createUser(2L, "user2@example.com")
+            val admin1 = createOrganizationAdmin(1L, user1, organizationType, organizationId, OrganizationRole.ADMIN)
+            val admin2 = createOrganizationAdmin(2L, user2, organizationType, organizationId, OrganizationRole.MANAGER)
+
+            every {
+                organizationAdminService.getAdminsByOrganization(organizationType, organizationId)
+            } returns listOf(admin1, admin2)
+
+            // when & then
+            mockMvc.perform(
+                get("/api/backoffice/organizations/ASSOCIATION/1/admins")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+
+            verify(exactly = 1) {
+                organizationAdminService.getAdminsByOrganization(organizationType, organizationId)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/backoffice/organizations/by-user/{userId}")
+    inner class GetOrganizationsByUser {
+
+        @Test
+        fun `사용자가 관리하는 모든 조직을 조회할 수 있다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val admin1 = createOrganizationAdmin(1L, user, OrganizationType.ASSOCIATION, 1L, OrganizationRole.ADMIN)
+            val admin2 = createOrganizationAdmin(2L, user, OrganizationType.LEAGUE, 2L, OrganizationRole.MANAGER)
+
+            every { organizationAdminService.getOrganizationsByUser(userId) } returns listOf(admin1, admin2)
+
+            // when & then
+            mockMvc.perform(
+                get("/api/backoffice/organizations/by-user/$userId")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+
+            verify(exactly = 1) { organizationAdminService.getOrganizationsByUser(userId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/backoffice/organizations/{type}/{id}/admins/{userId}/role")
+    inner class ChangeRole {
+
+        @Test
+        fun `관리자 역할을 변경할 수 있다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val organizationType = OrganizationType.ASSOCIATION
+            val organizationId = 1L
+            val newRole = OrganizationRole.MANAGER
+            val admin = createOrganizationAdmin(1L, user, organizationType, organizationId, newRole)
+
+            val request = ChangeRoleRequest(role = newRole)
+
+            every {
+                organizationAdminService.changeRole(
+                    userId = userId,
+                    organizationType = organizationType,
+                    organizationId = organizationId,
+                    newRole = newRole
+                )
+            } returns admin
+
+            // when & then
+            mockMvc.perform(
+                put("/api/backoffice/organizations/ASSOCIATION/1/admins/$userId/role")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.role").value("MANAGER"))
+
+            verify(exactly = 1) {
+                organizationAdminService.changeRole(
+                    userId = userId,
+                    organizationType = organizationType,
+                    organizationId = organizationId,
+                    newRole = newRole
+                )
+            }
+        }
+    }
+
+    // Helper methods
+
+    private fun createUser(id: Long, email: String): User {
+        val user = User.createLocalUser(
+            email = email,
+            encodedPassword = "password",
+            nickname = "Test User"
+        )
+        setEntityId(user, id)
+        return user
+    }
+
+    private fun createOrganizationAdmin(
+        id: Long,
+        user: User,
+        organizationType: OrganizationType,
+        organizationId: Long,
+        role: OrganizationRole = OrganizationRole.ADMIN
+    ): OrganizationAdmin {
+        val admin = OrganizationAdmin.create(
+            user = user,
+            organizationType = organizationType,
+            organizationId = organizationId,
+            role = role
+        )
+        setEntityId(admin, id)
+        return admin
+    }
+
+    private fun setEntityId(entity: Any, id: Long) {
+        val idField = entity::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(entity, id)
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/OrganizationAdminExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/OrganizationAdminExceptions.kt
@@ -1,0 +1,97 @@
+package com.nextup.common.exception
+
+/**
+ * 조직 관리자를 찾을 수 없을 때 발생하는 예외
+ */
+class OrganizationAdminNotFoundException(
+    organizationType: String,
+    organizationId: Long,
+    userId: Long
+) : NotFoundException(
+    "ORGANIZATION_ADMIN_NOT_FOUND",
+    "Organization admin not found: type=$organizationType, orgId=$organizationId, userId=$userId"
+)
+
+/**
+ * 조직 관리자 ID로 찾을 수 없을 때 발생하는 예외
+ */
+class OrganizationAdminNotFoundByIdException(adminId: Long) :
+    NotFoundException(
+        "ORGANIZATION_ADMIN_NOT_FOUND",
+        "Organization admin not found: $adminId"
+    )
+
+/**
+ * 조직 관리자가 이미 존재할 때 발생하는 예외
+ */
+class OrganizationAdminAlreadyExistsException(
+    organizationType: String,
+    organizationId: Long,
+    userId: Long
+) : BusinessException(
+    "ORGANIZATION_ADMIN_ALREADY_EXISTS",
+    "Organization admin already exists: type=$organizationType, orgId=$organizationId, userId=$userId"
+)
+
+/**
+ * 조직을 찾을 수 없을 때 발생하는 예외
+ */
+class OrganizationNotFoundException(
+    organizationType: String,
+    organizationId: Long
+) : NotFoundException(
+    "ORGANIZATION_NOT_FOUND",
+    "Organization not found: type=$organizationType, id=$organizationId"
+)
+
+/**
+ * 유효하지 않은 조직 유형일 때 발생하는 예외
+ */
+class InvalidOrganizationTypeException(value: String) :
+    BusinessException(
+        "INVALID_ORGANIZATION_TYPE",
+        "Invalid organization type: $value"
+    )
+
+/**
+ * 조직에 대한 권한이 없을 때 발생하는 예외
+ */
+class UnauthorizedOrganizationAccessException(
+    organizationType: String,
+    organizationId: Long
+) : BusinessException(
+    "UNAUTHORIZED_ORGANIZATION_ACCESS",
+    "Unauthorized access to organization: type=$organizationType, id=$organizationId"
+)
+
+/**
+ * 같은 리그 내 여러 팀의 관리자가 될 수 없을 때 발생하는 예외
+ */
+class SameLeagueConflictException(
+    leagueId: Long,
+    existingTeamId: Long,
+    newTeamId: Long
+) : BusinessException(
+    "SAME_LEAGUE_CONFLICT",
+    "Cannot manage multiple teams in the same league: leagueId=$leagueId, existingTeamId=$existingTeamId, newTeamId=$newTeamId"
+)
+
+/**
+ * 관리자 역할 수준이 부족할 때 발생하는 예외
+ */
+class InsufficientRoleLevelException(
+    requiredRole: String,
+    currentRole: String
+) : BusinessException(
+    "INSUFFICIENT_ROLE_LEVEL",
+    "Insufficient role level: required=$requiredRole, current=$currentRole"
+)
+
+/**
+ * 비활성화된 관리자일 때 발생하는 예외
+ */
+class OrganizationAdminDeactivatedException(adminId: Long) :
+    InvalidStateException(
+        "ORGANIZATION_ADMIN_DEACTIVATED",
+        "Organization admin is deactivated: $adminId"
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/TeamExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/TeamExceptions.kt
@@ -1,0 +1,28 @@
+package com.nextup.common.exception
+
+/**
+ * 팀을 찾을 수 없을 때 발생하는 예외
+ */
+class TeamNotFoundException(teamId: Long) :
+    NotFoundException(
+        "TEAM_NOT_FOUND",
+        "Team not found: $teamId"
+    )
+
+/**
+ * 팀이 이미 존재할 때 발생하는 예외
+ */
+class TeamAlreadyExistsException(teamName: String) :
+    BusinessException(
+        "TEAM_ALREADY_EXISTS",
+        "Team already exists: $teamName"
+    )
+
+/**
+ * 유효하지 않은 팀 상태일 때 발생하는 예외
+ */
+class InvalidTeamStateException(message: String) :
+    InvalidStateException(
+        "INVALID_TEAM_STATE",
+        message
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationAdmin.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationAdmin.kt
@@ -1,0 +1,207 @@
+package com.nextup.core.domain.admin
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.user.User
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * 조직-관리자 매핑 엔티티
+ *
+ * 다형적 관계(Polymorphic Association)를 사용하여
+ * 협회, 리그, 팀 등 다양한 조직과 관리자를 매핑합니다.
+ *
+ * - organizationType: 조직의 유형 (ASSOCIATION, LEAGUE, TEAM)
+ * - organizationId: 해당 조직의 ID
+ *
+ * 복합 유니크 제약: (user_id, organization_type, organization_id)
+ */
+@Entity
+@Table(
+    name = "organization_admins",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_organization_admin_user_org",
+            columnNames = ["user_id", "organization_type", "organization_id"]
+        )
+    ],
+    indexes = [
+        Index(name = "idx_org_admin_user", columnList = "user_id"),
+        Index(name = "idx_org_admin_org", columnList = "organization_type, organization_id"),
+        Index(name = "idx_org_admin_active", columnList = "is_active")
+    ]
+)
+class OrganizationAdmin private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "organization_type", nullable = false, length = 20)
+    val organizationType: OrganizationType,
+
+    @Column(name = "organization_id", nullable = false)
+    val organizationId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    var role: OrganizationRole,
+
+    @Column(name = "assigned_at", nullable = false)
+    val assignedAt: Instant = Instant.now(),
+
+    @Column(name = "assigned_by")
+    val assignedBy: Long? = null,
+
+    @Column(name = "is_active", nullable = false)
+    var isActive: Boolean = true,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+) : BaseTimeEntity() {
+
+    /**
+     * 관리자 역할을 변경합니다.
+     *
+     * @param newRole 새로운 역할
+     * @throws IllegalStateException 비활성화된 관리자인 경우
+     */
+    fun changeRole(newRole: OrganizationRole) {
+        require(isActive) { "비활성화된 관리자의 역할은 변경할 수 없습니다." }
+        this.role = newRole
+    }
+
+    /**
+     * 관리자를 비활성화합니다.
+     */
+    fun deactivate() {
+        this.isActive = false
+    }
+
+    /**
+     * 관리자를 활성화합니다.
+     */
+    fun activate() {
+        this.isActive = true
+    }
+
+    /**
+     * 특정 역할 이상의 권한을 가지고 있는지 확인합니다.
+     *
+     * @param requiredRole 필요한 최소 역할
+     * @return 권한 보유 여부
+     */
+    fun hasRoleOrHigher(requiredRole: OrganizationRole): Boolean {
+        return isActive && role.isHigherOrEqual(requiredRole)
+    }
+
+    /**
+     * 협회 관리자인지 확인합니다.
+     */
+    val isAssociationAdmin: Boolean
+        get() = organizationType == OrganizationType.ASSOCIATION
+
+    /**
+     * 리그 관리자인지 확인합니다.
+     */
+    val isLeagueAdmin: Boolean
+        get() = organizationType == OrganizationType.LEAGUE
+
+    /**
+     * 팀 관리자인지 확인합니다.
+     */
+    val isTeamAdmin: Boolean
+        get() = organizationType == OrganizationType.TEAM
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OrganizationAdmin) return false
+        if (id == 0L) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    override fun toString(): String =
+        "OrganizationAdmin(id=$id, userId=${user.id}, organizationType=$organizationType, " +
+            "organizationId=$organizationId, role=$role, isActive=$isActive)"
+
+    companion object {
+        /**
+         * 조직 관리자를 생성합니다.
+         *
+         * @param user 관리자로 지정할 사용자
+         * @param organizationType 조직 유형
+         * @param organizationId 조직 ID
+         * @param role 부여할 역할
+         * @param assignedBy 관리자를 할당한 사용자 ID (선택)
+         * @return 생성된 OrganizationAdmin
+         */
+        fun create(
+            user: User,
+            organizationType: OrganizationType,
+            organizationId: Long,
+            role: OrganizationRole,
+            assignedBy: Long? = null
+        ): OrganizationAdmin {
+            require(organizationId > 0) { "조직 ID는 0보다 커야 합니다." }
+
+            return OrganizationAdmin(
+                user = user,
+                organizationType = organizationType,
+                organizationId = organizationId,
+                role = role,
+                assignedBy = assignedBy
+            )
+        }
+
+        /**
+         * 협회 관리자를 생성합니다.
+         */
+        fun createAssociationAdmin(
+            user: User,
+            associationId: Long,
+            role: OrganizationRole = OrganizationRole.ADMIN,
+            assignedBy: Long? = null
+        ): OrganizationAdmin = create(
+            user = user,
+            organizationType = OrganizationType.ASSOCIATION,
+            organizationId = associationId,
+            role = role,
+            assignedBy = assignedBy
+        )
+
+        /**
+         * 리그 관리자를 생성합니다.
+         */
+        fun createLeagueAdmin(
+            user: User,
+            leagueId: Long,
+            role: OrganizationRole = OrganizationRole.ADMIN,
+            assignedBy: Long? = null
+        ): OrganizationAdmin = create(
+            user = user,
+            organizationType = OrganizationType.LEAGUE,
+            organizationId = leagueId,
+            role = role,
+            assignedBy = assignedBy
+        )
+
+        /**
+         * 팀 관리자를 생성합니다.
+         */
+        fun createTeamAdmin(
+            user: User,
+            teamId: Long,
+            role: OrganizationRole = OrganizationRole.ADMIN,
+            assignedBy: Long? = null
+        ): OrganizationAdmin = create(
+            user = user,
+            organizationType = OrganizationType.TEAM,
+            organizationId = teamId,
+            role = role,
+            assignedBy = assignedBy
+        )
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationRole.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationRole.kt
@@ -1,0 +1,51 @@
+package com.nextup.core.domain.admin
+
+/**
+ * 조직 내 관리자 역할을 나타내는 열거형
+ *
+ * 조직별로 부여할 수 있는 권한 수준을 정의합니다.
+ */
+enum class OrganizationRole(
+    val displayName: String,
+    val description: String,
+    val level: Int
+) {
+    /**
+     * 관리자 - 조직의 모든 권한을 가진 최고 관리자
+     */
+    ADMIN("관리자", "조직의 모든 권한을 가진 최고 관리자", 100),
+
+    /**
+     * 매니저 - 조직 운영 관련 권한을 가진 관리자
+     */
+    MANAGER("매니저", "조직 운영 관련 권한을 가진 관리자", 50),
+
+    /**
+     * 기록원 - 경기 기록 입력 권한만 가진 관리자
+     */
+    SCORER("기록원", "경기 기록 입력 권한만 가진 관리자", 10);
+
+    /**
+     * 다른 역할보다 높은 권한인지 확인합니다.
+     */
+    fun isHigherThan(other: OrganizationRole): Boolean = this.level > other.level
+
+    /**
+     * 다른 역할보다 높거나 같은 권한인지 확인합니다.
+     */
+    fun isHigherOrEqual(other: OrganizationRole): Boolean = this.level >= other.level
+
+    companion object {
+        /**
+         * 문자열로부터 OrganizationRole을 찾습니다.
+         *
+         * @param value 역할 문자열
+         * @return OrganizationRole
+         * @throws IllegalArgumentException 유효하지 않은 값인 경우
+         */
+        fun fromValue(value: String): OrganizationRole {
+            return entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: throw IllegalArgumentException("Invalid organization role: $value")
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationType.kt
@@ -1,0 +1,40 @@
+package com.nextup.core.domain.admin
+
+/**
+ * 조직 유형을 나타내는 열거형
+ *
+ * 다형적 관계(Polymorphic Association)에서 조직의 종류를 구분합니다.
+ */
+enum class OrganizationType(
+    val displayName: String,
+    val description: String
+) {
+    /**
+     * 협회 (최상위 조직)
+     */
+    ASSOCIATION("협회", "사회인 야구 협회"),
+
+    /**
+     * 리그 (협회 하위 조직)
+     */
+    LEAGUE("리그", "협회에 속한 리그"),
+
+    /**
+     * 팀 (리그 하위 조직)
+     */
+    TEAM("팀", "리그에 속한 팀");
+
+    companion object {
+        /**
+         * 문자열로부터 OrganizationType을 찾습니다.
+         *
+         * @param value 조직 유형 문자열
+         * @return OrganizationType
+         * @throws IllegalArgumentException 유효하지 않은 값인 경우
+         */
+        fun fromValue(value: String): OrganizationType {
+            return entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: throw IllegalArgumentException("Invalid organization type: $value")
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationAdminTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationAdminTest.kt
@@ -1,0 +1,466 @@
+package com.nextup.core.domain.admin
+
+import com.nextup.core.domain.user.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("OrganizationAdmin 테스트")
+class OrganizationAdminTest {
+
+    @Nested
+    @DisplayName("create 팩토리 메서드")
+    inner class Create {
+
+        @Test
+        fun `should create organization admin successfully`() {
+            // given
+            val user = createUser()
+
+            // when
+            val admin = OrganizationAdmin.create(
+                user = user,
+                organizationType = OrganizationType.ASSOCIATION,
+                organizationId = 1L,
+                role = OrganizationRole.ADMIN
+            )
+
+            // then
+            assertThat(admin.user).isEqualTo(user)
+            assertThat(admin.organizationType).isEqualTo(OrganizationType.ASSOCIATION)
+            assertThat(admin.organizationId).isEqualTo(1L)
+            assertThat(admin.role).isEqualTo(OrganizationRole.ADMIN)
+            assertThat(admin.isActive).isTrue()
+            assertThat(admin.assignedBy).isNull()
+        }
+
+        @Test
+        fun `should create organization admin with assignedBy`() {
+            // given
+            val user = createUser()
+            val assignedByUserId = 100L
+
+            // when
+            val admin = OrganizationAdmin.create(
+                user = user,
+                organizationType = OrganizationType.LEAGUE,
+                organizationId = 2L,
+                role = OrganizationRole.MANAGER,
+                assignedBy = assignedByUserId
+            )
+
+            // then
+            assertThat(admin.assignedBy).isEqualTo(assignedByUserId)
+        }
+
+        @Test
+        fun `should throw exception when organizationId is zero`() {
+            // given
+            val user = createUser()
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                OrganizationAdmin.create(
+                    user = user,
+                    organizationType = OrganizationType.TEAM,
+                    organizationId = 0L,
+                    role = OrganizationRole.SCORER
+                )
+            }
+        }
+
+        @Test
+        fun `should throw exception when organizationId is negative`() {
+            // given
+            val user = createUser()
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                OrganizationAdmin.create(
+                    user = user,
+                    organizationType = OrganizationType.TEAM,
+                    organizationId = -1L,
+                    role = OrganizationRole.SCORER
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("createAssociationAdmin 팩토리 메서드")
+    inner class CreateAssociationAdmin {
+
+        @Test
+        fun `should create association admin with default role`() {
+            // given
+            val user = createUser()
+
+            // when
+            val admin = OrganizationAdmin.createAssociationAdmin(
+                user = user,
+                associationId = 1L
+            )
+
+            // then
+            assertThat(admin.organizationType).isEqualTo(OrganizationType.ASSOCIATION)
+            assertThat(admin.organizationId).isEqualTo(1L)
+            assertThat(admin.role).isEqualTo(OrganizationRole.ADMIN)
+        }
+
+        @Test
+        fun `should create association admin with custom role`() {
+            // given
+            val user = createUser()
+
+            // when
+            val admin = OrganizationAdmin.createAssociationAdmin(
+                user = user,
+                associationId = 1L,
+                role = OrganizationRole.MANAGER
+            )
+
+            // then
+            assertThat(admin.role).isEqualTo(OrganizationRole.MANAGER)
+        }
+    }
+
+    @Nested
+    @DisplayName("createLeagueAdmin 팩토리 메서드")
+    inner class CreateLeagueAdmin {
+
+        @Test
+        fun `should create league admin with default role`() {
+            // given
+            val user = createUser()
+
+            // when
+            val admin = OrganizationAdmin.createLeagueAdmin(
+                user = user,
+                leagueId = 2L
+            )
+
+            // then
+            assertThat(admin.organizationType).isEqualTo(OrganizationType.LEAGUE)
+            assertThat(admin.organizationId).isEqualTo(2L)
+            assertThat(admin.role).isEqualTo(OrganizationRole.ADMIN)
+        }
+
+        @Test
+        fun `should create league admin with assignedBy`() {
+            // given
+            val user = createUser()
+
+            // when
+            val admin = OrganizationAdmin.createLeagueAdmin(
+                user = user,
+                leagueId = 2L,
+                assignedBy = 99L
+            )
+
+            // then
+            assertThat(admin.assignedBy).isEqualTo(99L)
+        }
+    }
+
+    @Nested
+    @DisplayName("createTeamAdmin 팩토리 메서드")
+    inner class CreateTeamAdmin {
+
+        @Test
+        fun `should create team admin with default role`() {
+            // given
+            val user = createUser()
+
+            // when
+            val admin = OrganizationAdmin.createTeamAdmin(
+                user = user,
+                teamId = 3L
+            )
+
+            // then
+            assertThat(admin.organizationType).isEqualTo(OrganizationType.TEAM)
+            assertThat(admin.organizationId).isEqualTo(3L)
+            assertThat(admin.role).isEqualTo(OrganizationRole.ADMIN)
+        }
+
+        @Test
+        fun `should create team admin with scorer role`() {
+            // given
+            val user = createUser()
+
+            // when
+            val admin = OrganizationAdmin.createTeamAdmin(
+                user = user,
+                teamId = 3L,
+                role = OrganizationRole.SCORER
+            )
+
+            // then
+            assertThat(admin.role).isEqualTo(OrganizationRole.SCORER)
+        }
+    }
+
+    @Nested
+    @DisplayName("changeRole 메서드")
+    inner class ChangeRole {
+
+        @Test
+        fun `should change role successfully when active`() {
+            // given
+            val admin = createAdmin(role = OrganizationRole.ADMIN)
+
+            // when
+            admin.changeRole(OrganizationRole.MANAGER)
+
+            // then
+            assertThat(admin.role).isEqualTo(OrganizationRole.MANAGER)
+        }
+
+        @Test
+        fun `should throw exception when changing role of deactivated admin`() {
+            // given
+            val admin = createAdmin(role = OrganizationRole.ADMIN)
+            admin.deactivate()
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                admin.changeRole(OrganizationRole.MANAGER)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("activate/deactivate 메서드")
+    inner class ActivateDeactivate {
+
+        @Test
+        fun `should deactivate admin successfully`() {
+            // given
+            val admin = createAdmin()
+
+            // when
+            admin.deactivate()
+
+            // then
+            assertThat(admin.isActive).isFalse()
+        }
+
+        @Test
+        fun `should activate admin successfully`() {
+            // given
+            val admin = createAdmin()
+            admin.deactivate()
+
+            // when
+            admin.activate()
+
+            // then
+            assertThat(admin.isActive).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("hasRoleOrHigher 메서드")
+    inner class HasRoleOrHigher {
+
+        @Test
+        fun `should return true when admin has higher role`() {
+            // given
+            val admin = createAdmin(role = OrganizationRole.ADMIN)
+
+            // when & then
+            assertThat(admin.hasRoleOrHigher(OrganizationRole.MANAGER)).isTrue()
+            assertThat(admin.hasRoleOrHigher(OrganizationRole.SCORER)).isTrue()
+        }
+
+        @Test
+        fun `should return true when admin has equal role`() {
+            // given
+            val admin = createAdmin(role = OrganizationRole.MANAGER)
+
+            // when & then
+            assertThat(admin.hasRoleOrHigher(OrganizationRole.MANAGER)).isTrue()
+        }
+
+        @Test
+        fun `should return false when admin has lower role`() {
+            // given
+            val admin = createAdmin(role = OrganizationRole.SCORER)
+
+            // when & then
+            assertThat(admin.hasRoleOrHigher(OrganizationRole.MANAGER)).isFalse()
+            assertThat(admin.hasRoleOrHigher(OrganizationRole.ADMIN)).isFalse()
+        }
+
+        @Test
+        fun `should return false when admin is inactive`() {
+            // given
+            val admin = createAdmin(role = OrganizationRole.ADMIN)
+            admin.deactivate()
+
+            // when & then
+            assertThat(admin.hasRoleOrHigher(OrganizationRole.SCORER)).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("조직 유형 프로퍼티")
+    inner class OrganizationTypeProperties {
+
+        @Test
+        fun `should return true for isAssociationAdmin when type is ASSOCIATION`() {
+            // given
+            val admin = createAdmin(organizationType = OrganizationType.ASSOCIATION)
+
+            // when & then
+            assertThat(admin.isAssociationAdmin).isTrue()
+            assertThat(admin.isLeagueAdmin).isFalse()
+            assertThat(admin.isTeamAdmin).isFalse()
+        }
+
+        @Test
+        fun `should return true for isLeagueAdmin when type is LEAGUE`() {
+            // given
+            val admin = createAdmin(organizationType = OrganizationType.LEAGUE)
+
+            // when & then
+            assertThat(admin.isAssociationAdmin).isFalse()
+            assertThat(admin.isLeagueAdmin).isTrue()
+            assertThat(admin.isTeamAdmin).isFalse()
+        }
+
+        @Test
+        fun `should return true for isTeamAdmin when type is TEAM`() {
+            // given
+            val admin = createAdmin(organizationType = OrganizationType.TEAM)
+
+            // when & then
+            assertThat(admin.isAssociationAdmin).isFalse()
+            assertThat(admin.isLeagueAdmin).isFalse()
+            assertThat(admin.isTeamAdmin).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("equals/hashCode")
+    inner class EqualsHashCode {
+
+        @Test
+        fun `should be equal when same instance`() {
+            // given
+            val admin = createAdminWithId(1L)
+
+            // when & then
+            assertThat(admin).isEqualTo(admin)
+        }
+
+        @Test
+        fun `should be equal when same id`() {
+            // given
+            val admin1 = createAdminWithId(1L)
+            val admin2 = createAdminWithId(1L)
+
+            // when & then
+            assertThat(admin1).isEqualTo(admin2)
+            assertThat(admin1.hashCode()).isEqualTo(admin2.hashCode())
+        }
+
+        @Test
+        fun `should not be equal when different id`() {
+            // given
+            val admin1 = createAdminWithId(1L)
+            val admin2 = createAdminWithId(2L)
+
+            // when & then
+            assertThat(admin1).isNotEqualTo(admin2)
+        }
+
+        @Test
+        fun `should not be equal when id is zero`() {
+            // given
+            val admin1 = createAdmin()
+            val admin2 = createAdmin()
+
+            // when & then
+            assertThat(admin1).isNotEqualTo(admin2)
+        }
+
+        @Test
+        fun `should not be equal to null`() {
+            // given
+            val admin = createAdminWithId(1L)
+
+            // when & then
+            assertThat(admin).isNotEqualTo(null)
+        }
+
+        @Test
+        fun `should not be equal to different type`() {
+            // given
+            val admin = createAdminWithId(1L)
+
+            // when & then
+            assertThat(admin).isNotEqualTo("string")
+        }
+    }
+
+    @Nested
+    @DisplayName("toString")
+    inner class ToString {
+
+        @Test
+        fun `should return readable string representation`() {
+            // given
+            val admin = createAdminWithId(1L, OrganizationType.ASSOCIATION, 10L, OrganizationRole.ADMIN)
+
+            // when
+            val result = admin.toString()
+
+            // then
+            assertThat(result).contains("OrganizationAdmin")
+            assertThat(result).contains("id=1")
+            assertThat(result).contains("organizationType=ASSOCIATION")
+            assertThat(result).contains("organizationId=10")
+            assertThat(result).contains("role=ADMIN")
+            assertThat(result).contains("isActive=true")
+        }
+    }
+
+    // Helper methods
+
+    private fun createUser(): User {
+        return User.createLocalUser(
+            email = "test@example.com",
+            encodedPassword = "password",
+            nickname = "테스터"
+        )
+    }
+
+    private fun createAdmin(
+        organizationType: OrganizationType = OrganizationType.ASSOCIATION,
+        organizationId: Long = 1L,
+        role: OrganizationRole = OrganizationRole.ADMIN
+    ): OrganizationAdmin {
+        return OrganizationAdmin.create(
+            user = createUser(),
+            organizationType = organizationType,
+            organizationId = organizationId,
+            role = role
+        )
+    }
+
+    private fun createAdminWithId(
+        id: Long,
+        organizationType: OrganizationType = OrganizationType.ASSOCIATION,
+        organizationId: Long = 1L,
+        role: OrganizationRole = OrganizationRole.ADMIN
+    ): OrganizationAdmin {
+        val admin = createAdmin(organizationType, organizationId, role)
+        val idField = OrganizationAdmin::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(admin, id)
+        return admin
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationRoleTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationRoleTest.kt
@@ -1,0 +1,154 @@
+package com.nextup.core.domain.admin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+@DisplayName("OrganizationRole 테스트")
+class OrganizationRoleTest {
+
+    @Nested
+    @DisplayName("enum 값")
+    inner class EnumValues {
+
+        @Test
+        fun `should have correct ADMIN properties`() {
+            // given
+            val role = OrganizationRole.ADMIN
+
+            // then
+            assertThat(role.displayName).isEqualTo("관리자")
+            assertThat(role.description).isEqualTo("조직의 모든 권한을 가진 최고 관리자")
+            assertThat(role.level).isEqualTo(100)
+        }
+
+        @Test
+        fun `should have correct MANAGER properties`() {
+            // given
+            val role = OrganizationRole.MANAGER
+
+            // then
+            assertThat(role.displayName).isEqualTo("매니저")
+            assertThat(role.description).isEqualTo("조직 운영 관련 권한을 가진 관리자")
+            assertThat(role.level).isEqualTo(50)
+        }
+
+        @Test
+        fun `should have correct SCORER properties`() {
+            // given
+            val role = OrganizationRole.SCORER
+
+            // then
+            assertThat(role.displayName).isEqualTo("기록원")
+            assertThat(role.description).isEqualTo("경기 기록 입력 권한만 가진 관리자")
+            assertThat(role.level).isEqualTo(10)
+        }
+    }
+
+    @Nested
+    @DisplayName("isHigherThan 메서드")
+    inner class IsHigherThan {
+
+        @Test
+        fun `ADMIN should be higher than MANAGER`() {
+            assertThat(OrganizationRole.ADMIN.isHigherThan(OrganizationRole.MANAGER)).isTrue()
+        }
+
+        @Test
+        fun `ADMIN should be higher than SCORER`() {
+            assertThat(OrganizationRole.ADMIN.isHigherThan(OrganizationRole.SCORER)).isTrue()
+        }
+
+        @Test
+        fun `MANAGER should be higher than SCORER`() {
+            assertThat(OrganizationRole.MANAGER.isHigherThan(OrganizationRole.SCORER)).isTrue()
+        }
+
+        @Test
+        fun `MANAGER should not be higher than ADMIN`() {
+            assertThat(OrganizationRole.MANAGER.isHigherThan(OrganizationRole.ADMIN)).isFalse()
+        }
+
+        @Test
+        fun `SCORER should not be higher than MANAGER`() {
+            assertThat(OrganizationRole.SCORER.isHigherThan(OrganizationRole.MANAGER)).isFalse()
+        }
+
+        @Test
+        fun `same role should not be higher than itself`() {
+            assertThat(OrganizationRole.ADMIN.isHigherThan(OrganizationRole.ADMIN)).isFalse()
+            assertThat(OrganizationRole.MANAGER.isHigherThan(OrganizationRole.MANAGER)).isFalse()
+            assertThat(OrganizationRole.SCORER.isHigherThan(OrganizationRole.SCORER)).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("isHigherOrEqual 메서드")
+    inner class IsHigherOrEqual {
+
+        @Test
+        fun `ADMIN should be higher or equal to all roles`() {
+            assertThat(OrganizationRole.ADMIN.isHigherOrEqual(OrganizationRole.ADMIN)).isTrue()
+            assertThat(OrganizationRole.ADMIN.isHigherOrEqual(OrganizationRole.MANAGER)).isTrue()
+            assertThat(OrganizationRole.ADMIN.isHigherOrEqual(OrganizationRole.SCORER)).isTrue()
+        }
+
+        @Test
+        fun `MANAGER should be higher or equal to MANAGER and SCORER`() {
+            assertThat(OrganizationRole.MANAGER.isHigherOrEqual(OrganizationRole.ADMIN)).isFalse()
+            assertThat(OrganizationRole.MANAGER.isHigherOrEqual(OrganizationRole.MANAGER)).isTrue()
+            assertThat(OrganizationRole.MANAGER.isHigherOrEqual(OrganizationRole.SCORER)).isTrue()
+        }
+
+        @Test
+        fun `SCORER should only be higher or equal to itself`() {
+            assertThat(OrganizationRole.SCORER.isHigherOrEqual(OrganizationRole.ADMIN)).isFalse()
+            assertThat(OrganizationRole.SCORER.isHigherOrEqual(OrganizationRole.MANAGER)).isFalse()
+            assertThat(OrganizationRole.SCORER.isHigherOrEqual(OrganizationRole.SCORER)).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("fromValue 메서드")
+    inner class FromValue {
+
+        @ParameterizedTest
+        @CsvSource(
+            "ADMIN, ADMIN",
+            "admin, ADMIN",
+            "Admin, ADMIN",
+            "MANAGER, MANAGER",
+            "manager, MANAGER",
+            "SCORER, SCORER",
+            "scorer, SCORER"
+        )
+        fun `should return correct role for valid values`(input: String, expected: OrganizationRole) {
+            // when
+            val result = OrganizationRole.fromValue(input)
+
+            // then
+            assertThat(result).isEqualTo(expected)
+        }
+
+        @Test
+        fun `should throw exception for invalid value`() {
+            // when & then
+            val exception = assertThrows<IllegalArgumentException> {
+                OrganizationRole.fromValue("INVALID")
+            }
+            assertThat(exception.message).contains("Invalid organization role")
+        }
+
+        @Test
+        fun `should throw exception for empty value`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                OrganizationRole.fromValue("")
+            }
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationTypeTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationTypeTest.kt
@@ -1,0 +1,109 @@
+package com.nextup.core.domain.admin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+@DisplayName("OrganizationType 테스트")
+class OrganizationTypeTest {
+
+    @Nested
+    @DisplayName("enum 값")
+    inner class EnumValues {
+
+        @Test
+        fun `should have correct ASSOCIATION properties`() {
+            // given
+            val type = OrganizationType.ASSOCIATION
+
+            // then
+            assertThat(type.displayName).isEqualTo("협회")
+            assertThat(type.description).isEqualTo("사회인 야구 협회")
+        }
+
+        @Test
+        fun `should have correct LEAGUE properties`() {
+            // given
+            val type = OrganizationType.LEAGUE
+
+            // then
+            assertThat(type.displayName).isEqualTo("리그")
+            assertThat(type.description).isEqualTo("협회에 속한 리그")
+        }
+
+        @Test
+        fun `should have correct TEAM properties`() {
+            // given
+            val type = OrganizationType.TEAM
+
+            // then
+            assertThat(type.displayName).isEqualTo("팀")
+            assertThat(type.description).isEqualTo("리그에 속한 팀")
+        }
+    }
+
+    @Nested
+    @DisplayName("fromValue 메서드")
+    inner class FromValue {
+
+        @ParameterizedTest
+        @CsvSource(
+            "ASSOCIATION, ASSOCIATION",
+            "association, ASSOCIATION",
+            "Association, ASSOCIATION",
+            "LEAGUE, LEAGUE",
+            "league, LEAGUE",
+            "League, LEAGUE",
+            "TEAM, TEAM",
+            "team, TEAM",
+            "Team, TEAM"
+        )
+        fun `should return correct type for valid values`(input: String, expected: OrganizationType) {
+            // when
+            val result = OrganizationType.fromValue(input)
+
+            // then
+            assertThat(result).isEqualTo(expected)
+        }
+
+        @Test
+        fun `should throw exception for invalid value`() {
+            // when & then
+            val exception = assertThrows<IllegalArgumentException> {
+                OrganizationType.fromValue("INVALID")
+            }
+            assertThat(exception.message).contains("Invalid organization type")
+        }
+
+        @Test
+        fun `should throw exception for empty value`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                OrganizationType.fromValue("")
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 enum 값")
+    inner class AllValues {
+
+        @Test
+        fun `should have exactly three types`() {
+            // when
+            val allTypes = OrganizationType.entries
+
+            // then
+            assertThat(allTypes).hasSize(3)
+            assertThat(allTypes).containsExactly(
+                OrganizationType.ASSOCIATION,
+                OrganizationType.LEAGUE,
+                OrganizationType.TEAM
+            )
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/admin/OrganizationAdminRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/admin/OrganizationAdminRepository.kt
@@ -1,0 +1,192 @@
+package com.nextup.infrastructure.repository.admin
+
+import com.nextup.core.domain.admin.OrganizationAdmin
+import com.nextup.core.domain.admin.OrganizationRole
+import com.nextup.core.domain.admin.OrganizationType
+import com.nextup.core.domain.user.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface OrganizationAdminRepository : JpaRepository<OrganizationAdmin, Long> {
+
+    /**
+     * 특정 사용자의 모든 조직 관리자 권한을 조회합니다.
+     */
+    fun findByUser(user: User): List<OrganizationAdmin>
+
+    /**
+     * 특정 사용자 ID의 모든 조직 관리자 권한을 조회합니다.
+     */
+    @Query("SELECT oa FROM OrganizationAdmin oa WHERE oa.user.id = :userId")
+    fun findByUserId(userId: Long): List<OrganizationAdmin>
+
+    /**
+     * 특정 사용자의 활성화된 조직 관리자 권한만 조회합니다.
+     */
+    @Query("SELECT oa FROM OrganizationAdmin oa WHERE oa.user.id = :userId AND oa.isActive = true")
+    fun findActiveByUserId(userId: Long): List<OrganizationAdmin>
+
+    /**
+     * 특정 조직의 모든 관리자를 조회합니다.
+     */
+    fun findByOrganizationTypeAndOrganizationId(
+        organizationType: OrganizationType,
+        organizationId: Long
+    ): List<OrganizationAdmin>
+
+    /**
+     * 특정 조직의 활성화된 관리자만 조회합니다.
+     */
+    @Query("""
+        SELECT oa FROM OrganizationAdmin oa
+        WHERE oa.organizationType = :organizationType
+        AND oa.organizationId = :organizationId
+        AND oa.isActive = true
+    """)
+    fun findActiveByOrganizationTypeAndOrganizationId(
+        organizationType: OrganizationType,
+        organizationId: Long
+    ): List<OrganizationAdmin>
+
+    /**
+     * 특정 사용자가 특정 조직의 관리자인지 조회합니다.
+     */
+    fun findByUserAndOrganizationTypeAndOrganizationId(
+        user: User,
+        organizationType: OrganizationType,
+        organizationId: Long
+    ): OrganizationAdmin?
+
+    /**
+     * 특정 사용자 ID가 특정 조직의 관리자인지 조회합니다.
+     */
+    @Query("""
+        SELECT oa FROM OrganizationAdmin oa
+        WHERE oa.user.id = :userId
+        AND oa.organizationType = :organizationType
+        AND oa.organizationId = :organizationId
+    """)
+    fun findByUserIdAndOrganizationTypeAndOrganizationId(
+        userId: Long,
+        organizationType: OrganizationType,
+        organizationId: Long
+    ): OrganizationAdmin?
+
+    /**
+     * 특정 사용자가 특정 조직의 관리자인지 확인합니다.
+     */
+    fun existsByUserAndOrganizationTypeAndOrganizationId(
+        user: User,
+        organizationType: OrganizationType,
+        organizationId: Long
+    ): Boolean
+
+    /**
+     * 특정 사용자 ID가 특정 조직의 관리자인지 확인합니다.
+     */
+    @Query("""
+        SELECT CASE WHEN COUNT(oa) > 0 THEN true ELSE false END
+        FROM OrganizationAdmin oa
+        WHERE oa.user.id = :userId
+        AND oa.organizationType = :organizationType
+        AND oa.organizationId = :organizationId
+    """)
+    fun existsByUserIdAndOrganizationTypeAndOrganizationId(
+        userId: Long,
+        organizationType: OrganizationType,
+        organizationId: Long
+    ): Boolean
+
+    /**
+     * 특정 사용자 ID가 특정 조직의 활성화된 관리자인지 확인합니다.
+     */
+    @Query("""
+        SELECT CASE WHEN COUNT(oa) > 0 THEN true ELSE false END
+        FROM OrganizationAdmin oa
+        WHERE oa.user.id = :userId
+        AND oa.organizationType = :organizationType
+        AND oa.organizationId = :organizationId
+        AND oa.isActive = true
+    """)
+    fun existsActiveByUserIdAndOrganizationTypeAndOrganizationId(
+        userId: Long,
+        organizationType: OrganizationType,
+        organizationId: Long
+    ): Boolean
+
+    /**
+     * 특정 사용자 ID의 특정 조직 유형 관리자 권한을 조회합니다.
+     */
+    @Query("""
+        SELECT oa FROM OrganizationAdmin oa
+        WHERE oa.user.id = :userId
+        AND oa.organizationType = :organizationType
+    """)
+    fun findByUserIdAndOrganizationType(
+        userId: Long,
+        organizationType: OrganizationType
+    ): List<OrganizationAdmin>
+
+    /**
+     * 특정 사용자 ID의 특정 조직 유형 활성화된 관리자 권한을 조회합니다.
+     */
+    @Query("""
+        SELECT oa FROM OrganizationAdmin oa
+        WHERE oa.user.id = :userId
+        AND oa.organizationType = :organizationType
+        AND oa.isActive = true
+    """)
+    fun findActiveByUserIdAndOrganizationType(
+        userId: Long,
+        organizationType: OrganizationType
+    ): List<OrganizationAdmin>
+
+    /**
+     * 특정 조직의 특정 역할을 가진 관리자를 조회합니다.
+     */
+    @Query("""
+        SELECT oa FROM OrganizationAdmin oa
+        WHERE oa.organizationType = :organizationType
+        AND oa.organizationId = :organizationId
+        AND oa.role = :role
+        AND oa.isActive = true
+    """)
+    fun findByOrganizationAndRole(
+        organizationType: OrganizationType,
+        organizationId: Long,
+        role: OrganizationRole
+    ): List<OrganizationAdmin>
+
+    /**
+     * 특정 사용자가 관리하는 팀 ID 목록을 조회합니다.
+     */
+    @Query("""
+        SELECT oa.organizationId FROM OrganizationAdmin oa
+        WHERE oa.user.id = :userId
+        AND oa.organizationType = 'TEAM'
+        AND oa.isActive = true
+    """)
+    fun findTeamIdsByUserId(userId: Long): List<Long>
+
+    /**
+     * 특정 사용자가 관리하는 리그 ID 목록을 조회합니다.
+     */
+    @Query("""
+        SELECT oa.organizationId FROM OrganizationAdmin oa
+        WHERE oa.user.id = :userId
+        AND oa.organizationType = 'LEAGUE'
+        AND oa.isActive = true
+    """)
+    fun findLeagueIdsByUserId(userId: Long): List<Long>
+
+    /**
+     * 특정 사용자가 관리하는 협회 ID 목록을 조회합니다.
+     */
+    @Query("""
+        SELECT oa.organizationId FROM OrganizationAdmin oa
+        WHERE oa.user.id = :userId
+        AND oa.organizationType = 'ASSOCIATION'
+        AND oa.isActive = true
+    """)
+    fun findAssociationIdsByUserId(userId: Long): List<Long>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/admin/OrganizationAdminService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/admin/OrganizationAdminService.kt
@@ -1,0 +1,234 @@
+package com.nextup.infrastructure.service.admin
+
+import com.nextup.common.exception.*
+import com.nextup.core.domain.admin.OrganizationAdmin
+import com.nextup.core.domain.admin.OrganizationRole
+import com.nextup.core.domain.admin.OrganizationType
+import com.nextup.infrastructure.repository.TeamRepository
+import com.nextup.infrastructure.repository.admin.OrganizationAdminRepository
+import com.nextup.infrastructure.repository.user.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 조직 관리자 서비스
+ *
+ * 조직-관리자 매핑을 관리하고, 같은 리그 내 여러 팀 관리자 충돌을 검증합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class OrganizationAdminService(
+    private val organizationAdminRepository: OrganizationAdminRepository,
+    private val userRepository: UserRepository,
+    private val teamRepository: TeamRepository
+) {
+
+    /**
+     * 관리자를 할당합니다.
+     *
+     * @param userId 사용자 ID
+     * @param organizationType 조직 유형
+     * @param organizationId 조직 ID
+     * @param role 역할
+     * @param assignedBy 할당한 사용자 ID (선택)
+     * @return 생성된 OrganizationAdmin
+     * @throws UserNotFoundException 사용자를 찾을 수 없는 경우
+     * @throws OrganizationAdminAlreadyExistsException 이미 할당된 경우
+     * @throws SameLeagueConflictException 같은 리그 내 여러 팀 관리자 충돌 시
+     */
+    @Transactional
+    fun assignAdmin(
+        userId: Long,
+        organizationType: OrganizationType,
+        organizationId: Long,
+        role: OrganizationRole,
+        assignedBy: Long? = null
+    ): OrganizationAdmin {
+        // 사용자 존재 확인
+        val user = userRepository.findById(userId)
+            .orElseThrow { UserNotFoundException(userId) }
+
+        // 이미 할당되어 있는지 확인
+        val existing = organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+            userId, organizationType, organizationId
+        )
+        if (existing != null) {
+            throw OrganizationAdminAlreadyExistsException(
+                organizationType.name,
+                organizationId,
+                userId
+            )
+        }
+
+        // 팀 관리자인 경우 같은 리그 내 여러 팀 관리자 검증
+        if (organizationType == OrganizationType.TEAM) {
+            validateSameLeagueConflict(userId, organizationId)
+        }
+
+        // 관리자 생성
+        val admin = OrganizationAdmin.create(
+            user = user,
+            organizationType = organizationType,
+            organizationId = organizationId,
+            role = role,
+            assignedBy = assignedBy
+        )
+
+        return organizationAdminRepository.save(admin)
+    }
+
+    /**
+     * 같은 리그 내 여러 팀의 관리자가 될 수 없도록 검증합니다.
+     *
+     * @param userId 사용자 ID
+     * @param newTeamId 새로 할당하려는 팀 ID
+     * @throws SameLeagueConflictException 같은 리그 내 다른 팀의 관리자인 경우
+     * @throws TeamNotFoundException 팀을 찾을 수 없는 경우
+     */
+    private fun validateSameLeagueConflict(userId: Long, newTeamId: Long) {
+        // 새 팀의 리그 ID 조회
+        val newTeam = teamRepository.findByIdWithLeague(newTeamId)
+            ?: throw TeamNotFoundException(newTeamId)
+        val newTeamLeagueId = newTeam.league.id
+
+        // 사용자의 활성화된 팀 관리자 권한 조회
+        val existingTeamAdmins = organizationAdminRepository.findActiveByUserIdAndOrganizationType(
+            userId,
+            OrganizationType.TEAM
+        )
+
+        // 같은 리그 내 다른 팀의 관리자인지 확인
+        for (admin in existingTeamAdmins) {
+            val existingTeam = teamRepository.findByIdWithLeague(admin.organizationId)
+                ?: continue
+
+            val existingTeamLeagueId = existingTeam.league.id
+
+            if (existingTeamLeagueId == newTeamLeagueId) {
+                throw SameLeagueConflictException(
+                    leagueId = newTeamLeagueId,
+                    existingTeamId = admin.organizationId,
+                    newTeamId = newTeamId
+                )
+            }
+        }
+    }
+
+    /**
+     * 관리자 권한을 해제합니다.
+     *
+     * @param userId 사용자 ID
+     * @param organizationType 조직 유형
+     * @param organizationId 조직 ID
+     * @throws OrganizationAdminNotFoundException 관리자를 찾을 수 없는 경우
+     */
+    @Transactional
+    fun removeAdmin(
+        userId: Long,
+        organizationType: OrganizationType,
+        organizationId: Long
+    ) {
+        val admin = organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+            userId, organizationType, organizationId
+        ) ?: throw OrganizationAdminNotFoundException(
+            organizationType.name,
+            organizationId,
+            userId
+        )
+
+        admin.deactivate()
+    }
+
+    /**
+     * 특정 조직의 관리자 목록을 조회합니다.
+     *
+     * @param organizationType 조직 유형
+     * @param organizationId 조직 ID
+     * @return 관리자 목록 (활성화된 관리자만)
+     */
+    fun getAdminsByOrganization(
+        organizationType: OrganizationType,
+        organizationId: Long
+    ): List<OrganizationAdmin> {
+        return organizationAdminRepository.findActiveByOrganizationTypeAndOrganizationId(
+            organizationType,
+            organizationId
+        )
+    }
+
+    /**
+     * 특정 사용자가 관리하는 모든 조직을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 관리하는 조직 목록 (활성화된 것만)
+     */
+    fun getOrganizationsByUser(userId: Long): List<OrganizationAdmin> {
+        return organizationAdminRepository.findActiveByUserId(userId)
+    }
+
+    /**
+     * 관리자의 역할을 변경합니다.
+     *
+     * @param userId 사용자 ID
+     * @param organizationType 조직 유형
+     * @param organizationId 조직 ID
+     * @param newRole 새로운 역할
+     * @return 수정된 OrganizationAdmin
+     * @throws OrganizationAdminNotFoundException 관리자를 찾을 수 없는 경우
+     * @throws OrganizationAdminDeactivatedException 비활성화된 관리자인 경우
+     */
+    @Transactional
+    fun changeRole(
+        userId: Long,
+        organizationType: OrganizationType,
+        organizationId: Long,
+        newRole: OrganizationRole
+    ): OrganizationAdmin {
+        val admin = organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+            userId, organizationType, organizationId
+        ) ?: throw OrganizationAdminNotFoundException(
+            organizationType.name,
+            organizationId,
+            userId
+        )
+
+        if (!admin.isActive) {
+            throw OrganizationAdminDeactivatedException(admin.id)
+        }
+
+        admin.changeRole(newRole)
+        return admin
+    }
+
+    /**
+     * 사용자가 특정 조직에 대한 권한을 가지고 있는지 확인합니다.
+     *
+     * @param userId 사용자 ID
+     * @param organizationType 조직 유형
+     * @param organizationId 조직 ID
+     * @return 권한 보유 여부
+     */
+    fun hasPermission(
+        userId: Long,
+        organizationType: OrganizationType,
+        organizationId: Long
+    ): Boolean {
+        return organizationAdminRepository.existsActiveByUserIdAndOrganizationTypeAndOrganizationId(
+            userId,
+            organizationType,
+            organizationId
+        )
+    }
+
+    /**
+     * ID로 관리자를 조회합니다.
+     *
+     * @param id 관리자 ID
+     * @return OrganizationAdmin
+     * @throws OrganizationAdminNotFoundByIdException 관리자를 찾을 수 없는 경우
+     */
+    fun getById(id: Long): OrganizationAdmin {
+        return organizationAdminRepository.findById(id)
+            .orElseThrow { OrganizationAdminNotFoundByIdException(id) }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/admin/OrganizationAdminServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/admin/OrganizationAdminServiceTest.kt
@@ -403,6 +403,136 @@ class OrganizationAdminServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("getById")
+    inner class GetById {
+
+        @Test
+        fun `ID로 관리자를 조회할 수 있다`() {
+            // given
+            val adminId = 1L
+            val user = createUser(1L, "test@example.com")
+            val admin = createOrganizationAdmin(adminId, user, OrganizationType.ASSOCIATION, 1L)
+
+            every { organizationAdminRepository.findById(adminId) } returns Optional.of(admin)
+
+            // when
+            val result = organizationAdminService.getById(adminId)
+
+            // then
+            assertThat(result.id).isEqualTo(adminId)
+            assertThat(result.user.id).isEqualTo(1L)
+        }
+
+        @Test
+        fun `존재하지 않는 ID로 조회하면 예외가 발생한다`() {
+            // given
+            val adminId = 99999L
+            every { organizationAdminRepository.findById(adminId) } returns Optional.empty()
+
+            // when & then
+            assertThatThrownBy {
+                organizationAdminService.getById(adminId)
+            }.isInstanceOf(OrganizationAdminNotFoundByIdException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("validateSameLeagueConflict edge cases")
+    inner class ValidateSameLeagueConflictEdgeCases {
+
+        @Test
+        fun `새 팀을 찾을 수 없으면 TeamNotFoundException 발생`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val newTeamId = 99L
+
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, OrganizationType.TEAM, newTeamId
+                )
+            } returns null
+            every { teamRepository.findByIdWithLeague(newTeamId) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                organizationAdminService.assignAdmin(
+                    userId = userId,
+                    organizationType = OrganizationType.TEAM,
+                    organizationId = newTeamId,
+                    role = OrganizationRole.ADMIN
+                )
+            }.isInstanceOf(TeamNotFoundException::class.java)
+        }
+
+        @Test
+        fun `기존 관리 팀을 찾을 수 없으면 무시하고 계속 진행한다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val existingTeamId = 1L
+            val newTeamId = 2L
+
+            val association = createAssociation(1L, "Test Association")
+            val league = createLeague(100L, "Test League", association)
+            val newTeam = createTeam(newTeamId, "New Team", league)
+
+            val existingAdmin = createOrganizationAdmin(1L, user, OrganizationType.TEAM, existingTeamId)
+
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, OrganizationType.TEAM, newTeamId
+                )
+            } returns null
+            every { teamRepository.findByIdWithLeague(newTeamId) } returns newTeam
+            every {
+                organizationAdminRepository.findActiveByUserIdAndOrganizationType(
+                    userId, OrganizationType.TEAM
+                )
+            } returns listOf(existingAdmin)
+            every { teamRepository.findByIdWithLeague(existingTeamId) } returns null
+            every { organizationAdminRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val admin = organizationAdminService.assignAdmin(
+                userId = userId,
+                organizationType = OrganizationType.TEAM,
+                organizationId = newTeamId,
+                role = OrganizationRole.ADMIN
+            )
+
+            // then
+            assertThat(admin.organizationId).isEqualTo(newTeamId)
+            verify { organizationAdminRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("changeRole edge cases")
+    inner class ChangeRoleEdgeCases {
+
+        @Test
+        fun `존재하지 않는 관리자의 역할을 변경하면 예외가 발생한다`() {
+            // given
+            val userId = 1L
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, OrganizationType.ASSOCIATION, 1L
+                )
+            } returns null
+
+            // when & then
+            assertThatThrownBy {
+                organizationAdminService.changeRole(
+                    userId, OrganizationType.ASSOCIATION, 1L, OrganizationRole.MANAGER
+                )
+            }.isInstanceOf(OrganizationAdminNotFoundException::class.java)
+        }
+    }
+
     // Helper methods
 
     private fun createUser(id: Long, email: String): User {

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/admin/OrganizationAdminServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/admin/OrganizationAdminServiceTest.kt
@@ -1,0 +1,472 @@
+package com.nextup.infrastructure.service.admin
+
+import com.nextup.common.exception.*
+import com.nextup.core.domain.admin.OrganizationAdmin
+import com.nextup.core.domain.admin.OrganizationRole
+import com.nextup.core.domain.admin.OrganizationType
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.TeamRepository
+import com.nextup.infrastructure.repository.admin.OrganizationAdminRepository
+import com.nextup.infrastructure.repository.user.UserRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.*
+
+@DisplayName("OrganizationAdminService")
+class OrganizationAdminServiceTest {
+
+    private lateinit var organizationAdminRepository: OrganizationAdminRepository
+    private lateinit var userRepository: UserRepository
+    private lateinit var teamRepository: TeamRepository
+    private lateinit var organizationAdminService: OrganizationAdminService
+
+    @BeforeEach
+    fun setUp() {
+        organizationAdminRepository = mockk()
+        userRepository = mockk()
+        teamRepository = mockk()
+        organizationAdminService = OrganizationAdminService(
+            organizationAdminRepository,
+            userRepository,
+            teamRepository
+        )
+    }
+
+    @Nested
+    @DisplayName("assignAdmin")
+    inner class AssignAdmin {
+
+        @Test
+        fun `관리자를 할당할 수 있다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val organizationType = OrganizationType.ASSOCIATION
+            val organizationId = 1L
+            val role = OrganizationRole.ADMIN
+
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, organizationType, organizationId
+                )
+            } returns null
+            every { organizationAdminRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val admin = organizationAdminService.assignAdmin(
+                userId = userId,
+                organizationType = organizationType,
+                organizationId = organizationId,
+                role = role
+            )
+
+            // then
+            assertThat(admin.user.id).isEqualTo(userId)
+            assertThat(admin.organizationType).isEqualTo(organizationType)
+            assertThat(admin.organizationId).isEqualTo(organizationId)
+            assertThat(admin.role).isEqualTo(role)
+            assertThat(admin.isActive).isTrue()
+            verify { organizationAdminRepository.save(any()) }
+        }
+
+        @Test
+        fun `존재하지 않는 사용자에게는 관리자를 할당할 수 없다`() {
+            // given
+            val userId = 99999L
+            every { userRepository.findById(userId) } returns Optional.empty()
+
+            // when & then
+            assertThatThrownBy {
+                organizationAdminService.assignAdmin(
+                    userId = userId,
+                    organizationType = OrganizationType.ASSOCIATION,
+                    organizationId = 1L,
+                    role = OrganizationRole.ADMIN
+                )
+            }.isInstanceOf(UserNotFoundException::class.java)
+        }
+
+        @Test
+        fun `이미 할당된 관리자는 다시 할당할 수 없다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val organizationType = OrganizationType.ASSOCIATION
+            val organizationId = 1L
+            val existingAdmin = createOrganizationAdmin(1L, user, organizationType, organizationId)
+
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, organizationType, organizationId
+                )
+            } returns existingAdmin
+
+            // when & then
+            assertThatThrownBy {
+                organizationAdminService.assignAdmin(
+                    userId = userId,
+                    organizationType = organizationType,
+                    organizationId = organizationId,
+                    role = OrganizationRole.MANAGER
+                )
+            }.isInstanceOf(OrganizationAdminAlreadyExistsException::class.java)
+        }
+
+        @Test
+        fun `같은 리그 내 여러 팀의 관리자가 될 수 없다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val leagueId = 100L
+            val team1Id = 1L
+            val team2Id = 2L
+
+            val association = createAssociation(1L, "Test Association")
+            val league = createLeague(leagueId, "Test League", association)
+            val team1 = createTeam(team1Id, "Team 1", league)
+            val team2 = createTeam(team2Id, "Team 2", league)
+
+            val existingAdmin = createOrganizationAdmin(1L, user, OrganizationType.TEAM, team1Id)
+
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, OrganizationType.TEAM, team2Id
+                )
+            } returns null
+            every { teamRepository.findByIdWithLeague(team2Id) } returns team2
+            every {
+                organizationAdminRepository.findActiveByUserIdAndOrganizationType(
+                    userId, OrganizationType.TEAM
+                )
+            } returns listOf(existingAdmin)
+            every { teamRepository.findByIdWithLeague(team1Id) } returns team1
+
+            // when & then
+            assertThatThrownBy {
+                organizationAdminService.assignAdmin(
+                    userId = userId,
+                    organizationType = OrganizationType.TEAM,
+                    organizationId = team2Id,
+                    role = OrganizationRole.ADMIN
+                )
+            }.isInstanceOf(SameLeagueConflictException::class.java)
+                .hasMessageContaining("leagueId=$leagueId")
+                .hasMessageContaining("existingTeamId=$team1Id")
+                .hasMessageContaining("newTeamId=$team2Id")
+        }
+
+        @Test
+        fun `서로 다른 리그의 여러 팀 관리자가 될 수 있다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val league1Id = 100L
+            val league2Id = 200L
+            val team1Id = 1L
+            val team2Id = 2L
+
+            val association = createAssociation(1L, "Test Association")
+            val league1 = createLeague(league1Id, "League 1", association)
+            val league2 = createLeague(league2Id, "League 2", association)
+            val team1 = createTeam(team1Id, "Team 1", league1)
+            val team2 = createTeam(team2Id, "Team 2", league2)
+
+            val existingAdmin = createOrganizationAdmin(1L, user, OrganizationType.TEAM, team1Id)
+
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, OrganizationType.TEAM, team2Id
+                )
+            } returns null
+            every { teamRepository.findByIdWithLeague(team2Id) } returns team2
+            every {
+                organizationAdminRepository.findActiveByUserIdAndOrganizationType(
+                    userId, OrganizationType.TEAM
+                )
+            } returns listOf(existingAdmin)
+            every { teamRepository.findByIdWithLeague(team1Id) } returns team1
+            every { organizationAdminRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val admin = organizationAdminService.assignAdmin(
+                userId = userId,
+                organizationType = OrganizationType.TEAM,
+                organizationId = team2Id,
+                role = OrganizationRole.ADMIN
+            )
+
+            // then
+            assertThat(admin.organizationId).isEqualTo(team2Id)
+            verify { organizationAdminRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("removeAdmin")
+    inner class RemoveAdmin {
+
+        @Test
+        fun `관리자 권한을 해제할 수 있다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val organizationType = OrganizationType.ASSOCIATION
+            val organizationId = 1L
+            val admin = createOrganizationAdmin(1L, user, organizationType, organizationId)
+
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, organizationType, organizationId
+                )
+            } returns admin
+
+            // when
+            organizationAdminService.removeAdmin(userId, organizationType, organizationId)
+
+            // then
+            assertThat(admin.isActive).isFalse()
+        }
+
+        @Test
+        fun `존재하지 않는 관리자는 해제할 수 없다`() {
+            // given
+            val userId = 1L
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, OrganizationType.ASSOCIATION, 1L
+                )
+            } returns null
+
+            // when & then
+            assertThatThrownBy {
+                organizationAdminService.removeAdmin(
+                    userId = userId,
+                    organizationType = OrganizationType.ASSOCIATION,
+                    organizationId = 1L
+                )
+            }.isInstanceOf(OrganizationAdminNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getAdminsByOrganization")
+    inner class GetAdminsByOrganization {
+
+        @Test
+        fun `특정 조직의 관리자 목록을 조회할 수 있다`() {
+            // given
+            val organizationType = OrganizationType.ASSOCIATION
+            val organizationId = 1L
+            val user1 = createUser(1L, "user1@example.com")
+            val user2 = createUser(2L, "user2@example.com")
+            val admin1 = createOrganizationAdmin(1L, user1, organizationType, organizationId, OrganizationRole.ADMIN)
+            val admin2 = createOrganizationAdmin(2L, user2, organizationType, organizationId, OrganizationRole.MANAGER)
+
+            every {
+                organizationAdminRepository.findActiveByOrganizationTypeAndOrganizationId(
+                    organizationType, organizationId
+                )
+            } returns listOf(admin1, admin2)
+
+            // when
+            val admins = organizationAdminService.getAdminsByOrganization(organizationType, organizationId)
+
+            // then
+            assertThat(admins).hasSize(2)
+            assertThat(admins.map { it.user.id }).containsExactlyInAnyOrder(1L, 2L)
+        }
+    }
+
+    @Nested
+    @DisplayName("getOrganizationsByUser")
+    inner class GetOrganizationsByUser {
+
+        @Test
+        fun `사용자가 관리하는 모든 조직을 조회할 수 있다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val admin1 = createOrganizationAdmin(1L, user, OrganizationType.ASSOCIATION, 1L)
+            val admin2 = createOrganizationAdmin(2L, user, OrganizationType.LEAGUE, 2L)
+
+            every { organizationAdminRepository.findActiveByUserId(userId) } returns listOf(admin1, admin2)
+
+            // when
+            val organizations = organizationAdminService.getOrganizationsByUser(userId)
+
+            // then
+            assertThat(organizations).hasSize(2)
+            assertThat(organizations.map { it.organizationType }).containsExactlyInAnyOrder(
+                OrganizationType.ASSOCIATION,
+                OrganizationType.LEAGUE
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("changeRole")
+    inner class ChangeRole {
+
+        @Test
+        fun `관리자 역할을 변경할 수 있다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val organizationType = OrganizationType.ASSOCIATION
+            val organizationId = 1L
+            val admin = createOrganizationAdmin(1L, user, organizationType, organizationId, OrganizationRole.ADMIN)
+
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, organizationType, organizationId
+                )
+            } returns admin
+
+            // when
+            val updated = organizationAdminService.changeRole(
+                userId, organizationType, organizationId, OrganizationRole.MANAGER
+            )
+
+            // then
+            assertThat(updated.role).isEqualTo(OrganizationRole.MANAGER)
+        }
+
+        @Test
+        fun `비활성화된 관리자의 역할은 변경할 수 없다`() {
+            // given
+            val userId = 1L
+            val user = createUser(userId, "test@example.com")
+            val organizationType = OrganizationType.ASSOCIATION
+            val organizationId = 1L
+            val admin = createOrganizationAdmin(1L, user, organizationType, organizationId)
+            admin.deactivate()
+
+            every {
+                organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, organizationType, organizationId
+                )
+            } returns admin
+
+            // when & then
+            assertThatThrownBy {
+                organizationAdminService.changeRole(
+                    userId, organizationType, organizationId, OrganizationRole.MANAGER
+                )
+            }.isInstanceOf(OrganizationAdminDeactivatedException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("hasPermission")
+    inner class HasPermission {
+
+        @Test
+        fun `사용자가 특정 조직에 대한 권한을 가지고 있는지 확인할 수 있다`() {
+            // given
+            val userId = 1L
+            every {
+                organizationAdminRepository.existsActiveByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, OrganizationType.ASSOCIATION, 1L
+                )
+            } returns true
+            every {
+                organizationAdminRepository.existsActiveByUserIdAndOrganizationTypeAndOrganizationId(
+                    userId, OrganizationType.LEAGUE, 2L
+                )
+            } returns false
+
+            // when
+            val hasPermission = organizationAdminService.hasPermission(
+                userId, OrganizationType.ASSOCIATION, 1L
+            )
+            val noPermission = organizationAdminService.hasPermission(
+                userId, OrganizationType.LEAGUE, 2L
+            )
+
+            // then
+            assertThat(hasPermission).isTrue()
+            assertThat(noPermission).isFalse()
+        }
+    }
+
+    // Helper methods
+
+    private fun createUser(id: Long, email: String): User {
+        val user = User.createLocalUser(
+            email = email,
+            encodedPassword = "password",
+            nickname = "Test User"
+        )
+        setEntityId(user, id)
+        return user
+    }
+
+    private fun createAssociation(id: Long, name: String): Association {
+        val association = Association(
+            name = name,
+            abbreviation = name.substring(0, 2),
+            region = "Seoul"
+        )
+        setEntityId(association, id)
+        return association
+    }
+
+    private fun createLeague(id: Long, name: String, association: Association): League {
+        val league = League(
+            association = association,
+            name = name,
+            abbreviation = name.substring(0, 2),
+            foundedYear = 2020
+        )
+        setEntityId(league, id)
+        return league
+    }
+
+    private fun createTeam(id: Long, name: String, league: League): Team {
+        val team = Team(
+            league = league,
+            name = name,
+            city = "Seoul",
+            foundedYear = 2020
+        )
+        setEntityId(team, id)
+        return team
+    }
+
+    private fun createOrganizationAdmin(
+        id: Long,
+        user: User,
+        organizationType: OrganizationType,
+        organizationId: Long,
+        role: OrganizationRole = OrganizationRole.ADMIN
+    ): OrganizationAdmin {
+        val admin = OrganizationAdmin.create(
+            user = user,
+            organizationType = organizationType,
+            organizationId = organizationId,
+            role = role
+        )
+        setEntityId(admin, id)
+        return admin
+    }
+
+    private fun setEntityId(entity: Any, id: Long) {
+        val idField = entity::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(entity, id)
+    }
+}


### PR DESCRIPTION
## Summary

- close #28

사용자와 조직(협회/리그/팀) 간의 관리자 권한 매핑 시스템을 구현했습니다. **같은 리그 내 여러 팀 관리자 불가** 비즈니스 규칙이 적용되었습니다.

## Tasks

- [x] `OrganizationType` enum 생성 (ASSOCIATION, LEAGUE, TEAM)
- [x] `OrganizationRole` enum 생성 (ADMIN, MANAGER, SCORER)
- [x] `OrganizationAdmin` 엔티티 구현 (Rich Domain Model)
- [x] `OrganizationAdminExceptions` 예외 클래스 생성 (9개)
- [x] `OrganizationAdminRepository` 인터페이스 구현
- [x] `OrganizationAdminService` 비즈니스 로직 구현
- [x] 같은 리그 내 여러 팀 관리자 충돌 검증 로직 구현
- [x] `OrganizationAdminController` API 엔드포인트 구현
- [x] Request/Response DTO 구현
- [x] `OrganizationAdminServiceTest` 유닛 테스트 (11개)
- [x] `OrganizationAdminControllerTest` 컨트롤러 테스트 (5개)

## To Reviewer

**API Endpoints:**
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/backoffice/organizations/{type}/{id}/admins` | 관리자 할당 |
| DELETE | `/api/backoffice/organizations/{type}/{id}/admins/{userId}` | 관리자 해제 |
| GET | `/api/backoffice/organizations/{type}/{id}/admins` | 관리자 목록 |
| GET | `/api/backoffice/organizations/by-user/{userId}` | 사용자별 조직 |
| PUT | `/api/backoffice/organizations/{type}/{id}/admins/{userId}/role` | 역할 변경 |

**비즈니스 규칙:**
- 한 사용자가 여러 조직의 관리자 가능
- 같은 리그 내 여러 팀 관리자는 불가 (`SameLeagueConflictException`)
- 서로 다른 리그의 여러 팀 관리자는 가능