### PR TITLE
feat(#27): OAuth2 소셜 로그인 구현 (Kakao, Google, Naver)

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
@@ -4,6 +4,9 @@ import com.nextup.infrastructure.security.handler.CustomAccessDeniedHandler
 import com.nextup.infrastructure.security.handler.CustomAuthenticationEntryPoint
 import com.nextup.infrastructure.security.jwt.JwtAuthenticationFilter
 import com.nextup.infrastructure.security.jwt.JwtProperties
+import com.nextup.infrastructure.security.oauth2.CustomOAuth2UserService
+import com.nextup.infrastructure.security.oauth2.OAuth2AuthenticationFailureHandler
+import com.nextup.infrastructure.security.oauth2.OAuth2AuthenticationSuccessHandler
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -29,7 +32,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
     private val customAuthenticationEntryPoint: CustomAuthenticationEntryPoint,
-    private val customAccessDeniedHandler: CustomAccessDeniedHandler
+    private val customAccessDeniedHandler: CustomAccessDeniedHandler,
+    private val customOAuth2UserService: CustomOAuth2UserService,
+    private val oAuth2AuthenticationSuccessHandler: OAuth2AuthenticationSuccessHandler,
+    private val oAuth2AuthenticationFailureHandler: OAuth2AuthenticationFailureHandler
 ) {
 
     @Bean
@@ -47,6 +53,10 @@ class SecurityConfig(
                     .requestMatchers("/api/auth/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/associations/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/stats/**").permitAll()
+
+                    // OAuth2 endpoints
+                    .requestMatchers("/oauth2/**").permitAll()
+                    .requestMatchers("/login/oauth2/**").permitAll()
 
                     // Swagger/OpenAPI
                     .requestMatchers(
@@ -67,6 +77,12 @@ class SecurityConfig(
 
                     // All other endpoints require authentication
                     .anyRequest().authenticated()
+            }
+            .oauth2Login { oauth2 ->
+                oauth2
+                    .userInfoEndpoint { it.userService(customOAuth2UserService) }
+                    .successHandler(oAuth2AuthenticationSuccessHandler)
+                    .failureHandler(oAuth2AuthenticationFailureHandler)
             }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/oauth/OAuthController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/oauth/OAuthController.kt
@@ -1,0 +1,91 @@
+package com.nextup.api.controller.oauth
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.oauth.LinkedOAuthAccountsResponse
+import com.nextup.api.dto.oauth.OAuthLinkStartResponse
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.infrastructure.service.oauth.OAuthLinkService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.util.UriComponentsBuilder
+
+/**
+ * OAuth 계정 연동 관련 API Controller
+ */
+@RestController
+@RequestMapping("/api/me/oauth-accounts")
+class OAuthController(
+    private val oauthLinkService: OAuthLinkService,
+    @Value("\${app.oauth2.base-url:http://localhost:8080}")
+    private val baseUrl: String
+) {
+
+    /**
+     * 연동된 소셜 계정 목록 조회
+     *
+     * GET /api/me/oauth-accounts
+     */
+    @GetMapping
+    fun getLinkedOAuthAccounts(
+        @AuthenticationPrincipal userId: Long
+    ): ResponseEntity<ApiResponse<LinkedOAuthAccountsResponse>> {
+        val providers = oauthLinkService.getLinkedProviders(userId)
+        val response = LinkedOAuthAccountsResponse(providers = providers)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    /**
+     * 소셜 계정 연동 시작
+     *
+     * POST /api/me/oauth-accounts/{provider}/link
+     *
+     * OAuth2 인증 URL을 생성하여 반환합니다.
+     * 클라이언트는 이 URL로 리다이렉트하여 OAuth2 플로우를 시작합니다.
+     */
+    @PostMapping("/{provider}/link")
+    fun startOAuthLink(
+        @PathVariable provider: OAuthProvider,
+        @AuthenticationPrincipal userId: Long
+    ): ResponseEntity<ApiResponse<OAuthLinkStartResponse>> {
+        // OAuth2 인증 URL 생성
+        val authorizationUrl = buildAuthorizationUrl(provider)
+
+        val response = OAuthLinkStartResponse(
+            authorizationUrl = authorizationUrl,
+            provider = provider
+        )
+
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    /**
+     * 소셜 계정 연결 해제
+     *
+     * DELETE /api/me/oauth-accounts/{provider}
+     */
+    @DeleteMapping("/{provider}")
+    fun unlinkOAuthAccount(
+        @PathVariable provider: OAuthProvider,
+        @AuthenticationPrincipal userId: Long
+    ): ResponseEntity<ApiResponse<Unit>> {
+        oauthLinkService.unlinkOAuthAccount(userId, provider)
+        return ResponseEntity.ok(ApiResponse.success(Unit))
+    }
+
+    /**
+     * OAuth2 인증 URL을 생성합니다.
+     *
+     * Spring Security OAuth2 Client의 표준 엔드포인트를 사용합니다.
+     * 형식: /oauth2/authorization/{registrationId}
+     */
+    private fun buildAuthorizationUrl(provider: OAuthProvider): String {
+        val registrationId = provider.name.lowercase()
+
+        return UriComponentsBuilder.fromUriString(baseUrl)
+            .path("/oauth2/authorization/$registrationId")
+            .build()
+            .toUriString()
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/oauth/OAuthLinkRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/oauth/OAuthLinkRequest.kt
@@ -1,0 +1,14 @@
+package com.nextup.api.dto.oauth
+
+import com.nextup.core.domain.user.OAuthProvider
+import jakarta.validation.constraints.NotNull
+
+/**
+ * OAuth 계정 연동 요청 DTO
+ *
+ * 소셜 로그인 연동 시작 시 사용됩니다.
+ */
+data class OAuthLinkRequest(
+    @field:NotNull(message = "OAuth provider is required")
+    val provider: OAuthProvider
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/oauth/OAuthLinkResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/oauth/OAuthLinkResponse.kt
@@ -1,0 +1,26 @@
+package com.nextup.api.dto.oauth
+
+import com.nextup.core.domain.user.OAuthProvider
+
+/**
+ * OAuth 계정 연동 응답 DTO
+ */
+data class OAuthLinkResponse(
+    val provider: OAuthProvider,
+    val linkedAt: String
+)
+
+/**
+ * 연동된 OAuth 계정 목록 응답 DTO
+ */
+data class LinkedOAuthAccountsResponse(
+    val providers: List<OAuthProvider>
+)
+
+/**
+ * OAuth 계정 연동 시작 응답 DTO
+ */
+data class OAuthLinkStartResponse(
+    val authorizationUrl: String,
+    val provider: OAuthProvider
+)

--- a/nextup-api/src/main/resources/application.yml
+++ b/nextup-api/src/main/resources/application.yml
@@ -21,6 +21,55 @@ spring:
     property-naming-strategy: SNAKE_CASE
     default-property-inclusion: non_null
 
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID:}
+            client-secret: ${KAKAO_CLIENT_SECRET:}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope:
+              - profile_nickname
+              - account_email
+
+          google:
+            client-id: ${GOOGLE_CLIENT_ID:}
+            client-secret: ${GOOGLE_CLIENT_SECRET:}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - email
+              - profile
+
+          naver:
+            client-id: ${NAVER_CLIENT_ID:}
+            client-secret: ${NAVER_CLIENT_SECRET:}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+app:
+  oauth2:
+    base-url: ${APP_BASE_URL:http://localhost:8080}
+    redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/oauth2/callback}
+
 jwt:
   secret: ${JWT_SECRET:dGhpcyBpcyBhIHNhbXBsZSBiYXNlNjQgZW5jb2RlZCBzZWNyZXQga2V5IGZvciBkZXZlbG9wbWVudCBvbmx5}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION:1800000}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/oauth/OAuthControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/oauth/OAuthControllerTest.kt
@@ -1,0 +1,105 @@
+package com.nextup.api.controller.oauth
+
+import com.nextup.common.exception.OAuthAccountNotFoundException
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.infrastructure.service.oauth.OAuthLinkService
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("OAuthController 테스트")
+class OAuthControllerTest {
+
+    private lateinit var oauthLinkService: OAuthLinkService
+    private lateinit var oauthController: OAuthController
+
+    private val testUserId = 1L
+    private val baseUrl = "http://localhost:8080"
+
+    @BeforeEach
+    fun setUp() {
+        oauthLinkService = mockk()
+        oauthController = OAuthController(oauthLinkService, baseUrl)
+    }
+
+    @Test
+    @DisplayName("GET /api/me/oauth-accounts - 연동된 소셜 계정 목록 조회 성공")
+    fun getLinkedOAuthAccounts_Success() {
+        // given
+        val linkedProviders = listOf(OAuthProvider.KAKAO, OAuthProvider.GOOGLE)
+        every { oauthLinkService.getLinkedProviders(testUserId) } returns linkedProviders
+
+        // when
+        val response = oauthController.getLinkedOAuthAccounts(testUserId)
+
+        // then
+        assertThat(response.statusCode.value()).isEqualTo(200)
+        assertThat(response.body?.success).isTrue()
+        assertThat(response.body?.data?.providers).containsExactly(
+            OAuthProvider.KAKAO,
+            OAuthProvider.GOOGLE
+        )
+    }
+
+    @Test
+    @DisplayName("GET /api/me/oauth-accounts - 연동된 계정이 없는 경우")
+    fun getLinkedOAuthAccounts_Empty() {
+        // given
+        every { oauthLinkService.getLinkedProviders(testUserId) } returns emptyList()
+
+        // when
+        val response = oauthController.getLinkedOAuthAccounts(testUserId)
+
+        // then
+        assertThat(response.statusCode.value()).isEqualTo(200)
+        assertThat(response.body?.success).isTrue()
+        assertThat(response.body?.data?.providers).isEmpty()
+    }
+
+    @Test
+    @DisplayName("POST /api/me/oauth-accounts/{provider}/link - 소셜 계정 연동 시작 성공")
+    fun startOAuthLink_Success() {
+        // when
+        val response = oauthController.startOAuthLink(OAuthProvider.KAKAO, testUserId)
+
+        // then
+        assertThat(response.statusCode.value()).isEqualTo(200)
+        assertThat(response.body?.success).isTrue()
+        assertThat(response.body?.data?.provider).isEqualTo(OAuthProvider.KAKAO)
+        assertThat(response.body?.data?.authorizationUrl)
+            .isEqualTo("$baseUrl/oauth2/authorization/kakao")
+    }
+
+    @Test
+    @DisplayName("DELETE /api/me/oauth-accounts/{provider} - 소셜 계정 연결 해제 성공")
+    fun unlinkOAuthAccount_Success() {
+        // given
+        every { oauthLinkService.unlinkOAuthAccount(testUserId, OAuthProvider.KAKAO) } returns Unit
+
+        // when
+        val response = oauthController.unlinkOAuthAccount(OAuthProvider.KAKAO, testUserId)
+
+        // then
+        assertThat(response.statusCode.value()).isEqualTo(200)
+        assertThat(response.body?.success).isTrue()
+    }
+
+    @Test
+    @DisplayName("DELETE /api/me/oauth-accounts/{provider} - 연결되지 않은 계정 해제 시도 시 예외 발생")
+    fun unlinkOAuthAccount_NotFound() {
+        // given
+        every {
+            oauthLinkService.unlinkOAuthAccount(testUserId, OAuthProvider.NAVER)
+        } throws OAuthAccountNotFoundException("NAVER", "unknown")
+
+        // when & then
+        try {
+            oauthController.unlinkOAuthAccount(OAuthProvider.NAVER, testUserId)
+        } catch (e: OAuthAccountNotFoundException) {
+            assertThat(e.code).isEqualTo("OAUTH_ACCOUNT_NOT_FOUND")
+        }
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/AuthExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/AuthExceptions.kt
@@ -67,3 +67,23 @@ class RefreshTokenRevokedException(
     "REFRESH_TOKEN_REVOKED",
     message
 )
+
+/**
+ * 지원하지 않는 OAuth2 Provider일 때 발생하는 예외
+ */
+class UnsupportedOAuth2ProviderException(
+    provider: String
+) : AuthenticationException(
+    "UNSUPPORTED_OAUTH2_PROVIDER",
+    "Unsupported OAuth2 provider: $provider"
+)
+
+/**
+ * OAuth2 인증 처리 중 오류가 발생했을 때 발생하는 예외
+ */
+class OAuth2AuthenticationProcessingException(
+    message: String
+) : AuthenticationException(
+    "OAUTH2_PROCESSING_ERROR",
+    message
+)

--- a/nextup-infrastructure/build.gradle.kts
+++ b/nextup-infrastructure/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
     // Spring Security
     api("org.springframework.boot:spring-boot-starter-security")
 
+    // OAuth2 Client
+    api("org.springframework.boot:spring-boot-starter-oauth2-client")
+
     // JWT
     api("io.jsonwebtoken:jjwt-api:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserService.kt
@@ -1,0 +1,104 @@
+package com.nextup.infrastructure.security.oauth2
+
+import com.nextup.common.exception.OAuth2AuthenticationProcessingException
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.user.OAuthAccountRepository
+import com.nextup.infrastructure.security.userdetails.UserJpaRepository
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * OAuth2 로그인 시 사용자 정보를 처리하는 서비스
+ *
+ * 1. 기존 OAuthAccount 존재 → User 조회
+ * 2. 이메일로 User 조회 → 기존 User에 OAuthAccount 추가
+ * 3. 신규 User + OAuthAccount 생성
+ */
+@Service
+@Transactional
+class CustomOAuth2UserService(
+    private val userJpaRepository: UserJpaRepository,
+    private val oAuthAccountRepository: OAuthAccountRepository
+) : DefaultOAuth2UserService() {
+
+    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
+        val oAuth2User = super.loadUser(userRequest)
+        return processOAuth2User(userRequest, oAuth2User)
+    }
+
+    private fun processOAuth2User(
+        userRequest: OAuth2UserRequest,
+        oAuth2User: OAuth2User
+    ): OAuth2UserPrincipal {
+        val registrationId = userRequest.clientRegistration.registrationId
+        val attributes = oAuth2User.attributes
+
+        val oAuth2UserInfo = OAuth2UserInfoFactory.create(registrationId, attributes)
+        val provider = oAuth2UserInfo.provider
+
+        if (oAuth2UserInfo.id.isBlank()) {
+            throw OAuth2AuthenticationProcessingException(
+                "OAuth2 provider did not return user ID"
+            )
+        }
+
+        // 1. 기존 OAuthAccount로 User 조회
+        val existingOAuthAccount = oAuthAccountRepository.findByProviderAndOauthId(
+            provider,
+            oAuth2UserInfo.id
+        )
+
+        if (existingOAuthAccount != null) {
+            return OAuth2UserPrincipal(
+                user = existingOAuthAccount.user,
+                oAuth2UserInfo = oAuth2UserInfo,
+                isNewUser = false
+            )
+        }
+
+        // 2. 이메일로 기존 User 조회 후 OAuthAccount 연동
+        val email = oAuth2UserInfo.email
+        if (!email.isNullOrBlank()) {
+            val existingUser = userJpaRepository.findByEmail(email)
+            if (existingUser != null) {
+                existingUser.addOAuthAccount(
+                    provider = provider,
+                    oauthId = oAuth2UserInfo.id,
+                    email = email
+                )
+                userJpaRepository.save(existingUser)
+
+                return OAuth2UserPrincipal(
+                    user = existingUser,
+                    oAuth2UserInfo = oAuth2UserInfo,
+                    isNewUser = false
+                )
+            }
+        }
+
+        // 3. 신규 User 생성
+        val nickname = oAuth2UserInfo.name
+            ?: email?.substringBefore("@")
+            ?: "${provider.displayName}사용자"
+
+        val userEmail = email ?: "${provider.name.lowercase()}_${oAuth2UserInfo.id}@oauth.local"
+
+        val newUser = User.createOAuthUser(
+            email = userEmail,
+            nickname = nickname,
+            provider = provider,
+            oauthId = oAuth2UserInfo.id,
+            profileImageUrl = oAuth2UserInfo.profileImageUrl
+        )
+        userJpaRepository.save(newUser)
+
+        return OAuth2UserPrincipal(
+            user = newUser,
+            oAuth2UserInfo = oAuth2UserInfo,
+            isNewUser = true
+        )
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationFailureHandler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationFailureHandler.kt
@@ -1,0 +1,40 @@
+package com.nextup.infrastructure.security.oauth2
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler
+import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * OAuth2 인증 실패 핸들러
+ *
+ * 인증 실패 시 에러 정보와 함께 프론트엔드로 리다이렉트합니다.
+ */
+@Component
+class OAuth2AuthenticationFailureHandler(
+    @Value("\${app.oauth2.redirect-uri:http://localhost:3000/oauth/callback}")
+    private val redirectUri: String
+) : SimpleUrlAuthenticationFailureHandler() {
+
+    override fun onAuthenticationFailure(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        exception: AuthenticationException
+    ) {
+        val errorMessage = exception.message ?: "Authentication failed"
+        val encodedMessage = URLEncoder.encode(errorMessage, StandardCharsets.UTF_8)
+
+        val targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+            .queryParam("error", "oauth_error")
+            .queryParam("message", encodedMessage)
+            .build()
+            .toUriString()
+
+        response.sendRedirect(targetUrl)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
@@ -1,0 +1,69 @@
+package com.nextup.infrastructure.security.oauth2
+
+import com.nextup.core.domain.auth.RefreshToken
+import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
+import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
+
+/**
+ * OAuth2 인증 성공 핸들러
+ *
+ * 인증 성공 시 JWT 토큰을 발급하고 프론트엔드로 리다이렉트합니다.
+ */
+@Component
+class OAuth2AuthenticationSuccessHandler(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    @Value("\${app.oauth2.redirect-uri:http://localhost:3000/oauth/callback}")
+    private val redirectUri: String
+) : SimpleUrlAuthenticationSuccessHandler() {
+
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
+    ) {
+        val principal = authentication.principal as OAuth2UserPrincipal
+
+        val roles = principal.getRoleNames()
+        val accessToken = jwtTokenProvider.createAccessToken(
+            userId = principal.userId,
+            email = principal.email,
+            roles = roles
+        )
+
+        val refreshTokenString = jwtTokenProvider.createRefreshToken(principal.userId)
+        val refreshToken = RefreshToken.create(
+            userId = principal.userId,
+            token = refreshTokenString,
+            expiresAt = jwtTokenProvider.getRefreshTokenExpiration(),
+            deviceInfo = request.getHeader("User-Agent"),
+            ipAddress = getClientIpAddress(request)
+        )
+        refreshTokenRepository.save(refreshToken)
+
+        val targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+            .queryParam("accessToken", accessToken)
+            .queryParam("refreshToken", refreshTokenString)
+            .queryParam("isNewUser", principal.isNewUser)
+            .build()
+            .toUriString()
+
+        response.sendRedirect(targetUrl)
+    }
+
+    private fun getClientIpAddress(request: HttpServletRequest): String {
+        val xForwardedFor = request.getHeader("X-Forwarded-For")
+        return if (!xForwardedFor.isNullOrBlank()) {
+            xForwardedFor.split(",").first().trim()
+        } else {
+            request.remoteAddr
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserInfo.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserInfo.kt
@@ -1,0 +1,15 @@
+package com.nextup.infrastructure.security.oauth2
+
+import com.nextup.core.domain.user.OAuthProvider
+
+/**
+ * OAuth2 Provider로부터 받은 사용자 정보 인터페이스
+ */
+interface OAuth2UserInfo {
+    val provider: OAuthProvider
+    val id: String
+    val email: String?
+    val name: String?
+    val profileImageUrl: String?
+    val attributes: Map<String, Any>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserInfoFactory.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserInfoFactory.kt
@@ -1,0 +1,46 @@
+package com.nextup.infrastructure.security.oauth2
+
+import com.nextup.common.exception.UnsupportedOAuth2ProviderException
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.infrastructure.security.oauth2.impl.GoogleOAuth2UserInfo
+import com.nextup.infrastructure.security.oauth2.impl.KakaoOAuth2UserInfo
+import com.nextup.infrastructure.security.oauth2.impl.NaverOAuth2UserInfo
+
+/**
+ * OAuth2 Provider별 UserInfo 객체를 생성하는 팩토리
+ */
+object OAuth2UserInfoFactory {
+
+    /**
+     * registrationId에 맞는 OAuth2UserInfo 구현체를 생성합니다.
+     *
+     * @param registrationId OAuth2 클라이언트 등록 ID (kakao, google, naver)
+     * @param attributes OAuth2 Provider로부터 받은 사용자 속성
+     * @return OAuth2UserInfo 구현체
+     * @throws UnsupportedOAuth2ProviderException 지원하지 않는 Provider인 경우
+     */
+    fun create(registrationId: String, attributes: Map<String, Any>): OAuth2UserInfo {
+        return when (registrationId.lowercase()) {
+            "kakao" -> KakaoOAuth2UserInfo(attributes)
+            "google" -> GoogleOAuth2UserInfo(attributes)
+            "naver" -> NaverOAuth2UserInfo(attributes)
+            else -> throw UnsupportedOAuth2ProviderException(registrationId)
+        }
+    }
+
+    /**
+     * registrationId를 OAuthProvider로 변환합니다.
+     *
+     * @param registrationId OAuth2 클라이언트 등록 ID
+     * @return OAuthProvider enum
+     * @throws UnsupportedOAuth2ProviderException 지원하지 않는 Provider인 경우
+     */
+    fun toOAuthProvider(registrationId: String): OAuthProvider {
+        return when (registrationId.lowercase()) {
+            "kakao" -> OAuthProvider.KAKAO
+            "google" -> OAuthProvider.GOOGLE
+            "naver" -> OAuthProvider.NAVER
+            else -> throw UnsupportedOAuth2ProviderException(registrationId)
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserPrincipal.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserPrincipal.kt
@@ -1,0 +1,42 @@
+package com.nextup.infrastructure.security.oauth2
+
+import com.nextup.core.domain.user.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+/**
+ * OAuth2 인증된 사용자 Principal
+ *
+ * Spring Security OAuth2와 내부 User Entity를 연결합니다.
+ */
+class OAuth2UserPrincipal(
+    private val user: User,
+    private val oAuth2UserInfo: OAuth2UserInfo,
+    val isNewUser: Boolean = false
+) : OAuth2User {
+
+    val userId: Long
+        get() = user.id
+
+    val email: String
+        get() = user.email
+
+    val nickname: String
+        get() = user.nickname
+
+    override fun getName(): String = user.id.toString()
+
+    override fun getAttributes(): Map<String, Any> = oAuth2UserInfo.attributes
+
+    override fun getAuthorities(): Collection<GrantedAuthority> {
+        return user.roles.map { role ->
+            SimpleGrantedAuthority("ROLE_${role.name}")
+        }
+    }
+
+    /**
+     * 사용자 역할 이름 목록을 반환합니다 (ROLE_ 접두사 없음).
+     */
+    fun getRoleNames(): Set<String> = user.roles.map { it.name }.toSet()
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/GoogleOAuth2UserInfo.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/GoogleOAuth2UserInfo.kt
@@ -1,0 +1,34 @@
+package com.nextup.infrastructure.security.oauth2.impl
+
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.infrastructure.security.oauth2.OAuth2UserInfo
+
+/**
+ * 구글 OAuth2 사용자 정보
+ *
+ * 구글 응답 형식:
+ * {
+ *   "sub": "123456789",
+ *   "email": "user@gmail.com",
+ *   "name": "홍길동",
+ *   "picture": "http://..."
+ * }
+ */
+class GoogleOAuth2UserInfo(
+    override val attributes: Map<String, Any>
+) : OAuth2UserInfo {
+
+    override val provider: OAuthProvider = OAuthProvider.GOOGLE
+
+    override val id: String
+        get() = attributes["sub"] as? String ?: ""
+
+    override val email: String?
+        get() = attributes["email"] as? String
+
+    override val name: String?
+        get() = attributes["name"] as? String
+
+    override val profileImageUrl: String?
+        get() = attributes["picture"] as? String
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/KakaoOAuth2UserInfo.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/KakaoOAuth2UserInfo.kt
@@ -1,0 +1,49 @@
+package com.nextup.infrastructure.security.oauth2.impl
+
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.infrastructure.security.oauth2.OAuth2UserInfo
+
+/**
+ * 카카오 OAuth2 사용자 정보
+ *
+ * 카카오 응답 형식:
+ * {
+ *   "id": 123456789,
+ *   "kakao_account": {
+ *     "email": "user@kakao.com",
+ *     "profile": {
+ *       "nickname": "홍길동",
+ *       "profile_image_url": "http://..."
+ *     }
+ *   }
+ * }
+ */
+class KakaoOAuth2UserInfo(
+    override val attributes: Map<String, Any>
+) : OAuth2UserInfo {
+
+    override val provider: OAuthProvider = OAuthProvider.KAKAO
+
+    override val id: String
+        get() = attributes["id"].toString()
+
+    override val email: String?
+        get() {
+            val kakaoAccount = attributes["kakao_account"] as? Map<*, *> ?: return null
+            return kakaoAccount["email"] as? String
+        }
+
+    override val name: String?
+        get() {
+            val kakaoAccount = attributes["kakao_account"] as? Map<*, *> ?: return null
+            val profile = kakaoAccount["profile"] as? Map<*, *> ?: return null
+            return profile["nickname"] as? String
+        }
+
+    override val profileImageUrl: String?
+        get() {
+            val kakaoAccount = attributes["kakao_account"] as? Map<*, *> ?: return null
+            val profile = kakaoAccount["profile"] as? Map<*, *> ?: return null
+            return profile["profile_image_url"] as? String
+        }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/NaverOAuth2UserInfo.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/NaverOAuth2UserInfo.kt
@@ -1,0 +1,41 @@
+package com.nextup.infrastructure.security.oauth2.impl
+
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.infrastructure.security.oauth2.OAuth2UserInfo
+
+/**
+ * 네이버 OAuth2 사용자 정보
+ *
+ * 네이버 응답 형식:
+ * {
+ *   "resultcode": "00",
+ *   "message": "success",
+ *   "response": {
+ *     "id": "123456789",
+ *     "email": "user@naver.com",
+ *     "name": "홍길동",
+ *     "profile_image": "http://..."
+ *   }
+ * }
+ */
+class NaverOAuth2UserInfo(
+    override val attributes: Map<String, Any>
+) : OAuth2UserInfo {
+
+    private val response: Map<*, *>?
+        get() = attributes["response"] as? Map<*, *>
+
+    override val provider: OAuthProvider = OAuthProvider.NAVER
+
+    override val id: String
+        get() = response?.get("id") as? String ?: ""
+
+    override val email: String?
+        get() = response?.get("email") as? String
+
+    override val name: String?
+        get() = response?.get("name") as? String
+
+    override val profileImageUrl: String?
+        get() = response?.get("profile_image") as? String
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkService.kt
@@ -1,0 +1,108 @@
+package com.nextup.infrastructure.service.oauth
+
+import com.nextup.common.exception.UserNotFoundException
+import com.nextup.core.domain.user.OAuthAccount
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.user.OAuthAccountRepository
+import com.nextup.infrastructure.security.userdetails.UserJpaRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * OAuth 계정 연동/해제 서비스
+ */
+@Service
+@Transactional
+class OAuthLinkService(
+    private val userJpaRepository: UserJpaRepository,
+    private val oAuthAccountRepository: OAuthAccountRepository
+) {
+
+    /**     * 기존 사용자에게 OAuth 계정을 연동합니다.
+     *
+     * @param userId 사용자 ID
+     * @param provider OAuth 제공자
+     * @param oauthId OAuth 제공자에서 발급한 사용자 ID
+     * @param email OAuth 제공자에서 제공하는 이메일 (선택)
+     * @return 연동된 OAuthAccount
+     * @throws UserNotFoundException 사용자를 찾을 수 없는 경우
+     * @throws IllegalArgumentException 이미 연동된 Provider인 경우
+     */
+    fun linkOAuthAccount(
+        userId: Long,
+        provider: OAuthProvider,
+        oauthId: String,
+        email: String? = null
+    ): OAuthAccount {
+        val user = userJpaRepository.findById(userId)
+            .orElseThrow { UserNotFoundException(userId) }
+
+        val oauthAccount = user.addOAuthAccount(provider, oauthId, email)
+        userJpaRepository.save(user)
+
+        return oauthAccount
+    }
+
+    /**
+     * OAuth 계정 연동을 해제합니다.
+     *
+     * @param userId 사용자 ID
+     * @param provider 해제할 OAuth 제공자
+     * @throws UserNotFoundException 사용자를 찾을 수 없는 경우
+     * @throws IllegalStateException 최소 1개의 인증 수단이 없는 경우
+     */
+    fun unlinkOAuthAccount(userId: Long, provider: OAuthProvider) {
+        val user = userJpaRepository.findById(userId)
+            .orElseThrow { UserNotFoundException(userId) }
+
+        user.removeOAuthAccount(provider)
+        userJpaRepository.save(user)
+    }
+
+    /**
+     * 사용자의 연동된 OAuth 제공자 목록을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 연동된 OAuth 제공자 목록
+     */
+    @Transactional(readOnly = true)
+    fun getLinkedProviders(userId: Long): List<OAuthProvider> {
+        return oAuthAccountRepository.findProvidersByUserId(userId)
+    }
+
+    /**
+     * 사용자의 연동된 OAuth 계정 목록을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 연동된 OAuth 계정 목록
+     */
+    @Transactional(readOnly = true)
+    fun getLinkedAccounts(userId: Long): List<OAuthAccount> {
+        return oAuthAccountRepository.findAllByUserId(userId)
+    }
+
+    /**
+     * 특정 OAuth 제공자가 연동되어 있는지 확인합니다.
+     *
+     * @param userId 사용자 ID
+     * @param provider OAuth 제공자
+     * @return 연동 여부
+     */
+    @Transactional(readOnly = true)
+    fun isLinked(userId: Long, provider: OAuthProvider): Boolean {
+        return oAuthAccountRepository.findByUserIdAndProvider(userId, provider) != null
+    }
+
+    /**
+     * OAuth 정보로 사용자를 조회합니다.
+     *
+     * @param provider OAuth 제공자
+     * @param oauthId OAuth 제공자에서 발급한 사용자 ID
+     * @return 사용자 (없으면 null)
+     */
+    @Transactional(readOnly = true)
+    fun findUserByOAuth(provider: OAuthProvider, oauthId: String): User? {
+        return oAuthAccountRepository.findByProviderAndOauthId(provider, oauthId)?.user
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserServiceTest.kt
@@ -1,0 +1,280 @@
+package com.nextup.infrastructure.security.oauth2
+
+import com.nextup.common.exception.OAuth2AuthenticationProcessingException
+import com.nextup.core.domain.user.OAuthAccount
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.user.OAuthAccountRepository
+import com.nextup.infrastructure.security.userdetails.UserJpaRepository
+import io.mockk.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.security.oauth2.core.user.OAuth2User
+import java.time.Instant
+
+@DisplayName("CustomOAuth2UserService 테스트")
+class CustomOAuth2UserServiceTest {
+
+    private lateinit var userJpaRepository: UserJpaRepository
+    private lateinit var oAuthAccountRepository: OAuthAccountRepository
+    private lateinit var customOAuth2UserService: TestableCustomOAuth2UserService
+
+    /**
+     * 테스트 가능한 서브클래스 - super.loadUser() 호출을 모킹 가능하게 함
+     */
+    private class TestableCustomOAuth2UserService(
+        userJpaRepository: UserJpaRepository,
+        oAuthAccountRepository: OAuthAccountRepository
+    ) : CustomOAuth2UserService(userJpaRepository, oAuthAccountRepository) {
+
+        var mockOAuth2User: OAuth2User? = null
+
+        override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
+            val oAuth2User = mockOAuth2User
+                ?: throw IllegalStateException("mockOAuth2User must be set before calling loadUser")
+
+            // processOAuth2User is private, so we need to access it via reflection
+            val method = CustomOAuth2UserService::class.java.getDeclaredMethod(
+                "processOAuth2User",
+                OAuth2UserRequest::class.java,
+                OAuth2User::class.java
+            )
+            method.isAccessible = true
+            return method.invoke(this, userRequest, oAuth2User) as OAuth2User
+        }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        userJpaRepository = mockk(relaxed = true)
+        oAuthAccountRepository = mockk(relaxed = true)
+        customOAuth2UserService = TestableCustomOAuth2UserService(userJpaRepository, oAuthAccountRepository)
+    }
+
+    private fun createUserRequest(registrationId: String): OAuth2UserRequest {
+        val clientRegistration = ClientRegistration
+            .withRegistrationId(registrationId)
+            .clientId("test-client-id")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost/callback")
+            .authorizationUri("http://auth.example.com/authorize")
+            .tokenUri("http://auth.example.com/token")
+            .userInfoUri("http://auth.example.com/userinfo")
+            .userNameAttributeName("id")
+            .clientName("Test Client")
+            .build()
+
+        val accessToken = OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            "test-access-token",
+            Instant.now(),
+            Instant.now().plusSeconds(3600)
+        )
+
+        return OAuth2UserRequest(clientRegistration, accessToken)
+    }
+
+    private fun createOAuth2User(attributes: Map<String, Any>): OAuth2User {
+        return mockk {
+            every { getAttributes() } returns attributes
+            every { getName() } returns "test-user"
+        }
+    }
+
+    private fun createUser(id: Long, email: String, nickname: String): User {
+        val user = User.createOAuthUser(
+            email = email,
+            nickname = nickname,
+            provider = OAuthProvider.KAKAO,
+            oauthId = "kakao_$id"
+        )
+        val idField = User::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(user, id)
+        return user
+    }
+
+    @Nested
+    @DisplayName("기존 OAuthAccount 존재 시")
+    inner class ExistingOAuthAccountTest {
+
+        @Test
+        fun `should return existing user when OAuthAccount exists`() {
+            // given
+            val userRequest = createUserRequest("kakao")
+            customOAuth2UserService.mockOAuth2User = createOAuth2User(
+                mapOf(
+                    "id" to 123456L,
+                    "kakao_account" to mapOf(
+                        "email" to "existing@kakao.com",
+                        "profile" to mapOf("nickname" to "기존사용자")
+                    )
+                )
+            )
+
+            val existingUser = createUser(1L, "existing@kakao.com", "기존사용자")
+            val existingOAuthAccount = mockk<OAuthAccount> {
+                every { user } returns existingUser
+            }
+
+            every { oAuthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "123456") } returns existingOAuthAccount
+
+            // when
+            val result = customOAuth2UserService.loadUser(userRequest)
+
+            // then
+            assertThat(result).isInstanceOf(OAuth2UserPrincipal::class.java)
+            val principal = result as OAuth2UserPrincipal
+            assertThat(principal.isNewUser).isFalse()
+            assertThat(principal.userId).isEqualTo(1L)
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일로 기존 User 조회")
+    inner class ExistingUserByEmailTest {
+
+        @Test
+        fun `should link OAuthAccount to existing user when email matches`() {
+            // given
+            val userRequest = createUserRequest("google")
+            customOAuth2UserService.mockOAuth2User = createOAuth2User(
+                mapOf(
+                    "sub" to "google_123",
+                    "email" to "existing@gmail.com",
+                    "name" to "기존사용자"
+                )
+            )
+
+            val existingUser = createUser(2L, "existing@gmail.com", "기존사용자")
+
+            every { oAuthAccountRepository.findByProviderAndOauthId(OAuthProvider.GOOGLE, "google_123") } returns null
+            every { userJpaRepository.findByEmail("existing@gmail.com") } returns existingUser
+            every { userJpaRepository.save(existingUser) } returns existingUser
+
+            // when
+            val result = customOAuth2UserService.loadUser(userRequest)
+
+            // then
+            assertThat(result).isInstanceOf(OAuth2UserPrincipal::class.java)
+            val principal = result as OAuth2UserPrincipal
+            assertThat(principal.isNewUser).isFalse()
+            assertThat(principal.userId).isEqualTo(2L)
+            verify { userJpaRepository.save(existingUser) }
+        }
+    }
+
+    @Nested
+    @DisplayName("신규 User 생성")
+    inner class NewUserCreationTest {
+
+        @Test
+        fun `should create new user when no existing account found`() {
+            // given
+            val userRequest = createUserRequest("naver")
+            customOAuth2UserService.mockOAuth2User = createOAuth2User(
+                mapOf(
+                    "response" to mapOf(
+                        "id" to "naver_new_123",
+                        "email" to "newuser@naver.com",
+                        "name" to "신규사용자"
+                    )
+                )
+            )
+
+            val savedUserSlot = slot<User>()
+
+            every { oAuthAccountRepository.findByProviderAndOauthId(OAuthProvider.NAVER, "naver_new_123") } returns null
+            every { userJpaRepository.findByEmail("newuser@naver.com") } returns null
+            every { userJpaRepository.save(capture(savedUserSlot)) } answers { savedUserSlot.captured }
+
+            // when
+            val result = customOAuth2UserService.loadUser(userRequest)
+
+            // then
+            assertThat(result).isInstanceOf(OAuth2UserPrincipal::class.java)
+            val principal = result as OAuth2UserPrincipal
+            assertThat(principal.isNewUser).isTrue()
+            verify { userJpaRepository.save(any<User>()) }
+        }
+
+        @Test
+        fun `should use email prefix as nickname when name is null`() {
+            // given
+            val userRequest = createUserRequest("google")
+            customOAuth2UserService.mockOAuth2User = createOAuth2User(
+                mapOf(
+                    "sub" to "google_456",
+                    "email" to "testuser@gmail.com"
+                    // name is missing
+                )
+            )
+
+            val savedUserSlot = slot<User>()
+
+            every { oAuthAccountRepository.findByProviderAndOauthId(OAuthProvider.GOOGLE, "google_456") } returns null
+            every { userJpaRepository.findByEmail("testuser@gmail.com") } returns null
+            every { userJpaRepository.save(capture(savedUserSlot)) } answers { savedUserSlot.captured }
+
+            // when
+            customOAuth2UserService.loadUser(userRequest)
+
+            // then
+            assertThat(savedUserSlot.captured.nickname).isEqualTo("testuser")
+        }
+
+        @Test
+        fun `should use provider default nickname when both name and email are null`() {
+            // given
+            val userRequest = createUserRequest("kakao")
+            customOAuth2UserService.mockOAuth2User = createOAuth2User(
+                mapOf(
+                    "id" to 789L
+                    // No kakao_account, so no email or name
+                )
+            )
+
+            val savedUserSlot = slot<User>()
+
+            every { oAuthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "789") } returns null
+            every { userJpaRepository.save(capture(savedUserSlot)) } answers { savedUserSlot.captured }
+
+            // when
+            customOAuth2UserService.loadUser(userRequest)
+
+            // then
+            assertThat(savedUserSlot.captured.nickname).isEqualTo("카카오사용자")
+            assertThat(savedUserSlot.captured.email).isEqualTo("kakao_789@oauth.local")
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 처리")
+    inner class ExceptionHandlingTest {
+
+        @Test
+        fun `should throw exception when OAuth2 provider returns blank id`() {
+            // given
+            val userRequest = createUserRequest("google")
+            customOAuth2UserService.mockOAuth2User = createOAuth2User(
+                mapOf(
+                    "email" to "user@gmail.com"
+                    // sub is missing, so id will be blank
+                )
+            )
+
+            // when & then
+            // 리플렉션으로 인해 InvocationTargetException으로 래핑됨
+            assertThatThrownBy { customOAuth2UserService.loadUser(userRequest) }
+                .hasCauseInstanceOf(OAuth2AuthenticationProcessingException::class.java)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationHandlersTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationHandlersTest.kt
@@ -1,0 +1,229 @@
+package com.nextup.infrastructure.security.oauth2
+
+import com.nextup.core.domain.auth.RefreshToken
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
+import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import com.nextup.infrastructure.security.oauth2.impl.KakaoOAuth2UserInfo
+import io.mockk.*
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
+import org.springframework.security.oauth2.core.OAuth2Error
+import java.time.Instant
+
+@DisplayName("OAuth2 Authentication Handlers 테스트")
+class OAuth2AuthenticationHandlersTest {
+
+    @Nested
+    @DisplayName("OAuth2AuthenticationSuccessHandler")
+    inner class SuccessHandlerTest {
+
+        private lateinit var jwtTokenProvider: JwtTokenProvider
+        private lateinit var refreshTokenRepository: RefreshTokenRepository
+        private lateinit var successHandler: OAuth2AuthenticationSuccessHandler
+        private lateinit var request: HttpServletRequest
+        private lateinit var response: HttpServletResponse
+        private lateinit var authentication: Authentication
+
+        private val redirectUri = "http://localhost:3000/oauth/callback"
+
+        @BeforeEach
+        fun setUp() {
+            jwtTokenProvider = mockk()
+            refreshTokenRepository = mockk(relaxed = true)
+            successHandler = OAuth2AuthenticationSuccessHandler(
+                jwtTokenProvider,
+                refreshTokenRepository,
+                redirectUri
+            )
+            request = mockk(relaxed = true)
+            response = mockk(relaxed = true)
+            authentication = mockk()
+        }
+
+        private fun createPrincipal(userId: Long, isNewUser: Boolean): OAuth2UserPrincipal {
+            val user = User.createOAuthUser(
+                email = "test@example.com",
+                nickname = "테스터",
+                provider = OAuthProvider.KAKAO,
+                oauthId = "kakao_123"
+            )
+            val idField = User::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(user, userId)
+
+            val oAuth2UserInfo = KakaoOAuth2UserInfo(mapOf("id" to 123L))
+            return OAuth2UserPrincipal(user, oAuth2UserInfo, isNewUser)
+        }
+
+        @Test
+        fun `should redirect with tokens on success`() {
+            // given
+            val principal = createPrincipal(userId = 1L, isNewUser = false)
+            val redirectUrlSlot = slot<String>()
+
+            every { authentication.principal } returns principal
+            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access-token"
+            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh-token"
+            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(604800)
+            every { request.getHeader("User-Agent") } returns "Mozilla/5.0"
+            every { request.getHeader("X-Forwarded-For") } returns null
+            every { request.remoteAddr } returns "127.0.0.1"
+            every { refreshTokenRepository.save(any<RefreshToken>()) } returns mockk()
+            every { response.sendRedirect(capture(redirectUrlSlot)) } just Runs
+
+            // when
+            successHandler.onAuthenticationSuccess(request, response, authentication)
+
+            // then
+            verify { refreshTokenRepository.save(any<RefreshToken>()) }
+            assertThat(redirectUrlSlot.captured).contains("accessToken=access-token")
+            assertThat(redirectUrlSlot.captured).contains("refreshToken=refresh-token")
+            assertThat(redirectUrlSlot.captured).contains("isNewUser=false")
+        }
+
+        @Test
+        fun `should set isNewUser to true for new users`() {
+            // given
+            val principal = createPrincipal(userId = 1L, isNewUser = true)
+            val redirectUrlSlot = slot<String>()
+
+            every { authentication.principal } returns principal
+            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access-token"
+            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh-token"
+            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(604800)
+            every { request.getHeader("User-Agent") } returns "Mozilla/5.0"
+            every { request.getHeader("X-Forwarded-For") } returns null
+            every { request.remoteAddr } returns "127.0.0.1"
+            every { refreshTokenRepository.save(any<RefreshToken>()) } returns mockk()
+            every { response.sendRedirect(capture(redirectUrlSlot)) } just Runs
+
+            // when
+            successHandler.onAuthenticationSuccess(request, response, authentication)
+
+            // then
+            assertThat(redirectUrlSlot.captured).contains("isNewUser=true")
+        }
+
+        @Test
+        fun `should use X-Forwarded-For header for client IP`() {
+            // given
+            val principal = createPrincipal(userId = 1L, isNewUser = false)
+            val refreshTokenSlot = slot<RefreshToken>()
+
+            every { authentication.principal } returns principal
+            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access-token"
+            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh-token"
+            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(604800)
+            every { request.getHeader("User-Agent") } returns "Mozilla/5.0"
+            every { request.getHeader("X-Forwarded-For") } returns "192.168.1.1, 10.0.0.1"
+            every { refreshTokenRepository.save(capture(refreshTokenSlot)) } returns mockk()
+            every { response.sendRedirect(any()) } just Runs
+
+            // when
+            successHandler.onAuthenticationSuccess(request, response, authentication)
+
+            // then
+            assertThat(refreshTokenSlot.captured.ipAddress).isEqualTo("192.168.1.1")
+        }
+
+        @Test
+        fun `should use remoteAddr when X-Forwarded-For is not present`() {
+            // given
+            val principal = createPrincipal(userId = 1L, isNewUser = false)
+            val refreshTokenSlot = slot<RefreshToken>()
+
+            every { authentication.principal } returns principal
+            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access-token"
+            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh-token"
+            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(604800)
+            every { request.getHeader("User-Agent") } returns "Mozilla/5.0"
+            every { request.getHeader("X-Forwarded-For") } returns null
+            every { request.remoteAddr } returns "10.0.0.5"
+            every { refreshTokenRepository.save(capture(refreshTokenSlot)) } returns mockk()
+            every { response.sendRedirect(any()) } just Runs
+
+            // when
+            successHandler.onAuthenticationSuccess(request, response, authentication)
+
+            // then
+            assertThat(refreshTokenSlot.captured.ipAddress).isEqualTo("10.0.0.5")
+        }
+    }
+
+    @Nested
+    @DisplayName("OAuth2AuthenticationFailureHandler")
+    inner class FailureHandlerTest {
+
+        private lateinit var failureHandler: OAuth2AuthenticationFailureHandler
+        private lateinit var request: HttpServletRequest
+        private lateinit var response: HttpServletResponse
+
+        private val redirectUri = "http://localhost:3000/oauth/callback"
+
+        @BeforeEach
+        fun setUp() {
+            failureHandler = OAuth2AuthenticationFailureHandler(redirectUri)
+            request = mockk(relaxed = true)
+            response = mockk(relaxed = true)
+        }
+
+        @Test
+        fun `should redirect with error on failure`() {
+            // given
+            val exception = OAuth2AuthenticationException(
+                OAuth2Error("invalid_token"),
+                "Token validation failed"
+            )
+            val redirectUrlSlot = slot<String>()
+            every { response.sendRedirect(capture(redirectUrlSlot)) } just Runs
+
+            // when
+            failureHandler.onAuthenticationFailure(request, response, exception)
+
+            // then
+            assertThat(redirectUrlSlot.captured).contains("error=oauth_error")
+            assertThat(redirectUrlSlot.captured).contains("message=")
+        }
+
+        @Test
+        fun `should URL encode error message`() {
+            // given
+            val exception = OAuth2AuthenticationException(
+                OAuth2Error("error"),
+                "Error with special chars: &?="
+            )
+            val redirectUrlSlot = slot<String>()
+            every { response.sendRedirect(capture(redirectUrlSlot)) } just Runs
+
+            // when
+            failureHandler.onAuthenticationFailure(request, response, exception)
+
+            // then
+            assertThat(redirectUrlSlot.captured).doesNotContain("Error with special chars: &?=")
+            assertThat(redirectUrlSlot.captured).contains("Error+with+special+chars")
+        }
+
+        @Test
+        fun `should use default message when exception message is null`() {
+            // given
+            val exception = OAuth2AuthenticationException(OAuth2Error("error"))
+            val redirectUrlSlot = slot<String>()
+            every { response.sendRedirect(capture(redirectUrlSlot)) } just Runs
+
+            // when
+            failureHandler.onAuthenticationFailure(request, response, exception)
+
+            // then
+            assertThat(redirectUrlSlot.captured).contains("message=")
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserInfoFactoryTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserInfoFactoryTest.kt
@@ -1,0 +1,130 @@
+package com.nextup.infrastructure.security.oauth2
+
+import com.nextup.common.exception.UnsupportedOAuth2ProviderException
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.infrastructure.security.oauth2.impl.GoogleOAuth2UserInfo
+import com.nextup.infrastructure.security.oauth2.impl.KakaoOAuth2UserInfo
+import com.nextup.infrastructure.security.oauth2.impl.NaverOAuth2UserInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@DisplayName("OAuth2UserInfoFactory 테스트")
+class OAuth2UserInfoFactoryTest {
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+
+        @Test
+        fun `should create KakaoOAuth2UserInfo for kakao`() {
+            // given
+            val attributes = mapOf("id" to 123L)
+
+            // when
+            val result = OAuth2UserInfoFactory.create("kakao", attributes)
+
+            // then
+            assertThat(result).isInstanceOf(KakaoOAuth2UserInfo::class.java)
+            assertThat(result.provider).isEqualTo(OAuthProvider.KAKAO)
+        }
+
+        @Test
+        fun `should create GoogleOAuth2UserInfo for google`() {
+            // given
+            val attributes = mapOf("sub" to "123")
+
+            // when
+            val result = OAuth2UserInfoFactory.create("google", attributes)
+
+            // then
+            assertThat(result).isInstanceOf(GoogleOAuth2UserInfo::class.java)
+            assertThat(result.provider).isEqualTo(OAuthProvider.GOOGLE)
+        }
+
+        @Test
+        fun `should create NaverOAuth2UserInfo for naver`() {
+            // given
+            val attributes = mapOf("response" to mapOf("id" to "123"))
+
+            // when
+            val result = OAuth2UserInfoFactory.create("naver", attributes)
+
+            // then
+            assertThat(result).isInstanceOf(NaverOAuth2UserInfo::class.java)
+            assertThat(result.provider).isEqualTo(OAuthProvider.NAVER)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["KAKAO", "Kakao", "GOOGLE", "Google", "NAVER", "Naver"])
+        fun `should be case insensitive`(registrationId: String) {
+            // when
+            val result = OAuth2UserInfoFactory.create(registrationId, emptyMap())
+
+            // then
+            assertThat(result).isNotNull
+        }
+
+        @Test
+        fun `should throw exception for unsupported provider`() {
+            // when & then
+            assertThatThrownBy {
+                OAuth2UserInfoFactory.create("facebook", emptyMap())
+            }.isInstanceOf(UnsupportedOAuth2ProviderException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("toOAuthProvider")
+    inner class ToOAuthProvider {
+
+        @Test
+        fun `should return KAKAO for kakao`() {
+            // when
+            val result = OAuth2UserInfoFactory.toOAuthProvider("kakao")
+
+            // then
+            assertThat(result).isEqualTo(OAuthProvider.KAKAO)
+        }
+
+        @Test
+        fun `should return GOOGLE for google`() {
+            // when
+            val result = OAuth2UserInfoFactory.toOAuthProvider("google")
+
+            // then
+            assertThat(result).isEqualTo(OAuthProvider.GOOGLE)
+        }
+
+        @Test
+        fun `should return NAVER for naver`() {
+            // when
+            val result = OAuth2UserInfoFactory.toOAuthProvider("naver")
+
+            // then
+            assertThat(result).isEqualTo(OAuthProvider.NAVER)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["KAKAO", "Kakao", "GOOGLE", "Google", "NAVER", "Naver"])
+        fun `should be case insensitive`(registrationId: String) {
+            // when
+            val result = OAuth2UserInfoFactory.toOAuthProvider(registrationId)
+
+            // then
+            assertThat(result).isNotNull
+        }
+
+        @Test
+        fun `should throw exception for unsupported provider`() {
+            // when & then
+            assertThatThrownBy {
+                OAuth2UserInfoFactory.toOAuthProvider("twitter")
+            }.isInstanceOf(UnsupportedOAuth2ProviderException::class.java)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserPrincipalTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserPrincipalTest.kt
@@ -1,0 +1,163 @@
+package com.nextup.infrastructure.security.oauth2
+
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.core.domain.user.Role
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.security.oauth2.impl.KakaoOAuth2UserInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("OAuth2UserPrincipal 테스트")
+class OAuth2UserPrincipalTest {
+
+    private fun createTestUser(id: Long = 1L): User {
+        val user = User.createOAuthUser(
+            email = "test@example.com",
+            nickname = "테스터",
+            provider = OAuthProvider.KAKAO,
+            oauthId = "kakao_123"
+        )
+        val idField = User::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(user, id)
+        return user
+    }
+
+    private fun createOAuth2UserInfo(): OAuth2UserInfo {
+        return KakaoOAuth2UserInfo(
+            mapOf(
+                "id" to 123456789L,
+                "kakao_account" to mapOf(
+                    "email" to "test@kakao.com",
+                    "profile" to mapOf(
+                        "nickname" to "카카오유저"
+                    )
+                )
+            )
+        )
+    }
+
+    @Nested
+    @DisplayName("기본 속성")
+    inner class BasicProperties {
+
+        @Test
+        fun `should return user id`() {
+            // given
+            val user = createTestUser(id = 42L)
+            val oAuth2UserInfo = createOAuth2UserInfo()
+            val principal = OAuth2UserPrincipal(user, oAuth2UserInfo)
+
+            // then
+            assertThat(principal.userId).isEqualTo(42L)
+        }
+
+        @Test
+        fun `should return user email`() {
+            // given
+            val user = createTestUser()
+            val oAuth2UserInfo = createOAuth2UserInfo()
+            val principal = OAuth2UserPrincipal(user, oAuth2UserInfo)
+
+            // then
+            assertThat(principal.email).isEqualTo("test@example.com")
+        }
+
+        @Test
+        fun `should return user nickname`() {
+            // given
+            val user = createTestUser()
+            val oAuth2UserInfo = createOAuth2UserInfo()
+            val principal = OAuth2UserPrincipal(user, oAuth2UserInfo)
+
+            // then
+            assertThat(principal.nickname).isEqualTo("테스터")
+        }
+
+        @Test
+        fun `should return isNewUser flag`() {
+            // given
+            val user = createTestUser()
+            val oAuth2UserInfo = createOAuth2UserInfo()
+
+            // when
+            val newUserPrincipal = OAuth2UserPrincipal(user, oAuth2UserInfo, isNewUser = true)
+            val existingUserPrincipal = OAuth2UserPrincipal(user, oAuth2UserInfo, isNewUser = false)
+
+            // then
+            assertThat(newUserPrincipal.isNewUser).isTrue()
+            assertThat(existingUserPrincipal.isNewUser).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("OAuth2User 인터페이스")
+    inner class OAuth2UserInterface {
+
+        @Test
+        fun `getName should return user id as string`() {
+            // given
+            val user = createTestUser(id = 123L)
+            val oAuth2UserInfo = createOAuth2UserInfo()
+            val principal = OAuth2UserPrincipal(user, oAuth2UserInfo)
+
+            // when
+            val name = principal.name
+
+            // then
+            assertThat(name).isEqualTo("123")
+        }
+
+        @Test
+        fun `getAttributes should return OAuth2UserInfo attributes`() {
+            // given
+            val user = createTestUser()
+            val oAuth2UserInfo = createOAuth2UserInfo()
+            val principal = OAuth2UserPrincipal(user, oAuth2UserInfo)
+
+            // when
+            val attributes = principal.attributes
+
+            // then
+            assertThat(attributes).containsKey("id")
+            assertThat(attributes).containsKey("kakao_account")
+        }
+
+        @Test
+        fun `getAuthorities should return user roles with ROLE_ prefix`() {
+            // given
+            val user = createTestUser()
+            user.addRole(Role.ADMIN)
+            val oAuth2UserInfo = createOAuth2UserInfo()
+            val principal = OAuth2UserPrincipal(user, oAuth2UserInfo)
+
+            // when
+            val authorities = principal.authorities.map { it.authority }
+
+            // then
+            assertThat(authorities).contains("ROLE_USER", "ROLE_ADMIN")
+        }
+    }
+
+    @Nested
+    @DisplayName("getRoleNames")
+    inner class GetRoleNames {
+
+        @Test
+        fun `should return role names without ROLE_ prefix`() {
+            // given
+            val user = createTestUser()
+            user.addRole(Role.SCORER)
+            val oAuth2UserInfo = createOAuth2UserInfo()
+            val principal = OAuth2UserPrincipal(user, oAuth2UserInfo)
+
+            // when
+            val roleNames = principal.getRoleNames()
+
+            // then
+            assertThat(roleNames).containsExactlyInAnyOrder("USER", "SCORER")
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/impl/OAuth2UserInfoImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/impl/OAuth2UserInfoImplTest.kt
@@ -1,0 +1,197 @@
+package com.nextup.infrastructure.security.oauth2.impl
+
+import com.nextup.core.domain.user.OAuthProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("OAuth2UserInfo 구현체 테스트")
+class OAuth2UserInfoImplTest {
+
+    @Nested
+    @DisplayName("KakaoOAuth2UserInfo")
+    inner class KakaoOAuth2UserInfoTest {
+
+        @Test
+        fun `should parse kakao user info correctly`() {
+            // given
+            val attributes = mapOf<String, Any>(
+                "id" to 123456789L,
+                "kakao_account" to mapOf(
+                    "email" to "user@kakao.com",
+                    "profile" to mapOf(
+                        "nickname" to "홍길동",
+                        "profile_image_url" to "http://example.com/image.jpg"
+                    )
+                )
+            )
+
+            // when
+            val userInfo = KakaoOAuth2UserInfo(attributes)
+
+            // then
+            assertThat(userInfo.provider).isEqualTo(OAuthProvider.KAKAO)
+            assertThat(userInfo.id).isEqualTo("123456789")
+            assertThat(userInfo.email).isEqualTo("user@kakao.com")
+            assertThat(userInfo.name).isEqualTo("홍길동")
+            assertThat(userInfo.profileImageUrl).isEqualTo("http://example.com/image.jpg")
+            assertThat(userInfo.attributes).isEqualTo(attributes)
+        }
+
+        @Test
+        fun `should return null when kakao_account is missing`() {
+            // given
+            val attributes = mapOf<String, Any>("id" to 123456789L)
+
+            // when
+            val userInfo = KakaoOAuth2UserInfo(attributes)
+
+            // then
+            assertThat(userInfo.id).isEqualTo("123456789")
+            assertThat(userInfo.email).isNull()
+            assertThat(userInfo.name).isNull()
+            assertThat(userInfo.profileImageUrl).isNull()
+        }
+
+        @Test
+        fun `should return null when profile is missing`() {
+            // given
+            val attributes = mapOf<String, Any>(
+                "id" to 123456789L,
+                "kakao_account" to mapOf(
+                    "email" to "user@kakao.com"
+                )
+            )
+
+            // when
+            val userInfo = KakaoOAuth2UserInfo(attributes)
+
+            // then
+            assertThat(userInfo.email).isEqualTo("user@kakao.com")
+            assertThat(userInfo.name).isNull()
+            assertThat(userInfo.profileImageUrl).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("GoogleOAuth2UserInfo")
+    inner class GoogleOAuth2UserInfoTest {
+
+        @Test
+        fun `should parse google user info correctly`() {
+            // given
+            val attributes = mapOf<String, Any>(
+                "sub" to "google_123456789",
+                "email" to "user@gmail.com",
+                "name" to "홍길동",
+                "picture" to "http://example.com/image.jpg"
+            )
+
+            // when
+            val userInfo = GoogleOAuth2UserInfo(attributes)
+
+            // then
+            assertThat(userInfo.provider).isEqualTo(OAuthProvider.GOOGLE)
+            assertThat(userInfo.id).isEqualTo("google_123456789")
+            assertThat(userInfo.email).isEqualTo("user@gmail.com")
+            assertThat(userInfo.name).isEqualTo("홍길동")
+            assertThat(userInfo.profileImageUrl).isEqualTo("http://example.com/image.jpg")
+            assertThat(userInfo.attributes).isEqualTo(attributes)
+        }
+
+        @Test
+        fun `should return empty string when sub is missing`() {
+            // given
+            val attributes = mapOf<String, Any>("email" to "user@gmail.com")
+
+            // when
+            val userInfo = GoogleOAuth2UserInfo(attributes)
+
+            // then
+            assertThat(userInfo.id).isEqualTo("")
+            assertThat(userInfo.email).isEqualTo("user@gmail.com")
+        }
+
+        @Test
+        fun `should return null for optional fields when missing`() {
+            // given
+            val attributes = mapOf<String, Any>("sub" to "google_123")
+
+            // when
+            val userInfo = GoogleOAuth2UserInfo(attributes)
+
+            // then
+            assertThat(userInfo.id).isEqualTo("google_123")
+            assertThat(userInfo.email).isNull()
+            assertThat(userInfo.name).isNull()
+            assertThat(userInfo.profileImageUrl).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("NaverOAuth2UserInfo")
+    inner class NaverOAuth2UserInfoTest {
+
+        @Test
+        fun `should parse naver user info correctly`() {
+            // given
+            val attributes = mapOf<String, Any>(
+                "resultcode" to "00",
+                "message" to "success",
+                "response" to mapOf(
+                    "id" to "naver_123456789",
+                    "email" to "user@naver.com",
+                    "name" to "홍길동",
+                    "profile_image" to "http://example.com/image.jpg"
+                )
+            )
+
+            // when
+            val userInfo = NaverOAuth2UserInfo(attributes)
+
+            // then
+            assertThat(userInfo.provider).isEqualTo(OAuthProvider.NAVER)
+            assertThat(userInfo.id).isEqualTo("naver_123456789")
+            assertThat(userInfo.email).isEqualTo("user@naver.com")
+            assertThat(userInfo.name).isEqualTo("홍길동")
+            assertThat(userInfo.profileImageUrl).isEqualTo("http://example.com/image.jpg")
+            assertThat(userInfo.attributes).isEqualTo(attributes)
+        }
+
+        @Test
+        fun `should return empty string when response is missing`() {
+            // given
+            val attributes = mapOf<String, Any>(
+                "resultcode" to "00",
+                "message" to "success"
+            )
+
+            // when
+            val userInfo = NaverOAuth2UserInfo(attributes)
+
+            // then
+            assertThat(userInfo.id).isEqualTo("")
+            assertThat(userInfo.email).isNull()
+            assertThat(userInfo.name).isNull()
+            assertThat(userInfo.profileImageUrl).isNull()
+        }
+
+        @Test
+        fun `should return null for optional fields when missing in response`() {
+            // given
+            val attributes = mapOf<String, Any>(
+                "response" to mapOf("id" to "naver_123")
+            )
+
+            // when
+            val userInfo = NaverOAuth2UserInfo(attributes)
+
+            // then
+            assertThat(userInfo.id).isEqualTo("naver_123")
+            assertThat(userInfo.email).isNull()
+            assertThat(userInfo.name).isNull()
+            assertThat(userInfo.profileImageUrl).isNull()
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkServiceTest.kt
@@ -1,0 +1,257 @@
+package com.nextup.infrastructure.service.oauth
+
+import com.nextup.common.exception.UserNotFoundException
+import com.nextup.core.domain.user.OAuthAccount
+import com.nextup.core.domain.user.OAuthProvider
+import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.user.OAuthAccountRepository
+import com.nextup.infrastructure.security.userdetails.UserJpaRepository
+import io.mockk.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.*
+
+@DisplayName("OAuthLinkService")
+class OAuthLinkServiceTest {
+
+    private lateinit var userJpaRepository: UserJpaRepository
+    private lateinit var oauthAccountRepository: OAuthAccountRepository
+    private lateinit var oauthLinkService: OAuthLinkService
+
+    @BeforeEach
+    fun setUp() {
+        userJpaRepository = mockk()
+        oauthAccountRepository = mockk()
+        oauthLinkService = OAuthLinkService(userJpaRepository, oauthAccountRepository)
+    }
+
+    @Nested
+    @DisplayName("linkOAuthAccount")
+    inner class LinkOAuthAccount {
+
+        @Test
+        fun `should link oauth account to existing user`() {
+            // given
+            val userId = 1L
+            val provider = OAuthProvider.KAKAO
+            val oauthId = "kakao_123"
+            val user = createLocalUser(userId)
+
+            every { userJpaRepository.findById(userId) } returns Optional.of(user)
+            every { userJpaRepository.save(any()) } returns user
+
+            // when
+            val result = oauthLinkService.linkOAuthAccount(userId, provider, oauthId)
+
+            // then
+            assertThat(result.provider).isEqualTo(provider)
+            assertThat(result.oauthId).isEqualTo(oauthId)
+            verify { userJpaRepository.findById(userId) }
+            verify { userJpaRepository.save(user) }
+        }
+
+        @Test
+        fun `should throw UserNotFoundException when user not found`() {
+            // given
+            val userId = 999L
+            every { userJpaRepository.findById(userId) } returns Optional.empty()
+
+            // when & then
+            assertThatThrownBy {
+                oauthLinkService.linkOAuthAccount(userId, OAuthProvider.KAKAO, "kakao_123")
+            }.isInstanceOf(UserNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw IllegalArgumentException when provider already linked`() {
+            // given
+            val userId = 1L
+            val provider = OAuthProvider.KAKAO
+            val oauthId = "kakao_123"
+            val user = createOAuthUser(userId)
+
+            every { userJpaRepository.findById(userId) } returns Optional.of(user)
+
+            // when & then
+            assertThatThrownBy {
+                oauthLinkService.linkOAuthAccount(userId, provider, oauthId)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("unlinkOAuthAccount")
+    inner class UnlinkOAuthAccount {
+
+        @Test
+        fun `should unlink oauth account from user`() {
+            // given
+            val userId = 1L
+            val provider = OAuthProvider.KAKAO
+            val user = createOAuthUser(userId)
+
+            every { userJpaRepository.findById(userId) } returns Optional.of(user)
+            every { userJpaRepository.save(any()) } returns user
+
+            // when
+            oauthLinkService.unlinkOAuthAccount(userId, provider)
+
+            // then
+            verify { userJpaRepository.findById(userId) }
+            verify { userJpaRepository.save(user) }
+        }
+
+        @Test
+        fun `should throw UserNotFoundException when user not found`() {
+            // given
+            val userId = 999L
+            every { userJpaRepository.findById(userId) } returns Optional.empty()
+
+            // when & then
+            assertThatThrownBy {
+                oauthLinkService.unlinkOAuthAccount(userId, OAuthProvider.KAKAO)
+            }.isInstanceOf(UserNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getLinkedProviders")
+    inner class GetLinkedProviders {
+
+        @Test
+        fun `should return list of linked providers`() {
+            // given
+            val userId = 1L
+            val providers = listOf(OAuthProvider.KAKAO, OAuthProvider.GOOGLE)
+
+            every { oauthAccountRepository.findProvidersByUserId(userId) } returns providers
+
+            // when
+            val result = oauthLinkService.getLinkedProviders(userId)
+
+            // then
+            assertThat(result).containsExactlyInAnyOrder(OAuthProvider.KAKAO, OAuthProvider.GOOGLE)
+        }
+
+        @Test
+        fun `should return empty list when no providers linked`() {
+            // given
+            val userId = 1L
+            every { oauthAccountRepository.findProvidersByUserId(userId) } returns emptyList()
+
+            // when
+            val result = oauthLinkService.getLinkedProviders(userId)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("isLinked")
+    inner class IsLinked {
+
+        @Test
+        fun `should return true when oauth account is linked`() {
+            // given
+            val userId = 1L
+            val provider = OAuthProvider.KAKAO
+            val oauthAccount = mockk<OAuthAccount>()
+
+            every { oauthAccountRepository.findByUserIdAndProvider(userId, provider) } returns oauthAccount
+
+            // when
+            val result = oauthLinkService.isLinked(userId, provider)
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `should return false when oauth account is not linked`() {
+            // given
+            val userId = 1L
+            val provider = OAuthProvider.KAKAO
+
+            every { oauthAccountRepository.findByUserIdAndProvider(userId, provider) } returns null
+
+            // when
+            val result = oauthLinkService.isLinked(userId, provider)
+
+            // then
+            assertThat(result).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("findUserByOAuth")
+    inner class FindUserByOAuth {
+
+        @Test
+        fun `should return user when oauth account found`() {
+            // given
+            val provider = OAuthProvider.KAKAO
+            val oauthId = "kakao_123"
+            val user = createOAuthUser(1L)
+            val oauthAccount = mockk<OAuthAccount>()
+
+            every { oauthAccountRepository.findByProviderAndOauthId(provider, oauthId) } returns oauthAccount
+            every { oauthAccount.user } returns user
+
+            // when
+            val result = oauthLinkService.findUserByOAuth(provider, oauthId)
+
+            // then
+            assertThat(result).isEqualTo(user)
+        }
+
+        @Test
+        fun `should return null when oauth account not found`() {
+            // given
+            val provider = OAuthProvider.KAKAO
+            val oauthId = "kakao_123"
+
+            every { oauthAccountRepository.findByProviderAndOauthId(provider, oauthId) } returns null
+
+            // when
+            val result = oauthLinkService.findUserByOAuth(provider, oauthId)
+
+            // then
+            assertThat(result).isNull()
+        }
+    }
+
+    // Helper methods
+    private fun createLocalUser(id: Long): User {
+        val user = User.createLocalUser(
+            email = "test@example.com",
+            encodedPassword = "encoded_password",
+            nickname = "testuser"
+        )
+        setUserId(user, id)
+        return user
+    }
+
+    private fun createOAuthUser(id: Long): User {
+        val user = User.createOAuthUser(
+            email = "test@kakao.com",
+            nickname = "kakao_user",
+            provider = OAuthProvider.KAKAO,
+            oauthId = "kakao_123"
+        )
+        // Add password so user can remove OAuth account
+        user.changePassword("encoded_password")
+        setUserId(user, id)
+        return user
+    }
+
+    private fun setUserId(user: User, id: Long) {
+        val idField = User::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(user, id)
+    }
+}


### PR DESCRIPTION
## Summary

>- close #27

Kakao, Google, Naver OAuth2 소셜 로그인 기능을 구현하고, 기존 JWT 인증 시스템과 통합했습니다.

## Tasks

- OAuth2UserInfo 인터페이스 및 제공자별 구현체 추가 (Kakao, Google, Naver)
- CustomOAuth2UserService 구현 (OAuth2 사용자 정보 처리 및 User 생성/연동)
- OAuth2AuthenticationSuccessHandler 구현 (로그인 성공 시 JWT 발급)
- OAuth2AuthenticationFailureHandler 구현 (로그인 실패 처리)
- OAuthLinkService 구현 (계정 연동/해제 서비스)
- OAuthController 구현 (계정 관리 REST API)
- SecurityConfig에 OAuth2 로그인 설정 추가
- OAuth2 관련 커스텀 예외 클래스 추가
- OAuthController, OAuthLinkService 단위 테스트 추가

## To Reviewer

OAuth2 클라이언트 설정이 `application.yml`에 필요합니다:
```yaml
spring:
  security:
    oauth2:
      client:
        registration:
          kakao:
            client-id: ${KAKAO_CLIENT_ID}
            client-secret: ${KAKAO_CLIENT_SECRET}
          google:
            client-id: ${GOOGLE_CLIENT_ID}
            client-secret: ${GOOGLE_CLIENT_SECRET}
          naver:
            client-id: ${NAVER_CLIENT_ID}
            client-secret: ${NAVER_CLIENT_SECRET}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)