### PR TITLE
feat(#52): 기록원 이벤트 입력 API 구현

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+trim_trailing_whitespace = true
+
+[*.{kt,kts}]
+ktlint_standard_trailing-comma-on-call-site = disabled
+ktlint_standard_trailing-comma-on-declaration-site = disabled
+ktlint_standard_function-expression-body = disabled
+# ktlint_standard_multiline-expression-wrapping = disabled (has dependencies)
+ktlint_standard_chain-method-continuation = disabled
+ktlint_standard_no-empty-first-line-in-class-body = disabled
+ktlint_standard_no-blank-lines-in-chained-method-calls = disabled
+ktlint_standard_wrapping = disabled
+ktlint_standard_no-wildcard-imports = disabled
+
+[*.md]
+trim_trailing_whitespace = false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
     kotlin("plugin.jpa") version "2.1.10" apply false
     id("org.springframework.boot") version "3.4.1" apply false
     id("io.spring.dependency-management") version "1.1.7" apply false
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.0"
+    // TODO: detekt 1.23.8은 Kotlin 2.0.21까지만 지원. Kotlin 2.1.x 지원 버전 출시 시 업데이트 필요
+    id("io.gitlab.arturbosch.detekt") version "1.23.8"
     jacoco
 }
 
@@ -18,34 +21,55 @@ allprojects {
 
 subprojects {
     apply(plugin = "jacoco")
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+    apply(plugin = "io.gitlab.arturbosch.detekt")
 
     configure<JacocoPluginExtension> {
         toolVersion = "0.8.12"
     }
 
+    configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
+        version.set("1.5.0")
+        android.set(false)
+        outputToConsole.set(true)
+        ignoreFailures.set(false)
+        filter {
+            exclude("**/generated/**")
+        }
+    }
+
+    configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> {
+        buildUponDefaultConfig = true
+        allRules = false
+        config.setFrom(files("${rootProject.projectDir}/detekt.yml"))
+    }
+
+    // TODO: detekt가 Kotlin 2.1.x를 지원할 때까지 비활성화
+    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+        enabled = false
+    }
+    tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configureEach {
+        enabled = false
+    }
+
     // Jacoco 커버리지 제외 대상 (Ant 스타일 패턴)
-    val jacocoExcludes = listOf(
-        // Kotlin generated
-        "**/*\$default*",
-
-        // Config classes - 모든 config 패키지
-        "**/config/**",
-
-        // Application classes
-        "**/*Application*",
-
-        // DTO classes
-        "**/dto/**",
-
-        // Exception classes
-        "**/exception/**",
-
-        // Mapper classes
-        "**/mapper/**",
-
-        // Health controllers
-        "**/HealthController*"
-    )
+    val jacocoExcludes =
+        listOf(
+            // Kotlin generated
+            "**/*\$default*",
+            // Config classes - 모든 config 패키지
+            "**/config/**",
+            // Application classes
+            "**/*Application*",
+            // DTO classes
+            "**/dto/**",
+            // Exception classes
+            "**/exception/**",
+            // Mapper classes
+            "**/mapper/**",
+            // Health controllers
+            "**/HealthController*",
+        )
 
     tasks.withType<JacocoReport> {
         reports {
@@ -53,11 +77,13 @@ subprojects {
             html.required = true
         }
         classDirectories.setFrom(
-            files(classDirectories.files.map {
-                fileTree(it) {
-                    exclude(jacocoExcludes)
-                }
-            })
+            files(
+                classDirectories.files.map {
+                    fileTree(it) {
+                        exclude(jacocoExcludes)
+                    }
+                },
+            ),
         )
     }
 
@@ -70,11 +96,13 @@ subprojects {
             }
         }
         classDirectories.setFrom(
-            files(classDirectories.files.map {
-                fileTree(it) {
-                    exclude(jacocoExcludes)
-                }
-            })
+            files(
+                classDirectories.files.map {
+                    fileTree(it) {
+                        exclude(jacocoExcludes)
+                    }
+                },
+            ),
         )
     }
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,88 @@
+build:
+  maxIssues: 0
+  excludeCorrectable: false
+
+config:
+  validation: true
+  warningsAsErrors: false
+
+complexity:
+  active: true
+  LongMethod:
+    active: true
+    threshold: 60
+  LongParameterList:
+    active: true
+    functionThreshold: 10
+    constructorThreshold: 15
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 30
+    thresholdInClasses: 30
+    thresholdInInterfaces: 20
+    thresholdInObjects: 20
+    thresholdInEnums: 10
+
+exceptions:
+  active: true
+  TooGenericExceptionCaught:
+    active: true
+    exceptionNames:
+      - Error
+      - Exception
+      - RuntimeException
+      - Throwable
+    allowedExceptionNameRegex: _|(ignore|expected).*
+  TooGenericExceptionThrown:
+    active: true
+    exceptionNames:
+      - Error
+      - Exception
+      - RuntimeException
+      - Throwable
+
+naming:
+  active: true
+  FunctionNaming:
+    active: true
+    excludes:
+      - '**/test/**'
+      - '**/androidTest/**'
+      - '**/commonTest/**'
+      - '**/jvmTest/**'
+      - '**/jsTest/**'
+      - '**/iosTest/**'
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+
+potential-bugs:
+  active: true
+  DoubleMutabilityForCollection:
+    active: true
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  UnreachableCatchBlock:
+    active: true
+  UnsafeCallOnNullableType:
+    active: false
+
+style:
+  active: true
+  ForbiddenComment:
+    active: false
+  MagicNumber:
+    active: false
+  MaxLineLength:
+    active: true
+    maxLineLength: 140
+  ReturnCount:
+    active: true
+    max: 5
+  UnusedPrivateMember:
+    active: true
+    allowedNames: (_|ignored|expected|serialVersionUID)
+  WildcardImport:
+    active: false

--- a/nextup-api/build.gradle.kts
+++ b/nextup-api/build.gradle.kts
@@ -45,16 +45,18 @@ tasks.jacocoTestReport {
     }
 
     classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/dto/**",
-                    "**/config/**",
-                    "**/NextUpApplication*",
-                    "**/HealthController*"
-                )
-            }
-        })
+        files(
+            classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/dto/**",
+                        "**/config/**",
+                        "**/NextUpApplication*",
+                        "**/HealthController*",
+                    )
+                }
+            },
+        ),
     )
 }
 
@@ -68,15 +70,17 @@ tasks.jacocoTestCoverageVerification {
     }
 
     classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/dto/**",
-                    "**/config/**",
-                    "**/NextUpApplication*",
-                    "**/HealthController*"
-                )
-            }
-        })
+        files(
+            classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/dto/**",
+                        "**/config/**",
+                        "**/NextUpApplication*",
+                        "**/HealthController*",
+                    )
+                }
+            },
+        ),
     )
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
@@ -35,66 +35,61 @@ class SecurityConfig(
     private val customAccessDeniedHandler: CustomAccessDeniedHandler,
     private val customOAuth2UserService: CustomOAuth2UserService,
     private val oAuth2AuthenticationSuccessHandler: OAuth2AuthenticationSuccessHandler,
-    private val oAuth2AuthenticationFailureHandler: OAuth2AuthenticationFailureHandler
+    private val oAuth2AuthenticationFailureHandler: OAuth2AuthenticationFailureHandler,
 ) {
-
     @Bean
-    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        return http
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain =
+        http
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .exceptionHandling {
                 it.authenticationEntryPoint(customAuthenticationEntryPoint)
                 it.accessDeniedHandler(customAccessDeniedHandler)
-            }
-            .authorizeHttpRequests { auth ->
+            }.authorizeHttpRequests { auth ->
                 auth
                     // Public endpoints
-                    .requestMatchers("/api/auth/**").permitAll()
-                    .requestMatchers(HttpMethod.GET, "/api/associations/**").permitAll()
-                    .requestMatchers(HttpMethod.GET, "/api/stats/**").permitAll()
-
+                    .requestMatchers("/api/auth/**")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/associations/**")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/stats/**")
+                    .permitAll()
                     // OAuth2 endpoints
-                    .requestMatchers("/oauth2/**").permitAll()
-                    .requestMatchers("/login/oauth2/**").permitAll()
-
+                    .requestMatchers("/oauth2/**")
+                    .permitAll()
+                    .requestMatchers("/login/oauth2/**")
+                    .permitAll()
                     // Swagger/OpenAPI
                     .requestMatchers(
                         "/swagger-ui/**",
                         "/swagger-ui.html",
                         "/v3/api-docs/**",
-                        "/swagger-resources/**"
+                        "/swagger-resources/**",
                     ).permitAll()
-
                     // Actuator endpoints
-                    .requestMatchers("/actuator/health").permitAll()
-
+                    .requestMatchers("/actuator/health")
+                    .permitAll()
                     // Admin endpoints
-                    .requestMatchers("/api/admin/**").hasRole("ADMIN")
-
+                    .requestMatchers("/api/admin/**")
+                    .hasRole("ADMIN")
                     // Scorer endpoints (for game recording)
-                    .requestMatchers("/api/games/*/records/**").hasAnyRole("SCORER", "ADMIN")
-
+                    .requestMatchers("/api/games/*/records/**")
+                    .hasAnyRole("SCORER", "ADMIN")
                     // All other endpoints require authentication
-                    .anyRequest().authenticated()
-            }
-            .oauth2Login { oauth2 ->
+                    .anyRequest()
+                    .authenticated()
+            }.oauth2Login { oauth2 ->
                 oauth2
                     .userInfoEndpoint { it.userService(customOAuth2UserService) }
                     .successHandler(oAuth2AuthenticationSuccessHandler)
                     .failureHandler(oAuth2AuthenticationFailureHandler)
-            }
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            }.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
-    }
 
     @Bean
-    fun passwordEncoder(): PasswordEncoder {
-        return BCryptPasswordEncoder()
-    }
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 
     @Bean
-    fun authenticationManager(authenticationConfiguration: AuthenticationConfiguration): AuthenticationManager {
-        return authenticationConfiguration.authenticationManager
-    }
+    fun authenticationManager(authenticationConfiguration: AuthenticationConfiguration): AuthenticationManager =
+        authenticationConfiguration.authenticationManager
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/association/AssociationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/association/AssociationController.kt
@@ -16,24 +16,24 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/associations")
 class AssociationController(
-    private val associationService: AssociationService
+    private val associationService: AssociationService,
 ) {
-
     /**
      * 활성화된 협회 목록을 조회합니다.
      */
     @GetMapping
     fun getAssociations(
-        @RequestParam(required = false) region: String?
+        @RequestParam(required = false) region: String?,
     ): ApiResponse<List<AssociationSummaryResponse>> {
-        val associations = if (region != null) {
-            associationService.getActiveByRegion(region)
-        } else {
-            associationService.getAllActive()
-        }
+        val associations =
+            if (region != null) {
+                associationService.getActiveByRegion(region)
+            } else {
+                associationService.getAllActive()
+            }
 
         return ApiResponse.success(
-            associations.map { AssociationSummaryResponse.from(it) }
+            associations.map { AssociationSummaryResponse.from(it) },
         )
     }
 
@@ -42,7 +42,7 @@ class AssociationController(
      */
     @GetMapping("/{id}")
     fun getAssociation(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<AssociationResponse> {
         val association = associationService.getById(id)
         return ApiResponse.success(AssociationResponse.from(association))

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/auth/AuthController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/auth/AuthController.kt
@@ -5,7 +5,6 @@ import com.nextup.api.dto.common.ApiResponse
 import com.nextup.infrastructure.security.AuthenticationService
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
@@ -16,9 +15,8 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/auth")
 class AuthController(
-    private val authenticationService: AuthenticationService
+    private val authenticationService: AuthenticationService,
 ) {
-
     /**
      * 로그인
      *
@@ -27,17 +25,18 @@ class AuthController(
     @PostMapping("/login")
     fun login(
         @Valid @RequestBody request: LoginRequest,
-        httpRequest: HttpServletRequest
+        httpRequest: HttpServletRequest,
     ): ResponseEntity<ApiResponse<TokenResponse>> {
         val deviceInfo = httpRequest.getHeader("User-Agent")
         val ipAddress = getClientIpAddress(httpRequest)
 
-        val tokenPair = authenticationService.login(
-            email = request.email,
-            password = request.password,
-            deviceInfo = deviceInfo,
-            ipAddress = ipAddress
-        )
+        val tokenPair =
+            authenticationService.login(
+                email = request.email,
+                password = request.password,
+                deviceInfo = deviceInfo,
+                ipAddress = ipAddress,
+            )
 
         return ResponseEntity.ok(ApiResponse.success(TokenResponse.from(tokenPair)))
     }
@@ -50,16 +49,17 @@ class AuthController(
     @PostMapping("/refresh")
     fun refresh(
         @Valid @RequestBody request: RefreshTokenRequest,
-        httpRequest: HttpServletRequest
+        httpRequest: HttpServletRequest,
     ): ResponseEntity<ApiResponse<TokenResponse>> {
         val deviceInfo = httpRequest.getHeader("User-Agent")
         val ipAddress = getClientIpAddress(httpRequest)
 
-        val tokenPair = authenticationService.refresh(
-            refreshTokenString = request.refreshToken,
-            deviceInfo = deviceInfo,
-            ipAddress = ipAddress
-        )
+        val tokenPair =
+            authenticationService.refresh(
+                refreshTokenString = request.refreshToken,
+                deviceInfo = deviceInfo,
+                ipAddress = ipAddress,
+            )
 
         return ResponseEntity.ok(ApiResponse.success(TokenResponse.from(tokenPair)))
     }
@@ -71,7 +71,7 @@ class AuthController(
      */
     @PostMapping("/logout")
     fun logout(
-        @Valid @RequestBody request: LogoutRequest
+        @Valid @RequestBody request: LogoutRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
         authenticationService.logout(request.refreshToken)
         return ResponseEntity.ok(ApiResponse.success(Unit))
@@ -84,7 +84,7 @@ class AuthController(
      */
     @PostMapping("/logout-all")
     fun logoutAll(
-        @AuthenticationPrincipal userId: Long
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<Unit>> {
         authenticationService.logoutAll(userId)
         return ResponseEntity.ok(ApiResponse.success(Unit))
@@ -97,17 +97,18 @@ class AuthController(
      */
     @GetMapping("/me")
     fun getCurrentUser(
-        @AuthenticationPrincipal userId: Long
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<CurrentUserResponse>> {
         val userDetails = authenticationService.getUserDetails(userId)
 
-        val response = CurrentUserResponse(
-            id = userDetails.id,
-            email = userDetails.email,
-            nickname = userDetails.nickname,
-            roles = userDetails.getRoleNames(),
-            isActive = userDetails.isEnabled
-        )
+        val response =
+            CurrentUserResponse(
+                id = userDetails.id,
+                email = userDetails.email,
+                nickname = userDetails.nickname,
+                roles = userDetails.getRoleNames(),
+                isActive = userDetails.isEnabled,
+            )
 
         return ResponseEntity.ok(ApiResponse.success(response))
     }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
@@ -6,7 +6,6 @@ import com.nextup.core.service.competition.CompetitionService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
@@ -15,9 +14,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/competitions")
 class CompetitionController(
-    private val competitionService: CompetitionService
+    private val competitionService: CompetitionService,
 ) {
-
     /**
      * 진행 중인 대회 목록을 조회합니다.
      */
@@ -25,7 +23,7 @@ class CompetitionController(
     fun getCompetitions(): ApiResponse<List<CompetitionResponse>> {
         val competitions = competitionService.getInProgress()
         return ApiResponse.success(
-            competitions.map { CompetitionResponse.from(it) }
+            competitions.map { CompetitionResponse.from(it) },
         )
     }
 
@@ -34,7 +32,7 @@ class CompetitionController(
      */
     @GetMapping("/{id}")
     fun getCompetition(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<CompetitionResponse> {
         val competition = competitionService.getByIdWithLeague(id)
         return ApiResponse.success(CompetitionResponse.from(competition))
@@ -45,11 +43,11 @@ class CompetitionController(
      */
     @GetMapping("/by-league/{leagueId}")
     fun getCompetitionsByLeague(
-        @PathVariable leagueId: Long
+        @PathVariable leagueId: Long,
     ): ApiResponse<List<CompetitionResponse>> {
         val competitions = competitionService.getByLeagueId(leagueId)
         return ApiResponse.success(
-            competitions.map { CompetitionResponse.from(it) }
+            competitions.map { CompetitionResponse.from(it) },
         )
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BattingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BattingRecordController.kt
@@ -5,8 +5,8 @@ import com.nextup.api.dto.game.BattingRecordResponse
 import com.nextup.api.dto.game.CreateBattingRecordRequest
 import com.nextup.api.mapper.game.toResponse
 import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
-import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import com.nextup.core.service.game.BattingRecordService
+import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,12 +21,11 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/games/{gameId}/batting-records")
 class BattingRecordController(
     private val battingRecordService: BattingRecordService,
-    private val gamePlayerRepository: GamePlayerRepository
+    private val gamePlayerRepository: GamePlayerRepository,
 ) {
-
     @GetMapping
     fun getBattingRecordsByGame(
-        @PathVariable gameId: Long
+        @PathVariable gameId: Long,
     ): ApiResponse<List<BattingRecordResponse>> {
         val records = battingRecordService.getAllByGameId(gameId)
         return ApiResponse.success(records.toResponse())
@@ -36,10 +35,11 @@ class BattingRecordController(
     @ResponseStatus(HttpStatus.CREATED)
     fun createBattingRecord(
         @PathVariable gameId: Long,
-        @Valid @RequestBody request: CreateBattingRecordRequest
+        @Valid @RequestBody request: CreateBattingRecordRequest,
     ): ApiResponse<BattingRecordResponse> {
-        val gamePlayer = gamePlayerRepository.findByGameIdAndPlayerId(gameId, request.playerId)
-            ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, request.playerId)
+        val gamePlayer =
+            gamePlayerRepository.findByGameIdAndPlayerId(gameId, request.playerId)
+                ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, request.playerId)
 
         val record = battingRecordService.createRecord(gamePlayer.id)
         return ApiResponse.success(record.toResponse())

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BoxScoreController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BoxScoreController.kt
@@ -15,14 +15,15 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/games/{gameId}/boxscore")
 class BoxScoreController(
-    private val boxScoreService: BoxScoreService
+    private val boxScoreService: BoxScoreService,
 ) {
-
     /**
      * 경기의 박스스코어를 조회합니다.
      */
     @GetMapping
-    fun getBoxScore(@PathVariable gameId: Long): ApiResponse<BoxScoreResponse> {
+    fun getBoxScore(
+        @PathVariable gameId: Long,
+    ): ApiResponse<BoxScoreResponse> {
         val boxScore = boxScoreService.getBoxScore(gameId)
         return ApiResponse.success(boxScore.toResponse())
     }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/PitchingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/PitchingRecordController.kt
@@ -5,8 +5,8 @@ import com.nextup.api.dto.game.CreatePitchingRecordRequest
 import com.nextup.api.dto.game.PitchingRecordResponse
 import com.nextup.api.mapper.game.toResponse
 import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
-import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import com.nextup.core.service.game.PitchingRecordService
+import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,12 +21,11 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/games/{gameId}/pitching-records")
 class PitchingRecordController(
     private val pitchingRecordService: PitchingRecordService,
-    private val gamePlayerRepository: GamePlayerRepository
+    private val gamePlayerRepository: GamePlayerRepository,
 ) {
-
     @GetMapping
     fun getPitchingRecordsByGame(
-        @PathVariable gameId: Long
+        @PathVariable gameId: Long,
     ): ApiResponse<List<PitchingRecordResponse>> {
         val records = pitchingRecordService.getAllByGameId(gameId)
         return ApiResponse.success(records.toResponse())
@@ -36,10 +35,11 @@ class PitchingRecordController(
     @ResponseStatus(HttpStatus.CREATED)
     fun createPitchingRecord(
         @PathVariable gameId: Long,
-        @Valid @RequestBody request: CreatePitchingRecordRequest
+        @Valid @RequestBody request: CreatePitchingRecordRequest,
     ): ApiResponse<PitchingRecordResponse> {
-        val gamePlayer = gamePlayerRepository.findByGameIdAndPlayerId(gameId, request.playerId)
-            ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, request.playerId)
+        val gamePlayer =
+            gamePlayerRepository.findByGameIdAndPlayerId(gameId, request.playerId)
+                ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, request.playerId)
 
         val record = pitchingRecordService.createRecord(gamePlayer.id, request.isStartingPitcher)
         return ApiResponse.success(record.toResponse())

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/league/LeagueController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/league/LeagueController.kt
@@ -15,9 +15,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api")
 class LeagueController(
-    private val leagueService: LeagueService
+    private val leagueService: LeagueService,
 ) {
-
     /**
      * 활성화된 리그 목록을 조회합니다.
      */
@@ -25,7 +24,7 @@ class LeagueController(
     fun getLeagues(): ApiResponse<List<LeagueSummaryResponse>> {
         val leagues = leagueService.getAllActive()
         return ApiResponse.success(
-            leagues.map { LeagueSummaryResponse.from(it) }
+            leagues.map { LeagueSummaryResponse.from(it) },
         )
     }
 
@@ -34,7 +33,7 @@ class LeagueController(
      */
     @GetMapping("/leagues/{id}")
     fun getLeague(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<LeagueResponse> {
         val league = leagueService.getById(id)
         return ApiResponse.success(LeagueResponse.from(league))
@@ -45,11 +44,11 @@ class LeagueController(
      */
     @GetMapping("/associations/{associationId}/leagues")
     fun getLeaguesByAssociation(
-        @PathVariable associationId: Long
+        @PathVariable associationId: Long,
     ): ApiResponse<List<LeagueSummaryResponse>> {
         val leagues = leagueService.getActiveByAssociationId(associationId)
         return ApiResponse.success(
-            leagues.map { LeagueSummaryResponse.from(it) }
+            leagues.map { LeagueSummaryResponse.from(it) },
         )
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/oauth/OAuthController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/oauth/OAuthController.kt
@@ -19,9 +19,8 @@ import org.springframework.web.util.UriComponentsBuilder
 class OAuthController(
     private val oauthLinkService: OAuthLinkService,
     @Value("\${app.oauth2.base-url:http://localhost:8080}")
-    private val baseUrl: String
+    private val baseUrl: String,
 ) {
-
     /**
      * 연동된 소셜 계정 목록 조회
      *
@@ -29,7 +28,7 @@ class OAuthController(
      */
     @GetMapping
     fun getLinkedOAuthAccounts(
-        @AuthenticationPrincipal userId: Long
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<LinkedOAuthAccountsResponse>> {
         val providers = oauthLinkService.getLinkedProviders(userId)
         val response = LinkedOAuthAccountsResponse(providers = providers)
@@ -47,15 +46,16 @@ class OAuthController(
     @PostMapping("/{provider}/link")
     fun startOAuthLink(
         @PathVariable provider: OAuthProvider,
-        @AuthenticationPrincipal userId: Long
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<OAuthLinkStartResponse>> {
         // OAuth2 인증 URL 생성
         val authorizationUrl = buildAuthorizationUrl(provider)
 
-        val response = OAuthLinkStartResponse(
-            authorizationUrl = authorizationUrl,
-            provider = provider
-        )
+        val response =
+            OAuthLinkStartResponse(
+                authorizationUrl = authorizationUrl,
+                provider = provider,
+            )
 
         return ResponseEntity.ok(ApiResponse.success(response))
     }
@@ -68,7 +68,7 @@ class OAuthController(
     @DeleteMapping("/{provider}")
     fun unlinkOAuthAccount(
         @PathVariable provider: OAuthProvider,
-        @AuthenticationPrincipal userId: Long
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<Unit>> {
         oauthLinkService.unlinkOAuthAccount(userId, provider)
         return ResponseEntity.ok(ApiResponse.success(Unit))
@@ -83,7 +83,8 @@ class OAuthController(
     private fun buildAuthorizationUrl(provider: OAuthProvider): String {
         val registrationId = provider.name.lowercase()
 
-        return UriComponentsBuilder.fromUriString(baseUrl)
+        return UriComponentsBuilder
+            .fromUriString(baseUrl)
             .path("/oauth2/authorization/$registrationId")
             .build()
             .toUriString()

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/PlayerStatsController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/PlayerStatsController.kt
@@ -23,9 +23,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/players/{playerId}/stats")
 class PlayerStatsController(
-    private val playerStatsService: PlayerStatsService
+    private val playerStatsService: PlayerStatsService,
 ) {
-
     /**
      * 시즌 타격 통계 조회
      *
@@ -38,7 +37,7 @@ class PlayerStatsController(
     @GetMapping("/batting/season/{year}")
     fun getSeasonBattingStats(
         @PathVariable playerId: Long,
-        @PathVariable year: Int
+        @PathVariable year: Int,
     ): ApiResponse<SeasonBattingStatsResponse> {
         val stats = playerStatsService.getSeasonBattingStats(playerId, year)
         return ApiResponse.success(stats.toResponse())
@@ -56,7 +55,7 @@ class PlayerStatsController(
     @GetMapping("/pitching/season/{year}")
     fun getSeasonPitchingStats(
         @PathVariable playerId: Long,
-        @PathVariable year: Int
+        @PathVariable year: Int,
     ): ApiResponse<SeasonPitchingStatsResponse> {
         val stats = playerStatsService.getSeasonPitchingStats(playerId, year)
         return ApiResponse.success(stats.toResponse())
@@ -72,7 +71,7 @@ class PlayerStatsController(
      */
     @GetMapping("/batting/career")
     fun getCareerBattingStats(
-        @PathVariable playerId: Long
+        @PathVariable playerId: Long,
     ): ApiResponse<CareerBattingStatsResponse> {
         val stats = playerStatsService.getCareerBattingStats(playerId)
         return ApiResponse.success(stats.toResponse())
@@ -88,7 +87,7 @@ class PlayerStatsController(
      */
     @GetMapping("/pitching/career")
     fun getCareerPitchingStats(
-        @PathVariable playerId: Long
+        @PathVariable playerId: Long,
     ): ApiResponse<CareerPitchingStatsResponse> {
         val stats = playerStatsService.getCareerPitchingStats(playerId)
         return ApiResponse.success(stats.toResponse())
@@ -104,7 +103,7 @@ class PlayerStatsController(
      */
     @GetMapping("/batting/seasons")
     fun getAllSeasonBattingStats(
-        @PathVariable playerId: Long
+        @PathVariable playerId: Long,
     ): ApiResponse<List<SeasonBattingStatsResponse>> {
         val statsList = playerStatsService.getAllSeasonBattingStats(playerId)
         return ApiResponse.success(statsList.toSeasonBattingResponse())
@@ -120,7 +119,7 @@ class PlayerStatsController(
      */
     @GetMapping("/pitching/seasons")
     fun getAllSeasonPitchingStats(
-        @PathVariable playerId: Long
+        @PathVariable playerId: Long,
     ): ApiResponse<List<SeasonPitchingStatsResponse>> {
         val statsList = playerStatsService.getAllSeasonPitchingStats(playerId)
         return ApiResponse.success(statsList.toSeasonPitchingResponse())

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/user/ProfileController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/user/ProfileController.kt
@@ -15,15 +15,14 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/v1/me")
 class ProfileController(
-    private val userService: UserService
+    private val userService: UserService,
 ) {
-
     /**
      * 내 프로필을 조회합니다.
      */
     @GetMapping
     fun getMyProfile(
-        @AuthenticationPrincipal userId: Long
+        @AuthenticationPrincipal userId: Long,
     ): ApiResponse<ProfileResponse> {
         val user = userService.getActiveById(userId)
         return ApiResponse.success(ProfileResponse.from(user))
@@ -35,13 +34,14 @@ class ProfileController(
     @PutMapping
     fun updateMyProfile(
         @AuthenticationPrincipal userId: Long,
-        @Valid @RequestBody request: UpdateProfileRequest
+        @Valid @RequestBody request: UpdateProfileRequest,
     ): ApiResponse<ProfileResponse> {
-        val user = userService.updateProfile(
-            userId = userId,
-            nickname = request.nickname,
-            profileImageUrl = request.profileImageUrl
-        )
+        val user =
+            userService.updateProfile(
+                userId = userId,
+                nickname = request.nickname,
+                profileImageUrl = request.profileImageUrl,
+            )
         return ApiResponse.success(ProfileResponse.from(user))
     }
 
@@ -50,16 +50,17 @@ class ProfileController(
      */
     @GetMapping("/oauth-accounts")
     fun getLinkedOAuthAccounts(
-        @AuthenticationPrincipal userId: Long
+        @AuthenticationPrincipal userId: Long,
     ): ApiResponse<List<LinkedOAuthProvider>> {
         val user = userService.getActiveById(userId)
-        val providers = user.oauthAccounts.map {
-            LinkedOAuthProvider(
-                provider = it.provider.name,
-                displayName = it.provider.displayName,
-                connectedAt = it.connectedAt
-            )
-        }
+        val providers =
+            user.oauthAccounts.map {
+                LinkedOAuthProvider(
+                    provider = it.provider.name,
+                    displayName = it.provider.displayName,
+                    connectedAt = it.connectedAt,
+                )
+            }
         return ApiResponse.success(providers)
     }
 
@@ -68,7 +69,7 @@ class ProfileController(
      */
     @DeleteMapping
     fun deactivateMyAccount(
-        @AuthenticationPrincipal userId: Long
+        @AuthenticationPrincipal userId: Long,
     ): ApiResponse<Unit> {
         userService.deactivate(userId)
         return ApiResponse.success(Unit)
@@ -83,15 +84,14 @@ class ProfileController(
 @RestController
 @RequestMapping("/api/v1/users")
 class PublicProfileController(
-    private val userService: UserService
+    private val userService: UserService,
 ) {
-
     /**
      * 사용자의 공개 프로필을 조회합니다.
      */
     @GetMapping("/{userId}")
     fun getPublicProfile(
-        @PathVariable userId: Long
+        @PathVariable userId: Long,
     ): ApiResponse<PublicProfileResponse> {
         val user = userService.getActiveById(userId)
         return ApiResponse.success(PublicProfileResponse.from(user))

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/association/AssociationResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/association/AssociationResponse.kt
@@ -16,11 +16,11 @@ data class AssociationResponse(
     val websiteUrl: String?,
     val isActive: Boolean,
     val createdAt: Instant,
-    val updatedAt: Instant
+    val updatedAt: Instant,
 ) {
     companion object {
-        fun from(association: Association): AssociationResponse {
-            return AssociationResponse(
+        fun from(association: Association): AssociationResponse =
+            AssociationResponse(
                 id = association.id,
                 name = association.name,
                 abbreviation = association.abbreviation,
@@ -30,9 +30,8 @@ data class AssociationResponse(
                 websiteUrl = association.websiteUrl,
                 isActive = association.isActive,
                 createdAt = association.createdAt,
-                updatedAt = association.updatedAt
+                updatedAt = association.updatedAt,
             )
-        }
     }
 }
 
@@ -44,17 +43,16 @@ data class AssociationSummaryResponse(
     val name: String,
     val abbreviation: String?,
     val region: String?,
-    val logoUrl: String?
+    val logoUrl: String?,
 ) {
     companion object {
-        fun from(association: Association): AssociationSummaryResponse {
-            return AssociationSummaryResponse(
+        fun from(association: Association): AssociationSummaryResponse =
+            AssociationSummaryResponse(
                 id = association.id,
                 name = association.name,
                 abbreviation = association.abbreviation,
                 region = association.region,
-                logoUrl = association.logoUrl
+                logoUrl = association.logoUrl,
             )
-        }
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthRequest.kt
@@ -11,9 +11,8 @@ data class LoginRequest(
     @field:NotBlank(message = "Email is required")
     @field:Email(message = "Invalid email format")
     val email: String,
-
     @field:NotBlank(message = "Password is required")
-    val password: String
+    val password: String,
 )
 
 /**
@@ -23,14 +22,12 @@ data class SignUpRequest(
     @field:NotBlank(message = "Email is required")
     @field:Email(message = "Invalid email format")
     val email: String,
-
     @field:NotBlank(message = "Password is required")
     @field:Size(min = 8, max = 100, message = "Password must be 8-100 characters")
     val password: String,
-
     @field:NotBlank(message = "Nickname is required")
     @field:Size(min = 2, max = 50, message = "Nickname must be 2-50 characters")
-    val nickname: String
+    val nickname: String,
 )
 
 /**
@@ -38,7 +35,7 @@ data class SignUpRequest(
  */
 data class RefreshTokenRequest(
     @field:NotBlank(message = "Refresh token is required")
-    val refreshToken: String
+    val refreshToken: String,
 )
 
 /**
@@ -46,7 +43,7 @@ data class RefreshTokenRequest(
  */
 data class LogoutRequest(
     @field:NotBlank(message = "Refresh token is required")
-    val refreshToken: String
+    val refreshToken: String,
 )
 
 /**
@@ -55,8 +52,7 @@ data class LogoutRequest(
 data class ChangePasswordRequest(
     @field:NotBlank(message = "Current password is required")
     val currentPassword: String,
-
     @field:NotBlank(message = "New password is required")
     @field:Size(min = 8, max = 100, message = "Password must be 8-100 characters")
-    val newPassword: String
+    val newPassword: String,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthResponse.kt
@@ -8,15 +8,14 @@ import com.nextup.infrastructure.security.TokenPair
 data class TokenResponse(
     val accessToken: String,
     val refreshToken: String,
-    val tokenType: String = "Bearer"
+    val tokenType: String = "Bearer",
 ) {
     companion object {
-        fun from(tokenPair: TokenPair): TokenResponse {
-            return TokenResponse(
+        fun from(tokenPair: TokenPair): TokenResponse =
+            TokenResponse(
                 accessToken = tokenPair.accessToken,
-                refreshToken = tokenPair.refreshToken
+                refreshToken = tokenPair.refreshToken,
             )
-        }
     }
 }
 
@@ -28,7 +27,7 @@ data class CurrentUserResponse(
     val email: String,
     val nickname: String,
     val roles: Set<String>,
-    val isActive: Boolean
+    val isActive: Boolean,
 )
 
 /**
@@ -37,5 +36,5 @@ data class CurrentUserResponse(
 data class SignUpResponse(
     val id: Long,
     val email: String,
-    val nickname: String
+    val nickname: String,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/common/ApiResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/common/ApiResponse.kt
@@ -13,25 +13,25 @@ package com.nextup.api.dto.common
 data class ApiResponse<T>(
     val success: Boolean,
     val data: T?,
-    val error: ErrorDetails?
+    val error: ErrorDetails?,
 ) {
     companion object {
         /**
          * 성공 응답을 생성합니다.
          */
-        fun <T> success(data: T): ApiResponse<T> {
-            return ApiResponse(success = true, data = data, error = null)
-        }
+        fun <T> success(data: T): ApiResponse<T> = ApiResponse(success = true, data = data, error = null)
 
         /**
          * 실패 응답을 생성합니다.
          */
-        fun <T> error(code: String, message: String): ApiResponse<T> {
-            return ApiResponse(
+        fun <T> error(
+            code: String,
+            message: String,
+        ): ApiResponse<T> =
+            ApiResponse(
                 success = false,
                 data = null,
-                error = ErrorDetails(code, message)
+                error = ErrorDetails(code, message),
             )
-        }
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/common/ErrorDetails.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/common/ErrorDetails.kt
@@ -8,5 +8,5 @@ package com.nextup.api.dto.common
  */
 data class ErrorDetails(
     val code: String,
-    val message: String
+    val message: String,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/competition/CompetitionResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/competition/CompetitionResponse.kt
@@ -22,11 +22,11 @@ data class CompetitionResponse(
     val endDate: LocalDate?,
     val status: CompetitionStatus,
     val description: String?,
-    val maxTeams: Int?
+    val maxTeams: Int?,
 ) {
     companion object {
-        fun from(competition: Competition): CompetitionResponse {
-            return CompetitionResponse(
+        fun from(competition: Competition): CompetitionResponse =
+            CompetitionResponse(
                 id = competition.id,
                 leagueId = competition.league.id,
                 leagueName = competition.league.name,
@@ -38,8 +38,7 @@ data class CompetitionResponse(
                 endDate = competition.endDate,
                 status = competition.status,
                 description = competition.description,
-                maxTeams = competition.maxTeams
+                maxTeams = competition.maxTeams,
             )
-        }
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/BattingRecordResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/BattingRecordResponse.kt
@@ -14,7 +14,6 @@ data class BattingRecordResponse(
     val gamePlayerId: Long,
     val createdAt: Instant,
     val updatedAt: Instant,
-
     // 기본 타격 기록
     val plateAppearances: Int,
     val atBats: Int,
@@ -33,18 +32,16 @@ data class BattingRecordResponse(
     val stolenBases: Int,
     val caughtStealing: Int,
     val groundedIntoDoublePlays: Int,
-
     // 계산 속성
     val singles: Int,
     val totalBases: Int,
     val extraBaseHits: Int,
     val sacrifices: Int,
     val totalWalks: Int,
-
     // 비율 지표 (String으로 변환, 소수점 3자리)
-    val battingAverage: String,       // "0.300"
-    val onBasePercentage: String,     // "0.400"
-    val sluggingPercentage: String,   // "0.500"
-    val ops: String,                  // "0.900"
-    val stolenBasePercentage: String  // "0.750"
+    val battingAverage: String, // "0.300"
+    val onBasePercentage: String, // "0.400"
+    val sluggingPercentage: String, // "0.500"
+    val ops: String, // "0.900"
+    val stolenBasePercentage: String, // "0.750"
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/BoxScoreResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/BoxScoreResponse.kt
@@ -8,7 +8,7 @@ data class BoxScoreResponse(
     val homeTeam: TeamBoxScoreResponse,
     val awayTeam: TeamBoxScoreResponse,
     val currentInning: String,
-    val gameStatus: String
+    val gameStatus: String,
 )
 
 /**
@@ -22,7 +22,7 @@ data class TeamBoxScoreResponse(
     val hits: Int,
     val errors: Int,
     val batters: List<BatterLineResponse>,
-    val pitchers: List<PitcherLineResponse>
+    val pitchers: List<PitcherLineResponse>,
 )
 
 /**
@@ -40,7 +40,7 @@ data class BatterLineResponse(
     val rbis: Int,
     val walks: Int,
     val strikeouts: Int,
-    val avg: String
+    val avg: String,
 )
 
 /**
@@ -57,5 +57,5 @@ data class PitcherLineResponse(
     val strikeouts: Int,
     val homeRuns: Int,
     val decision: String?,
-    val era: String
+    val era: String,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/CreateBattingRecordRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/CreateBattingRecordRequest.kt
@@ -9,5 +9,5 @@ import jakarta.validation.constraints.NotNull
  */
 data class CreateBattingRecordRequest(
     @field:NotNull(message = "playerId is required")
-    val playerId: Long
+    val playerId: Long,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/CreatePitchingRecordRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/CreatePitchingRecordRequest.kt
@@ -11,5 +11,5 @@ import jakarta.validation.constraints.NotNull
 data class CreatePitchingRecordRequest(
     @field:NotNull(message = "playerId is required")
     val playerId: Long,
-    val isStartingPitcher: Boolean = false
+    val isStartingPitcher: Boolean = false,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/PitchingRecordResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/PitchingRecordResponse.kt
@@ -14,7 +14,6 @@ data class PitchingRecordResponse(
     val gamePlayerId: Long,
     val createdAt: Instant,
     val updatedAt: Instant,
-
     // 기본 투구 기록
     val inningsPitchedOuts: Int,
     val earnedRuns: Int,
@@ -27,22 +26,21 @@ data class PitchingRecordResponse(
     val wildPitches: Int,
     val balks: Int,
     val battersFaced: Int,
-    val decision: String,          // Enum.name ("WIN", "LOSS", "SAVE", etc.)
+    val decision: String, // Enum.name ("WIN", "LOSS", "SAVE", etc.)
     val isStartingPitcher: Boolean,
-    val pitchesThrown: Int?,       // nullable
-    val strikesThrown: Int?,       // nullable
-
+    val pitchesThrown: Int?, // nullable
+    val strikesThrown: Int?, // nullable
     // 계산 속성
     val completeInnings: Int,
     val remainingOuts: Int,
-    val inningsPitched: String,           // "5.33"
-    val inningsPitchedDisplay: String,    // "5.1"
-    val earnedRunAverage: String,         // "3.50"
-    val whip: String,                     // "1.20"
-    val strikeoutsPer9: String,           // "9.00"
-    val walksPer9: String,                // "2.50"
-    val strikeoutToWalkRatio: String,     // "3.60"
-    val strikePercentage: String?,        // "0.650" (nullable)
+    val inningsPitched: String, // "5.33"
+    val inningsPitchedDisplay: String, // "5.1"
+    val earnedRunAverage: String, // "3.50"
+    val whip: String, // "1.20"
+    val strikeoutsPer9: String, // "9.00"
+    val walksPer9: String, // "2.50"
+    val strikeoutToWalkRatio: String, // "3.60"
+    val strikePercentage: String?, // "0.650" (nullable)
     val unearnedRuns: Int,
-    val isQualifiedForWin: Boolean
+    val isQualifiedForWin: Boolean,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/RecordPitchingEventRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/RecordPitchingEventRequest.kt
@@ -12,7 +12,7 @@ sealed class RecordPitchingEventRequest {
      * 아웃 기록
      */
     data class RecordOut(
-        val isStrikeout: Boolean = false
+        val isStrikeout: Boolean = false,
     ) : RecordPitchingEventRequest()
 
     /**
@@ -23,21 +23,21 @@ sealed class RecordPitchingEventRequest {
         @field:Min(0, message = "실점은 0 이상이어야 합니다.")
         val runsScored: Int = 0,
         @field:Min(0, message = "자책점은 0 이상이어야 합니다.")
-        val earnedRuns: Int = 0
+        val earnedRuns: Int = 0,
     ) : RecordPitchingEventRequest()
 
     /**
      * 볼넷 기록
      */
     data class RecordWalk(
-        val dummy: Boolean = true
+        val dummy: Boolean = true,
     ) : RecordPitchingEventRequest()
 
     /**
      * 사구 기록
      */
     data class RecordHitByPitch(
-        val dummy: Boolean = true
+        val dummy: Boolean = true,
     ) : RecordPitchingEventRequest()
 
     /**
@@ -47,6 +47,6 @@ sealed class RecordPitchingEventRequest {
         @field:Min(1, message = "총 투구 수는 1 이상이어야 합니다.")
         val totalPitches: Int,
         @field:Min(0, message = "스트라이크 수는 0 이상이어야 합니다.")
-        val strikes: Int
+        val strikes: Int,
     ) : RecordPitchingEventRequest()
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/RecordPlateAppearanceRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/RecordPlateAppearanceRequest.kt
@@ -12,9 +12,7 @@ import jakarta.validation.constraints.NotNull
 data class RecordPlateAppearanceRequest(
     @field:NotNull(message = "타석 결과는 필수입니다.")
     val result: PlateAppearanceResult,
-
     @field:Min(value = 0, message = "타점은 0 이상이어야 합니다.")
     val runsBattedIn: Int = 0,
-
-    val runsScored: Boolean = false
+    val runsScored: Boolean = false,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/league/LeagueResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/league/LeagueResponse.kt
@@ -18,11 +18,11 @@ data class LeagueResponse(
     val logoUrl: String?,
     val isActive: Boolean,
     val createdAt: Instant,
-    val updatedAt: Instant
+    val updatedAt: Instant,
 ) {
     companion object {
-        fun from(league: League): LeagueResponse {
-            return LeagueResponse(
+        fun from(league: League): LeagueResponse =
+            LeagueResponse(
                 id = league.id,
                 associationId = league.association.id,
                 associationName = league.association.name,
@@ -34,9 +34,8 @@ data class LeagueResponse(
                 logoUrl = league.logoUrl,
                 isActive = league.isActive,
                 createdAt = league.createdAt,
-                updatedAt = league.updatedAt
+                updatedAt = league.updatedAt,
             )
-        }
     }
 }
 
@@ -50,19 +49,18 @@ data class LeagueSummaryResponse(
     val name: String,
     val abbreviation: String?,
     val divisionLevel: Int?,
-    val logoUrl: String?
+    val logoUrl: String?,
 ) {
     companion object {
-        fun from(league: League): LeagueSummaryResponse {
-            return LeagueSummaryResponse(
+        fun from(league: League): LeagueSummaryResponse =
+            LeagueSummaryResponse(
                 id = league.id,
                 associationId = league.association.id,
                 associationName = league.association.name,
                 name = league.name,
                 abbreviation = league.abbreviation,
                 divisionLevel = league.divisionLevel,
-                logoUrl = league.logoUrl
+                logoUrl = league.logoUrl,
             )
-        }
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/oauth/OAuthLinkRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/oauth/OAuthLinkRequest.kt
@@ -10,5 +10,5 @@ import jakarta.validation.constraints.NotNull
  */
 data class OAuthLinkRequest(
     @field:NotNull(message = "OAuth provider is required")
-    val provider: OAuthProvider
+    val provider: OAuthProvider,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/oauth/OAuthLinkResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/oauth/OAuthLinkResponse.kt
@@ -7,14 +7,14 @@ import com.nextup.core.domain.user.OAuthProvider
  */
 data class OAuthLinkResponse(
     val provider: OAuthProvider,
-    val linkedAt: String
+    val linkedAt: String,
 )
 
 /**
  * 연동된 OAuth 계정 목록 응답 DTO
  */
 data class LinkedOAuthAccountsResponse(
-    val providers: List<OAuthProvider>
+    val providers: List<OAuthProvider>,
 )
 
 /**
@@ -22,5 +22,5 @@ data class LinkedOAuthAccountsResponse(
  */
 data class OAuthLinkStartResponse(
     val authorizationUrl: String,
-    val provider: OAuthProvider
+    val provider: OAuthProvider,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/CareerBattingStatsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/CareerBattingStatsResponse.kt
@@ -14,11 +14,9 @@ data class CareerBattingStatsResponse(
     val playerId: Long,
     val createdAt: Instant,
     val updatedAt: Instant,
-
     // 시즌 및 출전 정보
     val seasonsPlayed: Int,
     val gamesPlayed: Int,
-
     // 기본 타격 기록
     val plateAppearances: Int,
     val atBats: Int,
@@ -37,18 +35,16 @@ data class CareerBattingStatsResponse(
     val stolenBases: Int,
     val caughtStealing: Int,
     val groundedIntoDoublePlays: Int,
-
     // 계산 속성
     val singles: Int,
     val totalBases: Int,
     val extraBaseHits: Int,
     val sacrifices: Int,
     val totalWalks: Int,
-
     // 비율 지표 (String으로 변환, 소수점 3자리)
-    val battingAverage: String,       // "0.300"
-    val onBasePercentage: String,     // "0.400"
-    val sluggingPercentage: String,   // "0.500"
-    val ops: String,                  // "0.900"
-    val stolenBasePercentage: String  // "0.750"
+    val battingAverage: String, // "0.300"
+    val onBasePercentage: String, // "0.400"
+    val sluggingPercentage: String, // "0.500"
+    val ops: String, // "0.900"
+    val stolenBasePercentage: String, // "0.750"
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/CareerPitchingStatsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/CareerPitchingStatsResponse.kt
@@ -14,12 +14,10 @@ data class CareerPitchingStatsResponse(
     val playerId: Long,
     val createdAt: Instant,
     val updatedAt: Instant,
-
     // 시즌 및 출전 정보
     val seasonsPlayed: Int,
     val gamesPlayed: Int,
     val gamesStarted: Int,
-
     // 기본 투수 기록
     val inningsPitchedOuts: Int,
     val wins: Int,
@@ -37,20 +35,19 @@ data class CareerPitchingStatsResponse(
     val wildPitches: Int,
     val balks: Int,
     val battersFaced: Int,
-    val pitchesThrown: Int?,       // nullable
-    val strikesThrown: Int?,       // nullable
-
+    val pitchesThrown: Int?, // nullable
+    val strikesThrown: Int?, // nullable
     // 계산 속성
     val completeInnings: Int,
     val remainingOuts: Int,
-    val inningsPitched: String,           // "5.33"
-    val inningsPitchedDisplay: String,    // "5.1"
-    val earnedRunAverage: String,         // "3.50"
-    val whip: String,                     // "1.20"
-    val strikeoutsPer9: String,           // "9.00"
-    val walksPer9: String,                // "2.50"
-    val strikeoutToWalkRatio: String,     // "3.60"
-    val strikePercentage: String?,        // "0.650" (nullable)
+    val inningsPitched: String, // "5.33"
+    val inningsPitchedDisplay: String, // "5.1"
+    val earnedRunAverage: String, // "3.50"
+    val whip: String, // "1.20"
+    val strikeoutsPer9: String, // "9.00"
+    val walksPer9: String, // "2.50"
+    val strikeoutToWalkRatio: String, // "3.60"
+    val strikePercentage: String?, // "0.650" (nullable)
     val unearnedRuns: Int,
-    val winningPercentage: String         // "0.667"
+    val winningPercentage: String, // "0.667"
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/SeasonBattingStatsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/SeasonBattingStatsResponse.kt
@@ -15,10 +15,8 @@ data class SeasonBattingStatsResponse(
     val year: Int,
     val createdAt: Instant,
     val updatedAt: Instant,
-
     // 출전 정보
     val gamesPlayed: Int,
-
     // 기본 타격 기록
     val plateAppearances: Int,
     val atBats: Int,
@@ -37,18 +35,16 @@ data class SeasonBattingStatsResponse(
     val stolenBases: Int,
     val caughtStealing: Int,
     val groundedIntoDoublePlays: Int,
-
     // 계산 속성
     val singles: Int,
     val totalBases: Int,
     val extraBaseHits: Int,
     val sacrifices: Int,
     val totalWalks: Int,
-
     // 비율 지표 (String으로 변환, 소수점 3자리)
-    val battingAverage: String,       // "0.300"
-    val onBasePercentage: String,     // "0.400"
-    val sluggingPercentage: String,   // "0.500"
-    val ops: String,                  // "0.900"
-    val stolenBasePercentage: String  // "0.750"
+    val battingAverage: String, // "0.300"
+    val onBasePercentage: String, // "0.400"
+    val sluggingPercentage: String, // "0.500"
+    val ops: String, // "0.900"
+    val stolenBasePercentage: String, // "0.750"
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/SeasonPitchingStatsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/SeasonPitchingStatsResponse.kt
@@ -15,11 +15,9 @@ data class SeasonPitchingStatsResponse(
     val year: Int,
     val createdAt: Instant,
     val updatedAt: Instant,
-
     // 출전 정보
     val gamesPlayed: Int,
     val gamesStarted: Int,
-
     // 기본 투수 기록
     val inningsPitchedOuts: Int,
     val wins: Int,
@@ -37,20 +35,19 @@ data class SeasonPitchingStatsResponse(
     val wildPitches: Int,
     val balks: Int,
     val battersFaced: Int,
-    val pitchesThrown: Int?,       // nullable
-    val strikesThrown: Int?,       // nullable
-
+    val pitchesThrown: Int?, // nullable
+    val strikesThrown: Int?, // nullable
     // 계산 속성
     val completeInnings: Int,
     val remainingOuts: Int,
-    val inningsPitched: String,           // "5.33"
-    val inningsPitchedDisplay: String,    // "5.1"
-    val earnedRunAverage: String,         // "3.50"
-    val whip: String,                     // "1.20"
-    val strikeoutsPer9: String,           // "9.00"
-    val walksPer9: String,                // "2.50"
-    val strikeoutToWalkRatio: String,     // "3.60"
-    val strikePercentage: String?,        // "0.650" (nullable)
+    val inningsPitched: String, // "5.33"
+    val inningsPitchedDisplay: String, // "5.1"
+    val earnedRunAverage: String, // "3.50"
+    val whip: String, // "1.20"
+    val strikeoutsPer9: String, // "9.00"
+    val walksPer9: String, // "2.50"
+    val strikeoutToWalkRatio: String, // "3.60"
+    val strikePercentage: String?, // "0.650" (nullable)
     val unearnedRuns: Int,
-    val winningPercentage: String         // "0.667"
+    val winningPercentage: String, // "0.667"
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/user/ProfileRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/user/ProfileRequest.kt
@@ -8,8 +8,7 @@ import jakarta.validation.constraints.Size
 data class UpdateProfileRequest(
     @field:Size(min = 2, max = 50, message = "닉네임은 2~50자 사이여야 합니다")
     val nickname: String? = null,
-
-    val profileImageUrl: String? = null
+    val profileImageUrl: String? = null,
 )
 
 /**
@@ -17,7 +16,6 @@ data class UpdateProfileRequest(
  */
 data class ChangePasswordRequest(
     val currentPassword: String,
-
     @field:Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
-    val newPassword: String
+    val newPassword: String,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/user/ProfileResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/user/ProfileResponse.kt
@@ -18,29 +18,29 @@ data class ProfileResponse(
     val linkedOAuthProviders: List<LinkedOAuthProvider>,
     val hasLinkedPlayer: Boolean,
     val playerId: Long?,
-    val createdAt: Instant
+    val createdAt: Instant,
 ) {
     companion object {
-        fun from(user: User): ProfileResponse {
-            return ProfileResponse(
+        fun from(user: User): ProfileResponse =
+            ProfileResponse(
                 id = user.id,
                 email = user.email,
                 nickname = user.nickname,
                 profileImageUrl = user.profileImageUrl,
                 roles = user.roles.map { it.name }.toSet(),
                 isLocalUser = user.isLocalUser,
-                linkedOAuthProviders = user.oauthAccounts.map {
-                    LinkedOAuthProvider(
-                        provider = it.provider.name,
-                        displayName = it.provider.displayName,
-                        connectedAt = it.connectedAt
-                    )
-                },
+                linkedOAuthProviders =
+                    user.oauthAccounts.map {
+                        LinkedOAuthProvider(
+                            provider = it.provider.name,
+                            displayName = it.provider.displayName,
+                            connectedAt = it.connectedAt,
+                        )
+                    },
                 hasLinkedPlayer = user.hasLinkedPlayer,
                 playerId = user.player?.id,
-                createdAt = user.createdAt
+                createdAt = user.createdAt,
             )
-        }
     }
 }
 
@@ -50,7 +50,7 @@ data class ProfileResponse(
 data class LinkedOAuthProvider(
     val provider: String,
     val displayName: String,
-    val connectedAt: Instant
+    val connectedAt: Instant,
 )
 
 /**
@@ -61,17 +61,16 @@ data class PublicProfileResponse(
     val nickname: String,
     val profileImageUrl: String?,
     val hasLinkedPlayer: Boolean,
-    val playerId: Long?
+    val playerId: Long?,
 ) {
     companion object {
-        fun from(user: User): PublicProfileResponse {
-            return PublicProfileResponse(
+        fun from(user: User): PublicProfileResponse =
+            PublicProfileResponse(
                 id = user.id,
                 nickname = user.nickname,
                 profileImageUrl = user.profileImageUrl,
                 hasLinkedPlayer = user.hasLinkedPlayer,
-                playerId = user.player?.id
+                playerId = user.player?.id,
             )
-        }
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
-
     private val log = LoggerFactory.getLogger(javaClass)
 
     @ExceptionHandler(AuthenticationException::class)
@@ -51,8 +50,9 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
-        val errors = ex.bindingResult.fieldErrors
-            .joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
+        val errors =
+            ex.bindingResult.fieldErrors
+                .joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
         log.warn("ValidationException: {}", errors)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/BattingRecordMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/BattingRecordMapper.kt
@@ -6,14 +6,13 @@ import com.nextup.core.domain.game.BattingRecord
 /**
  * BattingRecord Entity를 BattingRecordResponse DTO로 변환하는 Extension Function
  */
-fun BattingRecord.toResponse(): BattingRecordResponse {
-    return BattingRecordResponse(
+fun BattingRecord.toResponse(): BattingRecordResponse =
+    BattingRecordResponse(
         // 메타 정보
         id = this.id,
         gamePlayerId = this.gamePlayer.id,
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
-
         // 기본 타격 기록
         plateAppearances = this.plateAppearances,
         atBats = this.atBats,
@@ -32,26 +31,21 @@ fun BattingRecord.toResponse(): BattingRecordResponse {
         stolenBases = this.stolenBases,
         caughtStealing = this.caughtStealing,
         groundedIntoDoublePlays = this.groundedIntoDoublePlays,
-
         // 계산 속성
         singles = this.singles,
         totalBases = this.totalBases,
         extraBaseHits = this.extraBaseHits,
         sacrifices = this.sacrifices,
         totalWalks = this.totalWalks,
-
         // BigDecimal → String 변환 (소수점 3자리 고정)
         battingAverage = this.battingAverage.toPlainString(),
         onBasePercentage = this.onBasePercentage.toPlainString(),
         sluggingPercentage = this.sluggingPercentage.toPlainString(),
         ops = this.ops.toPlainString(),
-        stolenBasePercentage = this.stolenBasePercentage.toPlainString()
+        stolenBasePercentage = this.stolenBasePercentage.toPlainString(),
     )
-}
 
 /**
  * List<BattingRecord>를 List<BattingRecordResponse>로 변환
  */
-fun List<BattingRecord>.toResponse(): List<BattingRecordResponse> {
-    return this.map { it.toResponse() }
-}
+fun List<BattingRecord>.toResponse(): List<BattingRecordResponse> = this.map { it.toResponse() }

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/BoxScoreMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/BoxScoreMapper.kt
@@ -6,59 +6,63 @@ import com.nextup.core.service.game.dto.*
 /**
  * BoxScoreDto를 BoxScoreResponse로 변환합니다.
  */
-fun BoxScoreDto.toResponse(): BoxScoreResponse = BoxScoreResponse(
-    gameId = gameId,
-    homeTeam = homeTeam.toResponse(),
-    awayTeam = awayTeam.toResponse(),
-    currentInning = currentInning,
-    gameStatus = gameStatus
-)
+fun BoxScoreDto.toResponse(): BoxScoreResponse =
+    BoxScoreResponse(
+        gameId = gameId,
+        homeTeam = homeTeam.toResponse(),
+        awayTeam = awayTeam.toResponse(),
+        currentInning = currentInning,
+        gameStatus = gameStatus,
+    )
 
 /**
  * TeamBoxScoreDto를 TeamBoxScoreResponse로 변환합니다.
  */
-fun TeamBoxScoreDto.toResponse(): TeamBoxScoreResponse = TeamBoxScoreResponse(
-    teamId = teamId,
-    teamName = teamName,
-    inningScores = inningScores,
-    runs = runs,
-    hits = hits,
-    errors = errors,
-    batters = batters.map { it.toResponse() },
-    pitchers = pitchers.map { it.toResponse() }
-)
+fun TeamBoxScoreDto.toResponse(): TeamBoxScoreResponse =
+    TeamBoxScoreResponse(
+        teamId = teamId,
+        teamName = teamName,
+        inningScores = inningScores,
+        runs = runs,
+        hits = hits,
+        errors = errors,
+        batters = batters.map { it.toResponse() },
+        pitchers = pitchers.map { it.toResponse() },
+    )
 
 /**
  * BatterLineDto를 BatterLineResponse로 변환합니다.
  */
-fun BatterLineDto.toResponse(): BatterLineResponse = BatterLineResponse(
-    playerId = playerId,
-    name = name,
-    position = position,
-    battingOrder = battingOrder,
-    plateAppearances = plateAppearances,
-    atBats = atBats,
-    runs = runs,
-    hits = hits,
-    rbis = rbis,
-    walks = walks,
-    strikeouts = strikeouts,
-    avg = avg
-)
+fun BatterLineDto.toResponse(): BatterLineResponse =
+    BatterLineResponse(
+        playerId = playerId,
+        name = name,
+        position = position,
+        battingOrder = battingOrder,
+        plateAppearances = plateAppearances,
+        atBats = atBats,
+        runs = runs,
+        hits = hits,
+        rbis = rbis,
+        walks = walks,
+        strikeouts = strikeouts,
+        avg = avg,
+    )
 
 /**
  * PitcherLineDto를 PitcherLineResponse로 변환합니다.
  */
-fun PitcherLineDto.toResponse(): PitcherLineResponse = PitcherLineResponse(
-    playerId = playerId,
-    name = name,
-    inningsPitched = inningsPitched,
-    hits = hits,
-    runs = runs,
-    earnedRuns = earnedRuns,
-    walks = walks,
-    strikeouts = strikeouts,
-    homeRuns = homeRuns,
-    decision = decision,
-    era = era
-)
+fun PitcherLineDto.toResponse(): PitcherLineResponse =
+    PitcherLineResponse(
+        playerId = playerId,
+        name = name,
+        inningsPitched = inningsPitched,
+        hits = hits,
+        runs = runs,
+        earnedRuns = earnedRuns,
+        walks = walks,
+        strikeouts = strikeouts,
+        homeRuns = homeRuns,
+        decision = decision,
+        era = era,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/PitchingRecordMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/PitchingRecordMapper.kt
@@ -6,14 +6,13 @@ import com.nextup.core.domain.game.PitchingRecord
 /**
  * PitchingRecord Entity를 PitchingRecordResponse DTO로 변환하는 Extension Function
  */
-fun PitchingRecord.toResponse(): PitchingRecordResponse {
-    return PitchingRecordResponse(
+fun PitchingRecord.toResponse(): PitchingRecordResponse =
+    PitchingRecordResponse(
         // 메타 정보
         id = this.id,
         gamePlayerId = this.gamePlayer.id,
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
-
         // 기본 투구 기록
         inningsPitchedOuts = this.inningsPitchedOuts,
         earnedRuns = this.earnedRuns,
@@ -26,11 +25,10 @@ fun PitchingRecord.toResponse(): PitchingRecordResponse {
         wildPitches = this.wildPitches,
         balks = this.balks,
         battersFaced = this.battersFaced,
-        decision = this.decision.name,  // Enum → String
+        decision = this.decision.name, // Enum → String
         isStartingPitcher = this.isStartingPitcher,
-        pitchesThrown = this.pitchesThrown,  // nullable
-        strikesThrown = this.strikesThrown,  // nullable
-
+        pitchesThrown = this.pitchesThrown, // nullable
+        strikesThrown = this.strikesThrown, // nullable
         // 계산 속성
         completeInnings = this.completeInnings,
         remainingOuts = this.remainingOuts,
@@ -41,15 +39,12 @@ fun PitchingRecord.toResponse(): PitchingRecordResponse {
         strikeoutsPer9 = this.strikeoutsPer9.toPlainString(),
         walksPer9 = this.walksPer9.toPlainString(),
         strikeoutToWalkRatio = this.strikeoutToWalkRatio.toPlainString(),
-        strikePercentage = this.strikePercentage?.toPlainString(),  // nullable
+        strikePercentage = this.strikePercentage?.toPlainString(), // nullable
         unearnedRuns = this.unearnedRuns,
-        isQualifiedForWin = this.isQualifiedForWin
+        isQualifiedForWin = this.isQualifiedForWin,
     )
-}
 
 /**
  * List<PitchingRecord>를 List<PitchingRecordResponse>로 변환
  */
-fun List<PitchingRecord>.toResponse(): List<PitchingRecordResponse> {
-    return this.map { it.toResponse() }
-}
+fun List<PitchingRecord>.toResponse(): List<PitchingRecordResponse> = this.map { it.toResponse() }

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/StatsMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/StatsMapper.kt
@@ -12,18 +12,16 @@ import com.nextup.core.domain.stats.SeasonPitchingStats
 /**
  * SeasonBattingStats Entity를 SeasonBattingStatsResponse DTO로 변환하는 Extension Function
  */
-fun SeasonBattingStats.toResponse(): SeasonBattingStatsResponse {
-    return SeasonBattingStatsResponse(
+fun SeasonBattingStats.toResponse(): SeasonBattingStatsResponse =
+    SeasonBattingStatsResponse(
         // 메타 정보
         id = this.id,
         playerId = this.player.id,
         year = this.year,
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
-
         // 출전 정보
         gamesPlayed = this.gamesPlayed,
-
         // 기본 타격 기록
         plateAppearances = this.plateAppearances,
         atBats = this.atBats,
@@ -42,39 +40,34 @@ fun SeasonBattingStats.toResponse(): SeasonBattingStatsResponse {
         stolenBases = this.stolenBases,
         caughtStealing = this.caughtStealing,
         groundedIntoDoublePlays = this.groundedIntoDoublePlays,
-
         // 계산 속성
         singles = this.singles,
         totalBases = this.totalBases,
         extraBaseHits = this.extraBaseHits,
         sacrifices = this.sacrifices,
         totalWalks = this.totalWalks,
-
         // BigDecimal → String 변환 (소수점 3자리 고정)
         battingAverage = this.battingAverage.toPlainString(),
         onBasePercentage = this.onBasePercentage.toPlainString(),
         sluggingPercentage = this.sluggingPercentage.toPlainString(),
         ops = this.ops.toPlainString(),
-        stolenBasePercentage = this.stolenBasePercentage.toPlainString()
+        stolenBasePercentage = this.stolenBasePercentage.toPlainString(),
     )
-}
 
 /**
  * SeasonPitchingStats Entity를 SeasonPitchingStatsResponse DTO로 변환하는 Extension Function
  */
-fun SeasonPitchingStats.toResponse(): SeasonPitchingStatsResponse {
-    return SeasonPitchingStatsResponse(
+fun SeasonPitchingStats.toResponse(): SeasonPitchingStatsResponse =
+    SeasonPitchingStatsResponse(
         // 메타 정보
         id = this.id,
         playerId = this.player.id,
         year = this.year,
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
-
         // 출전 정보
         gamesPlayed = this.gamesPlayed,
         gamesStarted = this.gamesStarted,
-
         // 기본 투수 기록
         inningsPitchedOuts = this.inningsPitchedOuts,
         wins = this.wins,
@@ -94,7 +87,6 @@ fun SeasonPitchingStats.toResponse(): SeasonPitchingStatsResponse {
         battersFaced = this.battersFaced,
         pitchesThrown = this.pitchesThrown,
         strikesThrown = this.strikesThrown,
-
         // 계산 속성
         completeInnings = this.completeInnings,
         remainingOuts = this.remainingOuts,
@@ -107,25 +99,22 @@ fun SeasonPitchingStats.toResponse(): SeasonPitchingStatsResponse {
         strikeoutToWalkRatio = this.strikeoutToWalkRatio.toPlainString(),
         strikePercentage = this.strikePercentage?.toPlainString(),
         unearnedRuns = this.unearnedRuns,
-        winningPercentage = this.winningPercentage.toPlainString()
+        winningPercentage = this.winningPercentage.toPlainString(),
     )
-}
 
 /**
  * CareerBattingStats Entity를 CareerBattingStatsResponse DTO로 변환하는 Extension Function
  */
-fun CareerBattingStats.toResponse(): CareerBattingStatsResponse {
-    return CareerBattingStatsResponse(
+fun CareerBattingStats.toResponse(): CareerBattingStatsResponse =
+    CareerBattingStatsResponse(
         // 메타 정보
         id = this.id,
         playerId = this.player.id,
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
-
         // 시즌 및 출전 정보
         seasonsPlayed = this.seasonsPlayed,
         gamesPlayed = this.gamesPlayed,
-
         // 기본 타격 기록
         plateAppearances = this.plateAppearances,
         atBats = this.atBats,
@@ -144,39 +133,34 @@ fun CareerBattingStats.toResponse(): CareerBattingStatsResponse {
         stolenBases = this.stolenBases,
         caughtStealing = this.caughtStealing,
         groundedIntoDoublePlays = this.groundedIntoDoublePlays,
-
         // 계산 속성
         singles = this.singles,
         totalBases = this.totalBases,
         extraBaseHits = this.extraBaseHits,
         sacrifices = this.sacrifices,
         totalWalks = this.totalWalks,
-
         // BigDecimal → String 변환 (소수점 3자리 고정)
         battingAverage = this.battingAverage.toPlainString(),
         onBasePercentage = this.onBasePercentage.toPlainString(),
         sluggingPercentage = this.sluggingPercentage.toPlainString(),
         ops = this.ops.toPlainString(),
-        stolenBasePercentage = this.stolenBasePercentage.toPlainString()
+        stolenBasePercentage = this.stolenBasePercentage.toPlainString(),
     )
-}
 
 /**
  * CareerPitchingStats Entity를 CareerPitchingStatsResponse DTO로 변환하는 Extension Function
  */
-fun CareerPitchingStats.toResponse(): CareerPitchingStatsResponse {
-    return CareerPitchingStatsResponse(
+fun CareerPitchingStats.toResponse(): CareerPitchingStatsResponse =
+    CareerPitchingStatsResponse(
         // 메타 정보
         id = this.id,
         playerId = this.player.id,
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
-
         // 시즌 및 출전 정보
         seasonsPlayed = this.seasonsPlayed,
         gamesPlayed = this.gamesPlayed,
         gamesStarted = this.gamesStarted,
-
         // 기본 투수 기록
         inningsPitchedOuts = this.inningsPitchedOuts,
         wins = this.wins,
@@ -196,7 +180,6 @@ fun CareerPitchingStats.toResponse(): CareerPitchingStatsResponse {
         battersFaced = this.battersFaced,
         pitchesThrown = this.pitchesThrown,
         strikesThrown = this.strikesThrown,
-
         // 계산 속성
         completeInnings = this.completeInnings,
         remainingOuts = this.remainingOuts,
@@ -209,20 +192,18 @@ fun CareerPitchingStats.toResponse(): CareerPitchingStatsResponse {
         strikeoutToWalkRatio = this.strikeoutToWalkRatio.toPlainString(),
         strikePercentage = this.strikePercentage?.toPlainString(),
         unearnedRuns = this.unearnedRuns,
-        winningPercentage = this.winningPercentage.toPlainString()
+        winningPercentage = this.winningPercentage.toPlainString(),
     )
-}
 
 /**
  * List<SeasonBattingStats>를 List<SeasonBattingStatsResponse>로 변환
  */
-fun List<SeasonBattingStats>.toSeasonBattingResponse(): List<SeasonBattingStatsResponse> {
-    return this.map { it.toResponse() }
-}
+fun List<SeasonBattingStats>.toSeasonBattingResponse(): List<SeasonBattingStatsResponse> = this.map { it.toResponse() }
 
 /**
  * List<SeasonPitchingStats>를 List<SeasonPitchingStatsResponse>로 변환
  */
-fun List<SeasonPitchingStats>.toSeasonPitchingResponse(): List<SeasonPitchingStatsResponse> {
-    return this.map { it.toResponse() }
-}
+fun List<SeasonPitchingStats>.toSeasonPitchingResponse(): List<SeasonPitchingStatsResponse> =
+    this.map {
+        it.toResponse()
+    }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/association/AssociationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/association/AssociationControllerTest.kt
@@ -1,11 +1,9 @@
 package com.nextup.api.controller.association
 
-import com.nextup.common.exception.AssociationNotFoundException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.service.association.AssociationService
 import io.mockk.every
 import io.mockk.mockk
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -18,7 +16,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("AssociationController")
 class AssociationControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var associationService: AssociationService
     private lateinit var controller: AssociationController
@@ -33,18 +30,19 @@ class AssociationControllerTest {
     @Nested
     @DisplayName("GET /api/associations")
     inner class GetAssociations {
-
         @Test
         fun `should return all active associations`() {
             // given
-            val associations = listOf(
-                createAssociation(1L, "서울시야구협회", "서울"),
-                createAssociation(2L, "경기도야구협회", "경기")
-            )
+            val associations =
+                listOf(
+                    createAssociation(1L, "서울시야구협회", "서울"),
+                    createAssociation(2L, "경기도야구협회", "경기"),
+                )
             every { associationService.getAllActive() } returns associations
 
             // when & then
-            mockMvc.perform(get("/api/associations"))
+            mockMvc
+                .perform(get("/api/associations"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -55,13 +53,15 @@ class AssociationControllerTest {
         @Test
         fun `should filter by region when region parameter is provided`() {
             // given
-            val associations = listOf(
-                createAssociation(1L, "서울시야구협회", "서울")
-            )
+            val associations =
+                listOf(
+                    createAssociation(1L, "서울시야구협회", "서울"),
+                )
             every { associationService.getActiveByRegion("서울") } returns associations
 
             // when & then
-            mockMvc.perform(get("/api/associations").param("region", "서울"))
+            mockMvc
+                .perform(get("/api/associations").param("region", "서울"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.length()").value(1))
@@ -72,7 +72,6 @@ class AssociationControllerTest {
     @Nested
     @DisplayName("GET /api/associations/{id}")
     inner class GetAssociation {
-
         @Test
         fun `should return association when found`() {
             // given
@@ -80,7 +79,8 @@ class AssociationControllerTest {
             every { associationService.getById(1L) } returns association
 
             // when & then
-            mockMvc.perform(get("/api/associations/1"))
+            mockMvc
+                .perform(get("/api/associations/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -89,18 +89,21 @@ class AssociationControllerTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String, region: String): Association {
-        return Association(
+    private fun createAssociation(
+        id: Long,
+        name: String,
+        region: String,
+    ): Association =
+        Association(
             name = name,
             abbreviation = null,
             region = region,
             description = null,
             logoUrl = null,
-            websiteUrl = null
+            websiteUrl = null,
         ).apply {
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/auth/AuthControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/auth/AuthControllerTest.kt
@@ -3,7 +3,6 @@ package com.nextup.api.controller.auth
 import com.nextup.api.dto.auth.LoginRequest
 import com.nextup.api.dto.auth.LogoutRequest
 import com.nextup.api.dto.auth.RefreshTokenRequest
-import com.nextup.core.domain.user.Role
 import com.nextup.core.domain.user.User
 import com.nextup.infrastructure.security.AuthenticationService
 import com.nextup.infrastructure.security.TokenPair
@@ -22,7 +21,6 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("AuthController 테스트")
 class AuthControllerTest {
-
     private lateinit var authenticationService: AuthenticationService
     private lateinit var authController: AuthController
     private lateinit var httpServletRequest: HttpServletRequest
@@ -37,15 +35,15 @@ class AuthControllerTest {
     @Nested
     @DisplayName("로그인")
     inner class Login {
-
         @Test
         fun `should return token pair on successful login`() {
             // given
             val request = LoginRequest(email = "test@example.com", password = "password123")
-            val tokenPair = TokenPair(
-                accessToken = "access_token",
-                refreshToken = "refresh_token"
-            )
+            val tokenPair =
+                TokenPair(
+                    accessToken = "access_token",
+                    refreshToken = "refresh_token",
+                )
 
             every { httpServletRequest.getHeader("User-Agent") } returns "Mozilla/5.0"
             every { httpServletRequest.getHeader("X-Forwarded-For") } returns null
@@ -55,7 +53,7 @@ class AuthControllerTest {
                     email = "test@example.com",
                     password = "password123",
                     deviceInfo = "Mozilla/5.0",
-                    ipAddress = "127.0.0.1"
+                    ipAddress = "127.0.0.1",
                 )
             } returns tokenPair
 
@@ -82,7 +80,7 @@ class AuthControllerTest {
                     email = "test@example.com",
                     password = "password123",
                     deviceInfo = "Chrome",
-                    ipAddress = "192.168.1.1"
+                    ipAddress = "192.168.1.1",
                 )
             } returns tokenPair
 
@@ -96,7 +94,7 @@ class AuthControllerTest {
                     email = "test@example.com",
                     password = "password123",
                     deviceInfo = "Chrome",
-                    ipAddress = "192.168.1.1"
+                    ipAddress = "192.168.1.1",
                 )
             }
         }
@@ -105,15 +103,15 @@ class AuthControllerTest {
     @Nested
     @DisplayName("토큰 갱신")
     inner class Refresh {
-
         @Test
         fun `should return new token pair on successful refresh`() {
             // given
             val request = RefreshTokenRequest(refreshToken = "old_refresh_token")
-            val tokenPair = TokenPair(
-                accessToken = "new_access_token",
-                refreshToken = "new_refresh_token"
-            )
+            val tokenPair =
+                TokenPair(
+                    accessToken = "new_access_token",
+                    refreshToken = "new_refresh_token",
+                )
 
             every { httpServletRequest.getHeader("User-Agent") } returns "Safari"
             every { httpServletRequest.getHeader("X-Forwarded-For") } returns null
@@ -122,7 +120,7 @@ class AuthControllerTest {
                 authenticationService.refresh(
                     refreshTokenString = "old_refresh_token",
                     deviceInfo = "Safari",
-                    ipAddress = "10.0.0.1"
+                    ipAddress = "10.0.0.1",
                 )
             } returns tokenPair
 
@@ -139,7 +137,6 @@ class AuthControllerTest {
     @Nested
     @DisplayName("로그아웃")
     inner class Logout {
-
         @Test
         fun `should logout successfully`() {
             // given
@@ -159,7 +156,6 @@ class AuthControllerTest {
     @Nested
     @DisplayName("전체 로그아웃")
     inner class LogoutAll {
-
         @Test
         fun `should logout from all devices`() {
             // given
@@ -179,16 +175,16 @@ class AuthControllerTest {
     @Nested
     @DisplayName("현재 사용자 조회")
     inner class GetCurrentUser {
-
         @Test
         fun `should return current user info`() {
             // given
             val userId = 1L
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "encoded",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "encoded",
+                    nickname = "테스터",
+                )
             // Use reflection to set ID
             val idField = user.javaClass.getDeclaredField("id")
             idField.isAccessible = true

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerTest.kt
@@ -2,7 +2,6 @@ package com.nextup.api.controller.competition
 
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
-import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
 import com.nextup.core.service.competition.CompetitionService
@@ -21,7 +20,6 @@ import java.time.LocalDate
 
 @DisplayName("CompetitionController")
 class CompetitionControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var competitionService: CompetitionService
     private lateinit var controller: CompetitionController
@@ -36,20 +34,21 @@ class CompetitionControllerTest {
     @Nested
     @DisplayName("GET /api/v1/competitions")
     inner class GetCompetitions {
-
         @Test
         fun `should return all in-progress competitions`() {
             // given
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
-            val competitions = listOf(
-                createCompetition(1L, league, "2025 춘계대회", 2025, 1).apply { start() },
-                createCompetition(2L, league, "2025 하계대회", 2025, 2).apply { start() }
-            )
+            val competitions =
+                listOf(
+                    createCompetition(1L, league, "2025 춘계대회", 2025, 1).apply { start() },
+                    createCompetition(2L, league, "2025 하계대회", 2025, 2).apply { start() },
+                )
             every { competitionService.getInProgress() } returns competitions
 
             // when & then
-            mockMvc.perform(get("/api/v1/competitions"))
+            mockMvc
+                .perform(get("/api/v1/competitions"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -65,7 +64,8 @@ class CompetitionControllerTest {
             every { competitionService.getInProgress() } returns emptyList()
 
             // when & then
-            mockMvc.perform(get("/api/v1/competitions"))
+            mockMvc
+                .perform(get("/api/v1/competitions"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -76,7 +76,6 @@ class CompetitionControllerTest {
     @Nested
     @DisplayName("GET /api/v1/competitions/{id}")
     inner class GetCompetition {
-
         @Test
         fun `should return competition detail when found`() {
             // given
@@ -86,7 +85,8 @@ class CompetitionControllerTest {
             every { competitionService.getByIdWithLeague(1L) } returns competition
 
             // when & then
-            mockMvc.perform(get("/api/v1/competitions/1"))
+            mockMvc
+                .perform(get("/api/v1/competitions/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -103,22 +103,23 @@ class CompetitionControllerTest {
     @Nested
     @DisplayName("GET /api/v1/competitions/by-league/{leagueId}")
     inner class GetCompetitionsByLeague {
-
         @Test
         fun `should return competitions by league`() {
             // given
             val leagueId = 1L
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(leagueId, "1부 리그", association)
-            val competitions = listOf(
-                createCompetition(1L, league, "2025 춘계대회", 2025, 1),
-                createCompetition(2L, league, "2025 하계대회", 2025, 2),
-                createCompetition(3L, league, "2024 추계대회", 2024, 2)
-            )
+            val competitions =
+                listOf(
+                    createCompetition(1L, league, "2025 춘계대회", 2025, 1),
+                    createCompetition(2L, league, "2025 하계대회", 2025, 2),
+                    createCompetition(3L, league, "2024 추계대회", 2024, 2),
+                )
             every { competitionService.getByLeagueId(leagueId) } returns competitions
 
             // when & then
-            mockMvc.perform(get("/api/v1/competitions/by-league/$leagueId"))
+            mockMvc
+                .perform(get("/api/v1/competitions/by-league/$leagueId"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -136,7 +137,8 @@ class CompetitionControllerTest {
             every { competitionService.getByLeagueId(leagueId) } returns emptyList()
 
             // when & then
-            mockMvc.perform(get("/api/v1/competitions/by-league/$leagueId"))
+            mockMvc
+                .perform(get("/api/v1/competitions/by-league/$leagueId"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -144,45 +146,50 @@ class CompetitionControllerTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
-        return Association(
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association =
+        Association(
             name = name,
             abbreviation = null,
             region = "서울",
             description = null,
             logoUrl = null,
-            websiteUrl = null
+            websiteUrl = null,
         ).apply {
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
-    private fun createLeague(id: Long, name: String, association: Association): League {
-        return League(
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association,
+    ): League =
+        League(
             association = association,
             name = name,
             abbreviation = null,
             foundedYear = 2020,
             divisionLevel = 1,
             description = null,
-            logoUrl = null
+            logoUrl = null,
         ).apply {
             val idField = League::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
     private fun createCompetition(
         id: Long,
         league: League,
         name: String,
         year: Int,
-        season: Int
-    ): Competition {
-        return Competition(
+        season: Int,
+    ): Competition =
+        Competition(
             league = league,
             name = name,
             year = year,
@@ -191,11 +198,10 @@ class CompetitionControllerTest {
             startDate = LocalDate.of(year, 3, 1),
             endDate = null,
             description = null,
-            maxTeams = null
+            maxTeams = null,
         ).apply {
             val idField = Competition::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BattingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BattingRecordControllerTest.kt
@@ -4,12 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nextup.api.dto.game.CreateBattingRecordRequest
 import com.nextup.api.exception.GlobalExceptionHandler
-import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
 import com.nextup.common.exception.RecordAlreadyExistsException
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.GamePlayer
-import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import com.nextup.core.service.game.BattingRecordService
+import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
@@ -26,7 +25,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("BattingRecordController 테스트")
 class BattingRecordControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var battingRecordService: BattingRecordService
     private lateinit var gamePlayerRepository: GamePlayerRepository
@@ -43,59 +41,63 @@ class BattingRecordControllerTest {
         objectMapper = jacksonObjectMapper()
 
         val controller = BattingRecordController(battingRecordService, gamePlayerRepository)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller)
-            .setControllerAdvice(GlobalExceptionHandler())
-            .build()
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
     }
 
     @Nested
     @DisplayName("GET /api/games/{gameId}/batting-records")
     inner class GetBattingRecords {
-
         @Test
         fun `should return batting records for game`() {
             // given
-            val gamePlayer = mockk<GamePlayer> {
-                every { id } returns gamePlayerId
-            }
-            val record = mockk<BattingRecord> {
-                every { id } returns 1L
-                every { this@mockk.gamePlayer } returns gamePlayer
-                every { createdAt } returns java.time.Instant.now()
-                every { updatedAt } returns java.time.Instant.now()
-                every { plateAppearances } returns 4
-                every { atBats } returns 3
-                every { hits } returns 1
-                every { doubles } returns 0
-                every { triples } returns 0
-                every { homeRuns } returns 0
-                every { runs } returns 1
-                every { runsBattedIn } returns 0
-                every { walks } returns 1
-                every { intentionalWalks } returns 0
-                every { hitByPitch } returns 0
-                every { strikeouts } returns 1
-                every { sacrificeBunts } returns 0
-                every { sacrificeFlies } returns 0
-                every { stolenBases } returns 0
-                every { caughtStealing } returns 0
-                every { groundedIntoDoublePlays } returns 0
-                every { singles } returns 1
-                every { totalBases } returns 1
-                every { extraBaseHits } returns 0
-                every { sacrifices } returns 0
-                every { totalWalks } returns 1
-                every { battingAverage } returns java.math.BigDecimal("0.333")
-                every { onBasePercentage } returns java.math.BigDecimal("0.500")
-                every { sluggingPercentage } returns java.math.BigDecimal("0.333")
-                every { ops } returns java.math.BigDecimal("0.833")
-                every { stolenBasePercentage } returns java.math.BigDecimal("0.000")
-            }
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { id } returns gamePlayerId
+                }
+            val record =
+                mockk<BattingRecord> {
+                    every { id } returns 1L
+                    every { this@mockk.gamePlayer } returns gamePlayer
+                    every { createdAt } returns java.time.Instant.now()
+                    every { updatedAt } returns java.time.Instant.now()
+                    every { plateAppearances } returns 4
+                    every { atBats } returns 3
+                    every { hits } returns 1
+                    every { doubles } returns 0
+                    every { triples } returns 0
+                    every { homeRuns } returns 0
+                    every { runs } returns 1
+                    every { runsBattedIn } returns 0
+                    every { walks } returns 1
+                    every { intentionalWalks } returns 0
+                    every { hitByPitch } returns 0
+                    every { strikeouts } returns 1
+                    every { sacrificeBunts } returns 0
+                    every { sacrificeFlies } returns 0
+                    every { stolenBases } returns 0
+                    every { caughtStealing } returns 0
+                    every { groundedIntoDoublePlays } returns 0
+                    every { singles } returns 1
+                    every { totalBases } returns 1
+                    every { extraBaseHits } returns 0
+                    every { sacrifices } returns 0
+                    every { totalWalks } returns 1
+                    every { battingAverage } returns java.math.BigDecimal("0.333")
+                    every { onBasePercentage } returns java.math.BigDecimal("0.500")
+                    every { sluggingPercentage } returns java.math.BigDecimal("0.333")
+                    every { ops } returns java.math.BigDecimal("0.833")
+                    every { stolenBasePercentage } returns java.math.BigDecimal("0.000")
+                }
 
             every { battingRecordService.getAllByGameId(gameId) } returns listOf(record)
 
             // when & then
-            mockMvc.perform(get("/api/games/$gameId/batting-records"))
+            mockMvc
+                .perform(get("/api/games/$gameId/batting-records"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -109,7 +111,8 @@ class BattingRecordControllerTest {
             every { battingRecordService.getAllByGameId(gameId) } returns emptyList()
 
             // when & then
-            mockMvc.perform(get("/api/games/$gameId/batting-records"))
+            mockMvc
+                .perform(get("/api/games/$gameId/batting-records"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -120,58 +123,59 @@ class BattingRecordControllerTest {
     @Nested
     @DisplayName("POST /api/games/{gameId}/batting-records")
     inner class CreateBattingRecord {
-
         @Test
         fun `should create batting record successfully`() {
             // given
             val request = CreateBattingRecordRequest(playerId = playerId)
-            val gamePlayer = mockk<GamePlayer> {
-                every { id } returns gamePlayerId
-            }
-            val record = mockk<BattingRecord> {
-                every { id } returns 1L
-                every { this@mockk.gamePlayer } returns gamePlayer
-                every { createdAt } returns java.time.Instant.now()
-                every { updatedAt } returns java.time.Instant.now()
-                every { plateAppearances } returns 0
-                every { atBats } returns 0
-                every { hits } returns 0
-                every { doubles } returns 0
-                every { triples } returns 0
-                every { homeRuns } returns 0
-                every { runs } returns 0
-                every { runsBattedIn } returns 0
-                every { walks } returns 0
-                every { intentionalWalks } returns 0
-                every { hitByPitch } returns 0
-                every { strikeouts } returns 0
-                every { sacrificeBunts } returns 0
-                every { sacrificeFlies } returns 0
-                every { stolenBases } returns 0
-                every { caughtStealing } returns 0
-                every { groundedIntoDoublePlays } returns 0
-                every { singles } returns 0
-                every { totalBases } returns 0
-                every { extraBaseHits } returns 0
-                every { sacrifices } returns 0
-                every { totalWalks } returns 0
-                every { battingAverage } returns java.math.BigDecimal("0.000")
-                every { onBasePercentage } returns java.math.BigDecimal("0.000")
-                every { sluggingPercentage } returns java.math.BigDecimal("0.000")
-                every { ops } returns java.math.BigDecimal("0.000")
-                every { stolenBasePercentage } returns java.math.BigDecimal("0.000")
-            }
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { id } returns gamePlayerId
+                }
+            val record =
+                mockk<BattingRecord> {
+                    every { id } returns 1L
+                    every { this@mockk.gamePlayer } returns gamePlayer
+                    every { createdAt } returns java.time.Instant.now()
+                    every { updatedAt } returns java.time.Instant.now()
+                    every { plateAppearances } returns 0
+                    every { atBats } returns 0
+                    every { hits } returns 0
+                    every { doubles } returns 0
+                    every { triples } returns 0
+                    every { homeRuns } returns 0
+                    every { runs } returns 0
+                    every { runsBattedIn } returns 0
+                    every { walks } returns 0
+                    every { intentionalWalks } returns 0
+                    every { hitByPitch } returns 0
+                    every { strikeouts } returns 0
+                    every { sacrificeBunts } returns 0
+                    every { sacrificeFlies } returns 0
+                    every { stolenBases } returns 0
+                    every { caughtStealing } returns 0
+                    every { groundedIntoDoublePlays } returns 0
+                    every { singles } returns 0
+                    every { totalBases } returns 0
+                    every { extraBaseHits } returns 0
+                    every { sacrifices } returns 0
+                    every { totalWalks } returns 0
+                    every { battingAverage } returns java.math.BigDecimal("0.000")
+                    every { onBasePercentage } returns java.math.BigDecimal("0.000")
+                    every { sluggingPercentage } returns java.math.BigDecimal("0.000")
+                    every { ops } returns java.math.BigDecimal("0.000")
+                    every { stolenBasePercentage } returns java.math.BigDecimal("0.000")
+                }
 
             every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
             every { battingRecordService.createRecord(gamePlayerId) } returns record
 
             // when & then
-            mockMvc.perform(
-                post("/api/games/$gameId/batting-records")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isCreated)
+            mockMvc
+                .perform(
+                    post("/api/games/$gameId/batting-records")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.gamePlayerId").value(gamePlayerId))
@@ -184,12 +188,12 @@ class BattingRecordControllerTest {
             every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns null
 
             // when & then
-            mockMvc.perform(
-                post("/api/games/$gameId/batting-records")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isNotFound)
+            mockMvc
+                .perform(
+                    post("/api/games/$gameId/batting-records")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isNotFound)
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("GAME_PLAYER_NOT_FOUND"))
         }
@@ -198,24 +202,24 @@ class BattingRecordControllerTest {
         fun `should return 400 when record already exists`() {
             // given
             val request = CreateBattingRecordRequest(playerId = playerId)
-            val gamePlayer = mockk<GamePlayer> {
-                every { id } returns gamePlayerId
-            }
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { id } returns gamePlayerId
+                }
 
             every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
             every { battingRecordService.createRecord(gamePlayerId) } throws
                 RecordAlreadyExistsException(gamePlayerId, "Batting")
 
             // when & then
-            mockMvc.perform(
-                post("/api/games/$gameId/batting-records")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isBadRequest)
+            mockMvc
+                .perform(
+                    post("/api/games/$gameId/batting-records")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isBadRequest)
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("RECORD_ALREADY_EXISTS"))
         }
-
     }
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BoxScoreControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BoxScoreControllerTest.kt
@@ -17,7 +17,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("BoxScoreController 테스트")
 class BoxScoreControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var boxScoreService: BoxScoreService
 
@@ -26,107 +25,116 @@ class BoxScoreControllerTest {
         boxScoreService = mockk()
 
         val controller = BoxScoreController(boxScoreService)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller)
-            .setControllerAdvice(GlobalExceptionHandler())
-            .build()
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
     }
 
     @Nested
     @DisplayName("GET /api/games/{gameId}/boxscore")
     inner class GetBoxScore {
-
         @Test
         fun `경기의 박스스코어를 정상적으로 조회한다`() {
             // given
             val gameId = 1L
-            val boxScoreDto = BoxScoreDto(
-                gameId = gameId,
-                homeTeam = TeamBoxScoreDto(
-                    teamId = 10L,
-                    teamName = "홈팀",
-                    inningScores = listOf(1, 0, 2, 0, 0, 0, 3, 0, 0),
-                    runs = 6,
-                    hits = 10,
-                    errors = 1,
-                    batters = listOf(
-                        BatterLineDto(
-                            playerId = 100L,
-                            name = "홈타자1",
-                            position = "1B",
-                            battingOrder = 1,
-                            plateAppearances = 4,
-                            atBats = 3,
+            val boxScoreDto =
+                BoxScoreDto(
+                    gameId = gameId,
+                    homeTeam =
+                        TeamBoxScoreDto(
+                            teamId = 10L,
+                            teamName = "홈팀",
+                            inningScores = listOf(1, 0, 2, 0, 0, 0, 3, 0, 0),
+                            runs = 6,
+                            hits = 10,
+                            errors = 1,
+                            batters =
+                                listOf(
+                                    BatterLineDto(
+                                        playerId = 100L,
+                                        name = "홈타자1",
+                                        position = "1B",
+                                        battingOrder = 1,
+                                        plateAppearances = 4,
+                                        atBats = 3,
+                                        runs = 2,
+                                        hits = 2,
+                                        rbis = 1,
+                                        walks = 1,
+                                        strikeouts = 0,
+                                        avg = ".333",
+                                    ),
+                                ),
+                            pitchers =
+                                listOf(
+                                    PitcherLineDto(
+                                        playerId = 101L,
+                                        name = "홈투수1",
+                                        inningsPitched = "7.0",
+                                        hits = 5,
+                                        runs = 2,
+                                        earnedRuns = 2,
+                                        walks = 2,
+                                        strikeouts = 8,
+                                        homeRuns = 0,
+                                        decision = "W",
+                                        era = "2.57",
+                                    ),
+                                ),
+                        ),
+                    awayTeam =
+                        TeamBoxScoreDto(
+                            teamId = 20L,
+                            teamName = "원정팀",
+                            inningScores = listOf(0, 1, 0, 1, 0, 0, 0, 0, 0),
                             runs = 2,
-                            hits = 2,
-                            rbis = 1,
-                            walks = 1,
-                            strikeouts = 0,
-                            avg = ".333"
-                        )
-                    ),
-                    pitchers = listOf(
-                        PitcherLineDto(
-                            playerId = 101L,
-                            name = "홈투수1",
-                            inningsPitched = "7.0",
                             hits = 5,
-                            runs = 2,
-                            earnedRuns = 2,
-                            walks = 2,
-                            strikeouts = 8,
-                            homeRuns = 0,
-                            decision = "W",
-                            era = "2.57"
-                        )
-                    )
-                ),
-                awayTeam = TeamBoxScoreDto(
-                    teamId = 20L,
-                    teamName = "원정팀",
-                    inningScores = listOf(0, 1, 0, 1, 0, 0, 0, 0, 0),
-                    runs = 2,
-                    hits = 5,
-                    errors = 2,
-                    batters = listOf(
-                        BatterLineDto(
-                            playerId = 200L,
-                            name = "원정타자1",
-                            position = "CF",
-                            battingOrder = 1,
-                            plateAppearances = 4,
-                            atBats = 4,
-                            runs = 1,
-                            hits = 1,
-                            rbis = 0,
-                            walks = 0,
-                            strikeouts = 2,
-                            avg = ".250"
-                        )
-                    ),
-                    pitchers = listOf(
-                        PitcherLineDto(
-                            playerId = 201L,
-                            name = "원정투수1",
-                            inningsPitched = "6.2",
-                            hits = 8,
-                            runs = 5,
-                            earnedRuns = 4,
-                            walks = 3,
-                            strikeouts = 5,
-                            homeRuns = 1,
-                            decision = "L",
-                            era = "5.40"
-                        )
-                    )
-                ),
-                currentInning = "9회말",
-                gameStatus = "경기 종료"
-            )
+                            errors = 2,
+                            batters =
+                                listOf(
+                                    BatterLineDto(
+                                        playerId = 200L,
+                                        name = "원정타자1",
+                                        position = "CF",
+                                        battingOrder = 1,
+                                        plateAppearances = 4,
+                                        atBats = 4,
+                                        runs = 1,
+                                        hits = 1,
+                                        rbis = 0,
+                                        walks = 0,
+                                        strikeouts = 2,
+                                        avg = ".250",
+                                    ),
+                                ),
+                            pitchers =
+                                listOf(
+                                    PitcherLineDto(
+                                        playerId = 201L,
+                                        name = "원정투수1",
+                                        inningsPitched = "6.2",
+                                        hits = 8,
+                                        runs = 5,
+                                        earnedRuns = 4,
+                                        walks = 3,
+                                        strikeouts = 5,
+                                        homeRuns = 1,
+                                        decision = "L",
+                                        era = "5.40",
+                                    ),
+                                ),
+                        ),
+                    currentInning = "9회말",
+                    gameStatus = "경기 종료",
+                )
 
             every { boxScoreService.getBoxScore(gameId) } returns boxScoreDto
 
             // when & then
-            mockMvc.perform(get("/api/games/$gameId/boxscore"))
+            mockMvc
+                .perform(get("/api/games/$gameId/boxscore"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.gameId").value(gameId))
@@ -146,51 +154,56 @@ class BoxScoreControllerTest {
         fun `타자 정보를 정확하게 반환한다`() {
             // given
             val gameId = 1L
-            val boxScoreDto = BoxScoreDto(
-                gameId = gameId,
-                homeTeam = TeamBoxScoreDto(
-                    teamId = 10L,
-                    teamName = "홈팀",
-                    inningScores = emptyList(),
-                    runs = 0,
-                    hits = 0,
-                    errors = 0,
-                    batters = listOf(
-                        BatterLineDto(
-                            playerId = 100L,
-                            name = "타자A",
-                            position = "SS",
-                            battingOrder = 1,
-                            plateAppearances = 5,
-                            atBats = 4,
-                            runs = 2,
-                            hits = 3,
-                            rbis = 2,
-                            walks = 1,
-                            strikeouts = 1,
-                            avg = ".750"
-                        )
-                    ),
-                    pitchers = emptyList()
-                ),
-                awayTeam = TeamBoxScoreDto(
-                    teamId = 20L,
-                    teamName = "원정팀",
-                    inningScores = emptyList(),
-                    runs = 0,
-                    hits = 0,
-                    errors = 0,
-                    batters = emptyList(),
-                    pitchers = emptyList()
-                ),
-                currentInning = "5회초",
-                gameStatus = "경기 중"
-            )
+            val boxScoreDto =
+                BoxScoreDto(
+                    gameId = gameId,
+                    homeTeam =
+                        TeamBoxScoreDto(
+                            teamId = 10L,
+                            teamName = "홈팀",
+                            inningScores = emptyList(),
+                            runs = 0,
+                            hits = 0,
+                            errors = 0,
+                            batters =
+                                listOf(
+                                    BatterLineDto(
+                                        playerId = 100L,
+                                        name = "타자A",
+                                        position = "SS",
+                                        battingOrder = 1,
+                                        plateAppearances = 5,
+                                        atBats = 4,
+                                        runs = 2,
+                                        hits = 3,
+                                        rbis = 2,
+                                        walks = 1,
+                                        strikeouts = 1,
+                                        avg = ".750",
+                                    ),
+                                ),
+                            pitchers = emptyList(),
+                        ),
+                    awayTeam =
+                        TeamBoxScoreDto(
+                            teamId = 20L,
+                            teamName = "원정팀",
+                            inningScores = emptyList(),
+                            runs = 0,
+                            hits = 0,
+                            errors = 0,
+                            batters = emptyList(),
+                            pitchers = emptyList(),
+                        ),
+                    currentInning = "5회초",
+                    gameStatus = "경기 중",
+                )
 
             every { boxScoreService.getBoxScore(gameId) } returns boxScoreDto
 
             // when & then
-            mockMvc.perform(get("/api/games/$gameId/boxscore"))
+            mockMvc
+                .perform(get("/api/games/$gameId/boxscore"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.data.homeTeam.batters[0].playerId").value(100))
                 .andExpect(jsonPath("$.data.homeTeam.batters[0].name").value("타자A"))
@@ -210,50 +223,55 @@ class BoxScoreControllerTest {
         fun `투수 정보를 정확하게 반환한다`() {
             // given
             val gameId = 1L
-            val boxScoreDto = BoxScoreDto(
-                gameId = gameId,
-                homeTeam = TeamBoxScoreDto(
-                    teamId = 10L,
-                    teamName = "홈팀",
-                    inningScores = emptyList(),
-                    runs = 0,
-                    hits = 0,
-                    errors = 0,
-                    batters = emptyList(),
-                    pitchers = listOf(
-                        PitcherLineDto(
-                            playerId = 101L,
-                            name = "투수B",
-                            inningsPitched = "6.1",
-                            hits = 7,
-                            runs = 3,
-                            earnedRuns = 2,
-                            walks = 2,
-                            strikeouts = 10,
-                            homeRuns = 1,
-                            decision = "W",
-                            era = "2.84"
-                        )
-                    )
-                ),
-                awayTeam = TeamBoxScoreDto(
-                    teamId = 20L,
-                    teamName = "원정팀",
-                    inningScores = emptyList(),
-                    runs = 0,
-                    hits = 0,
-                    errors = 0,
-                    batters = emptyList(),
-                    pitchers = emptyList()
-                ),
-                currentInning = "7회초",
-                gameStatus = "경기 중"
-            )
+            val boxScoreDto =
+                BoxScoreDto(
+                    gameId = gameId,
+                    homeTeam =
+                        TeamBoxScoreDto(
+                            teamId = 10L,
+                            teamName = "홈팀",
+                            inningScores = emptyList(),
+                            runs = 0,
+                            hits = 0,
+                            errors = 0,
+                            batters = emptyList(),
+                            pitchers =
+                                listOf(
+                                    PitcherLineDto(
+                                        playerId = 101L,
+                                        name = "투수B",
+                                        inningsPitched = "6.1",
+                                        hits = 7,
+                                        runs = 3,
+                                        earnedRuns = 2,
+                                        walks = 2,
+                                        strikeouts = 10,
+                                        homeRuns = 1,
+                                        decision = "W",
+                                        era = "2.84",
+                                    ),
+                                ),
+                        ),
+                    awayTeam =
+                        TeamBoxScoreDto(
+                            teamId = 20L,
+                            teamName = "원정팀",
+                            inningScores = emptyList(),
+                            runs = 0,
+                            hits = 0,
+                            errors = 0,
+                            batters = emptyList(),
+                            pitchers = emptyList(),
+                        ),
+                    currentInning = "7회초",
+                    gameStatus = "경기 중",
+                )
 
             every { boxScoreService.getBoxScore(gameId) } returns boxScoreDto
 
             // when & then
-            mockMvc.perform(get("/api/games/$gameId/boxscore"))
+            mockMvc
+                .perform(get("/api/games/$gameId/boxscore"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.data.homeTeam.pitchers[0].playerId").value(101))
                 .andExpect(jsonPath("$.data.homeTeam.pitchers[0].name").value("투수B"))
@@ -272,36 +290,40 @@ class BoxScoreControllerTest {
         fun `이닝별 점수를 정확하게 반환한다`() {
             // given
             val gameId = 1L
-            val boxScoreDto = BoxScoreDto(
-                gameId = gameId,
-                homeTeam = TeamBoxScoreDto(
-                    teamId = 10L,
-                    teamName = "홈팀",
-                    inningScores = listOf(2, 0, 1, 0, 0, 3, 0, 1, 0),
-                    runs = 7,
-                    hits = 12,
-                    errors = 0,
-                    batters = emptyList(),
-                    pitchers = emptyList()
-                ),
-                awayTeam = TeamBoxScoreDto(
-                    teamId = 20L,
-                    teamName = "원정팀",
-                    inningScores = listOf(0, 1, 0, 0, 2, 0, 0, 0, 1),
-                    runs = 4,
-                    hits = 8,
-                    errors = 1,
-                    batters = emptyList(),
-                    pitchers = emptyList()
-                ),
-                currentInning = "9회말",
-                gameStatus = "경기 종료"
-            )
+            val boxScoreDto =
+                BoxScoreDto(
+                    gameId = gameId,
+                    homeTeam =
+                        TeamBoxScoreDto(
+                            teamId = 10L,
+                            teamName = "홈팀",
+                            inningScores = listOf(2, 0, 1, 0, 0, 3, 0, 1, 0),
+                            runs = 7,
+                            hits = 12,
+                            errors = 0,
+                            batters = emptyList(),
+                            pitchers = emptyList(),
+                        ),
+                    awayTeam =
+                        TeamBoxScoreDto(
+                            teamId = 20L,
+                            teamName = "원정팀",
+                            inningScores = listOf(0, 1, 0, 0, 2, 0, 0, 0, 1),
+                            runs = 4,
+                            hits = 8,
+                            errors = 1,
+                            batters = emptyList(),
+                            pitchers = emptyList(),
+                        ),
+                    currentInning = "9회말",
+                    gameStatus = "경기 종료",
+                )
 
             every { boxScoreService.getBoxScore(gameId) } returns boxScoreDto
 
             // when & then
-            mockMvc.perform(get("/api/games/$gameId/boxscore"))
+            mockMvc
+                .perform(get("/api/games/$gameId/boxscore"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.data.homeTeam.inningScores").isArray)
                 .andExpect(jsonPath("$.data.homeTeam.inningScores[0]").value(2))
@@ -318,7 +340,8 @@ class BoxScoreControllerTest {
             every { boxScoreService.getBoxScore(gameId) } throws IllegalArgumentException("경기를 찾을 수 없습니다")
 
             // when & then
-            mockMvc.perform(get("/api/games/$gameId/boxscore"))
+            mockMvc
+                .perform(get("/api/games/$gameId/boxscore"))
                 .andExpect(status().isBadRequest)
                 .andExpect(jsonPath("$.success").value(false))
         }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
@@ -8,8 +8,8 @@ import com.nextup.common.exception.RecordAlreadyExistsException
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.PitchingDecision
 import com.nextup.core.domain.game.PitchingRecord
-import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import com.nextup.core.service.game.PitchingRecordService
+import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
@@ -26,7 +26,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("PitchingRecordController 테스트")
 class PitchingRecordControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var pitchingRecordService: PitchingRecordService
     private lateinit var gamePlayerRepository: GamePlayerRepository
@@ -43,59 +42,63 @@ class PitchingRecordControllerTest {
         objectMapper = jacksonObjectMapper()
 
         val controller = PitchingRecordController(pitchingRecordService, gamePlayerRepository)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller)
-            .setControllerAdvice(GlobalExceptionHandler())
-            .build()
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
     }
 
     @Nested
     @DisplayName("GET /api/games/{gameId}/pitching-records")
     inner class GetPitchingRecords {
-
         @Test
         fun `should return pitching records for game`() {
             // given
-            val gamePlayer = mockk<GamePlayer> {
-                every { id } returns gamePlayerId
-            }
-            val record = mockk<PitchingRecord> {
-                every { id } returns 1L
-                every { this@mockk.gamePlayer } returns gamePlayer
-                every { createdAt } returns java.time.Instant.now()
-                every { updatedAt } returns java.time.Instant.now()
-                every { inningsPitchedOuts } returns 15
-                every { earnedRuns } returns 2
-                every { runsAllowed } returns 3
-                every { hitsAllowed } returns 5
-                every { walksAllowed } returns 2
-                every { strikeouts } returns 6
-                every { homeRunsAllowed } returns 1
-                every { hitBatsmen } returns 0
-                every { wildPitches } returns 1
-                every { balks } returns 0
-                every { battersFaced } returns 22
-                every { decision } returns PitchingDecision.WIN
-                every { isStartingPitcher } returns true
-                every { pitchesThrown } returns 85
-                every { strikesThrown } returns 55
-                every { completeInnings } returns 5
-                every { remainingOuts } returns 0
-                every { inningsPitched } returns java.math.BigDecimal("5.00")
-                every { inningsPitchedDisplay } returns "5.0"
-                every { earnedRunAverage } returns java.math.BigDecimal("3.60")
-                every { whip } returns java.math.BigDecimal("1.40")
-                every { strikeoutsPer9 } returns java.math.BigDecimal("10.80")
-                every { walksPer9 } returns java.math.BigDecimal("3.60")
-                every { strikeoutToWalkRatio } returns java.math.BigDecimal("3.00")
-                every { strikePercentage } returns java.math.BigDecimal("0.647")
-                every { unearnedRuns } returns 1
-                every { isQualifiedForWin } returns true
-            }
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { id } returns gamePlayerId
+                }
+            val record =
+                mockk<PitchingRecord> {
+                    every { id } returns 1L
+                    every { this@mockk.gamePlayer } returns gamePlayer
+                    every { createdAt } returns java.time.Instant.now()
+                    every { updatedAt } returns java.time.Instant.now()
+                    every { inningsPitchedOuts } returns 15
+                    every { earnedRuns } returns 2
+                    every { runsAllowed } returns 3
+                    every { hitsAllowed } returns 5
+                    every { walksAllowed } returns 2
+                    every { strikeouts } returns 6
+                    every { homeRunsAllowed } returns 1
+                    every { hitBatsmen } returns 0
+                    every { wildPitches } returns 1
+                    every { balks } returns 0
+                    every { battersFaced } returns 22
+                    every { decision } returns PitchingDecision.WIN
+                    every { isStartingPitcher } returns true
+                    every { pitchesThrown } returns 85
+                    every { strikesThrown } returns 55
+                    every { completeInnings } returns 5
+                    every { remainingOuts } returns 0
+                    every { inningsPitched } returns java.math.BigDecimal("5.00")
+                    every { inningsPitchedDisplay } returns "5.0"
+                    every { earnedRunAverage } returns java.math.BigDecimal("3.60")
+                    every { whip } returns java.math.BigDecimal("1.40")
+                    every { strikeoutsPer9 } returns java.math.BigDecimal("10.80")
+                    every { walksPer9 } returns java.math.BigDecimal("3.60")
+                    every { strikeoutToWalkRatio } returns java.math.BigDecimal("3.00")
+                    every { strikePercentage } returns java.math.BigDecimal("0.647")
+                    every { unearnedRuns } returns 1
+                    every { isQualifiedForWin } returns true
+                }
 
             every { pitchingRecordService.getAllByGameId(gameId) } returns listOf(record)
 
             // when & then
-            mockMvc.perform(get("/api/games/$gameId/pitching-records"))
+            mockMvc
+                .perform(get("/api/games/$gameId/pitching-records"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -110,7 +113,8 @@ class PitchingRecordControllerTest {
             every { pitchingRecordService.getAllByGameId(gameId) } returns emptyList()
 
             // when & then
-            mockMvc.perform(get("/api/games/$gameId/pitching-records"))
+            mockMvc
+                .perform(get("/api/games/$gameId/pitching-records"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -121,26 +125,26 @@ class PitchingRecordControllerTest {
     @Nested
     @DisplayName("POST /api/games/{gameId}/pitching-records")
     inner class CreatePitchingRecord {
-
         @Test
         fun `should create starting pitcher record successfully`() {
             // given
             val request = CreatePitchingRecordRequest(playerId = playerId, isStartingPitcher = true)
-            val gamePlayer = mockk<GamePlayer> {
-                every { id } returns gamePlayerId
-            }
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { id } returns gamePlayerId
+                }
             val record = createMockPitchingRecord(gamePlayer, isStartingPitcher = true)
 
             every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
             every { pitchingRecordService.createRecord(gamePlayerId, true) } returns record
 
             // when & then
-            mockMvc.perform(
-                post("/api/games/$gameId/pitching-records")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isCreated)
+            mockMvc
+                .perform(
+                    post("/api/games/$gameId/pitching-records")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.isStartingPitcher").value(true))
@@ -150,21 +154,22 @@ class PitchingRecordControllerTest {
         fun `should create relief pitcher record successfully`() {
             // given
             val request = CreatePitchingRecordRequest(playerId = playerId, isStartingPitcher = false)
-            val gamePlayer = mockk<GamePlayer> {
-                every { id } returns gamePlayerId
-            }
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { id } returns gamePlayerId
+                }
             val record = createMockPitchingRecord(gamePlayer, isStartingPitcher = false)
 
             every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
             every { pitchingRecordService.createRecord(gamePlayerId, false) } returns record
 
             // when & then
-            mockMvc.perform(
-                post("/api/games/$gameId/pitching-records")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isCreated)
+            mockMvc
+                .perform(
+                    post("/api/games/$gameId/pitching-records")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.isStartingPitcher").value(false))
         }
@@ -176,12 +181,12 @@ class PitchingRecordControllerTest {
             every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns null
 
             // when & then
-            mockMvc.perform(
-                post("/api/games/$gameId/pitching-records")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isNotFound)
+            mockMvc
+                .perform(
+                    post("/api/games/$gameId/pitching-records")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isNotFound)
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("GAME_PLAYER_NOT_FOUND"))
         }
@@ -190,28 +195,32 @@ class PitchingRecordControllerTest {
         fun `should return 400 when record already exists`() {
             // given
             val request = CreatePitchingRecordRequest(playerId = playerId)
-            val gamePlayer = mockk<GamePlayer> {
-                every { id } returns gamePlayerId
-            }
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { id } returns gamePlayerId
+                }
 
             every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
             every { pitchingRecordService.createRecord(gamePlayerId, false) } throws
                 RecordAlreadyExistsException(gamePlayerId, "Pitching")
 
             // when & then
-            mockMvc.perform(
-                post("/api/games/$gameId/pitching-records")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isBadRequest)
+            mockMvc
+                .perform(
+                    post("/api/games/$gameId/pitching-records")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isBadRequest)
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("RECORD_ALREADY_EXISTS"))
         }
     }
 
-    private fun createMockPitchingRecord(gamePlayer: GamePlayer, isStartingPitcher: Boolean): PitchingRecord {
-        return mockk {
+    private fun createMockPitchingRecord(
+        gamePlayer: GamePlayer,
+        isStartingPitcher: Boolean,
+    ): PitchingRecord =
+        mockk {
             every { id } returns 1L
             every { this@mockk.gamePlayer } returns gamePlayer
             every { createdAt } returns java.time.Instant.now()
@@ -244,5 +253,4 @@ class PitchingRecordControllerTest {
             every { unearnedRuns } returns 0
             every { isQualifiedForWin } returns false
         }
-    }
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/league/LeagueControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/league/LeagueControllerTest.kt
@@ -17,7 +17,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("LeagueController")
 class LeagueControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var leagueService: LeagueService
     private lateinit var controller: LeagueController
@@ -32,19 +31,20 @@ class LeagueControllerTest {
     @Nested
     @DisplayName("GET /api/leagues")
     inner class GetLeagues {
-
         @Test
         fun `should return all active leagues`() {
             // given
             val association = createAssociation(1L, "서울시야구협회")
-            val leagues = listOf(
-                createLeague(1L, "1부 리그", association),
-                createLeague(2L, "2부 리그", association)
-            )
+            val leagues =
+                listOf(
+                    createLeague(1L, "1부 리그", association),
+                    createLeague(2L, "2부 리그", association),
+                )
             every { leagueService.getAllActive() } returns leagues
 
             // when & then
-            mockMvc.perform(get("/api/leagues"))
+            mockMvc
+                .perform(get("/api/leagues"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -56,7 +56,6 @@ class LeagueControllerTest {
     @Nested
     @DisplayName("GET /api/leagues/{id}")
     inner class GetLeague {
-
         @Test
         fun `should return league when found`() {
             // given
@@ -65,7 +64,8 @@ class LeagueControllerTest {
             every { leagueService.getById(1L) } returns league
 
             // when & then
-            mockMvc.perform(get("/api/leagues/1"))
+            mockMvc
+                .perform(get("/api/leagues/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -78,20 +78,21 @@ class LeagueControllerTest {
     @Nested
     @DisplayName("GET /api/associations/{associationId}/leagues")
     inner class GetLeaguesByAssociation {
-
         @Test
         fun `should return leagues by association`() {
             // given
             val associationId = 1L
             val association = createAssociation(associationId, "서울시야구협회")
-            val leagues = listOf(
-                createLeague(1L, "1부 리그", association),
-                createLeague(2L, "2부 리그", association)
-            )
+            val leagues =
+                listOf(
+                    createLeague(1L, "1부 리그", association),
+                    createLeague(2L, "2부 리그", association),
+                )
             every { leagueService.getActiveByAssociationId(associationId) } returns leagues
 
             // when & then
-            mockMvc.perform(get("/api/associations/$associationId/leagues"))
+            mockMvc
+                .perform(get("/api/associations/$associationId/leagues"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -100,34 +101,39 @@ class LeagueControllerTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
-        return Association(
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association =
+        Association(
             name = name,
             abbreviation = null,
             region = "서울",
             description = null,
             logoUrl = null,
-            websiteUrl = null
+            websiteUrl = null,
         ).apply {
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
-    private fun createLeague(id: Long, name: String, association: Association): League {
-        return League(
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association,
+    ): League =
+        League(
             association = association,
             name = name,
             abbreviation = null,
             foundedYear = 2020,
             divisionLevel = 1,
             description = null,
-            logoUrl = null
+            logoUrl = null,
         ).apply {
             val idField = League::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/oauth/OAuthControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/oauth/OAuthControllerTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("OAuthController 테스트")
 class OAuthControllerTest {
-
     private lateinit var oauthLinkService: OAuthLinkService
     private lateinit var oauthController: OAuthController
 
@@ -40,7 +39,7 @@ class OAuthControllerTest {
         assertThat(response.body?.success).isTrue()
         assertThat(response.body?.data?.providers).containsExactly(
             OAuthProvider.KAKAO,
-            OAuthProvider.GOOGLE
+            OAuthProvider.GOOGLE,
         )
     }
 

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/PlayerStatsControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/PlayerStatsControllerTest.kt
@@ -26,7 +26,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("PlayerStatsController 테스트")
 class PlayerStatsControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var playerStatsService: PlayerStatsService
     private lateinit var objectMapper: ObjectMapper
@@ -34,13 +33,14 @@ class PlayerStatsControllerTest {
     private val playerId = 1L
     private val year = 2024
 
-    private val testPlayer = Player(
-        name = "홍길동",
-        primaryPosition = Position.CATCHER,
-        throwingHand = ThrowingHand.RIGHT,
-        battingHand = BattingHand.RIGHT,
-        id = playerId
-    )
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = playerId,
+        )
 
     @BeforeEach
     fun setUp() {
@@ -48,35 +48,38 @@ class PlayerStatsControllerTest {
         objectMapper = jacksonObjectMapper()
 
         val controller = PlayerStatsController(playerStatsService)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller)
-            .setControllerAdvice(GlobalExceptionHandler())
-            .build()
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
     }
 
     @Nested
     @DisplayName("GET /api/v1/players/{playerId}/stats/batting/season/{year}")
     inner class GetSeasonBattingStats {
-
         @Test
         fun `should return season batting stats successfully`() {
             // given
-            val stats = SeasonBattingStats.create(testPlayer, year).apply {
-                setStatsDirectly(
-                    gamesPlayed = 10,
-                    pa = 45,
-                    atBats = 40,
-                    hits = 12,
-                    doubles = 2,
-                    homeRuns = 1,
-                    runs = 5,
-                    rbi = 8
-                )
-            }
+            val stats =
+                SeasonBattingStats.create(testPlayer, year).apply {
+                    setStatsDirectly(
+                        gamesPlayed = 10,
+                        pa = 45,
+                        atBats = 40,
+                        hits = 12,
+                        doubles = 2,
+                        homeRuns = 1,
+                        runs = 5,
+                        rbi = 8,
+                    )
+                }
 
             every { playerStatsService.getSeasonBattingStats(playerId, year) } returns stats
 
             // when & then
-            mockMvc.perform(get("/api/v1/players/$playerId/stats/batting/season/$year"))
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/batting/season/$year"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.playerId").value(playerId))
@@ -95,7 +98,8 @@ class PlayerStatsControllerTest {
                 IllegalArgumentException("선수 ID $playerId 의 ${year}년도 타격 통계가 존재하지 않습니다.")
 
             // when & then
-            mockMvc.perform(get("/api/v1/players/$playerId/stats/batting/season/$year"))
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/batting/season/$year"))
                 .andExpect(status().isBadRequest)
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("INVALID_ARGUMENT"))
@@ -105,26 +109,27 @@ class PlayerStatsControllerTest {
     @Nested
     @DisplayName("GET /api/v1/players/{playerId}/stats/pitching/season/{year}")
     inner class GetSeasonPitchingStats {
-
         @Test
         fun `should return season pitching stats successfully`() {
             // given
-            val stats = SeasonPitchingStats.create(testPlayer, year).apply {
-                setStatsDirectly(
-                    gamesPlayed = 10,
-                    gamesStarted = 8,
-                    inningsPitchedOuts = 60, // 20 이닝
-                    wins = 5,
-                    losses = 3,
-                    earnedRuns = 15,
-                    strikeouts = 40
-                )
-            }
+            val stats =
+                SeasonPitchingStats.create(testPlayer, year).apply {
+                    setStatsDirectly(
+                        gamesPlayed = 10,
+                        gamesStarted = 8,
+                        inningsPitchedOuts = 60, // 20 이닝
+                        wins = 5,
+                        losses = 3,
+                        earnedRuns = 15,
+                        strikeouts = 40,
+                    )
+                }
 
             every { playerStatsService.getSeasonPitchingStats(playerId, year) } returns stats
 
             // when & then
-            mockMvc.perform(get("/api/v1/players/$playerId/stats/pitching/season/$year"))
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/pitching/season/$year"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.playerId").value(playerId))
@@ -143,7 +148,8 @@ class PlayerStatsControllerTest {
                 IllegalArgumentException("선수 ID $playerId 의 ${year}년도 투수 통계가 존재하지 않습니다.")
 
             // when & then
-            mockMvc.perform(get("/api/v1/players/$playerId/stats/pitching/season/$year"))
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/pitching/season/$year"))
                 .andExpect(status().isBadRequest)
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("INVALID_ARGUMENT"))
@@ -153,22 +159,24 @@ class PlayerStatsControllerTest {
     @Nested
     @DisplayName("GET /api/v1/players/{playerId}/stats/batting/seasons")
     inner class GetAllSeasonBattingStats {
-
         @Test
         fun `should return all season batting stats successfully`() {
             // given
-            val stats2023 = SeasonBattingStats.create(testPlayer, 2023).apply {
-                setStatsDirectly(gamesPlayed = 8, atBats = 30, hits = 9)
-            }
-            val stats2024 = SeasonBattingStats.create(testPlayer, 2024).apply {
-                setStatsDirectly(gamesPlayed = 10, atBats = 40, hits = 12)
-            }
+            val stats2023 =
+                SeasonBattingStats.create(testPlayer, 2023).apply {
+                    setStatsDirectly(gamesPlayed = 8, atBats = 30, hits = 9)
+                }
+            val stats2024 =
+                SeasonBattingStats.create(testPlayer, 2024).apply {
+                    setStatsDirectly(gamesPlayed = 10, atBats = 40, hits = 12)
+                }
 
             every { playerStatsService.getAllSeasonBattingStats(playerId) } returns
                 listOf(stats2023, stats2024)
 
             // when & then
-            mockMvc.perform(get("/api/v1/players/$playerId/stats/batting/seasons"))
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/batting/seasons"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -185,7 +193,8 @@ class PlayerStatsControllerTest {
             every { playerStatsService.getAllSeasonBattingStats(playerId) } returns emptyList()
 
             // when & then
-            mockMvc.perform(get("/api/v1/players/$playerId/stats/batting/seasons"))
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/batting/seasons"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -196,22 +205,24 @@ class PlayerStatsControllerTest {
     @Nested
     @DisplayName("GET /api/v1/players/{playerId}/stats/pitching/seasons")
     inner class GetAllSeasonPitchingStats {
-
         @Test
         fun `should return all season pitching stats successfully`() {
             // given
-            val stats2023 = SeasonPitchingStats.create(testPlayer, 2023).apply {
-                setStatsDirectly(gamesPlayed = 8, wins = 3, losses = 2)
-            }
-            val stats2024 = SeasonPitchingStats.create(testPlayer, 2024).apply {
-                setStatsDirectly(gamesPlayed = 10, wins = 5, losses = 3)
-            }
+            val stats2023 =
+                SeasonPitchingStats.create(testPlayer, 2023).apply {
+                    setStatsDirectly(gamesPlayed = 8, wins = 3, losses = 2)
+                }
+            val stats2024 =
+                SeasonPitchingStats.create(testPlayer, 2024).apply {
+                    setStatsDirectly(gamesPlayed = 10, wins = 5, losses = 3)
+                }
 
             every { playerStatsService.getAllSeasonPitchingStats(playerId) } returns
                 listOf(stats2023, stats2024)
 
             // when & then
-            mockMvc.perform(get("/api/v1/players/$playerId/stats/pitching/seasons"))
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/pitching/seasons"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -228,7 +239,8 @@ class PlayerStatsControllerTest {
             every { playerStatsService.getAllSeasonPitchingStats(playerId) } returns emptyList()
 
             // when & then
-            mockMvc.perform(get("/api/v1/players/$playerId/stats/pitching/seasons"))
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/pitching/seasons"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -239,23 +251,24 @@ class PlayerStatsControllerTest {
     @Nested
     @DisplayName("GET /api/v1/players/{playerId}/stats/batting/career")
     inner class GetCareerBattingStats {
-
         @Test
         fun `should return career batting stats successfully`() {
             // given
-            val stats = CareerBattingStats(testPlayer).apply {
-                setCareerBattingStatsDirectly(
-                    seasonsPlayed = 3,
-                    gamesPlayed = 30,
-                    atBats = 100,
-                    hits = 30
-                )
-            }
+            val stats =
+                CareerBattingStats(testPlayer).apply {
+                    setCareerBattingStatsDirectly(
+                        seasonsPlayed = 3,
+                        gamesPlayed = 30,
+                        atBats = 100,
+                        hits = 30,
+                    )
+                }
 
             every { playerStatsService.getCareerBattingStats(playerId) } returns stats
 
             // when & then
-            mockMvc.perform(get("/api/v1/players/$playerId/stats/batting/career"))
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/batting/career"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.playerId").value(playerId))
@@ -269,23 +282,24 @@ class PlayerStatsControllerTest {
     @Nested
     @DisplayName("GET /api/v1/players/{playerId}/stats/pitching/career")
     inner class GetCareerPitchingStats {
-
         @Test
         fun `should return career pitching stats successfully`() {
             // given
-            val stats = CareerPitchingStats(testPlayer).apply {
-                setCareerPitchingStatsDirectly(
-                    seasonsPlayed = 3,
-                    gamesPlayed = 20,
-                    wins = 10,
-                    losses = 5
-                )
-            }
+            val stats =
+                CareerPitchingStats(testPlayer).apply {
+                    setCareerPitchingStatsDirectly(
+                        seasonsPlayed = 3,
+                        gamesPlayed = 20,
+                        wins = 10,
+                        losses = 5,
+                    )
+                }
 
             every { playerStatsService.getCareerPitchingStats(playerId) } returns stats
 
             // when & then
-            mockMvc.perform(get("/api/v1/players/$playerId/stats/pitching/career"))
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/pitching/career"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.playerId").value(playerId))
@@ -308,7 +322,7 @@ class PlayerStatsControllerTest {
         homeRuns: Int = 0,
         runs: Int = 0,
         rbi: Int = 0,
-        walks: Int = 0
+        walks: Int = 0,
     ) {
         val clazz = SeasonBattingStats::class.java
         setField(clazz, this, "gamesPlayed", gamesPlayed)
@@ -331,7 +345,7 @@ class PlayerStatsControllerTest {
         losses: Int = 0,
         saves: Int = 0,
         earnedRuns: Int = 0,
-        strikeouts: Int = 0
+        strikeouts: Int = 0,
     ) {
         val clazz = SeasonPitchingStats::class.java
         setField(clazz, this, "gamesPlayed", gamesPlayed)
@@ -348,7 +362,7 @@ class PlayerStatsControllerTest {
         seasonsPlayed: Int = 0,
         gamesPlayed: Int = 0,
         atBats: Int = 0,
-        hits: Int = 0
+        hits: Int = 0,
     ) {
         val clazz = CareerBattingStats::class.java
         setField(clazz, this, "seasonsPlayed", seasonsPlayed)
@@ -361,7 +375,7 @@ class PlayerStatsControllerTest {
         seasonsPlayed: Int = 0,
         gamesPlayed: Int = 0,
         wins: Int = 0,
-        losses: Int = 0
+        losses: Int = 0,
     ) {
         val clazz = CareerPitchingStats::class.java
         setField(clazz, this, "seasonsPlayed", seasonsPlayed)
@@ -370,7 +384,12 @@ class PlayerStatsControllerTest {
         setField(clazz, this, "losses", losses)
     }
 
-    private fun setField(clazz: Class<*>, obj: Any, fieldName: String, value: Any?) {
+    private fun setField(
+        clazz: Class<*>,
+        obj: Any,
+        fieldName: String,
+        value: Any?,
+    ) {
         val field = clazz.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(obj, value)

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/user/ProfileControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/user/ProfileControllerTest.kt
@@ -1,25 +1,20 @@
 package com.nextup.api.controller.user
 
 import com.nextup.api.dto.user.UpdateProfileRequest
-import com.nextup.core.domain.user.OAuthAccount
 import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.User
 import com.nextup.core.service.user.UserService
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.time.Instant
 
 @DisplayName("ProfileController 테스트")
 class ProfileControllerTest {
-
     private lateinit var userService: UserService
     private lateinit var profileController: ProfileController
 
@@ -29,12 +24,16 @@ class ProfileControllerTest {
         profileController = ProfileController(userService)
     }
 
-    private fun createTestUser(id: Long = 1L, hasOAuth: Boolean = false): User {
-        val user = User.createLocalUser(
-            email = "test@example.com",
-            encodedPassword = "encoded",
-            nickname = "테스터"
-        )
+    private fun createTestUser(
+        id: Long = 1L,
+        hasOAuth: Boolean = false,
+    ): User {
+        val user =
+            User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "encoded",
+                nickname = "테스터",
+            )
         // Use reflection to set ID
         val idField = user.javaClass.getDeclaredField("id")
         idField.isAccessible = true
@@ -50,7 +49,6 @@ class ProfileControllerTest {
     @Nested
     @DisplayName("내 프로필 조회")
     inner class GetMyProfile {
-
         @Test
         fun `should return my profile successfully`() {
             // given
@@ -82,14 +80,18 @@ class ProfileControllerTest {
             // then
             assertThat(response.success).isTrue()
             assertThat(response.data?.linkedOAuthProviders).hasSize(1)
-            assertThat(response.data?.linkedOAuthProviders?.first()?.provider).isEqualTo("GOOGLE")
+            assertThat(
+                response.data
+                    ?.linkedOAuthProviders
+                    ?.first()
+                    ?.provider,
+            ).isEqualTo("GOOGLE")
         }
     }
 
     @Nested
     @DisplayName("프로필 수정")
     inner class UpdateMyProfile {
-
         @Test
         fun `should update profile with new nickname`() {
             // given
@@ -128,7 +130,6 @@ class ProfileControllerTest {
     @Nested
     @DisplayName("연동된 OAuth 계정 조회")
     inner class GetLinkedOAuthAccounts {
-
         @Test
         fun `should return empty list when no oauth linked`() {
             // given
@@ -165,7 +166,6 @@ class ProfileControllerTest {
     @Nested
     @DisplayName("회원 탈퇴")
     inner class DeactivateMyAccount {
-
         @Test
         fun `should deactivate account successfully`() {
             // given
@@ -185,7 +185,6 @@ class ProfileControllerTest {
 
 @DisplayName("PublicProfileController 테스트")
 class PublicProfileControllerTest {
-
     private lateinit var userService: UserService
     private lateinit var publicProfileController: PublicProfileController
 
@@ -196,11 +195,12 @@ class PublicProfileControllerTest {
     }
 
     private fun createTestUser(id: Long = 1L): User {
-        val user = User.createLocalUser(
-            email = "test@example.com",
-            encodedPassword = "encoded",
-            nickname = "테스터"
-        )
+        val user =
+            User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "encoded",
+                nickname = "테스터",
+            )
         val idField = user.javaClass.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(user, id)
@@ -210,7 +210,6 @@ class PublicProfileControllerTest {
     @Nested
     @DisplayName("공개 프로필 조회")
     inner class GetPublicProfile {
-
         @Test
         fun `should return public profile successfully`() {
             // given

--- a/nextup-api/src/test/kotlin/com/nextup/api/dto/game/RecordPitchingEventRequestTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/dto/game/RecordPitchingEventRequestTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class RecordPitchingEventRequestTest {
-
     private lateinit var validator: Validator
 
     @BeforeEach
@@ -28,11 +27,12 @@ class RecordPitchingEventRequestTest {
     @Test
     fun `should create RecordHit request with valid data`() {
         // when
-        val request = RecordPitchingEventRequest.RecordHit(
-            isHomeRun = true,
-            runsScored = 1,
-            earnedRuns = 1
-        )
+        val request =
+            RecordPitchingEventRequest.RecordHit(
+                isHomeRun = true,
+                runsScored = 1,
+                earnedRuns = 1,
+            )
 
         // then
         assertThat(request.isHomeRun).isTrue()
@@ -43,11 +43,12 @@ class RecordPitchingEventRequestTest {
     @Test
     fun `should fail validation when runsScored is negative`() {
         // given
-        val request = RecordPitchingEventRequest.RecordHit(
-            isHomeRun = false,
-            runsScored = -1,
-            earnedRuns = 0
-        )
+        val request =
+            RecordPitchingEventRequest.RecordHit(
+                isHomeRun = false,
+                runsScored = -1,
+                earnedRuns = 0,
+            )
 
         // when
         val violations = validator.validate(request)
@@ -77,10 +78,11 @@ class RecordPitchingEventRequestTest {
     @Test
     fun `should create RecordPitchCount request with valid data`() {
         // when
-        val request = RecordPitchingEventRequest.RecordPitchCount(
-            totalPitches = 100,
-            strikes = 65
-        )
+        val request =
+            RecordPitchingEventRequest.RecordPitchCount(
+                totalPitches = 100,
+                strikes = 65,
+            )
 
         // then
         assertThat(request.totalPitches).isEqualTo(100)
@@ -90,10 +92,11 @@ class RecordPitchingEventRequestTest {
     @Test
     fun `should fail validation when totalPitches is less than 1`() {
         // given
-        val request = RecordPitchingEventRequest.RecordPitchCount(
-            totalPitches = 0,
-            strikes = 0
-        )
+        val request =
+            RecordPitchingEventRequest.RecordPitchCount(
+                totalPitches = 0,
+                strikes = 0,
+            )
 
         // when
         val violations = validator.validate(request)
@@ -105,10 +108,11 @@ class RecordPitchingEventRequestTest {
     @Test
     fun `should pass validation with valid RecordPitchCount`() {
         // given
-        val request = RecordPitchingEventRequest.RecordPitchCount(
-            totalPitches = 1,
-            strikes = 1
-        )
+        val request =
+            RecordPitchingEventRequest.RecordPitchCount(
+                totalPitches = 1,
+                strikes = 1,
+            )
 
         // when
         val violations = validator.validate(request)

--- a/nextup-api/src/test/kotlin/com/nextup/api/dto/game/RecordPlateAppearanceRequestTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/dto/game/RecordPlateAppearanceRequestTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class RecordPlateAppearanceRequestTest {
-
     private lateinit var validator: Validator
 
     @BeforeEach
@@ -19,11 +18,12 @@ class RecordPlateAppearanceRequestTest {
     @Test
     fun `should create request with valid data`() {
         // when
-        val request = RecordPlateAppearanceRequest(
-            result = PlateAppearanceResult.SINGLE,
-            runsBattedIn = 1,
-            runsScored = true
-        )
+        val request =
+            RecordPlateAppearanceRequest(
+                result = PlateAppearanceResult.SINGLE,
+                runsBattedIn = 1,
+                runsScored = true,
+            )
 
         // then
         assertThat(request.result).isEqualTo(PlateAppearanceResult.SINGLE)
@@ -34,9 +34,10 @@ class RecordPlateAppearanceRequestTest {
     @Test
     fun `should use default values`() {
         // when
-        val request = RecordPlateAppearanceRequest(
-            result = PlateAppearanceResult.HOME_RUN
-        )
+        val request =
+            RecordPlateAppearanceRequest(
+                result = PlateAppearanceResult.HOME_RUN,
+            )
 
         // then
         assertThat(request.runsBattedIn).isEqualTo(0)
@@ -46,11 +47,12 @@ class RecordPlateAppearanceRequestTest {
     @Test
     fun `should pass validation with valid data`() {
         // given
-        val request = RecordPlateAppearanceRequest(
-            result = PlateAppearanceResult.DOUBLE,
-            runsBattedIn = 2,
-            runsScored = false
-        )
+        val request =
+            RecordPlateAppearanceRequest(
+                result = PlateAppearanceResult.DOUBLE,
+                runsBattedIn = 2,
+                runsScored = false,
+            )
 
         // when
         val violations = validator.validate(request)
@@ -62,11 +64,12 @@ class RecordPlateAppearanceRequestTest {
     @Test
     fun `should fail validation when runsBattedIn is negative`() {
         // given
-        val request = RecordPlateAppearanceRequest(
-            result = PlateAppearanceResult.SINGLE,
-            runsBattedIn = -1,
-            runsScored = false
-        )
+        val request =
+            RecordPlateAppearanceRequest(
+                result = PlateAppearanceResult.SINGLE,
+                runsBattedIn = -1,
+                runsScored = false,
+            )
 
         // when
         val violations = validator.validate(request)
@@ -79,11 +82,12 @@ class RecordPlateAppearanceRequestTest {
     @Test
     fun `should support data class copy`() {
         // given
-        val original = RecordPlateAppearanceRequest(
-            result = PlateAppearanceResult.SINGLE,
-            runsBattedIn = 1,
-            runsScored = true
-        )
+        val original =
+            RecordPlateAppearanceRequest(
+                result = PlateAppearanceResult.SINGLE,
+                runsBattedIn = 1,
+                runsScored = true,
+            )
 
         // when
         val copied = original.copy(runsBattedIn = 2)

--- a/nextup-api/src/test/kotlin/com/nextup/api/exception/GlobalExceptionHandlerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/exception/GlobalExceptionHandlerTest.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 
 @DisplayName("GlobalExceptionHandler 테스트")
 class GlobalExceptionHandlerTest {
-
     private lateinit var handler: GlobalExceptionHandler
 
     @BeforeEach
@@ -86,17 +85,21 @@ class GlobalExceptionHandlerTest {
     @Test
     fun `should handle MethodArgumentNotValidException and return 400`() {
         // given
-        data class TestRequest(val name: String?)
+        data class TestRequest(
+            val name: String?,
+        )
         val target = TestRequest(null)
         val bindingResult = BeanPropertyBindingResult(target, "testRequest")
         bindingResult.addError(FieldError("testRequest", "name", "must not be null"))
 
-        val exception = MethodArgumentNotValidException(
-            org.springframework.core.MethodParameter(
-                TestRequest::class.java.constructors.first(), -1
-            ),
-            bindingResult
-        )
+        val exception =
+            MethodArgumentNotValidException(
+                org.springframework.core.MethodParameter(
+                    TestRequest::class.java.constructors.first(),
+                    -1,
+                ),
+                bindingResult,
+            )
 
         // when
         val response = handler.handleValidationException(exception)

--- a/nextup-api/src/test/kotlin/com/nextup/api/mapper/game/BattingRecordMapperTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/mapper/game/BattingRecordMapperTest.kt
@@ -10,17 +10,17 @@ import org.junit.jupiter.api.Test
 import java.time.Instant
 
 class BattingRecordMapperTest {
-
     @Test
     fun `should map BattingRecord to BattingRecordResponse`() {
         // given
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 123L
 
-        val battingRecord = BattingRecord.create(gamePlayer).apply {
-            recordPlateAppearance(PlateAppearanceResult.SINGLE, 1, true)
-            recordPlateAppearance(PlateAppearanceResult.HOME_RUN, 2, true)
-        }
+        val battingRecord =
+            BattingRecord.create(gamePlayer).apply {
+                recordPlateAppearance(PlateAppearanceResult.SINGLE, 1, true)
+                recordPlateAppearance(PlateAppearanceResult.HOME_RUN, 2, true)
+            }
 
         // when
         val response = battingRecord.toResponse()
@@ -34,7 +34,7 @@ class BattingRecordMapperTest {
         assertThat(response.homeRuns).isEqualTo(1)
         assertThat(response.runs).isEqualTo(2)
         assertThat(response.runsBattedIn).isEqualTo(3)
-        assertThat(response.totalBases).isEqualTo(5)  // 1 + 4
+        assertThat(response.totalBases).isEqualTo(5) // 1 + 4
     }
 
     @Test
@@ -43,14 +43,15 @@ class BattingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val battingRecord = BattingRecord.create(gamePlayer).apply {
-            repeat(3) {
-                recordPlateAppearance(PlateAppearanceResult.SINGLE)
+        val battingRecord =
+            BattingRecord.create(gamePlayer).apply {
+                repeat(3) {
+                    recordPlateAppearance(PlateAppearanceResult.SINGLE)
+                }
+                repeat(2) {
+                    recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
+                }
             }
-            repeat(2) {
-                recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
-            }
-        }
 
         // when
         val response = battingRecord.toResponse()
@@ -66,9 +67,10 @@ class BattingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val battingRecord = BattingRecord.create(gamePlayer).apply {
-            recordPlateAppearance(PlateAppearanceResult.WALK)
-        }
+        val battingRecord =
+            BattingRecord.create(gamePlayer).apply {
+                recordPlateAppearance(PlateAppearanceResult.WALK)
+            }
 
         // when
         val response = battingRecord.toResponse()
@@ -84,13 +86,14 @@ class BattingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val battingRecord = BattingRecord.create(gamePlayer).apply {
-            // 2 hits (1 single, 1 home run) in 3 at-bats, 1 walk
-            recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
-            recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
-            recordPlateAppearance(PlateAppearanceResult.WALK)
-        }
+        val battingRecord =
+            BattingRecord.create(gamePlayer).apply {
+                // 2 hits (1 single, 1 home run) in 3 at-bats, 1 walk
+                recordPlateAppearance(PlateAppearanceResult.SINGLE)
+                recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
+                recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
+                recordPlateAppearance(PlateAppearanceResult.WALK)
+            }
 
         // when
         val response = battingRecord.toResponse()
@@ -112,10 +115,11 @@ class BattingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val battingRecord = BattingRecord.create(gamePlayer).apply {
-            repeat(3) { recordStolenBase() }
-            repeat(1) { recordCaughtStealing() }
-        }
+        val battingRecord =
+            BattingRecord.create(gamePlayer).apply {
+                repeat(3) { recordStolenBase() }
+                repeat(1) { recordCaughtStealing() }
+            }
 
         // when
         val response = battingRecord.toResponse()
@@ -149,12 +153,13 @@ class BattingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val battingRecord = BattingRecord.create(gamePlayer).apply {
-            recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            recordPlateAppearance(PlateAppearanceResult.DOUBLE)
-            recordPlateAppearance(PlateAppearanceResult.TRIPLE)
-            recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
-        }
+        val battingRecord =
+            BattingRecord.create(gamePlayer).apply {
+                recordPlateAppearance(PlateAppearanceResult.SINGLE)
+                recordPlateAppearance(PlateAppearanceResult.DOUBLE)
+                recordPlateAppearance(PlateAppearanceResult.TRIPLE)
+                recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
+            }
 
         // when
         val response = battingRecord.toResponse()
@@ -164,8 +169,8 @@ class BattingRecordMapperTest {
         assertThat(response.doubles).isEqualTo(1)
         assertThat(response.triples).isEqualTo(1)
         assertThat(response.homeRuns).isEqualTo(1)
-        assertThat(response.extraBaseHits).isEqualTo(3)  // 2B + 3B + HR
-        assertThat(response.totalBases).isEqualTo(10)    // 1 + 2 + 3 + 4
+        assertThat(response.extraBaseHits).isEqualTo(3) // 2B + 3B + HR
+        assertThat(response.totalBases).isEqualTo(10) // 1 + 2 + 3 + 4
     }
 
     @Test
@@ -174,11 +179,12 @@ class BattingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val battingRecord = BattingRecord.create(gamePlayer).apply {
-            recordPlateAppearance(PlateAppearanceResult.WALK)
-            recordPlateAppearance(PlateAppearanceResult.WALK)
-            recordPlateAppearance(PlateAppearanceResult.INTENTIONAL_WALK)
-        }
+        val battingRecord =
+            BattingRecord.create(gamePlayer).apply {
+                recordPlateAppearance(PlateAppearanceResult.WALK)
+                recordPlateAppearance(PlateAppearanceResult.WALK)
+                recordPlateAppearance(PlateAppearanceResult.INTENTIONAL_WALK)
+            }
 
         // when
         val response = battingRecord.toResponse()
@@ -195,10 +201,11 @@ class BattingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val battingRecord = BattingRecord.create(gamePlayer).apply {
-            recordPlateAppearance(PlateAppearanceResult.SACRIFICE_BUNT)
-            recordPlateAppearance(PlateAppearanceResult.SACRIFICE_FLY)
-        }
+        val battingRecord =
+            BattingRecord.create(gamePlayer).apply {
+                recordPlateAppearance(PlateAppearanceResult.SACRIFICE_BUNT)
+                recordPlateAppearance(PlateAppearanceResult.SACRIFICE_FLY)
+            }
 
         // when
         val response = battingRecord.toResponse()
@@ -217,14 +224,15 @@ class BattingRecordMapperTest {
         every { gamePlayer1.id } returns 1L
         every { gamePlayer2.id } returns 2L
 
-        val records = listOf(
-            BattingRecord.create(gamePlayer1).apply {
-                recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            },
-            BattingRecord.create(gamePlayer2).apply {
-                recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
-            }
-        )
+        val records =
+            listOf(
+                BattingRecord.create(gamePlayer1).apply {
+                    recordPlateAppearance(PlateAppearanceResult.SINGLE)
+                },
+                BattingRecord.create(gamePlayer2).apply {
+                    recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
+                },
+            )
 
         // when
         val responses = records.toResponse()
@@ -250,7 +258,7 @@ class BattingRecordMapperTest {
         val response = battingRecord.toResponse()
 
         // then
-        assertThat(response.id).isEqualTo(0L)  // Entity not persisted yet
+        assertThat(response.id).isEqualTo(0L) // Entity not persisted yet
         assertThat(response.gamePlayerId).isEqualTo(999L)
         assertThat(response.createdAt).isNotNull
         assertThat(response.updatedAt).isNotNull
@@ -262,11 +270,12 @@ class BattingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val battingRecord = BattingRecord.create(gamePlayer).apply {
-            recordPlateAppearance(PlateAppearanceResult.STRIKEOUT)
-            recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
-            recordPlateAppearance(PlateAppearanceResult.DOUBLE_PLAY)
-        }
+        val battingRecord =
+            BattingRecord.create(gamePlayer).apply {
+                recordPlateAppearance(PlateAppearanceResult.STRIKEOUT)
+                recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
+                recordPlateAppearance(PlateAppearanceResult.DOUBLE_PLAY)
+            }
 
         // when
         val response = battingRecord.toResponse()

--- a/nextup-api/src/test/kotlin/com/nextup/api/mapper/game/PitchingRecordMapperTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/mapper/game/PitchingRecordMapperTest.kt
@@ -1,28 +1,26 @@
 package com.nextup.api.mapper.game
 
 import com.nextup.core.domain.game.GamePlayer
-import com.nextup.core.domain.game.PitchingDecision
 import com.nextup.core.domain.game.PitchingRecord
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.time.Instant
 
 class PitchingRecordMapperTest {
-
     @Test
     fun `should map PitchingRecord to PitchingRecordResponse`() {
         // given
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 123L
 
-        val pitchingRecord = PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
-            repeat(15) { recordOut() }  // 5 innings
-            recordHit(isHomeRun = false, runsScored = 1, earnedRuns = 1)
-            recordWalk()
-            recordHitByPitch()
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                repeat(15) { recordOut() } // 5 innings
+                recordHit(isHomeRun = false, runsScored = 1, earnedRuns = 1)
+                recordWalk()
+                recordHitByPitch()
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -44,9 +42,10 @@ class PitchingRecordMapperTest {
         every { gamePlayer.id } returns 1L
 
         // 5.1 innings (16 outs)
-        val pitchingRecord = PitchingRecord.create(gamePlayer).apply {
-            repeat(16) { recordOut() }
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer).apply {
+                repeat(16) { recordOut() }
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -66,9 +65,10 @@ class PitchingRecordMapperTest {
         every { gamePlayer.id } returns 1L
 
         // 7.0 innings (21 outs)
-        val pitchingRecord = PitchingRecord.create(gamePlayer).apply {
-            repeat(21) { recordOut() }
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer).apply {
+                repeat(21) { recordOut() }
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -88,10 +88,11 @@ class PitchingRecordMapperTest {
         every { gamePlayer.id } returns 1L
 
         // 6 innings, 2 earned runs
-        val pitchingRecord = PitchingRecord.create(gamePlayer).apply {
-            repeat(18) { recordOut() }  // 6 innings
-            recordHit(runsScored = 2, earnedRuns = 2)
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer).apply {
+                repeat(18) { recordOut() } // 6 innings
+                recordHit(runsScored = 2, earnedRuns = 2)
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -123,11 +124,12 @@ class PitchingRecordMapperTest {
         every { gamePlayer.id } returns 1L
 
         // 6 innings, 5 hits, 2 walks
-        val pitchingRecord = PitchingRecord.create(gamePlayer).apply {
-            repeat(18) { recordOut() }  // 6 innings
-            repeat(5) { recordHit() }
-            repeat(2) { recordWalk() }
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer).apply {
+                repeat(18) { recordOut() } // 6 innings
+                repeat(5) { recordHit() }
+                repeat(2) { recordWalk() }
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -145,11 +147,12 @@ class PitchingRecordMapperTest {
         every { gamePlayer.id } returns 1L
 
         // 6 innings, 9 strikeouts, 3 walks
-        val pitchingRecord = PitchingRecord.create(gamePlayer).apply {
-            repeat(9) { recordOut(isStrikeout = true) }  // 3 innings with K
-            repeat(9) { recordOut() }  // 3 more innings
-            repeat(3) { recordWalk() }
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer).apply {
+                repeat(9) { recordOut(isStrikeout = true) } // 3 innings with K
+                repeat(9) { recordOut() } // 3 more innings
+                repeat(3) { recordWalk() }
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -168,10 +171,11 @@ class PitchingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val pitchingRecord = PitchingRecord.create(gamePlayer).apply {
-            repeat(9) { recordOut(isStrikeout = true) }
-            repeat(3) { recordWalk() }
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer).apply {
+                repeat(9) { recordOut(isStrikeout = true) }
+                repeat(3) { recordWalk() }
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -186,9 +190,10 @@ class PitchingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val pitchingRecord = PitchingRecord.create(gamePlayer).apply {
-            repeat(9) { recordOut(isStrikeout = true) }
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer).apply {
+                repeat(9) { recordOut(isStrikeout = true) }
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -205,9 +210,10 @@ class PitchingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val pitchingRecord = PitchingRecord.create(gamePlayer).apply {
-            recordPitchCount(totalPitches = 100, strikes = 65)
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer).apply {
+                recordPitchCount(totalPitches = 100, strikes = 65)
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -241,10 +247,11 @@ class PitchingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val pitchingRecord = PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
-            repeat(15) { recordOut() }  // 5 innings (qualified for win)
-            assignWin()
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                repeat(15) { recordOut() } // 5 innings (qualified for win)
+                assignWin()
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -260,9 +267,10 @@ class PitchingRecordMapperTest {
         val gamePlayer = mockk<GamePlayer>()
         every { gamePlayer.id } returns 1L
 
-        val pitchingRecord = PitchingRecord.create(gamePlayer).apply {
-            recordHit(runsScored = 3, earnedRuns = 1)  // 3 runs, 1 earned
-        }
+        val pitchingRecord =
+            PitchingRecord.create(gamePlayer).apply {
+                recordHit(runsScored = 3, earnedRuns = 1) // 3 runs, 1 earned
+            }
 
         // when
         val response = pitchingRecord.toResponse()
@@ -281,10 +289,11 @@ class PitchingRecordMapperTest {
         every { gamePlayer1.id } returns 1L
         every { gamePlayer2.id } returns 2L
 
-        val records = listOf(
-            PitchingRecord.create(gamePlayer1, isStartingPitcher = true),
-            PitchingRecord.create(gamePlayer2, isStartingPitcher = false)
-        )
+        val records =
+            listOf(
+                PitchingRecord.create(gamePlayer1, isStartingPitcher = true),
+                PitchingRecord.create(gamePlayer2, isStartingPitcher = false),
+            )
 
         // when
         val responses = records.toResponse()
@@ -309,7 +318,7 @@ class PitchingRecordMapperTest {
         val response = pitchingRecord.toResponse()
 
         // then
-        assertThat(response.id).isEqualTo(0L)  // Entity not persisted yet
+        assertThat(response.id).isEqualTo(0L) // Entity not persisted yet
         assertThat(response.gamePlayerId).isEqualTo(999L)
         assertThat(response.createdAt).isNotNull
         assertThat(response.updatedAt).isNotNull

--- a/nextup-backoffice/build.gradle.kts
+++ b/nextup-backoffice/build.gradle.kts
@@ -47,16 +47,18 @@ tasks.jacocoTestReport {
     }
 
     classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/dto/**",
-                    "**/config/**",
-                    "**/BackofficeApplication*",
-                    "**/HealthController*"
-                )
-            }
-        })
+        files(
+            classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/dto/**",
+                        "**/config/**",
+                        "**/BackofficeApplication*",
+                        "**/HealthController*",
+                    )
+                }
+            },
+        ),
     )
 }
 
@@ -70,15 +72,17 @@ tasks.jacocoTestCoverageVerification {
     }
 
     classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/dto/**",
-                    "**/config/**",
-                    "**/BackofficeApplication*",
-                    "**/HealthController*"
-                )
-            }
-        })
+        files(
+            classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/dto/**",
+                        "**/config/**",
+                        "**/BackofficeApplication*",
+                        "**/HealthController*",
+                    )
+                }
+            },
+        ),
     )
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
@@ -27,35 +27,31 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
     private val customAuthenticationEntryPoint: CustomAuthenticationEntryPoint,
-    private val customAccessDeniedHandler: CustomAccessDeniedHandler
+    private val customAccessDeniedHandler: CustomAccessDeniedHandler,
 ) {
-
     @Bean
-    fun filterChain(http: HttpSecurity): SecurityFilterChain {
-        return http
+    fun filterChain(http: HttpSecurity): SecurityFilterChain =
+        http
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .exceptionHandling {
                 it.authenticationEntryPoint(customAuthenticationEntryPoint)
                 it.accessDeniedHandler(customAccessDeniedHandler)
-            }
-            .authorizeHttpRequests { auth ->
+            }.authorizeHttpRequests { auth ->
                 auth
                     // Health check
-                    .requestMatchers("/actuator/health").permitAll()
-
+                    .requestMatchers("/actuator/health")
+                    .permitAll()
                     // Swagger/OpenAPI
                     .requestMatchers(
                         "/swagger-ui/**",
                         "/swagger-ui.html",
                         "/v3/api-docs/**",
-                        "/swagger-resources/**"
+                        "/swagger-resources/**",
                     ).permitAll()
-
                     // All other endpoints require ADMIN role
-                    .anyRequest().hasRole("ADMIN")
-            }
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+                    .anyRequest()
+                    .hasRole("ADMIN")
+            }.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
-    }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/HealthController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/HealthController.kt
@@ -7,21 +7,19 @@ import java.time.Instant
 
 @RestController
 class HealthController {
-
     @GetMapping("/health")
-    fun health(): ResponseEntity<HealthResponse> {
-        return ResponseEntity.ok(
+    fun health(): ResponseEntity<HealthResponse> =
+        ResponseEntity.ok(
             HealthResponse(
                 status = "UP",
                 service = "next-up-backoffice",
-                timestamp = Instant.now().toString()
-            )
+                timestamp = Instant.now().toString(),
+            ),
         )
-    }
 
     data class HealthResponse(
         val status: String,
         val service: String,
-        val timestamp: String
+        val timestamp: String,
     )
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/admin/OrganizationAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/admin/OrganizationAdminController.kt
@@ -18,9 +18,8 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/backoffice/organizations")
 class OrganizationAdminController(
-    private val organizationAdminService: OrganizationAdminService
+    private val organizationAdminService: OrganizationAdminService,
 ) {
-
     /**
      * 관리자를 할당합니다.
      *
@@ -34,17 +33,18 @@ class OrganizationAdminController(
     fun assignAdmin(
         @PathVariable type: String,
         @PathVariable id: Long,
-        @Valid @RequestBody request: AssignAdminRequest
+        @Valid @RequestBody request: AssignAdminRequest,
     ): ApiResponse<OrganizationAdminResponse> {
         val organizationType = OrganizationType.fromValue(type)
 
-        val admin = organizationAdminService.assignAdmin(
-            userId = request.userId,
-            organizationType = organizationType,
-            organizationId = id,
-            role = request.role,
-            assignedBy = null // TODO: 인증된 사용자 ID로 변경
-        )
+        val admin =
+            organizationAdminService.assignAdmin(
+                userId = request.userId,
+                organizationType = organizationType,
+                organizationId = id,
+                role = request.role,
+                assignedBy = null, // TODO: 인증된 사용자 ID로 변경
+            )
 
         return ApiResponse.success(OrganizationAdminResponse.from(admin))
     }
@@ -61,14 +61,14 @@ class OrganizationAdminController(
     fun removeAdmin(
         @PathVariable type: String,
         @PathVariable id: Long,
-        @PathVariable userId: Long
+        @PathVariable userId: Long,
     ): ApiResponse<Unit> {
         val organizationType = OrganizationType.fromValue(type)
 
         organizationAdminService.removeAdmin(
             userId = userId,
             organizationType = organizationType,
-            organizationId = id
+            organizationId = id,
         )
 
         return ApiResponse.success(Unit)
@@ -84,17 +84,18 @@ class OrganizationAdminController(
     @GetMapping("/{type}/{id}/admins")
     fun getAdminsByOrganization(
         @PathVariable type: String,
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<List<OrganizationAdminResponse>> {
         val organizationType = OrganizationType.fromValue(type)
 
-        val admins = organizationAdminService.getAdminsByOrganization(
-            organizationType = organizationType,
-            organizationId = id
-        )
+        val admins =
+            organizationAdminService.getAdminsByOrganization(
+                organizationType = organizationType,
+                organizationId = id,
+            )
 
         return ApiResponse.success(
-            admins.map { OrganizationAdminResponse.from(it) }
+            admins.map { OrganizationAdminResponse.from(it) },
         )
     }
 
@@ -106,12 +107,12 @@ class OrganizationAdminController(
      */
     @GetMapping("/by-user/{userId}")
     fun getOrganizationsByUser(
-        @PathVariable userId: Long
+        @PathVariable userId: Long,
     ): ApiResponse<List<OrganizationAdminResponse>> {
         val admins = organizationAdminService.getOrganizationsByUser(userId)
 
         return ApiResponse.success(
-            admins.map { OrganizationAdminResponse.from(it) }
+            admins.map { OrganizationAdminResponse.from(it) },
         )
     }
 
@@ -129,16 +130,17 @@ class OrganizationAdminController(
         @PathVariable type: String,
         @PathVariable id: Long,
         @PathVariable userId: Long,
-        @Valid @RequestBody request: ChangeRoleRequest
+        @Valid @RequestBody request: ChangeRoleRequest,
     ): ApiResponse<OrganizationAdminResponse> {
         val organizationType = OrganizationType.fromValue(type)
 
-        val admin = organizationAdminService.changeRole(
-            userId = userId,
-            organizationType = organizationType,
-            organizationId = id,
-            newRole = request.role
-        )
+        val admin =
+            organizationAdminService.changeRole(
+                userId = userId,
+                organizationType = organizationType,
+                organizationId = id,
+                newRole = request.role,
+            )
 
         return ApiResponse.success(OrganizationAdminResponse.from(admin))
     }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/association/AssociationAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/association/AssociationAdminController.kt
@@ -23,9 +23,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/backoffice/associations")
 class AssociationAdminController(
-    private val associationService: AssociationService
+    private val associationService: AssociationService,
 ) {
-
     /**
      * 모든 협회 목록을 조회합니다 (비활성화 포함).
      */
@@ -33,7 +32,7 @@ class AssociationAdminController(
     fun getAllAssociations(): ApiResponse<List<AssociationAdminResponse>> {
         val associations = associationService.getAll()
         return ApiResponse.success(
-            associations.map { AssociationAdminResponse.from(it) }
+            associations.map { AssociationAdminResponse.from(it) },
         )
     }
 
@@ -42,7 +41,7 @@ class AssociationAdminController(
      */
     @GetMapping("/{id}")
     fun getAssociation(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<AssociationAdminResponse> {
         val association = associationService.getById(id)
         return ApiResponse.success(AssociationAdminResponse.from(association))
@@ -54,16 +53,17 @@ class AssociationAdminController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun createAssociation(
-        @Valid @RequestBody request: CreateAssociationRequest
+        @Valid @RequestBody request: CreateAssociationRequest,
     ): ApiResponse<AssociationAdminResponse> {
-        val association = associationService.create(
-            name = request.name,
-            abbreviation = request.abbreviation,
-            region = request.region,
-            description = request.description,
-            logoUrl = request.logoUrl,
-            websiteUrl = request.websiteUrl
-        )
+        val association =
+            associationService.create(
+                name = request.name,
+                abbreviation = request.abbreviation,
+                region = request.region,
+                description = request.description,
+                logoUrl = request.logoUrl,
+                websiteUrl = request.websiteUrl,
+            )
         return ApiResponse.success(AssociationAdminResponse.from(association))
     }
 
@@ -73,14 +73,15 @@ class AssociationAdminController(
     @PutMapping("/{id}")
     fun updateAssociation(
         @PathVariable id: Long,
-        @Valid @RequestBody request: UpdateAssociationRequest
+        @Valid @RequestBody request: UpdateAssociationRequest,
     ): ApiResponse<AssociationAdminResponse> {
-        val association = associationService.update(
-            id = id,
-            description = request.description,
-            logoUrl = request.logoUrl,
-            websiteUrl = request.websiteUrl
-        )
+        val association =
+            associationService.update(
+                id = id,
+                description = request.description,
+                logoUrl = request.logoUrl,
+                websiteUrl = request.websiteUrl,
+            )
         return ApiResponse.success(AssociationAdminResponse.from(association))
     }
 
@@ -89,7 +90,7 @@ class AssociationAdminController(
      */
     @DeleteMapping("/{id}")
     fun deactivateAssociation(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<AssociationAdminResponse> {
         val association = associationService.deactivate(id)
         return ApiResponse.success(AssociationAdminResponse.from(association))
@@ -100,7 +101,7 @@ class AssociationAdminController(
      */
     @PostMapping("/{id}/activate")
     fun activateAssociation(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<AssociationAdminResponse> {
         val association = associationService.activate(id)
         return ApiResponse.success(AssociationAdminResponse.from(association))

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminController.kt
@@ -28,23 +28,23 @@ import java.time.LocalDate
 @RestController
 @RequestMapping("/api/backoffice/competitions")
 class CompetitionAdminController(
-    private val competitionService: CompetitionService
+    private val competitionService: CompetitionService,
 ) {
-
     /**
      * 모든 대회 목록을 조회합니다.
      */
     @GetMapping
     fun getAllCompetitions(
-        @RequestParam(required = false) status: CompetitionStatus?
+        @RequestParam(required = false) status: CompetitionStatus?,
     ): ApiResponse<List<CompetitionAdminResponse>> {
-        val competitions = if (status != null) {
-            competitionService.getByStatus(status)
-        } else {
-            competitionService.getAll()
-        }
+        val competitions =
+            if (status != null) {
+                competitionService.getByStatus(status)
+            } else {
+                competitionService.getAll()
+            }
         return ApiResponse.success(
-            competitions.map { CompetitionAdminResponse.from(it) }
+            competitions.map { CompetitionAdminResponse.from(it) },
         )
     }
 
@@ -53,7 +53,7 @@ class CompetitionAdminController(
      */
     @GetMapping("/{id}")
     fun getCompetition(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<CompetitionAdminResponse> {
         val competition = competitionService.getByIdWithLeague(id)
         return ApiResponse.success(CompetitionAdminResponse.from(competition))
@@ -64,11 +64,11 @@ class CompetitionAdminController(
      */
     @GetMapping("/by-league/{leagueId}")
     fun getCompetitionsByLeague(
-        @PathVariable leagueId: Long
+        @PathVariable leagueId: Long,
     ): ApiResponse<List<CompetitionAdminResponse>> {
         val competitions = competitionService.getByLeagueId(leagueId)
         return ApiResponse.success(
-            competitions.map { CompetitionAdminResponse.from(it) }
+            competitions.map { CompetitionAdminResponse.from(it) },
         )
     }
 
@@ -78,19 +78,20 @@ class CompetitionAdminController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun createCompetition(
-        @Valid @RequestBody request: CreateCompetitionRequest
+        @Valid @RequestBody request: CreateCompetitionRequest,
     ): ApiResponse<CompetitionAdminResponse> {
-        val competition = competitionService.create(
-            leagueId = request.leagueId,
-            name = request.name,
-            year = request.year,
-            season = request.season,
-            type = request.type,
-            startDate = request.startDate,
-            endDate = request.endDate,
-            description = request.description,
-            maxTeams = request.maxTeams
-        )
+        val competition =
+            competitionService.create(
+                leagueId = request.leagueId,
+                name = request.name,
+                year = request.year,
+                season = request.season,
+                type = request.type,
+                startDate = request.startDate,
+                endDate = request.endDate,
+                description = request.description,
+                maxTeams = request.maxTeams,
+            )
         return ApiResponse.success(CompetitionAdminResponse.from(competition))
     }
 
@@ -100,13 +101,14 @@ class CompetitionAdminController(
     @PutMapping("/{id}")
     fun updateCompetition(
         @PathVariable id: Long,
-        @Valid @RequestBody request: UpdateCompetitionRequest
+        @Valid @RequestBody request: UpdateCompetitionRequest,
     ): ApiResponse<CompetitionAdminResponse> {
-        val competition = competitionService.update(
-            id = id,
-            description = request.description,
-            endDate = request.endDate
-        )
+        val competition =
+            competitionService.update(
+                id = id,
+                description = request.description,
+                endDate = request.endDate,
+            )
         return ApiResponse.success(CompetitionAdminResponse.from(competition))
     }
 
@@ -115,7 +117,7 @@ class CompetitionAdminController(
      */
     @PostMapping("/{id}/start")
     fun startCompetition(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<CompetitionAdminResponse> {
         val competition = competitionService.start(id)
         return ApiResponse.success(CompetitionAdminResponse.from(competition))
@@ -127,7 +129,7 @@ class CompetitionAdminController(
     @PostMapping("/{id}/complete")
     fun completeCompetition(
         @PathVariable id: Long,
-        @RequestBody(required = false) endDate: LocalDate?
+        @RequestBody(required = false) endDate: LocalDate?,
     ): ApiResponse<CompetitionAdminResponse> {
         val competition = competitionService.complete(id, endDate ?: LocalDate.now())
         return ApiResponse.success(CompetitionAdminResponse.from(competition))
@@ -138,7 +140,7 @@ class CompetitionAdminController(
      */
     @DeleteMapping("/{id}")
     fun cancelCompetition(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<CompetitionAdminResponse> {
         val competition = competitionService.cancel(id)
         return ApiResponse.success(CompetitionAdminResponse.from(competition))
@@ -149,7 +151,7 @@ class CompetitionAdminController(
      */
     @PostMapping("/{id}/postpone")
     fun postponeCompetition(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<CompetitionAdminResponse> {
         val competition = competitionService.postpone(id)
         return ApiResponse.success(CompetitionAdminResponse.from(competition))

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/league/LeagueAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/league/LeagueAdminController.kt
@@ -23,9 +23,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/backoffice/leagues")
 class LeagueAdminController(
-    private val leagueService: LeagueService
+    private val leagueService: LeagueService,
 ) {
-
     /**
      * 모든 리그 목록을 조회합니다 (비활성화 포함).
      */
@@ -33,7 +32,7 @@ class LeagueAdminController(
     fun getAllLeagues(): ApiResponse<List<LeagueAdminResponse>> {
         val leagues = leagueService.getAll()
         return ApiResponse.success(
-            leagues.map { LeagueAdminResponse.from(it) }
+            leagues.map { LeagueAdminResponse.from(it) },
         )
     }
 
@@ -42,7 +41,7 @@ class LeagueAdminController(
      */
     @GetMapping("/{id}")
     fun getLeague(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<LeagueAdminResponse> {
         val league = leagueService.getById(id)
         return ApiResponse.success(LeagueAdminResponse.from(league))
@@ -54,17 +53,18 @@ class LeagueAdminController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun createLeague(
-        @Valid @RequestBody request: CreateLeagueRequest
+        @Valid @RequestBody request: CreateLeagueRequest,
     ): ApiResponse<LeagueAdminResponse> {
-        val league = leagueService.create(
-            associationId = request.associationId,
-            name = request.name,
-            abbreviation = request.abbreviation,
-            foundedYear = request.foundedYear,
-            divisionLevel = request.divisionLevel,
-            description = request.description,
-            logoUrl = request.logoUrl
-        )
+        val league =
+            leagueService.create(
+                associationId = request.associationId,
+                name = request.name,
+                abbreviation = request.abbreviation,
+                foundedYear = request.foundedYear,
+                divisionLevel = request.divisionLevel,
+                description = request.description,
+                logoUrl = request.logoUrl,
+            )
         return ApiResponse.success(LeagueAdminResponse.from(league))
     }
 
@@ -74,13 +74,14 @@ class LeagueAdminController(
     @PutMapping("/{id}")
     fun updateLeague(
         @PathVariable id: Long,
-        @Valid @RequestBody request: UpdateLeagueRequest
+        @Valid @RequestBody request: UpdateLeagueRequest,
     ): ApiResponse<LeagueAdminResponse> {
-        val league = leagueService.update(
-            id = id,
-            description = request.description,
-            logoUrl = request.logoUrl
-        )
+        val league =
+            leagueService.update(
+                id = id,
+                description = request.description,
+                logoUrl = request.logoUrl,
+            )
         return ApiResponse.success(LeagueAdminResponse.from(league))
     }
 
@@ -89,7 +90,7 @@ class LeagueAdminController(
      */
     @DeleteMapping("/{id}")
     fun deactivateLeague(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<LeagueAdminResponse> {
         val league = leagueService.deactivate(id)
         return ApiResponse.success(LeagueAdminResponse.from(league))
@@ -100,7 +101,7 @@ class LeagueAdminController(
      */
     @PostMapping("/{id}/activate")
     fun activateLeague(
-        @PathVariable id: Long
+        @PathVariable id: Long,
     ): ApiResponse<LeagueAdminResponse> {
         val league = leagueService.activate(id)
         return ApiResponse.success(LeagueAdminResponse.from(league))

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/player/PlayerTeamAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/player/PlayerTeamAdminController.kt
@@ -13,25 +13,25 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/backoffice/player-teams")
 class PlayerTeamAdminController(
-    private val playerTeamService: PlayerTeamService
+    private val playerTeamService: PlayerTeamService,
 ) {
-
     /**
      * 선수를 팀에 소속시킵니다.
      */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun registerAffiliation(
-        @Valid @RequestBody request: RegisterAffiliationRequest
+        @Valid @RequestBody request: RegisterAffiliationRequest,
     ): ApiResponse<PlayerTeamResponse> {
-        val affiliation = playerTeamService.registerAffiliation(
-            playerId = request.playerId,
-            teamId = request.teamId,
-            startDate = request.startDate,
-            position = request.position,
-            uniformNumber = request.uniformNumber,
-            contractType = request.contractType
-        )
+        val affiliation =
+            playerTeamService.registerAffiliation(
+                playerId = request.playerId,
+                teamId = request.teamId,
+                startDate = request.startDate,
+                position = request.position,
+                uniformNumber = request.uniformNumber,
+                contractType = request.contractType,
+            )
         return ApiResponse.success(PlayerTeamResponse.from(affiliation))
     }
 
@@ -41,12 +41,13 @@ class PlayerTeamAdminController(
     @PutMapping("/{id}/end")
     fun endAffiliation(
         @PathVariable id: Long,
-        @Valid @RequestBody request: EndAffiliationRequest
+        @Valid @RequestBody request: EndAffiliationRequest,
     ): ApiResponse<PlayerTeamResponse> {
-        val affiliation = playerTeamService.endAffiliation(
-            affiliationId = id,
-            endDate = request.endDate
-        )
+        val affiliation =
+            playerTeamService.endAffiliation(
+                affiliationId = id,
+                endDate = request.endDate,
+            )
         return ApiResponse.success(PlayerTeamResponse.from(affiliation))
     }
 
@@ -55,17 +56,18 @@ class PlayerTeamAdminController(
      */
     @PostMapping("/transfer")
     fun transferPlayer(
-        @Valid @RequestBody request: TransferPlayerRequest
+        @Valid @RequestBody request: TransferPlayerRequest,
     ): ApiResponse<PlayerTeamResponse> {
-        val affiliation = playerTeamService.transferPlayer(
-            playerId = request.playerId,
-            fromTeamId = request.fromTeamId,
-            toTeamId = request.toTeamId,
-            transferDate = request.transferDate,
-            newPosition = request.newPosition,
-            newUniformNumber = request.newUniformNumber,
-            newContractType = request.newContractType
-        )
+        val affiliation =
+            playerTeamService.transferPlayer(
+                playerId = request.playerId,
+                fromTeamId = request.fromTeamId,
+                toTeamId = request.toTeamId,
+                transferDate = request.transferDate,
+                newPosition = request.newPosition,
+                newUniformNumber = request.newUniformNumber,
+                newContractType = request.newContractType,
+            )
         return ApiResponse.success(PlayerTeamResponse.from(affiliation))
     }
 
@@ -75,12 +77,13 @@ class PlayerTeamAdminController(
     @PutMapping("/{id}/uniform-number")
     fun changeUniformNumber(
         @PathVariable id: Long,
-        @Valid @RequestBody request: ChangeUniformNumberRequest
+        @Valid @RequestBody request: ChangeUniformNumberRequest,
     ): ApiResponse<PlayerTeamResponse> {
-        val affiliation = playerTeamService.changeUniformNumber(
-            affiliationId = id,
-            uniformNumber = request.uniformNumber
-        )
+        val affiliation =
+            playerTeamService.changeUniformNumber(
+                affiliationId = id,
+                uniformNumber = request.uniformNumber,
+            )
         return ApiResponse.success(PlayerTeamResponse.from(affiliation))
     }
 
@@ -90,12 +93,13 @@ class PlayerTeamAdminController(
     @PutMapping("/{id}/position")
     fun changePosition(
         @PathVariable id: Long,
-        @Valid @RequestBody request: ChangePositionRequest
+        @Valid @RequestBody request: ChangePositionRequest,
     ): ApiResponse<PlayerTeamResponse> {
-        val affiliation = playerTeamService.changePosition(
-            affiliationId = id,
-            position = request.position
-        )
+        val affiliation =
+            playerTeamService.changePosition(
+                affiliationId = id,
+                position = request.position,
+            )
         return ApiResponse.success(PlayerTeamResponse.from(affiliation))
     }
 
@@ -104,11 +108,11 @@ class PlayerTeamAdminController(
      */
     @GetMapping("/player/{playerId}")
     fun getPlayerAffiliations(
-        @PathVariable playerId: Long
+        @PathVariable playerId: Long,
     ): ApiResponse<List<PlayerTeamResponse>> {
         val affiliations = playerTeamService.getActiveAffiliationsByPlayer(playerId)
         return ApiResponse.success(
-            affiliations.map { PlayerTeamResponse.from(it) }
+            affiliations.map { PlayerTeamResponse.from(it) },
         )
     }
 
@@ -117,11 +121,11 @@ class PlayerTeamAdminController(
      */
     @GetMapping("/team/{teamId}/roster")
     fun getTeamRoster(
-        @PathVariable teamId: Long
+        @PathVariable teamId: Long,
     ): ApiResponse<List<PlayerTeamResponse>> {
         val roster = playerTeamService.getTeamRoster(teamId)
         return ApiResponse.success(
-            roster.map { PlayerTeamResponse.from(it) }
+            roster.map { PlayerTeamResponse.from(it) },
         )
     }
 
@@ -130,11 +134,11 @@ class PlayerTeamAdminController(
      */
     @GetMapping("/player/{playerId}/history")
     fun getPlayerHistory(
-        @PathVariable playerId: Long
+        @PathVariable playerId: Long,
     ): ApiResponse<List<PlayerTeamResponse>> {
         val history = playerTeamService.getPlayerHistory(playerId)
         return ApiResponse.success(
-            history.map { PlayerTeamResponse.from(it) }
+            history.map { PlayerTeamResponse.from(it) },
         )
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/user/UserAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/user/UserAdminController.kt
@@ -19,22 +19,22 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/backoffice/users")
 class UserAdminController(
-    private val userService: UserService
+    private val userService: UserService,
 ) {
-
     /**
      * 모든 사용자 목록을 페이징으로 조회합니다.
      */
     @GetMapping
     fun getAllUsers(
         @PageableDefault(size = 20) pageable: Pageable,
-        @RequestParam(required = false) isActive: Boolean?
+        @RequestParam(required = false) isActive: Boolean?,
     ): ApiResponse<Page<UserListResponse>> {
-        val users = if (isActive != null) {
-            userService.getAllByStatus(isActive, pageable)
-        } else {
-            userService.getAll(pageable)
-        }
+        val users =
+            if (isActive != null) {
+                userService.getAllByStatus(isActive, pageable)
+            } else {
+                userService.getAll(pageable)
+            }
         return ApiResponse.success(users.map { UserListResponse.from(it) })
     }
 
@@ -44,7 +44,7 @@ class UserAdminController(
     @GetMapping("/search")
     fun searchUsers(
         @RequestParam keyword: String,
-        @PageableDefault(size = 20) pageable: Pageable
+        @PageableDefault(size = 20) pageable: Pageable,
     ): ApiResponse<Page<UserListResponse>> {
         val users = userService.search(keyword, pageable)
         return ApiResponse.success(users.map { UserListResponse.from(it) })
@@ -56,7 +56,7 @@ class UserAdminController(
     @GetMapping("/by-role/{role}")
     fun getUsersByRole(
         @PathVariable role: String,
-        @PageableDefault(size = 20) pageable: Pageable
+        @PageableDefault(size = 20) pageable: Pageable,
     ): ApiResponse<Page<UserListResponse>> {
         val roleEnum = Role.valueOf(role.uppercase())
         val users = userService.getAllByRole(roleEnum, pageable)
@@ -67,7 +67,9 @@ class UserAdminController(
      * 사용자 상세 정보를 조회합니다.
      */
     @GetMapping("/{id}")
-    fun getUser(@PathVariable id: Long): ApiResponse<UserAdminResponse> {
+    fun getUser(
+        @PathVariable id: Long,
+    ): ApiResponse<UserAdminResponse> {
         val user = userService.getById(id)
         return ApiResponse.success(UserAdminResponse.from(user))
     }
@@ -81,14 +83,15 @@ class UserAdminController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun createUser(
-        @Valid @RequestBody request: CreateUserRequest
+        @Valid @RequestBody request: CreateUserRequest,
     ): ApiResponse<UserAdminResponse> {
         // TODO: PasswordEncoder 적용 필요 (Issue #26)
-        val user = userService.createLocalUser(
-            email = request.email,
-            encodedPassword = request.password, // 임시: 실제로는 인코딩 필요
-            nickname = request.nickname
-        )
+        val user =
+            userService.createLocalUser(
+                email = request.email,
+                encodedPassword = request.password, // 임시: 실제로는 인코딩 필요
+                nickname = request.nickname,
+            )
 
         // 추가 역할 부여
         request.roles.forEach { roleName ->
@@ -107,13 +110,14 @@ class UserAdminController(
     @PutMapping("/{id}")
     fun updateUser(
         @PathVariable id: Long,
-        @Valid @RequestBody request: UpdateUserRequest
+        @Valid @RequestBody request: UpdateUserRequest,
     ): ApiResponse<UserAdminResponse> {
-        var user = userService.updateProfile(
-            userId = id,
-            nickname = request.nickname,
-            profileImageUrl = request.profileImageUrl
-        )
+        var user =
+            userService.updateProfile(
+                userId = id,
+                nickname = request.nickname,
+                profileImageUrl = request.profileImageUrl,
+            )
 
         // 역할 변경 처리
         request.roles?.let { newRoles ->
@@ -140,7 +144,7 @@ class UserAdminController(
     @PostMapping("/{id}/roles")
     fun addRole(
         @PathVariable id: Long,
-        @Valid @RequestBody request: RoleChangeRequest
+        @Valid @RequestBody request: RoleChangeRequest,
     ): ApiResponse<UserAdminResponse> {
         val role = Role.valueOf(request.role.uppercase())
         val user = userService.addRole(id, role)
@@ -153,7 +157,7 @@ class UserAdminController(
     @DeleteMapping("/{id}/roles/{role}")
     fun removeRole(
         @PathVariable id: Long,
-        @PathVariable role: String
+        @PathVariable role: String,
     ): ApiResponse<UserAdminResponse> {
         val roleEnum = Role.valueOf(role.uppercase())
         val user = userService.removeRole(id, roleEnum)
@@ -164,7 +168,9 @@ class UserAdminController(
      * 사용자를 비활성화합니다.
      */
     @DeleteMapping("/{id}")
-    fun deactivateUser(@PathVariable id: Long): ApiResponse<UserAdminResponse> {
+    fun deactivateUser(
+        @PathVariable id: Long,
+    ): ApiResponse<UserAdminResponse> {
         val user = userService.deactivate(id)
         return ApiResponse.success(UserAdminResponse.from(user))
     }
@@ -173,7 +179,9 @@ class UserAdminController(
      * 사용자를 활성화합니다.
      */
     @PostMapping("/{id}/activate")
-    fun activateUser(@PathVariable id: Long): ApiResponse<UserAdminResponse> {
+    fun activateUser(
+        @PathVariable id: Long,
+    ): ApiResponse<UserAdminResponse> {
         val user = userService.activate(id)
         return ApiResponse.success(UserAdminResponse.from(user))
     }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/admin/OrganizationAdminRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/admin/OrganizationAdminRequest.kt
@@ -11,9 +11,8 @@ data class AssignAdminRequest(
     @field:NotNull(message = "사용자 ID는 필수입니다")
     @field:Positive(message = "사용자 ID는 양수여야 합니다")
     val userId: Long,
-
     @field:NotNull(message = "역할은 필수입니다")
-    val role: OrganizationRole
+    val role: OrganizationRole,
 )
 
 /**
@@ -21,5 +20,5 @@ data class AssignAdminRequest(
  */
 data class ChangeRoleRequest(
     @field:NotNull(message = "역할은 필수입니다")
-    val role: OrganizationRole
+    val role: OrganizationRole,
 )

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/admin/OrganizationAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/admin/OrganizationAdminResponse.kt
@@ -23,7 +23,7 @@ data class OrganizationAdminResponse(
     val assignedBy: Long?,
     val isActive: Boolean,
     val createdAt: Instant,
-    val updatedAt: Instant
+    val updatedAt: Instant,
 ) {
     companion object {
         /**
@@ -32,8 +32,8 @@ data class OrganizationAdminResponse(
          * organizationName은 별도 조회가 필요하므로 null로 설정됩니다.
          * 필요한 경우 Service 레이어에서 추가 조회하여 설정해야 합니다.
          */
-        fun from(admin: OrganizationAdmin): OrganizationAdminResponse {
-            return OrganizationAdminResponse(
+        fun from(admin: OrganizationAdmin): OrganizationAdminResponse =
+            OrganizationAdminResponse(
                 id = admin.id,
                 userId = admin.user.id,
                 userName = admin.user.nickname,
@@ -46,15 +46,17 @@ data class OrganizationAdminResponse(
                 assignedBy = admin.assignedBy,
                 isActive = admin.isActive,
                 createdAt = admin.createdAt,
-                updatedAt = admin.updatedAt
+                updatedAt = admin.updatedAt,
             )
-        }
 
         /**
          * OrganizationAdmin Entity와 조직 이름으로부터 응답 DTO를 생성합니다.
          */
-        fun from(admin: OrganizationAdmin, organizationName: String?): OrganizationAdminResponse {
-            return OrganizationAdminResponse(
+        fun from(
+            admin: OrganizationAdmin,
+            organizationName: String?,
+        ): OrganizationAdminResponse =
+            OrganizationAdminResponse(
                 id = admin.id,
                 userId = admin.user.id,
                 userName = admin.user.nickname,
@@ -67,8 +69,7 @@ data class OrganizationAdminResponse(
                 assignedBy = admin.assignedBy,
                 isActive = admin.isActive,
                 createdAt = admin.createdAt,
-                updatedAt = admin.updatedAt
+                updatedAt = admin.updatedAt,
             )
-        }
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/association/AssociationAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/association/AssociationAdminResponse.kt
@@ -18,11 +18,11 @@ data class AssociationAdminResponse(
     val websiteUrl: String?,
     val isActive: Boolean,
     val createdAt: Instant,
-    val updatedAt: Instant
+    val updatedAt: Instant,
 ) {
     companion object {
-        fun from(association: Association): AssociationAdminResponse {
-            return AssociationAdminResponse(
+        fun from(association: Association): AssociationAdminResponse =
+            AssociationAdminResponse(
                 id = association.id,
                 name = association.name,
                 abbreviation = association.abbreviation,
@@ -32,8 +32,7 @@ data class AssociationAdminResponse(
                 websiteUrl = association.websiteUrl,
                 isActive = association.isActive,
                 createdAt = association.createdAt,
-                updatedAt = association.updatedAt
+                updatedAt = association.updatedAt,
             )
-        }
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/association/AssociationRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/association/AssociationRequest.kt
@@ -10,21 +10,16 @@ data class CreateAssociationRequest(
     @field:NotBlank(message = "협회 이름은 필수입니다")
     @field:Size(max = 100, message = "협회 이름은 100자를 초과할 수 없습니다")
     val name: String,
-
     @field:Size(max = 20, message = "약어는 20자를 초과할 수 없습니다")
     val abbreviation: String? = null,
-
     @field:Size(max = 50, message = "지역은 50자를 초과할 수 없습니다")
     val region: String? = null,
-
     @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
     val description: String? = null,
-
     @field:Size(max = 255, message = "로고 URL은 255자를 초과할 수 없습니다")
     val logoUrl: String? = null,
-
     @field:Size(max = 255, message = "웹사이트 URL은 255자를 초과할 수 없습니다")
-    val websiteUrl: String? = null
+    val websiteUrl: String? = null,
 )
 
 /**
@@ -33,10 +28,8 @@ data class CreateAssociationRequest(
 data class UpdateAssociationRequest(
     @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
     val description: String? = null,
-
     @field:Size(max = 255, message = "로고 URL은 255자를 초과할 수 없습니다")
     val logoUrl: String? = null,
-
     @field:Size(max = 255, message = "웹사이트 URL은 255자를 초과할 수 없습니다")
-    val websiteUrl: String? = null
+    val websiteUrl: String? = null,
 )

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/common/ApiResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/common/ApiResponse.kt
@@ -8,24 +8,24 @@ package com.nextup.backoffice.dto.common
 data class ApiResponse<T>(
     val success: Boolean,
     val data: T?,
-    val error: ErrorDetails?
+    val error: ErrorDetails?,
 ) {
     companion object {
-        fun <T> success(data: T): ApiResponse<T> {
-            return ApiResponse(success = true, data = data, error = null)
-        }
+        fun <T> success(data: T): ApiResponse<T> = ApiResponse(success = true, data = data, error = null)
 
-        fun <T> error(code: String, message: String): ApiResponse<T> {
-            return ApiResponse(
+        fun <T> error(
+            code: String,
+            message: String,
+        ): ApiResponse<T> =
+            ApiResponse(
                 success = false,
                 data = null,
-                error = ErrorDetails(code, message)
+                error = ErrorDetails(code, message),
             )
-        }
     }
 }
 
 data class ErrorDetails(
     val code: String,
-    val message: String
+    val message: String,
 )

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/CompetitionAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/CompetitionAdminResponse.kt
@@ -27,11 +27,11 @@ data class CompetitionAdminResponse(
     val maxTeams: Int?,
     val isActive: Boolean,
     val createdAt: Instant,
-    val updatedAt: Instant
+    val updatedAt: Instant,
 ) {
     companion object {
-        fun from(competition: Competition): CompetitionAdminResponse {
-            return CompetitionAdminResponse(
+        fun from(competition: Competition): CompetitionAdminResponse =
+            CompetitionAdminResponse(
                 id = competition.id,
                 leagueId = competition.league.id,
                 leagueName = competition.league.name,
@@ -47,8 +47,7 @@ data class CompetitionAdminResponse(
                 maxTeams = competition.maxTeams,
                 isActive = competition.isActive,
                 createdAt = competition.createdAt,
-                updatedAt = competition.updatedAt
+                updatedAt = competition.updatedAt,
             )
-        }
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/CompetitionRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/CompetitionRequest.kt
@@ -14,28 +14,20 @@ data class CreateCompetitionRequest(
     @field:NotNull(message = "리그 ID는 필수입니다")
     @field:Positive(message = "리그 ID는 양수여야 합니다")
     val leagueId: Long,
-
     @field:NotBlank(message = "대회 이름은 필수입니다")
     @field:Size(max = 100, message = "대회 이름은 100자를 초과할 수 없습니다")
     val name: String,
-
     @field:NotNull(message = "연도는 필수입니다")
     val year: Int,
-
     val season: Int = 1,
-
     @field:NotNull(message = "대회 타입은 필수입니다")
     val type: CompetitionType,
-
     @field:NotNull(message = "시작일은 필수입니다")
     val startDate: LocalDate,
-
     val endDate: LocalDate? = null,
-
     @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
     val description: String? = null,
-
-    val maxTeams: Int? = null
+    val maxTeams: Int? = null,
 )
 
 /**
@@ -44,6 +36,5 @@ data class CreateCompetitionRequest(
 data class UpdateCompetitionRequest(
     @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
     val description: String? = null,
-
-    val endDate: LocalDate? = null
+    val endDate: LocalDate? = null,
 )

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/league/LeagueAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/league/LeagueAdminResponse.kt
@@ -20,11 +20,11 @@ data class LeagueAdminResponse(
     val logoUrl: String?,
     val isActive: Boolean,
     val createdAt: Instant,
-    val updatedAt: Instant
+    val updatedAt: Instant,
 ) {
     companion object {
-        fun from(league: League): LeagueAdminResponse {
-            return LeagueAdminResponse(
+        fun from(league: League): LeagueAdminResponse =
+            LeagueAdminResponse(
                 id = league.id,
                 associationId = league.association.id,
                 associationName = league.association.name,
@@ -36,8 +36,7 @@ data class LeagueAdminResponse(
                 logoUrl = league.logoUrl,
                 isActive = league.isActive,
                 createdAt = league.createdAt,
-                updatedAt = league.updatedAt
+                updatedAt = league.updatedAt,
             )
-        }
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/league/LeagueRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/league/LeagueRequest.kt
@@ -12,24 +12,18 @@ data class CreateLeagueRequest(
     @field:NotNull(message = "협회 ID는 필수입니다")
     @field:Positive(message = "협회 ID는 양수여야 합니다")
     val associationId: Long,
-
     @field:NotBlank(message = "리그 이름은 필수입니다")
     @field:Size(max = 100, message = "리그 이름은 100자를 초과할 수 없습니다")
     val name: String,
-
     @field:Size(max = 20, message = "약어는 20자를 초과할 수 없습니다")
     val abbreviation: String? = null,
-
     @field:NotNull(message = "창단 연도는 필수입니다")
     val foundedYear: Int,
-
     val divisionLevel: Int? = null,
-
     @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
     val description: String? = null,
-
     @field:Size(max = 255, message = "로고 URL은 255자를 초과할 수 없습니다")
-    val logoUrl: String? = null
+    val logoUrl: String? = null,
 )
 
 /**
@@ -38,7 +32,6 @@ data class CreateLeagueRequest(
 data class UpdateLeagueRequest(
     @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
     val description: String? = null,
-
     @field:Size(max = 255, message = "로고 URL은 255자를 초과할 수 없습니다")
-    val logoUrl: String? = null
+    val logoUrl: String? = null,
 )

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/player/PlayerTeamRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/player/PlayerTeamRequest.kt
@@ -13,21 +13,16 @@ data class RegisterAffiliationRequest(
     @field:NotNull(message = "선수 ID는 필수입니다")
     @field:Positive(message = "선수 ID는 양수여야 합니다")
     val playerId: Long,
-
     @field:NotNull(message = "팀 ID는 필수입니다")
     @field:Positive(message = "팀 ID는 양수여야 합니다")
     val teamId: Long,
-
     @field:NotNull(message = "소속 시작일은 필수입니다")
     val startDate: LocalDate,
-
     @field:NotNull(message = "포지션은 필수입니다")
     val position: Position,
-
     val uniformNumber: Int? = null,
-
     @field:NotNull(message = "계약 유형은 필수입니다")
-    val contractType: ContractType = ContractType.REGULAR
+    val contractType: ContractType = ContractType.REGULAR,
 )
 
 /**
@@ -35,7 +30,7 @@ data class RegisterAffiliationRequest(
  */
 data class EndAffiliationRequest(
     @field:NotNull(message = "종료일은 필수입니다")
-    val endDate: LocalDate
+    val endDate: LocalDate,
 )
 
 /**
@@ -45,25 +40,19 @@ data class TransferPlayerRequest(
     @field:NotNull(message = "선수 ID는 필수입니다")
     @field:Positive(message = "선수 ID는 양수여야 합니다")
     val playerId: Long,
-
     @field:NotNull(message = "이전 팀 ID는 필수입니다")
     @field:Positive(message = "이전 팀 ID는 양수여야 합니다")
     val fromTeamId: Long,
-
     @field:NotNull(message = "새 팀 ID는 필수입니다")
     @field:Positive(message = "새 팀 ID는 양수여야 합니다")
     val toTeamId: Long,
-
     @field:NotNull(message = "이적일은 필수입니다")
     val transferDate: LocalDate,
-
     @field:NotNull(message = "새 포지션은 필수입니다")
     val newPosition: Position,
-
     val newUniformNumber: Int? = null,
-
     @field:NotNull(message = "새 계약 유형은 필수입니다")
-    val newContractType: ContractType = ContractType.REGULAR
+    val newContractType: ContractType = ContractType.REGULAR,
 )
 
 /**
@@ -72,7 +61,7 @@ data class TransferPlayerRequest(
 data class ChangeUniformNumberRequest(
     @field:NotNull(message = "등번호는 필수입니다")
     @field:Positive(message = "등번호는 양수여야 합니다")
-    val uniformNumber: Int
+    val uniformNumber: Int,
 )
 
 /**
@@ -80,5 +69,5 @@ data class ChangeUniformNumberRequest(
  */
 data class ChangePositionRequest(
     @field:NotNull(message = "포지션은 필수입니다")
-    val position: Position
+    val position: Position,
 )

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/player/PlayerTeamResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/player/PlayerTeamResponse.kt
@@ -29,11 +29,11 @@ data class PlayerTeamResponse(
     val isCurrentAffiliation: Boolean,
     val durationInDays: Long?,
     val createdAt: Instant,
-    val updatedAt: Instant
+    val updatedAt: Instant,
 ) {
     companion object {
-        fun from(history: PlayerTeamHistory): PlayerTeamResponse {
-            return PlayerTeamResponse(
+        fun from(history: PlayerTeamHistory): PlayerTeamResponse =
+            PlayerTeamResponse(
                 id = history.id,
                 playerId = history.player.id,
                 playerName = history.player.name,
@@ -50,8 +50,7 @@ data class PlayerTeamResponse(
                 isCurrentAffiliation = history.isCurrentAffiliation,
                 durationInDays = history.durationInDays,
                 createdAt = history.createdAt,
-                updatedAt = history.updatedAt
+                updatedAt = history.updatedAt,
             )
-        }
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/user/UserAdminRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/user/UserAdminRequest.kt
@@ -11,16 +11,13 @@ data class CreateUserRequest(
     @field:NotBlank(message = "이메일은 필수입니다")
     @field:Email(message = "올바른 이메일 형식이 아닙니다")
     val email: String,
-
     @field:NotBlank(message = "비밀번호는 필수입니다")
     @field:Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
     val password: String,
-
     @field:NotBlank(message = "닉네임은 필수입니다")
     @field:Size(min = 2, max = 50, message = "닉네임은 2~50자 사이여야 합니다")
     val nickname: String,
-
-    val roles: Set<String> = emptySet()
+    val roles: Set<String> = emptySet(),
 )
 
 /**
@@ -29,10 +26,8 @@ data class CreateUserRequest(
 data class UpdateUserRequest(
     @field:Size(min = 2, max = 50, message = "닉네임은 2~50자 사이여야 합니다")
     val nickname: String? = null,
-
     val profileImageUrl: String? = null,
-
-    val roles: Set<String>? = null
+    val roles: Set<String>? = null,
 )
 
 /**
@@ -40,7 +35,7 @@ data class UpdateUserRequest(
  */
 data class RoleChangeRequest(
     @field:NotBlank(message = "역할은 필수입니다")
-    val role: String
+    val role: String,
 )
 
 /**
@@ -49,5 +44,5 @@ data class RoleChangeRequest(
 data class UserSearchFilter(
     val keyword: String? = null,
     val role: String? = null,
-    val isActive: Boolean? = null
+    val isActive: Boolean? = null,
 )

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/user/UserAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/user/UserAdminResponse.kt
@@ -1,7 +1,5 @@
 package com.nextup.backoffice.dto.user
 
-import com.nextup.core.domain.user.OAuthProvider
-import com.nextup.core.domain.user.Role
 import com.nextup.core.domain.user.User
 import java.time.Instant
 
@@ -22,11 +20,11 @@ data class UserAdminResponse(
     val playerId: Long?,
     val isActive: Boolean,
     val createdAt: Instant,
-    val updatedAt: Instant
+    val updatedAt: Instant,
 ) {
     companion object {
-        fun from(user: User): UserAdminResponse {
-            return UserAdminResponse(
+        fun from(user: User): UserAdminResponse =
+            UserAdminResponse(
                 id = user.id,
                 email = user.email,
                 nickname = user.nickname,
@@ -38,9 +36,8 @@ data class UserAdminResponse(
                 playerId = user.player?.id,
                 isActive = user.isActive,
                 createdAt = user.createdAt,
-                updatedAt = user.updatedAt
+                updatedAt = user.updatedAt,
             )
-        }
     }
 }
 
@@ -53,19 +50,18 @@ data class UserListResponse(
     val nickname: String,
     val roles: Set<String>,
     val isActive: Boolean,
-    val createdAt: Instant
+    val createdAt: Instant,
 ) {
     companion object {
-        fun from(user: User): UserListResponse {
-            return UserListResponse(
+        fun from(user: User): UserListResponse =
+            UserListResponse(
                 id = user.id,
                 email = user.email,
                 nickname = user.nickname,
                 roles = user.roles.map { it.name }.toSet(),
                 isActive = user.isActive,
-                createdAt = user.createdAt
+                createdAt = user.createdAt,
             )
-        }
     }
 }
 
@@ -76,5 +72,5 @@ data class OAuthAccountResponse(
     val provider: String,
     val providerDisplayName: String,
     val email: String?,
-    val connectedAt: Instant
+    val connectedAt: Instant,
 )

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/HealthControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/HealthControllerTest.kt
@@ -11,7 +11,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("HealthController (Backoffice)")
 class HealthControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var controller: HealthController
 
@@ -23,7 +22,8 @@ class HealthControllerTest {
 
     @Test
     fun `should return health status`() {
-        mockMvc.perform(get("/health"))
+        mockMvc
+            .perform(get("/health"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value("UP"))
             .andExpect(jsonPath("$.service").value("next-up-backoffice"))

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/admin/OrganizationAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/admin/OrganizationAdminControllerTest.kt
@@ -23,7 +23,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("OrganizationAdminController")
 class OrganizationAdminControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var organizationAdminService: OrganizationAdminService
     private lateinit var controller: OrganizationAdminController
@@ -40,7 +39,6 @@ class OrganizationAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/organizations/{type}/{id}/admins")
     inner class AssignAdmin {
-
         @Test
         fun `관리자를 할당할 수 있다`() {
             // given
@@ -59,17 +57,17 @@ class OrganizationAdminControllerTest {
                     organizationType = organizationType,
                     organizationId = organizationId,
                     role = role,
-                    assignedBy = null
+                    assignedBy = null,
                 )
             } returns admin
 
             // when & then
-            mockMvc.perform(
-                post("/api/backoffice/organizations/ASSOCIATION/1/admins")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isCreated)
+            mockMvc
+                .perform(
+                    post("/api/backoffice/organizations/ASSOCIATION/1/admins")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.userId").value(userId))
                 .andExpect(jsonPath("$.data.organizationType").value("ASSOCIATION"))
@@ -83,7 +81,7 @@ class OrganizationAdminControllerTest {
                     organizationType = organizationType,
                     organizationId = organizationId,
                     role = role,
-                    assignedBy = null
+                    assignedBy = null,
                 )
             }
         }
@@ -92,7 +90,6 @@ class OrganizationAdminControllerTest {
     @Nested
     @DisplayName("DELETE /api/backoffice/organizations/{type}/{id}/admins/{userId}")
     inner class RemoveAdmin {
-
         @Test
         fun `관리자 권한을 해제할 수 있다`() {
             // given
@@ -104,22 +101,22 @@ class OrganizationAdminControllerTest {
                 organizationAdminService.removeAdmin(
                     userId = userId,
                     organizationType = organizationType,
-                    organizationId = organizationId
+                    organizationId = organizationId,
                 )
             } returns Unit
 
             // when & then
-            mockMvc.perform(
-                delete("/api/backoffice/organizations/ASSOCIATION/1/admins/$userId")
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    delete("/api/backoffice/organizations/ASSOCIATION/1/admins/$userId"),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
 
             verify(exactly = 1) {
                 organizationAdminService.removeAdmin(
                     userId = userId,
                     organizationType = organizationType,
-                    organizationId = organizationId
+                    organizationId = organizationId,
                 )
             }
         }
@@ -128,7 +125,6 @@ class OrganizationAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/organizations/{type}/{id}/admins")
     inner class GetAdminsByOrganization {
-
         @Test
         fun `특정 조직의 관리자 목록을 조회할 수 있다`() {
             // given
@@ -144,10 +140,10 @@ class OrganizationAdminControllerTest {
             } returns listOf(admin1, admin2)
 
             // when & then
-            mockMvc.perform(
-                get("/api/backoffice/organizations/ASSOCIATION/1/admins")
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    get("/api/backoffice/organizations/ASSOCIATION/1/admins"),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -161,7 +157,6 @@ class OrganizationAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/organizations/by-user/{userId}")
     inner class GetOrganizationsByUser {
-
         @Test
         fun `사용자가 관리하는 모든 조직을 조회할 수 있다`() {
             // given
@@ -173,10 +168,10 @@ class OrganizationAdminControllerTest {
             every { organizationAdminService.getOrganizationsByUser(userId) } returns listOf(admin1, admin2)
 
             // when & then
-            mockMvc.perform(
-                get("/api/backoffice/organizations/by-user/$userId")
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    get("/api/backoffice/organizations/by-user/$userId"),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -188,7 +183,6 @@ class OrganizationAdminControllerTest {
     @Nested
     @DisplayName("PUT /api/backoffice/organizations/{type}/{id}/admins/{userId}/role")
     inner class ChangeRole {
-
         @Test
         fun `관리자 역할을 변경할 수 있다`() {
             // given
@@ -206,17 +200,17 @@ class OrganizationAdminControllerTest {
                     userId = userId,
                     organizationType = organizationType,
                     organizationId = organizationId,
-                    newRole = newRole
+                    newRole = newRole,
                 )
             } returns admin
 
             // when & then
-            mockMvc.perform(
-                put("/api/backoffice/organizations/ASSOCIATION/1/admins/$userId/role")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    put("/api/backoffice/organizations/ASSOCIATION/1/admins/$userId/role")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.role").value("MANAGER"))
 
@@ -225,7 +219,7 @@ class OrganizationAdminControllerTest {
                     userId = userId,
                     organizationType = organizationType,
                     organizationId = organizationId,
-                    newRole = newRole
+                    newRole = newRole,
                 )
             }
         }
@@ -233,12 +227,16 @@ class OrganizationAdminControllerTest {
 
     // Helper methods
 
-    private fun createUser(id: Long, email: String): User {
-        val user = User.createLocalUser(
-            email = email,
-            encodedPassword = "password",
-            nickname = "Test User"
-        )
+    private fun createUser(
+        id: Long,
+        email: String,
+    ): User {
+        val user =
+            User.createLocalUser(
+                email = email,
+                encodedPassword = "password",
+                nickname = "Test User",
+            )
         setEntityId(user, id)
         return user
     }
@@ -248,19 +246,23 @@ class OrganizationAdminControllerTest {
         user: User,
         organizationType: OrganizationType,
         organizationId: Long,
-        role: OrganizationRole = OrganizationRole.ADMIN
+        role: OrganizationRole = OrganizationRole.ADMIN,
     ): OrganizationAdmin {
-        val admin = OrganizationAdmin.create(
-            user = user,
-            organizationType = organizationType,
-            organizationId = organizationId,
-            role = role
-        )
+        val admin =
+            OrganizationAdmin.create(
+                user = user,
+                organizationType = organizationType,
+                organizationId = organizationId,
+                role = role,
+            )
         setEntityId(admin, id)
         return admin
     }
 
-    private fun setEntityId(entity: Any, id: Long) {
+    private fun setEntityId(
+        entity: Any,
+        id: Long,
+    ) {
         val idField = entity::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(entity, id)

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/association/AssociationAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/association/AssociationAdminControllerTest.kt
@@ -24,7 +24,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("AssociationAdminController")
 class AssociationAdminControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var associationService: AssociationService
     private lateinit var controller: AssociationAdminController
@@ -41,18 +40,19 @@ class AssociationAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/associations")
     inner class GetAllAssociations {
-
         @Test
         fun `should return all associations including inactive`() {
             // given
-            val associations = listOf(
-                createAssociation(1L, "서울시야구협회", true),
-                createAssociation(2L, "경기도야구협회", false)
-            )
+            val associations =
+                listOf(
+                    createAssociation(1L, "서울시야구협회", true),
+                    createAssociation(2L, "경기도야구협회", false),
+                )
             every { associationService.getAll() } returns associations
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/associations"))
+            mockMvc
+                .perform(get("/api/backoffice/associations"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -68,7 +68,6 @@ class AssociationAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/associations/{id}")
     inner class GetAssociation {
-
         @Test
         fun `should return association when found`() {
             // given
@@ -76,7 +75,8 @@ class AssociationAdminControllerTest {
             every { associationService.getById(1L) } returns association
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/associations/1"))
+            mockMvc
+                .perform(get("/api/backoffice/associations/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -90,18 +90,18 @@ class AssociationAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/associations")
     inner class CreateAssociation {
-
         @Test
         fun `should create association with valid request`() {
             // given
-            val request = CreateAssociationRequest(
-                name = "서울시야구협회",
-                abbreviation = "SBA",
-                region = "서울",
-                description = "서울시 사회인 야구 협회",
-                logoUrl = "https://example.com/logo.png",
-                websiteUrl = "https://example.com"
-            )
+            val request =
+                CreateAssociationRequest(
+                    name = "서울시야구협회",
+                    abbreviation = "SBA",
+                    region = "서울",
+                    description = "서울시 사회인 야구 협회",
+                    logoUrl = "https://example.com/logo.png",
+                    websiteUrl = "https://example.com",
+                )
             val association = createAssociation(1L, "서울시야구협회", true)
 
             every {
@@ -111,17 +111,17 @@ class AssociationAdminControllerTest {
                     region = "서울",
                     description = "서울시 사회인 야구 협회",
                     logoUrl = "https://example.com/logo.png",
-                    websiteUrl = "https://example.com"
+                    websiteUrl = "https://example.com",
                 )
             } returns association
 
             // when & then
-            mockMvc.perform(
-                post("/api/backoffice/associations")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isCreated)
+            mockMvc
+                .perform(
+                    post("/api/backoffice/associations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.name").value("서울시야구협회"))
@@ -133,7 +133,7 @@ class AssociationAdminControllerTest {
                     region = "서울",
                     description = "서울시 사회인 야구 협회",
                     logoUrl = "https://example.com/logo.png",
-                    websiteUrl = "https://example.com"
+                    websiteUrl = "https://example.com",
                 )
             }
         }
@@ -142,15 +142,15 @@ class AssociationAdminControllerTest {
     @Nested
     @DisplayName("PUT /api/backoffice/associations/{id}")
     inner class UpdateAssociation {
-
         @Test
         fun `should update association with valid request`() {
             // given
-            val request = UpdateAssociationRequest(
-                description = "수정된 설명",
-                logoUrl = "https://example.com/new-logo.png",
-                websiteUrl = "https://example.com/new"
-            )
+            val request =
+                UpdateAssociationRequest(
+                    description = "수정된 설명",
+                    logoUrl = "https://example.com/new-logo.png",
+                    websiteUrl = "https://example.com/new",
+                )
             val association = createAssociation(1L, "서울시야구협회", true)
 
             every {
@@ -158,17 +158,17 @@ class AssociationAdminControllerTest {
                     id = 1L,
                     description = "수정된 설명",
                     logoUrl = "https://example.com/new-logo.png",
-                    websiteUrl = "https://example.com/new"
+                    websiteUrl = "https://example.com/new",
                 )
             } returns association
 
             // when & then
-            mockMvc.perform(
-                put("/api/backoffice/associations/1")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    put("/api/backoffice/associations/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
 
@@ -177,7 +177,7 @@ class AssociationAdminControllerTest {
                     id = 1L,
                     description = "수정된 설명",
                     logoUrl = "https://example.com/new-logo.png",
-                    websiteUrl = "https://example.com/new"
+                    websiteUrl = "https://example.com/new",
                 )
             }
         }
@@ -186,7 +186,6 @@ class AssociationAdminControllerTest {
     @Nested
     @DisplayName("DELETE /api/backoffice/associations/{id}")
     inner class DeactivateAssociation {
-
         @Test
         fun `should deactivate association`() {
             // given
@@ -194,7 +193,8 @@ class AssociationAdminControllerTest {
             every { associationService.deactivate(1L) } returns association
 
             // when & then
-            mockMvc.perform(delete("/api/backoffice/associations/1"))
+            mockMvc
+                .perform(delete("/api/backoffice/associations/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -207,7 +207,6 @@ class AssociationAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/associations/{id}/activate")
     inner class ActivateAssociation {
-
         @Test
         fun `should activate association`() {
             // given
@@ -215,7 +214,8 @@ class AssociationAdminControllerTest {
             every { associationService.activate(1L) } returns association
 
             // when & then
-            mockMvc.perform(post("/api/backoffice/associations/1/activate"))
+            mockMvc
+                .perform(post("/api/backoffice/associations/1/activate"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -225,14 +225,18 @@ class AssociationAdminControllerTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String, isActive: Boolean): Association {
-        return Association(
+    private fun createAssociation(
+        id: Long,
+        name: String,
+        isActive: Boolean,
+    ): Association =
+        Association(
             name = name,
             abbreviation = "SBA",
             region = "서울",
             description = "협회 설명",
             logoUrl = "https://example.com/logo.png",
-            websiteUrl = "https://example.com"
+            websiteUrl = "https://example.com",
         ).apply {
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
@@ -242,5 +246,4 @@ class AssociationAdminControllerTest {
                 this.deactivate()
             }
         }
-    }
 }

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminControllerTest.kt
@@ -29,7 +29,6 @@ import java.time.LocalDate
 
 @DisplayName("CompetitionAdminController")
 class CompetitionAdminControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var competitionService: CompetitionService
     private lateinit var controller: CompetitionAdminController
@@ -46,20 +45,21 @@ class CompetitionAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/competitions")
     inner class GetAllCompetitions {
-
         @Test
         fun `should return all competitions`() {
             // given
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
-            val competitions = listOf(
-                createCompetition(1L, "2025 춘계대회", league, 2025, 1),
-                createCompetition(2L, "2025 추계대회", league, 2025, 2)
-            )
+            val competitions =
+                listOf(
+                    createCompetition(1L, "2025 춘계대회", league, 2025, 1),
+                    createCompetition(2L, "2025 추계대회", league, 2025, 2),
+                )
             every { competitionService.getAll() } returns competitions
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/competitions"))
+            mockMvc
+                .perform(get("/api/backoffice/competitions"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -75,7 +75,6 @@ class CompetitionAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/competitions/{id}")
     inner class GetCompetition {
-
         @Test
         fun `should return competition when found`() {
             // given
@@ -85,7 +84,8 @@ class CompetitionAdminControllerTest {
             every { competitionService.getByIdWithLeague(1L) } returns competition
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/competitions/1"))
+            mockMvc
+                .perform(get("/api/backoffice/competitions/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -101,21 +101,21 @@ class CompetitionAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/competitions")
     inner class CreateCompetition {
-
         @Test
         fun `should create competition with valid request`() {
             // given
-            val request = CreateCompetitionRequest(
-                leagueId = 1L,
-                name = "2025 춘계대회",
-                year = 2025,
-                season = 1,
-                type = CompetitionType.LEAGUE,
-                startDate = LocalDate.of(2025, 3, 1),
-                endDate = LocalDate.of(2025, 6, 30),
-                description = "2025년 춘계 시즌",
-                maxTeams = 8
-            )
+            val request =
+                CreateCompetitionRequest(
+                    leagueId = 1L,
+                    name = "2025 춘계대회",
+                    year = 2025,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    endDate = LocalDate.of(2025, 6, 30),
+                    description = "2025년 춘계 시즌",
+                    maxTeams = 8,
+                )
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
             val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1)
@@ -130,17 +130,17 @@ class CompetitionAdminControllerTest {
                     startDate = LocalDate.of(2025, 3, 1),
                     endDate = LocalDate.of(2025, 6, 30),
                     description = "2025년 춘계 시즌",
-                    maxTeams = 8
+                    maxTeams = 8,
                 )
             } returns competition
 
             // when & then
-            mockMvc.perform(
-                post("/api/backoffice/competitions")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isCreated)
+            mockMvc
+                .perform(
+                    post("/api/backoffice/competitions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.name").value("2025 춘계대회"))
@@ -155,7 +155,7 @@ class CompetitionAdminControllerTest {
                     startDate = LocalDate.of(2025, 3, 1),
                     endDate = LocalDate.of(2025, 6, 30),
                     description = "2025년 춘계 시즌",
-                    maxTeams = 8
+                    maxTeams = 8,
                 )
             }
         }
@@ -164,14 +164,14 @@ class CompetitionAdminControllerTest {
     @Nested
     @DisplayName("PUT /api/backoffice/competitions/{id}")
     inner class UpdateCompetition {
-
         @Test
         fun `should update competition with valid request`() {
             // given
-            val request = UpdateCompetitionRequest(
-                description = "수정된 설명",
-                endDate = LocalDate.of(2025, 7, 15)
-            )
+            val request =
+                UpdateCompetitionRequest(
+                    description = "수정된 설명",
+                    endDate = LocalDate.of(2025, 7, 15),
+                )
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
             val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1)
@@ -180,17 +180,17 @@ class CompetitionAdminControllerTest {
                 competitionService.update(
                     id = 1L,
                     description = "수정된 설명",
-                    endDate = LocalDate.of(2025, 7, 15)
+                    endDate = LocalDate.of(2025, 7, 15),
                 )
             } returns competition
 
             // when & then
-            mockMvc.perform(
-                put("/api/backoffice/competitions/1")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    put("/api/backoffice/competitions/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
 
@@ -198,7 +198,7 @@ class CompetitionAdminControllerTest {
                 competitionService.update(
                     id = 1L,
                     description = "수정된 설명",
-                    endDate = LocalDate.of(2025, 7, 15)
+                    endDate = LocalDate.of(2025, 7, 15),
                 )
             }
         }
@@ -207,19 +207,20 @@ class CompetitionAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/competitions/{id}/start")
     inner class StartCompetition {
-
         @Test
         fun `should start competition`() {
             // given
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
-            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1).apply {
-                start()
-            }
+            val competition =
+                createCompetition(1L, "2025 춘계대회", league, 2025, 1).apply {
+                    start()
+                }
             every { competitionService.start(1L) } returns competition
 
             // when & then
-            mockMvc.perform(post("/api/backoffice/competitions/1/start"))
+            mockMvc
+                .perform(post("/api/backoffice/competitions/1/start"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -232,20 +233,21 @@ class CompetitionAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/competitions/{id}/complete")
     inner class CompleteCompetition {
-
         @Test
         fun `should complete competition`() {
             // given
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
-            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1).apply {
-                start()
-                complete(LocalDate.now())
-            }
+            val competition =
+                createCompetition(1L, "2025 춘계대회", league, 2025, 1).apply {
+                    start()
+                    complete(LocalDate.now())
+                }
             every { competitionService.complete(1L, any()) } returns competition
 
             // when & then
-            mockMvc.perform(post("/api/backoffice/competitions/1/complete"))
+            mockMvc
+                .perform(post("/api/backoffice/competitions/1/complete"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -255,45 +257,50 @@ class CompetitionAdminControllerTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
-        return Association(
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association =
+        Association(
             name = name,
             abbreviation = null,
             region = "서울",
             description = null,
             logoUrl = null,
-            websiteUrl = null
+            websiteUrl = null,
         ).apply {
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
-    private fun createLeague(id: Long, name: String, association: Association): League {
-        return League(
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association,
+    ): League =
+        League(
             association = association,
             name = name,
             abbreviation = null,
             foundedYear = 2020,
             divisionLevel = 1,
             description = null,
-            logoUrl = null
+            logoUrl = null,
         ).apply {
             val idField = League::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
     private fun createCompetition(
         id: Long,
         name: String,
         league: League,
         year: Int,
-        season: Int
-    ): Competition {
-        return Competition(
+        season: Int,
+    ): Competition =
+        Competition(
             league = league,
             name = name,
             year = year,
@@ -303,11 +310,10 @@ class CompetitionAdminControllerTest {
             endDate = LocalDate.of(year, 6, 30),
             status = CompetitionStatus.SCHEDULED,
             description = null,
-            maxTeams = null
+            maxTeams = null,
         ).apply {
             val idField = Competition::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 }

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/league/LeagueAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/league/LeagueAdminControllerTest.kt
@@ -25,7 +25,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("LeagueAdminController")
 class LeagueAdminControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var leagueService: LeagueService
     private lateinit var controller: LeagueAdminController
@@ -42,19 +41,20 @@ class LeagueAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/leagues")
     inner class GetAllLeagues {
-
         @Test
         fun `should return all leagues including inactive`() {
             // given
             val association = createAssociation(1L, "서울시야구협회")
-            val leagues = listOf(
-                createLeague(1L, "1부 리그", association, true),
-                createLeague(2L, "2부 리그", association, false)
-            )
+            val leagues =
+                listOf(
+                    createLeague(1L, "1부 리그", association, true),
+                    createLeague(2L, "2부 리그", association, false),
+                )
             every { leagueService.getAll() } returns leagues
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/leagues"))
+            mockMvc
+                .perform(get("/api/backoffice/leagues"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -70,7 +70,6 @@ class LeagueAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/leagues/{id}")
     inner class GetLeague {
-
         @Test
         fun `should return league when found`() {
             // given
@@ -79,7 +78,8 @@ class LeagueAdminControllerTest {
             every { leagueService.getById(1L) } returns league
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/leagues/1"))
+            mockMvc
+                .perform(get("/api/backoffice/leagues/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -94,19 +94,19 @@ class LeagueAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/leagues")
     inner class CreateLeague {
-
         @Test
         fun `should create league with valid request`() {
             // given
-            val request = CreateLeagueRequest(
-                associationId = 1L,
-                name = "1부 리그",
-                abbreviation = "1st",
-                foundedYear = 2020,
-                divisionLevel = 1,
-                description = "최상위 리그",
-                logoUrl = "https://example.com/logo.png"
-            )
+            val request =
+                CreateLeagueRequest(
+                    associationId = 1L,
+                    name = "1부 리그",
+                    abbreviation = "1st",
+                    foundedYear = 2020,
+                    divisionLevel = 1,
+                    description = "최상위 리그",
+                    logoUrl = "https://example.com/logo.png",
+                )
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association, true)
 
@@ -118,17 +118,17 @@ class LeagueAdminControllerTest {
                     foundedYear = 2020,
                     divisionLevel = 1,
                     description = "최상위 리그",
-                    logoUrl = "https://example.com/logo.png"
+                    logoUrl = "https://example.com/logo.png",
                 )
             } returns league
 
             // when & then
-            mockMvc.perform(
-                post("/api/backoffice/leagues")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isCreated)
+            mockMvc
+                .perform(
+                    post("/api/backoffice/leagues")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.name").value("1부 리그"))
@@ -141,7 +141,7 @@ class LeagueAdminControllerTest {
                     foundedYear = 2020,
                     divisionLevel = 1,
                     description = "최상위 리그",
-                    logoUrl = "https://example.com/logo.png"
+                    logoUrl = "https://example.com/logo.png",
                 )
             }
         }
@@ -150,14 +150,14 @@ class LeagueAdminControllerTest {
     @Nested
     @DisplayName("PUT /api/backoffice/leagues/{id}")
     inner class UpdateLeague {
-
         @Test
         fun `should update league with valid request`() {
             // given
-            val request = UpdateLeagueRequest(
-                description = "수정된 설명",
-                logoUrl = "https://example.com/new-logo.png"
-            )
+            val request =
+                UpdateLeagueRequest(
+                    description = "수정된 설명",
+                    logoUrl = "https://example.com/new-logo.png",
+                )
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association, true)
 
@@ -165,17 +165,17 @@ class LeagueAdminControllerTest {
                 leagueService.update(
                     id = 1L,
                     description = "수정된 설명",
-                    logoUrl = "https://example.com/new-logo.png"
+                    logoUrl = "https://example.com/new-logo.png",
                 )
             } returns league
 
             // when & then
-            mockMvc.perform(
-                put("/api/backoffice/leagues/1")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    put("/api/backoffice/leagues/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
 
@@ -183,7 +183,7 @@ class LeagueAdminControllerTest {
                 leagueService.update(
                     id = 1L,
                     description = "수정된 설명",
-                    logoUrl = "https://example.com/new-logo.png"
+                    logoUrl = "https://example.com/new-logo.png",
                 )
             }
         }
@@ -192,7 +192,6 @@ class LeagueAdminControllerTest {
     @Nested
     @DisplayName("DELETE /api/backoffice/leagues/{id}")
     inner class DeactivateLeague {
-
         @Test
         fun `should deactivate league`() {
             // given
@@ -201,7 +200,8 @@ class LeagueAdminControllerTest {
             every { leagueService.deactivate(1L) } returns league
 
             // when & then
-            mockMvc.perform(delete("/api/backoffice/leagues/1"))
+            mockMvc
+                .perform(delete("/api/backoffice/leagues/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -214,7 +214,6 @@ class LeagueAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/leagues/{id}/activate")
     inner class ActivateLeague {
-
         @Test
         fun `should activate league`() {
             // given
@@ -223,7 +222,8 @@ class LeagueAdminControllerTest {
             every { leagueService.activate(1L) } returns league
 
             // when & then
-            mockMvc.perform(post("/api/backoffice/leagues/1/activate"))
+            mockMvc
+                .perform(post("/api/backoffice/leagues/1/activate"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -233,30 +233,37 @@ class LeagueAdminControllerTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
-        return Association(
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association =
+        Association(
             name = name,
             abbreviation = null,
             region = "서울",
             description = null,
             logoUrl = null,
-            websiteUrl = null
+            websiteUrl = null,
         ).apply {
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
-    private fun createLeague(id: Long, name: String, association: Association, isActive: Boolean): League {
-        return League(
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association,
+        isActive: Boolean,
+    ): League =
+        League(
             association = association,
             name = name,
             abbreviation = null,
             foundedYear = 2020,
             divisionLevel = 1,
             description = null,
-            logoUrl = null
+            logoUrl = null,
         ).apply {
             val idField = League::class.java.getDeclaredField("id")
             idField.isAccessible = true
@@ -266,5 +273,4 @@ class LeagueAdminControllerTest {
                 this.deactivate()
             }
         }
-    }
 }

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/player/PlayerTeamAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/player/PlayerTeamAdminControllerTest.kt
@@ -24,7 +24,6 @@ import java.time.LocalDate
 
 @DisplayName("PlayerTeamAdminController")
 class PlayerTeamAdminControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var playerTeamService: PlayerTeamService
     private lateinit var controller: PlayerTeamAdminController
@@ -41,7 +40,6 @@ class PlayerTeamAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/player-teams")
     inner class RegisterAffiliation {
-
         @Test
         fun `선수 소속을 등록할 수 있다`() {
             // given
@@ -55,14 +53,15 @@ class PlayerTeamAdminControllerTest {
             val team = createTeam(teamId, "서울 타이거즈", 1L)
             val affiliation = createPlayerTeamHistory(1L, player, team)
 
-            val request = RegisterAffiliationRequest(
-                playerId = playerId,
-                teamId = teamId,
-                startDate = startDate,
-                position = position,
-                uniformNumber = uniformNumber,
-                contractType = ContractType.REGULAR
-            )
+            val request =
+                RegisterAffiliationRequest(
+                    playerId = playerId,
+                    teamId = teamId,
+                    startDate = startDate,
+                    position = position,
+                    uniformNumber = uniformNumber,
+                    contractType = ContractType.REGULAR,
+                )
 
             every {
                 playerTeamService.registerAffiliation(
@@ -71,17 +70,17 @@ class PlayerTeamAdminControllerTest {
                     startDate = startDate,
                     position = position,
                     uniformNumber = uniformNumber,
-                    contractType = ContractType.REGULAR
+                    contractType = ContractType.REGULAR,
                 )
             } returns affiliation
 
             // when & then
-            mockMvc.perform(
-                post("/api/backoffice/player-teams")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isCreated)
+            mockMvc
+                .perform(
+                    post("/api/backoffice/player-teams")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.playerId").value(playerId))
                 .andExpect(jsonPath("$.data.teamId").value(teamId))
@@ -96,7 +95,7 @@ class PlayerTeamAdminControllerTest {
                     startDate = startDate,
                     position = position,
                     uniformNumber = uniformNumber,
-                    contractType = ContractType.REGULAR
+                    contractType = ContractType.REGULAR,
                 )
             }
         }
@@ -105,7 +104,6 @@ class PlayerTeamAdminControllerTest {
     @Nested
     @DisplayName("PUT /api/backoffice/player-teams/{id}/end")
     inner class EndAffiliation {
-
         @Test
         fun `선수 소속을 종료할 수 있다`() {
             // given
@@ -113,9 +111,10 @@ class PlayerTeamAdminControllerTest {
             val endDate = LocalDate.of(2024, 12, 31)
             val player = createPlayer(1L, "홍길동")
             val team = createTeam(1L, "서울 타이거즈", 1L)
-            val affiliation = createPlayerTeamHistory(affiliationId, player, team).apply {
-                deactivate(endDate)
-            }
+            val affiliation =
+                createPlayerTeamHistory(affiliationId, player, team).apply {
+                    deactivate(endDate)
+                }
 
             val request = EndAffiliationRequest(endDate = endDate)
 
@@ -124,12 +123,12 @@ class PlayerTeamAdminControllerTest {
             } returns affiliation
 
             // when & then
-            mockMvc.perform(
-                put("/api/backoffice/player-teams/$affiliationId/end")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    put("/api/backoffice/player-teams/$affiliationId/end")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(affiliationId))
                 .andExpect(jsonPath("$.data.status").value("INACTIVE"))
@@ -143,7 +142,6 @@ class PlayerTeamAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/player-teams/transfer")
     inner class TransferPlayer {
-
         @Test
         fun `선수를 이적시킬 수 있다`() {
             // given
@@ -156,20 +154,22 @@ class PlayerTeamAdminControllerTest {
 
             val player = createPlayer(playerId, "홍길동")
             val toTeam = createTeam(toTeamId, "서울 라이온즈", 1L)
-            val newAffiliation = createPlayerTeamHistory(2L, player, toTeam).apply {
-                changePosition(newPosition)
-                changeUniformNumber(newUniformNumber)
-            }
+            val newAffiliation =
+                createPlayerTeamHistory(2L, player, toTeam).apply {
+                    changePosition(newPosition)
+                    changeUniformNumber(newUniformNumber)
+                }
 
-            val request = TransferPlayerRequest(
-                playerId = playerId,
-                fromTeamId = fromTeamId,
-                toTeamId = toTeamId,
-                transferDate = transferDate,
-                newPosition = newPosition,
-                newUniformNumber = newUniformNumber,
-                newContractType = ContractType.REGULAR
-            )
+            val request =
+                TransferPlayerRequest(
+                    playerId = playerId,
+                    fromTeamId = fromTeamId,
+                    toTeamId = toTeamId,
+                    transferDate = transferDate,
+                    newPosition = newPosition,
+                    newUniformNumber = newUniformNumber,
+                    newContractType = ContractType.REGULAR,
+                )
 
             every {
                 playerTeamService.transferPlayer(
@@ -179,17 +179,17 @@ class PlayerTeamAdminControllerTest {
                     transferDate = transferDate,
                     newPosition = newPosition,
                     newUniformNumber = newUniformNumber,
-                    newContractType = ContractType.REGULAR
+                    newContractType = ContractType.REGULAR,
                 )
             } returns newAffiliation
 
             // when & then
-            mockMvc.perform(
-                post("/api/backoffice/player-teams/transfer")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    post("/api/backoffice/player-teams/transfer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.playerId").value(playerId))
                 .andExpect(jsonPath("$.data.teamId").value(toTeamId))
@@ -204,7 +204,7 @@ class PlayerTeamAdminControllerTest {
                     transferDate = transferDate,
                     newPosition = newPosition,
                     newUniformNumber = newUniformNumber,
-                    newContractType = ContractType.REGULAR
+                    newContractType = ContractType.REGULAR,
                 )
             }
         }
@@ -213,7 +213,6 @@ class PlayerTeamAdminControllerTest {
     @Nested
     @DisplayName("PUT /api/backoffice/player-teams/{id}/uniform-number")
     inner class ChangeUniformNumber {
-
         @Test
         fun `등번호를 변경할 수 있다`() {
             // given
@@ -221,9 +220,10 @@ class PlayerTeamAdminControllerTest {
             val newUniformNumber = 99
             val player = createPlayer(1L, "홍길동")
             val team = createTeam(1L, "서울 타이거즈", 1L)
-            val affiliation = createPlayerTeamHistory(affiliationId, player, team).apply {
-                changeUniformNumber(newUniformNumber)
-            }
+            val affiliation =
+                createPlayerTeamHistory(affiliationId, player, team).apply {
+                    changeUniformNumber(newUniformNumber)
+                }
 
             val request = ChangeUniformNumberRequest(uniformNumber = newUniformNumber)
 
@@ -232,12 +232,12 @@ class PlayerTeamAdminControllerTest {
             } returns affiliation
 
             // when & then
-            mockMvc.perform(
-                put("/api/backoffice/player-teams/$affiliationId/uniform-number")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    put("/api/backoffice/player-teams/$affiliationId/uniform-number")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.uniformNumber").value(newUniformNumber))
 
@@ -250,7 +250,6 @@ class PlayerTeamAdminControllerTest {
     @Nested
     @DisplayName("PUT /api/backoffice/player-teams/{id}/position")
     inner class ChangePosition {
-
         @Test
         fun `포지션을 변경할 수 있다`() {
             // given
@@ -258,9 +257,10 @@ class PlayerTeamAdminControllerTest {
             val newPosition = Position.FIRST_BASE
             val player = createPlayer(1L, "홍길동")
             val team = createTeam(1L, "서울 타이거즈", 1L)
-            val affiliation = createPlayerTeamHistory(affiliationId, player, team).apply {
-                changePosition(newPosition)
-            }
+            val affiliation =
+                createPlayerTeamHistory(affiliationId, player, team).apply {
+                    changePosition(newPosition)
+                }
 
             val request = ChangePositionRequest(position = newPosition)
 
@@ -269,12 +269,12 @@ class PlayerTeamAdminControllerTest {
             } returns affiliation
 
             // when & then
-            mockMvc.perform(
-                put("/api/backoffice/player-teams/$affiliationId/position")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    put("/api/backoffice/player-teams/$affiliationId/position")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.position").value("FIRST_BASE"))
 
@@ -287,7 +287,6 @@ class PlayerTeamAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/player-teams/player/{playerId}")
     inner class GetPlayerAffiliations {
-
         @Test
         fun `선수의 활성 소속 목록을 조회할 수 있다`() {
             // given
@@ -295,18 +294,19 @@ class PlayerTeamAdminControllerTest {
             val player = createPlayer(playerId, "홍길동")
             val team1 = createTeam(1L, "서울 타이거즈", 1L)
             val team2 = createTeam(2L, "경기 라이온즈", 2L)
-            val affiliations = listOf(
-                createPlayerTeamHistory(1L, player, team1),
-                createPlayerTeamHistory(2L, player, team2)
-            )
+            val affiliations =
+                listOf(
+                    createPlayerTeamHistory(1L, player, team1),
+                    createPlayerTeamHistory(2L, player, team2),
+                )
 
             every { playerTeamService.getActiveAffiliationsByPlayer(playerId) } returns affiliations
 
             // when & then
-            mockMvc.perform(
-                get("/api/backoffice/player-teams/player/$playerId")
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    get("/api/backoffice/player-teams/player/$playerId"),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -320,7 +320,6 @@ class PlayerTeamAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/player-teams/team/{teamId}/roster")
     inner class GetTeamRoster {
-
         @Test
         fun `팀의 현재 로스터를 조회할 수 있다`() {
             // given
@@ -328,18 +327,19 @@ class PlayerTeamAdminControllerTest {
             val team = createTeam(teamId, "서울 타이거즈", 1L)
             val player1 = createPlayer(1L, "홍길동")
             val player2 = createPlayer(2L, "김철수")
-            val roster = listOf(
-                createPlayerTeamHistory(1L, player1, team),
-                createPlayerTeamHistory(2L, player2, team)
-            )
+            val roster =
+                listOf(
+                    createPlayerTeamHistory(1L, player1, team),
+                    createPlayerTeamHistory(2L, player2, team),
+                )
 
             every { playerTeamService.getTeamRoster(teamId) } returns roster
 
             // when & then
-            mockMvc.perform(
-                get("/api/backoffice/player-teams/team/$teamId/roster")
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    get("/api/backoffice/player-teams/team/$teamId/roster"),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -353,27 +353,27 @@ class PlayerTeamAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/player-teams/player/{playerId}/history")
     inner class GetPlayerHistory {
-
         @Test
         fun `선수의 전체 소속 이력을 조회할 수 있다`() {
             // given
             val playerId = 1L
             val player = createPlayer(playerId, "홍길동")
             val team = createTeam(1L, "서울 타이거즈", 1L)
-            val history = listOf(
-                createPlayerTeamHistory(1L, player, team),
-                createPlayerTeamHistory(2L, player, team).apply {
-                    deactivate(LocalDate.of(2024, 12, 31))
-                }
-            )
+            val history =
+                listOf(
+                    createPlayerTeamHistory(1L, player, team),
+                    createPlayerTeamHistory(2L, player, team).apply {
+                        deactivate(LocalDate.of(2024, 12, 31))
+                    },
+                )
 
             every { playerTeamService.getPlayerHistory(playerId) } returns history
 
             // when & then
-            mockMvc.perform(
-                get("/api/backoffice/player-teams/player/$playerId/history")
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    get("/api/backoffice/player-teams/player/$playerId/history"),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -386,43 +386,54 @@ class PlayerTeamAdminControllerTest {
 
     // Helper methods
 
-    private fun createPlayer(id: Long, name: String): Player {
-        val player = Player(
-            name = name,
-            primaryPosition = Position.STARTING_PITCHER
-        )
+    private fun createPlayer(
+        id: Long,
+        name: String,
+    ): Player {
+        val player =
+            Player(
+                name = name,
+                primaryPosition = Position.STARTING_PITCHER,
+            )
         setEntityId(player, id)
         return player
     }
 
-    private fun createTeam(id: Long, name: String, leagueId: Long): Team {
+    private fun createTeam(
+        id: Long,
+        name: String,
+        leagueId: Long,
+    ): Team {
         val league = createLeague(leagueId)
-        val team = Team(
-            league = league,
-            name = name,
-            city = "서울",
-            foundedYear = 2020
-        )
+        val team =
+            Team(
+                league = league,
+                name = name,
+                city = "서울",
+                foundedYear = 2020,
+            )
         setEntityId(team, id)
         return team
     }
 
     private fun createLeague(id: Long): League {
         val association = createAssociation(1L)
-        val league = League(
-            association = association,
-            name = "서울리그",
-            foundedYear = 2020
-        )
+        val league =
+            League(
+                association = association,
+                name = "서울리그",
+                foundedYear = 2020,
+            )
         setEntityId(league, id)
         return league
     }
 
     private fun createAssociation(id: Long): Association {
-        val association = Association(
-            name = "서울협회",
-            region = "서울"
-        )
+        val association =
+            Association(
+                name = "서울협회",
+                region = "서울",
+            )
         setEntityId(association, id)
         return association
     }
@@ -430,22 +441,26 @@ class PlayerTeamAdminControllerTest {
     private fun createPlayerTeamHistory(
         id: Long,
         player: Player,
-        team: Team
+        team: Team,
     ): PlayerTeamHistory {
-        val history = PlayerTeamHistory(
-            player = player,
-            team = team,
-            startDate = LocalDate.of(2024, 1, 1),
-            position = Position.STARTING_PITCHER,
-            uniformNumber = 10,
-            contractType = ContractType.REGULAR,
-            status = PlayerTeamStatus.ACTIVE
-        )
+        val history =
+            PlayerTeamHistory(
+                player = player,
+                team = team,
+                startDate = LocalDate.of(2024, 1, 1),
+                position = Position.STARTING_PITCHER,
+                uniformNumber = 10,
+                contractType = ContractType.REGULAR,
+                status = PlayerTeamStatus.ACTIVE,
+            )
         setEntityId(history, id)
         return history
     }
 
-    private fun setEntityId(entity: Any, id: Long) {
+    private fun setEntityId(
+        entity: Any,
+        id: Long,
+    ) {
         val idField = entity::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(entity, id)

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/user/UserAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/user/UserAdminControllerTest.kt
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
-import org.springframework.http.MediaType
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -29,7 +29,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("UserAdminController")
 class UserAdminControllerTest {
-
     private lateinit var mockMvc: MockMvc
     private lateinit var userService: UserService
     private lateinit var controller: UserAdminController
@@ -39,31 +38,35 @@ class UserAdminControllerTest {
     fun setUp() {
         userService = mockk()
         controller = UserAdminController(userService)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller)
-            .setCustomArgumentResolvers(PageableHandlerMethodArgumentResolver())
-            .build()
-        objectMapper = ObjectMapper().apply {
-            findAndRegisterModules()
-        }
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(PageableHandlerMethodArgumentResolver())
+                .build()
+        objectMapper =
+            ObjectMapper().apply {
+                findAndRegisterModules()
+            }
     }
 
     @Nested
     @DisplayName("GET /api/backoffice/users")
     inner class GetAllUsers {
-
         @Test
         fun `should return all users`() {
             // given
-            val users = listOf(
-                createTestUser(1L, "user1@example.com", "사용자1", true),
-                createTestUser(2L, "user2@example.com", "사용자2", false)
-            )
+            val users =
+                listOf(
+                    createTestUser(1L, "user1@example.com", "사용자1", true),
+                    createTestUser(2L, "user2@example.com", "사용자2", false),
+                )
             val pageable = PageRequest.of(0, 20)
             val page = PageImpl(users, pageable, 2)
             every { userService.getAll(any()) } returns page
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/users"))
+            mockMvc
+                .perform(get("/api/backoffice/users"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.content").isArray)
@@ -75,15 +78,17 @@ class UserAdminControllerTest {
         @Test
         fun `should filter by active status`() {
             // given
-            val users = listOf(
-                createTestUser(1L, "user1@example.com", "사용자1", true)
-            )
+            val users =
+                listOf(
+                    createTestUser(1L, "user1@example.com", "사용자1", true),
+                )
             val pageable = PageRequest.of(0, 20)
             val page = PageImpl(users, pageable, 1)
             every { userService.getAllByStatus(true, any()) } returns page
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/users").param("isActive", "true"))
+            mockMvc
+                .perform(get("/api/backoffice/users").param("isActive", "true"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.content.length()").value(1))
@@ -95,19 +100,20 @@ class UserAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/users/search")
     inner class SearchUsers {
-
         @Test
         fun `should search users by keyword`() {
             // given
-            val users = listOf(
-                createTestUser(1L, "user1@example.com", "검색결과", true)
-            )
+            val users =
+                listOf(
+                    createTestUser(1L, "user1@example.com", "검색결과", true),
+                )
             val pageable = PageRequest.of(0, 20)
             val page = PageImpl(users, pageable, 1)
             every { userService.search("검색", any()) } returns page
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/users/search").param("keyword", "검색"))
+            mockMvc
+                .perform(get("/api/backoffice/users/search").param("keyword", "검색"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.content.length()").value(1))
@@ -120,19 +126,20 @@ class UserAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/users/by-role/{role}")
     inner class GetUsersByRole {
-
         @Test
         fun `should get users by role`() {
             // given
-            val users = listOf(
-                createTestUser(1L, "admin@example.com", "관리자", true)
-            )
+            val users =
+                listOf(
+                    createTestUser(1L, "admin@example.com", "관리자", true),
+                )
             val pageable = PageRequest.of(0, 20)
             val page = PageImpl(users, pageable, 1)
             every { userService.getAllByRole(Role.ADMIN, any()) } returns page
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/users/by-role/ADMIN"))
+            mockMvc
+                .perform(get("/api/backoffice/users/by-role/ADMIN"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.content.length()").value(1))
@@ -144,7 +151,6 @@ class UserAdminControllerTest {
     @Nested
     @DisplayName("GET /api/backoffice/users/{id}")
     inner class GetUser {
-
         @Test
         fun `should return user when found`() {
             // given
@@ -152,7 +158,8 @@ class UserAdminControllerTest {
             every { userService.getById(1L) } returns user
 
             // when & then
-            mockMvc.perform(get("/api/backoffice/users/1"))
+            mockMvc
+                .perform(get("/api/backoffice/users/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -166,34 +173,34 @@ class UserAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/users")
     inner class CreateUser {
-
         @Test
         fun `should create user with valid request`() {
             // given
-            val request = CreateUserRequest(
-                email = "newuser@example.com",
-                password = "password123",
-                nickname = "새사용자",
-                roles = setOf("USER")
-            )
+            val request =
+                CreateUserRequest(
+                    email = "newuser@example.com",
+                    password = "password123",
+                    nickname = "새사용자",
+                    roles = setOf("USER"),
+                )
             val user = createTestUser(1L, "newuser@example.com", "새사용자", true)
 
             every {
                 userService.createLocalUser(
                     email = "newuser@example.com",
                     encodedPassword = "password123",
-                    nickname = "새사용자"
+                    nickname = "새사용자",
                 )
             } returns user
             every { userService.getById(1L) } returns user
 
             // when & then
-            mockMvc.perform(
-                post("/api/backoffice/users")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isCreated)
+            mockMvc
+                .perform(
+                    post("/api/backoffice/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.email").value("newuser@example.com"))
@@ -202,7 +209,7 @@ class UserAdminControllerTest {
                 userService.createLocalUser(
                     email = "newuser@example.com",
                     encodedPassword = "password123",
-                    nickname = "새사용자"
+                    nickname = "새사용자",
                 )
             }
         }
@@ -210,31 +217,32 @@ class UserAdminControllerTest {
         @Test
         fun `should create user with admin role`() {
             // given
-            val request = CreateUserRequest(
-                email = "admin@example.com",
-                password = "password123",
-                nickname = "관리자",
-                roles = setOf("USER", "ADMIN")
-            )
+            val request =
+                CreateUserRequest(
+                    email = "admin@example.com",
+                    password = "password123",
+                    nickname = "관리자",
+                    roles = setOf("USER", "ADMIN"),
+                )
             val user = createTestUser(1L, "admin@example.com", "관리자", true)
 
             every {
                 userService.createLocalUser(
                     email = "admin@example.com",
                     encodedPassword = "password123",
-                    nickname = "관리자"
+                    nickname = "관리자",
                 )
             } returns user
             every { userService.addRole(1L, Role.ADMIN) } returns user
             every { userService.getById(1L) } returns user
 
             // when & then
-            mockMvc.perform(
-                post("/api/backoffice/users")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isCreated)
+            mockMvc
+                .perform(
+                    post("/api/backoffice/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
                 .andExpect(jsonPath("$.success").value(true))
 
             verify(exactly = 1) { userService.addRole(1L, Role.ADMIN) }
@@ -244,32 +252,32 @@ class UserAdminControllerTest {
     @Nested
     @DisplayName("PUT /api/backoffice/users/{id}")
     inner class UpdateUser {
-
         @Test
         fun `should update user with valid request`() {
             // given
-            val request = UpdateUserRequest(
-                nickname = "수정된닉네임",
-                profileImageUrl = "https://example.com/image.jpg"
-            )
+            val request =
+                UpdateUserRequest(
+                    nickname = "수정된닉네임",
+                    profileImageUrl = "https://example.com/image.jpg",
+                )
             val user = createTestUser(1L, "user@example.com", "수정된닉네임", true)
 
             every {
                 userService.updateProfile(
                     userId = 1L,
                     nickname = "수정된닉네임",
-                    profileImageUrl = "https://example.com/image.jpg"
+                    profileImageUrl = "https://example.com/image.jpg",
                 )
             } returns user
             every { userService.getById(1L) } returns user
 
             // when & then
-            mockMvc.perform(
-                put("/api/backoffice/users/1")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    put("/api/backoffice/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
 
@@ -277,7 +285,7 @@ class UserAdminControllerTest {
                 userService.updateProfile(
                     userId = 1L,
                     nickname = "수정된닉네임",
-                    profileImageUrl = "https://example.com/image.jpg"
+                    profileImageUrl = "https://example.com/image.jpg",
                 )
             }
         }
@@ -285,17 +293,18 @@ class UserAdminControllerTest {
         @Test
         fun `should update user with role changes`() {
             // given
-            val request = UpdateUserRequest(
-                nickname = "수정된닉네임",
-                roles = setOf("USER", "ADMIN")
-            )
+            val request =
+                UpdateUserRequest(
+                    nickname = "수정된닉네임",
+                    roles = setOf("USER", "ADMIN"),
+                )
             val userWithRoles = createTestUserWithRoles(1L, "user@example.com", "수정된닉네임", setOf(Role.USER, Role.SCORER))
 
             every {
                 userService.updateProfile(
                     userId = 1L,
                     nickname = "수정된닉네임",
-                    profileImageUrl = null
+                    profileImageUrl = null,
                 )
             } returns userWithRoles
             every { userService.removeRole(1L, Role.SCORER) } returns userWithRoles
@@ -303,12 +312,12 @@ class UserAdminControllerTest {
             every { userService.getById(1L) } returns userWithRoles
 
             // when & then
-            mockMvc.perform(
-                put("/api/backoffice/users/1")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    put("/api/backoffice/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
 
             verify(exactly = 1) { userService.removeRole(1L, Role.SCORER) }
@@ -319,7 +328,6 @@ class UserAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/users/{id}/roles")
     inner class AddRole {
-
         @Test
         fun `should add role to user`() {
             // given
@@ -329,12 +337,12 @@ class UserAdminControllerTest {
             every { userService.addRole(1L, Role.ADMIN) } returns user
 
             // when & then
-            mockMvc.perform(
-                post("/api/backoffice/users/1/roles")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isOk)
+            mockMvc
+                .perform(
+                    post("/api/backoffice/users/1/roles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
 
@@ -345,7 +353,6 @@ class UserAdminControllerTest {
     @Nested
     @DisplayName("DELETE /api/backoffice/users/{id}/roles/{role}")
     inner class RemoveRole {
-
         @Test
         fun `should remove role from user`() {
             // given
@@ -353,7 +360,8 @@ class UserAdminControllerTest {
             every { userService.removeRole(1L, Role.ADMIN) } returns user
 
             // when & then
-            mockMvc.perform(delete("/api/backoffice/users/1/roles/ADMIN"))
+            mockMvc
+                .perform(delete("/api/backoffice/users/1/roles/ADMIN"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -365,7 +373,6 @@ class UserAdminControllerTest {
     @Nested
     @DisplayName("DELETE /api/backoffice/users/{id}")
     inner class DeactivateUser {
-
         @Test
         fun `should deactivate user`() {
             // given
@@ -373,7 +380,8 @@ class UserAdminControllerTest {
             every { userService.deactivate(1L) } returns user
 
             // when & then
-            mockMvc.perform(delete("/api/backoffice/users/1"))
+            mockMvc
+                .perform(delete("/api/backoffice/users/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -386,7 +394,6 @@ class UserAdminControllerTest {
     @Nested
     @DisplayName("POST /api/backoffice/users/{id}/activate")
     inner class ActivateUser {
-
         @Test
         fun `should activate user`() {
             // given
@@ -394,7 +401,8 @@ class UserAdminControllerTest {
             every { userService.activate(1L) } returns user
 
             // when & then
-            mockMvc.perform(post("/api/backoffice/users/1/activate"))
+            mockMvc
+                .perform(post("/api/backoffice/users/1/activate"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -404,12 +412,18 @@ class UserAdminControllerTest {
         }
     }
 
-    private fun createTestUser(id: Long, email: String, nickname: String, isActive: Boolean): User {
-        val user = User.createLocalUser(
-            email = email,
-            encodedPassword = "encoded",
-            nickname = nickname
-        )
+    private fun createTestUser(
+        id: Long,
+        email: String,
+        nickname: String,
+        isActive: Boolean,
+    ): User {
+        val user =
+            User.createLocalUser(
+                email = email,
+                encodedPassword = "encoded",
+                nickname = nickname,
+            )
         val idField = User::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(user, id)
@@ -421,12 +435,18 @@ class UserAdminControllerTest {
         return user
     }
 
-    private fun createTestUserWithRoles(id: Long, email: String, nickname: String, roles: Set<Role>): User {
-        val user = User.createLocalUser(
-            email = email,
-            encodedPassword = "encoded",
-            nickname = nickname
-        )
+    private fun createTestUserWithRoles(
+        id: Long,
+        email: String,
+        nickname: String,
+        roles: Set<Role>,
+    ): User {
+        val user =
+            User.createLocalUser(
+                email = email,
+                encodedPassword = "encoded",
+                nickname = nickname,
+            )
         val idField = User::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(user, id)

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/AssociationExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/AssociationExceptions.kt
@@ -3,17 +3,19 @@ package com.nextup.common.exception
 /**
  * 협회를 찾을 수 없을 때 발생하는 예외
  */
-class AssociationNotFoundException(associationId: Long) :
-    NotFoundException(
+class AssociationNotFoundException(
+    associationId: Long,
+) : NotFoundException(
         "ASSOCIATION_NOT_FOUND",
-        "Association not found: $associationId"
+        "Association not found: $associationId",
     )
 
 /**
  * 협회 이름이 중복될 때 발생하는 예외
  */
-class AssociationNameDuplicateException(name: String) :
-    BusinessException(
+class AssociationNameDuplicateException(
+    name: String,
+) : BusinessException(
         "ASSOCIATION_NAME_DUPLICATE",
-        "Association name already exists: $name"
+        "Association name already exists: $name",
     )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/AuthExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/AuthExceptions.kt
@@ -5,85 +5,85 @@ package com.nextup.common.exception
  */
 open class AuthenticationException(
     code: String,
-    message: String
+    message: String,
 ) : BusinessException(code, message)
 
 /**
  * 유효하지 않은 토큰일 때 발생하는 예외
  */
 class InvalidTokenException(
-    message: String = "Invalid token"
+    message: String = "Invalid token",
 ) : AuthenticationException(
-    "INVALID_TOKEN",
-    message
-)
+        "INVALID_TOKEN",
+        message,
+    )
 
 /**
  * 토큰이 만료되었을 때 발생하는 예외
  */
 class TokenExpiredException(
-    message: String = "Token has expired"
+    message: String = "Token has expired",
 ) : AuthenticationException(
-    "TOKEN_EXPIRED",
-    message
-)
+        "TOKEN_EXPIRED",
+        message,
+    )
 
 /**
  * Refresh Token을 찾을 수 없을 때 발생하는 예외
  */
 class RefreshTokenNotFoundException(
-    message: String = "Refresh token not found"
+    message: String = "Refresh token not found",
 ) : NotFoundException(
-    "REFRESH_TOKEN_NOT_FOUND",
-    message
-)
+        "REFRESH_TOKEN_NOT_FOUND",
+        message,
+    )
 
 /**
  * 잘못된 인증 정보일 때 발생하는 예외
  */
 class InvalidCredentialsException(
-    message: String = "Invalid email or password"
+    message: String = "Invalid email or password",
 ) : AuthenticationException(
-    "INVALID_CREDENTIALS",
-    message
-)
+        "INVALID_CREDENTIALS",
+        message,
+    )
 
 /**
  * Refresh Token이 만료되었을 때 발생하는 예외
  */
 class RefreshTokenExpiredException(
-    message: String = "Refresh token has expired"
+    message: String = "Refresh token has expired",
 ) : AuthenticationException(
-    "REFRESH_TOKEN_EXPIRED",
-    message
-)
+        "REFRESH_TOKEN_EXPIRED",
+        message,
+    )
 
 /**
  * Refresh Token이 폐기되었을 때 발생하는 예외
  */
 class RefreshTokenRevokedException(
-    message: String = "Refresh token has been revoked"
+    message: String = "Refresh token has been revoked",
 ) : AuthenticationException(
-    "REFRESH_TOKEN_REVOKED",
-    message
-)
+        "REFRESH_TOKEN_REVOKED",
+        message,
+    )
 
 /**
  * 지원하지 않는 OAuth2 Provider일 때 발생하는 예외
  */
 class UnsupportedOAuth2ProviderException(
-    provider: String
+    provider: String,
 ) : AuthenticationException(
-    "UNSUPPORTED_OAUTH2_PROVIDER",
-    "Unsupported OAuth2 provider: $provider"
-)
+        "UNSUPPORTED_OAUTH2_PROVIDER",
+        "Unsupported OAuth2 provider: $provider",
+    )
 
 /**
  * OAuth2 인증 처리 중 오류가 발생했을 때 발생하는 예외
  */
 class OAuth2AuthenticationProcessingException(
-    message: String
+    message: String,
 ) : AuthenticationException(
-    "OAUTH2_PROCESSING_ERROR",
-    message
-)
+        "OAUTH2_PROCESSING_ERROR",
+        message,
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/BusinessException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/BusinessException.kt
@@ -23,3 +23,11 @@ open class InvalidStateException(
     code: String,
     message: String
 ) : BusinessException(code, message)
+
+/**
+ * 유효하지 않은 입력일 때 발생하는 예외
+ */
+open class InvalidInputException(
+    code: String,
+    message: String
+) : BusinessException(code, message)

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/BusinessException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/BusinessException.kt
@@ -5,7 +5,7 @@ package com.nextup.common.exception
  */
 open class BusinessException(
     val code: String,
-    override val message: String
+    override val message: String,
 ) : RuntimeException(message)
 
 /**
@@ -13,7 +13,7 @@ open class BusinessException(
  */
 open class NotFoundException(
     code: String,
-    message: String
+    message: String,
 ) : BusinessException(code, message)
 
 /**
@@ -21,7 +21,7 @@ open class NotFoundException(
  */
 open class InvalidStateException(
     code: String,
-    message: String
+    message: String,
 ) : BusinessException(code, message)
 
 /**
@@ -29,5 +29,5 @@ open class InvalidStateException(
  */
 open class InvalidInputException(
     code: String,
-    message: String
+    message: String,
 ) : BusinessException(code, message)

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/CompetitionExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/CompetitionExceptions.kt
@@ -3,17 +3,19 @@ package com.nextup.common.exception
 /**
  * 대회를 찾을 수 없을 때 발생하는 예외
  */
-class CompetitionNotFoundException(competitionId: Long) :
-    NotFoundException(
+class CompetitionNotFoundException(
+    competitionId: Long,
+) : NotFoundException(
         "COMPETITION_NOT_FOUND",
-        "Competition not found: $competitionId"
+        "Competition not found: $competitionId",
     )
 
 /**
  * 대회 상태가 유효하지 않을 때 발생하는 예외
  */
-class InvalidCompetitionStateException(message: String) :
-    BusinessException(
+class InvalidCompetitionStateException(
+    message: String,
+) : BusinessException(
         "INVALID_COMPETITION_STATE",
-        message
+        message,
     )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/LeagueExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/LeagueExceptions.kt
@@ -3,17 +3,20 @@ package com.nextup.common.exception
 /**
  * 리그를 찾을 수 없을 때 발생하는 예외
  */
-class LeagueNotFoundException(leagueId: Long) :
-    NotFoundException(
+class LeagueNotFoundException(
+    leagueId: Long,
+) : NotFoundException(
         "LEAGUE_NOT_FOUND",
-        "League not found: $leagueId"
+        "League not found: $leagueId",
     )
 
 /**
  * 리그 이름이 해당 협회 내에서 중복될 때 발생하는 예외
  */
-class LeagueNameDuplicateException(associationId: Long, name: String) :
-    BusinessException(
+class LeagueNameDuplicateException(
+    associationId: Long,
+    name: String,
+) : BusinessException(
         "LEAGUE_NAME_DUPLICATE",
-        "League name already exists in association $associationId: $name"
+        "League name already exists in association $associationId: $name",
     )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/OrganizationAdminExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/OrganizationAdminExceptions.kt
@@ -6,19 +6,20 @@ package com.nextup.common.exception
 class OrganizationAdminNotFoundException(
     organizationType: String,
     organizationId: Long,
-    userId: Long
+    userId: Long,
 ) : NotFoundException(
-    "ORGANIZATION_ADMIN_NOT_FOUND",
-    "Organization admin not found: type=$organizationType, orgId=$organizationId, userId=$userId"
-)
+        "ORGANIZATION_ADMIN_NOT_FOUND",
+        "Organization admin not found: type=$organizationType, orgId=$organizationId, userId=$userId",
+    )
 
 /**
  * 조직 관리자 ID로 찾을 수 없을 때 발생하는 예외
  */
-class OrganizationAdminNotFoundByIdException(adminId: Long) :
-    NotFoundException(
+class OrganizationAdminNotFoundByIdException(
+    adminId: Long,
+) : NotFoundException(
         "ORGANIZATION_ADMIN_NOT_FOUND",
-        "Organization admin not found: $adminId"
+        "Organization admin not found: $adminId",
     )
 
 /**
@@ -27,30 +28,31 @@ class OrganizationAdminNotFoundByIdException(adminId: Long) :
 class OrganizationAdminAlreadyExistsException(
     organizationType: String,
     organizationId: Long,
-    userId: Long
+    userId: Long,
 ) : BusinessException(
-    "ORGANIZATION_ADMIN_ALREADY_EXISTS",
-    "Organization admin already exists: type=$organizationType, orgId=$organizationId, userId=$userId"
-)
+        "ORGANIZATION_ADMIN_ALREADY_EXISTS",
+        "Organization admin already exists: type=$organizationType, orgId=$organizationId, userId=$userId",
+    )
 
 /**
  * 조직을 찾을 수 없을 때 발생하는 예외
  */
 class OrganizationNotFoundException(
     organizationType: String,
-    organizationId: Long
+    organizationId: Long,
 ) : NotFoundException(
-    "ORGANIZATION_NOT_FOUND",
-    "Organization not found: type=$organizationType, id=$organizationId"
-)
+        "ORGANIZATION_NOT_FOUND",
+        "Organization not found: type=$organizationType, id=$organizationId",
+    )
 
 /**
  * 유효하지 않은 조직 유형일 때 발생하는 예외
  */
-class InvalidOrganizationTypeException(value: String) :
-    BusinessException(
+class InvalidOrganizationTypeException(
+    value: String,
+) : BusinessException(
         "INVALID_ORGANIZATION_TYPE",
-        "Invalid organization type: $value"
+        "Invalid organization type: $value",
     )
 
 /**
@@ -58,11 +60,11 @@ class InvalidOrganizationTypeException(value: String) :
  */
 class UnauthorizedOrganizationAccessException(
     organizationType: String,
-    organizationId: Long
+    organizationId: Long,
 ) : BusinessException(
-    "UNAUTHORIZED_ORGANIZATION_ACCESS",
-    "Unauthorized access to organization: type=$organizationType, id=$organizationId"
-)
+        "UNAUTHORIZED_ORGANIZATION_ACCESS",
+        "Unauthorized access to organization: type=$organizationType, id=$organizationId",
+    )
 
 /**
  * 같은 리그 내 여러 팀의 관리자가 될 수 없을 때 발생하는 예외
@@ -70,28 +72,29 @@ class UnauthorizedOrganizationAccessException(
 class SameLeagueConflictException(
     leagueId: Long,
     existingTeamId: Long,
-    newTeamId: Long
+    newTeamId: Long,
 ) : BusinessException(
-    "SAME_LEAGUE_CONFLICT",
-    "Cannot manage multiple teams in the same league: leagueId=$leagueId, existingTeamId=$existingTeamId, newTeamId=$newTeamId"
-)
+        "SAME_LEAGUE_CONFLICT",
+        "Cannot manage multiple teams in the same league: leagueId=$leagueId, existingTeamId=$existingTeamId, newTeamId=$newTeamId",
+    )
 
 /**
  * 관리자 역할 수준이 부족할 때 발생하는 예외
  */
 class InsufficientRoleLevelException(
     requiredRole: String,
-    currentRole: String
+    currentRole: String,
 ) : BusinessException(
-    "INSUFFICIENT_ROLE_LEVEL",
-    "Insufficient role level: required=$requiredRole, current=$currentRole"
-)
+        "INSUFFICIENT_ROLE_LEVEL",
+        "Insufficient role level: required=$requiredRole, current=$currentRole",
+    )
 
 /**
  * 비활성화된 관리자일 때 발생하는 예외
  */
-class OrganizationAdminDeactivatedException(adminId: Long) :
-    InvalidStateException(
+class OrganizationAdminDeactivatedException(
+    adminId: Long,
+) : InvalidStateException(
         "ORGANIZATION_ADMIN_DEACTIVATED",
-        "Organization admin is deactivated: $adminId"
+        "Organization admin is deactivated: $adminId",
     )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/PlayerTeamExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/PlayerTeamExceptions.kt
@@ -3,44 +3,51 @@ package com.nextup.common.exception
 /**
  * 선수 소속 이력을 찾을 수 없을 때 발생하는 예외
  */
-class PlayerTeamHistoryNotFoundException(id: Long) :
-    NotFoundException(
+class PlayerTeamHistoryNotFoundException(
+    id: Long,
+) : NotFoundException(
         "PLAYER_TEAM_HISTORY_NOT_FOUND",
-        "Player team history not found: $id"
+        "Player team history not found: $id",
     )
 
 /**
  * 선수가 해당 팀에 소속되어 있지 않을 때 발생하는 예외
  */
-class PlayerNotInTeamException(playerId: Long, teamId: Long) :
-    NotFoundException(
+class PlayerNotInTeamException(
+    playerId: Long,
+    teamId: Long,
+) : NotFoundException(
         "PLAYER_NOT_IN_TEAM",
-        "Player $playerId is not affiliated with team $teamId"
+        "Player $playerId is not affiliated with team $teamId",
     )
 
 /**
  * 선수가 이미 해당 리그에 소속되어 있을 때 발생하는 예외
  */
-class PlayerAlreadyInLeagueException(playerId: Long, leagueId: Long) :
-    BusinessException(
+class PlayerAlreadyInLeagueException(
+    playerId: Long,
+    leagueId: Long,
+) : BusinessException(
         "PLAYER_ALREADY_IN_LEAGUE",
-        "Player $playerId is already active in league $leagueId"
+        "Player $playerId is already active in league $leagueId",
     )
 
 /**
  * 유효하지 않은 선수 소속 상태일 때 발생하는 예외
  */
-class InvalidPlayerTeamStatusException(message: String) :
-    InvalidStateException(
+class InvalidPlayerTeamStatusException(
+    message: String,
+) : InvalidStateException(
         "INVALID_PLAYER_TEAM_STATUS",
-        message
+        message,
     )
 
 /**
  * 선수 이적이 불가능할 때 발생하는 예외
  */
-class PlayerTransferNotAllowedException(message: String) :
-    BusinessException(
+class PlayerTransferNotAllowedException(
+    message: String,
+) : BusinessException(
         "PLAYER_TRANSFER_NOT_ALLOWED",
-        message
+        message,
     )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
@@ -3,47 +3,56 @@ package com.nextup.common.exception
 /**
  * 타격 기록을 찾을 수 없을 때 발생하는 예외
  */
-class BattingRecordNotFoundException(gamePlayerId: Long) :
-    NotFoundException("BATTING_RECORD_NOT_FOUND", "Batting record not found for GamePlayer: $gamePlayerId")
+class BattingRecordNotFoundException(
+    gamePlayerId: Long,
+) : NotFoundException("BATTING_RECORD_NOT_FOUND", "Batting record not found for GamePlayer: $gamePlayerId")
 
 /**
  * 투수 기록을 찾을 수 없을 때 발생하는 예외
  */
-class PitchingRecordNotFoundException(gamePlayerId: Long) :
-    NotFoundException("PITCHING_RECORD_NOT_FOUND", "Pitching record not found for GamePlayer: $gamePlayerId")
+class PitchingRecordNotFoundException(
+    gamePlayerId: Long,
+) : NotFoundException("PITCHING_RECORD_NOT_FOUND", "Pitching record not found for GamePlayer: $gamePlayerId")
 
 /**
  * 경기 출전 선수를 찾을 수 없을 때 발생하는 예외
  */
-class GamePlayerNotFoundException(id: Long) :
-    NotFoundException("GAME_PLAYER_NOT_FOUND", "GamePlayer not found: $id")
+class GamePlayerNotFoundException(
+    id: Long,
+) : NotFoundException("GAME_PLAYER_NOT_FOUND", "GamePlayer not found: $id")
 
 /**
  * 경기 출전 선수를 게임과 선수 ID로 찾을 수 없을 때 발생하는 예외
  */
-class GamePlayerNotFoundByGameAndPlayerException(gameId: Long, playerId: Long) :
-    NotFoundException(
+class GamePlayerNotFoundByGameAndPlayerException(
+    gameId: Long,
+    playerId: Long,
+) : NotFoundException(
         "GAME_PLAYER_NOT_FOUND",
-        "GamePlayer not found for Game: $gameId and Player: $playerId"
+        "GamePlayer not found for Game: $gameId and Player: $playerId",
     )
 
 /**
  * 이미 기록이 존재할 때 발생하는 예외
  */
-class RecordAlreadyExistsException(gamePlayerId: Long, recordType: String) :
-    InvalidStateException(
+class RecordAlreadyExistsException(
+    gamePlayerId: Long,
+    recordType: String,
+) : InvalidStateException(
         "RECORD_ALREADY_EXISTS",
-        "$recordType record already exists for GamePlayer: $gamePlayerId"
+        "$recordType record already exists for GamePlayer: $gamePlayerId",
     )
 
 /**
  * 경기를 찾을 수 없을 때 발생하는 예외
  */
-class GameNotFoundException(id: Long) :
-    NotFoundException("GAME_NOT_FOUND", "Game not found: $id")
+class GameNotFoundException(
+    id: Long,
+) : NotFoundException("GAME_NOT_FOUND", "Game not found: $id")
 
 /**
  * 잘못된 경기 상태일 때 발생하는 예외
  */
-class InvalidGameStateException(message: String) :
-    InvalidStateException("INVALID_GAME_STATE", message)
+class InvalidGameStateException(
+    message: String,
+) : InvalidStateException("INVALID_GAME_STATE", message)

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
@@ -35,3 +35,15 @@ class RecordAlreadyExistsException(gamePlayerId: Long, recordType: String) :
         "RECORD_ALREADY_EXISTS",
         "$recordType record already exists for GamePlayer: $gamePlayerId"
     )
+
+/**
+ * 경기를 찾을 수 없을 때 발생하는 예외
+ */
+class GameNotFoundException(id: Long) :
+    NotFoundException("GAME_NOT_FOUND", "Game not found: $id")
+
+/**
+ * 잘못된 경기 상태일 때 발생하는 예외
+ */
+class InvalidGameStateException(message: String) :
+    InvalidStateException("INVALID_GAME_STATE", message)

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/StatsExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/StatsExceptions.kt
@@ -3,50 +3,58 @@ package com.nextup.common.exception
 /**
  * 시즌 타격 통계를 찾을 수 없을 때 발생하는 예외
  */
-class SeasonBattingStatsNotFoundException(playerId: Long, year: Int) :
-    NotFoundException(
+class SeasonBattingStatsNotFoundException(
+    playerId: Long,
+    year: Int,
+) : NotFoundException(
         "SEASON_BATTING_STATS_NOT_FOUND",
-        "Season batting stats not found for Player: $playerId, Year: $year"
+        "Season batting stats not found for Player: $playerId, Year: $year",
     )
 
 /**
  * 시즌 투수 통계를 찾을 수 없을 때 발생하는 예외
  */
-class SeasonPitchingStatsNotFoundException(playerId: Long, year: Int) :
-    NotFoundException(
+class SeasonPitchingStatsNotFoundException(
+    playerId: Long,
+    year: Int,
+) : NotFoundException(
         "SEASON_PITCHING_STATS_NOT_FOUND",
-        "Season pitching stats not found for Player: $playerId, Year: $year"
+        "Season pitching stats not found for Player: $playerId, Year: $year",
     )
 
 /**
  * 통산 타격 통계를 찾을 수 없을 때 발생하는 예외
  */
-class CareerBattingStatsNotFoundException(playerId: Long) :
-    NotFoundException(
+class CareerBattingStatsNotFoundException(
+    playerId: Long,
+) : NotFoundException(
         "CAREER_BATTING_STATS_NOT_FOUND",
-        "Career batting stats not found for Player: $playerId"
+        "Career batting stats not found for Player: $playerId",
     )
 
 /**
  * 통산 투수 통계를 찾을 수 없을 때 발생하는 예외
  */
-class CareerPitchingStatsNotFoundException(playerId: Long) :
-    NotFoundException(
+class CareerPitchingStatsNotFoundException(
+    playerId: Long,
+) : NotFoundException(
         "CAREER_PITCHING_STATS_NOT_FOUND",
-        "Career pitching stats not found for Player: $playerId"
+        "Career pitching stats not found for Player: $playerId",
     )
 
 /**
  * 선수를 찾을 수 없을 때 발생하는 예외
  */
-class PlayerNotFoundException(playerId: Long) :
-    NotFoundException(
+class PlayerNotFoundException(
+    playerId: Long,
+) : NotFoundException(
         "PLAYER_NOT_FOUND",
-        "Player not found: $playerId"
+        "Player not found: $playerId",
     )
 
 /**
  * 통계 유효성 검증 실패 시 발생하는 예외
  */
-class StatsValidationException(message: String) :
-    InvalidStateException("STATS_VALIDATION_ERROR", message)
+class StatsValidationException(
+    message: String,
+) : InvalidStateException("STATS_VALIDATION_ERROR", message)

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/TeamExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/TeamExceptions.kt
@@ -3,26 +3,29 @@ package com.nextup.common.exception
 /**
  * 팀을 찾을 수 없을 때 발생하는 예외
  */
-class TeamNotFoundException(teamId: Long) :
-    NotFoundException(
+class TeamNotFoundException(
+    teamId: Long,
+) : NotFoundException(
         "TEAM_NOT_FOUND",
-        "Team not found: $teamId"
+        "Team not found: $teamId",
     )
 
 /**
  * 팀이 이미 존재할 때 발생하는 예외
  */
-class TeamAlreadyExistsException(teamName: String) :
-    BusinessException(
+class TeamAlreadyExistsException(
+    teamName: String,
+) : BusinessException(
         "TEAM_ALREADY_EXISTS",
-        "Team already exists: $teamName"
+        "Team already exists: $teamName",
     )
 
 /**
  * 유효하지 않은 팀 상태일 때 발생하는 예외
  */
-class InvalidTeamStateException(message: String) :
-    InvalidStateException(
+class InvalidTeamStateException(
+    message: String,
+) : InvalidStateException(
         "INVALID_TEAM_STATE",
-        message
+        message,
     )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/UserExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/UserExceptions.kt
@@ -3,46 +3,52 @@ package com.nextup.common.exception
 /**
  * 사용자를 찾을 수 없을 때 발생하는 예외
  */
-class UserNotFoundException(userId: Long) :
-    NotFoundException(
+class UserNotFoundException(
+    userId: Long,
+) : NotFoundException(
         "USER_NOT_FOUND",
-        "User not found: $userId"
+        "User not found: $userId",
     )
 
 /**
  * 이메일로 사용자를 찾을 수 없을 때 발생하는 예외
  */
-class UserNotFoundByEmailException(email: String) :
-    NotFoundException(
+class UserNotFoundByEmailException(
+    email: String,
+) : NotFoundException(
         "USER_NOT_FOUND",
-        "User not found with email: $email"
+        "User not found with email: $email",
     )
 
 /**
  * 이메일이 중복될 때 발생하는 예외
  */
-class EmailDuplicateException(email: String) :
-    BusinessException(
+class EmailDuplicateException(
+    email: String,
+) : BusinessException(
         "EMAIL_DUPLICATE",
-        "Email already exists: $email"
+        "Email already exists: $email",
     )
 
 /**
  * OAuth 계정이 이미 연결되어 있을 때 발생하는 예외
  */
-class OAuthAccountAlreadyLinkedException(provider: String) :
-    BusinessException(
+class OAuthAccountAlreadyLinkedException(
+    provider: String,
+) : BusinessException(
         "OAUTH_ALREADY_LINKED",
-        "OAuth account already linked: $provider"
+        "OAuth account already linked: $provider",
     )
 
 /**
  * OAuth 계정을 찾을 수 없을 때 발생하는 예외
  */
-class OAuthAccountNotFoundException(provider: String, oauthId: String) :
-    NotFoundException(
+class OAuthAccountNotFoundException(
+    provider: String,
+    oauthId: String,
+) : NotFoundException(
         "OAUTH_ACCOUNT_NOT_FOUND",
-        "OAuth account not found: $provider, $oauthId"
+        "OAuth account not found: $provider, $oauthId",
     )
 
 /**
@@ -51,14 +57,15 @@ class OAuthAccountNotFoundException(provider: String, oauthId: String) :
 class InsufficientAuthMethodException :
     BusinessException(
         "INSUFFICIENT_AUTH_METHOD",
-        "At least one authentication method is required"
+        "At least one authentication method is required",
     )
 
 /**
  * 비활성화된 사용자일 때 발생하는 예외
  */
-class UserDeactivatedException(userId: Long) :
-    InvalidStateException(
+class UserDeactivatedException(
+    userId: Long,
+) : InvalidStateException(
         "USER_DEACTIVATED",
-        "User is deactivated: $userId"
+        "User is deactivated: $userId",
     )

--- a/nextup-common/src/main/kotlin/com/nextup/common/util/DateTimeUtils.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/util/DateTimeUtils.kt
@@ -7,19 +7,21 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 object DateTimeUtils {
-
     val KST: ZoneId = ZoneId.of("Asia/Seoul")
 
     fun nowInKst(): LocalDateTime = LocalDateTime.now(KST)
 
     fun todayInKst(): LocalDate = LocalDate.now(KST)
 
-    fun toKstLocalDateTime(instant: Instant): LocalDateTime =
-        LocalDateTime.ofInstant(instant, KST)
+    fun toKstLocalDateTime(instant: Instant): LocalDateTime = LocalDateTime.ofInstant(instant, KST)
 
-    fun formatDate(date: LocalDate, pattern: String = "yyyy-MM-dd"): String =
-        date.format(DateTimeFormatter.ofPattern(pattern))
+    fun formatDate(
+        date: LocalDate,
+        pattern: String = "yyyy-MM-dd",
+    ): String = date.format(DateTimeFormatter.ofPattern(pattern))
 
-    fun formatDateTime(dateTime: LocalDateTime, pattern: String = "yyyy-MM-dd HH:mm:ss"): String =
-        dateTime.format(DateTimeFormatter.ofPattern(pattern))
+    fun formatDateTime(
+        dateTime: LocalDateTime,
+        pattern: String = "yyyy-MM-dd HH:mm:ss",
+    ): String = dateTime.format(DateTimeFormatter.ofPattern(pattern))
 }

--- a/nextup-common/src/main/kotlin/com/nextup/common/util/StringUtils.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/util/StringUtils.kt
@@ -1,20 +1,25 @@
 package com.nextup.common.util
 
 object StringUtils {
-
     fun String.toSlug(): String =
-        this.lowercase()
+        this
+            .lowercase()
             .replace(Regex("[^a-z0-9\\s-]"), "")
             .replace(Regex("\\s+"), "-")
             .replace(Regex("-+"), "-")
             .trim('-')
 
-    fun String.truncate(maxLength: Int, suffix: String = "..."): String =
-        if (this.length <= maxLength) this
-        else this.take(maxLength - suffix.length) + suffix
+    fun String.truncate(
+        maxLength: Int,
+        suffix: String = "...",
+    ): String =
+        if (this.length <= maxLength) {
+            this
+        } else {
+            this.take(maxLength - suffix.length) + suffix
+        }
 
     fun String?.orEmpty(): String = this ?: ""
 
-    fun String?.isNullOrBlankOrEmpty(): Boolean =
-        this == null || this.isBlank() || this.isEmpty()
+    fun String?.isNullOrBlankOrEmpty(): Boolean = this == null || this.isBlank() || this.isEmpty()
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/common/BaseTimeEntity.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/common/BaseTimeEntity.kt
@@ -11,7 +11,6 @@ import java.time.Instant
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseTimeEntity {
-
     @CreatedDate
     @Column(nullable = false, updatable = false)
     var createdAt: Instant = Instant.now()

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationAdmin.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationAdmin.kt
@@ -22,45 +22,37 @@ import java.time.Instant
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_organization_admin_user_org",
-            columnNames = ["user_id", "organization_type", "organization_id"]
-        )
+            columnNames = ["user_id", "organization_type", "organization_id"],
+        ),
     ],
     indexes = [
         Index(name = "idx_org_admin_user", columnList = "user_id"),
         Index(name = "idx_org_admin_org", columnList = "organization_type, organization_id"),
-        Index(name = "idx_org_admin_active", columnList = "is_active")
-    ]
+        Index(name = "idx_org_admin_active", columnList = "is_active"),
+    ],
 )
 class OrganizationAdmin private constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     val user: User,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "organization_type", nullable = false, length = 20)
     val organizationType: OrganizationType,
-
     @Column(name = "organization_id", nullable = false)
     val organizationId: Long,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false, length = 20)
     var role: OrganizationRole,
-
     @Column(name = "assigned_at", nullable = false)
     val assignedAt: Instant = Instant.now(),
-
     @Column(name = "assigned_by")
     val assignedBy: Long? = null,
-
     @Column(name = "is_active", nullable = false)
     var isActive: Boolean = true,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     /**
      * 관리자 역할을 변경합니다.
      *
@@ -92,9 +84,7 @@ class OrganizationAdmin private constructor(
      * @param requiredRole 필요한 최소 역할
      * @return 권한 보유 여부
      */
-    fun hasRoleOrHigher(requiredRole: OrganizationRole): Boolean {
-        return isActive && role.isHigherOrEqual(requiredRole)
-    }
+    fun hasRoleOrHigher(requiredRole: OrganizationRole): Boolean = isActive && role.isHigherOrEqual(requiredRole)
 
     /**
      * 협회 관리자인지 확인합니다.
@@ -143,7 +133,7 @@ class OrganizationAdmin private constructor(
             organizationType: OrganizationType,
             organizationId: Long,
             role: OrganizationRole,
-            assignedBy: Long? = null
+            assignedBy: Long? = null,
         ): OrganizationAdmin {
             require(organizationId > 0) { "조직 ID는 0보다 커야 합니다." }
 
@@ -152,7 +142,7 @@ class OrganizationAdmin private constructor(
                 organizationType = organizationType,
                 organizationId = organizationId,
                 role = role,
-                assignedBy = assignedBy
+                assignedBy = assignedBy,
             )
         }
 
@@ -163,14 +153,15 @@ class OrganizationAdmin private constructor(
             user: User,
             associationId: Long,
             role: OrganizationRole = OrganizationRole.ADMIN,
-            assignedBy: Long? = null
-        ): OrganizationAdmin = create(
-            user = user,
-            organizationType = OrganizationType.ASSOCIATION,
-            organizationId = associationId,
-            role = role,
-            assignedBy = assignedBy
-        )
+            assignedBy: Long? = null,
+        ): OrganizationAdmin =
+            create(
+                user = user,
+                organizationType = OrganizationType.ASSOCIATION,
+                organizationId = associationId,
+                role = role,
+                assignedBy = assignedBy,
+            )
 
         /**
          * 리그 관리자를 생성합니다.
@@ -179,14 +170,15 @@ class OrganizationAdmin private constructor(
             user: User,
             leagueId: Long,
             role: OrganizationRole = OrganizationRole.ADMIN,
-            assignedBy: Long? = null
-        ): OrganizationAdmin = create(
-            user = user,
-            organizationType = OrganizationType.LEAGUE,
-            organizationId = leagueId,
-            role = role,
-            assignedBy = assignedBy
-        )
+            assignedBy: Long? = null,
+        ): OrganizationAdmin =
+            create(
+                user = user,
+                organizationType = OrganizationType.LEAGUE,
+                organizationId = leagueId,
+                role = role,
+                assignedBy = assignedBy,
+            )
 
         /**
          * 팀 관리자를 생성합니다.
@@ -195,13 +187,14 @@ class OrganizationAdmin private constructor(
             user: User,
             teamId: Long,
             role: OrganizationRole = OrganizationRole.ADMIN,
-            assignedBy: Long? = null
-        ): OrganizationAdmin = create(
-            user = user,
-            organizationType = OrganizationType.TEAM,
-            organizationId = teamId,
-            role = role,
-            assignedBy = assignedBy
-        )
+            assignedBy: Long? = null,
+        ): OrganizationAdmin =
+            create(
+                user = user,
+                organizationType = OrganizationType.TEAM,
+                organizationId = teamId,
+                role = role,
+                assignedBy = assignedBy,
+            )
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationRole.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationRole.kt
@@ -8,7 +8,7 @@ package com.nextup.core.domain.admin
 enum class OrganizationRole(
     val displayName: String,
     val description: String,
-    val level: Int
+    val level: Int,
 ) {
     /**
      * 관리자 - 조직의 모든 권한을 가진 최고 관리자
@@ -23,7 +23,8 @@ enum class OrganizationRole(
     /**
      * 기록원 - 경기 기록 입력 권한만 가진 관리자
      */
-    SCORER("기록원", "경기 기록 입력 권한만 가진 관리자", 10);
+    SCORER("기록원", "경기 기록 입력 권한만 가진 관리자", 10),
+    ;
 
     /**
      * 다른 역할보다 높은 권한인지 확인합니다.
@@ -43,9 +44,8 @@ enum class OrganizationRole(
          * @return OrganizationRole
          * @throws IllegalArgumentException 유효하지 않은 값인 경우
          */
-        fun fromValue(value: String): OrganizationRole {
-            return entries.find { it.name.equals(value, ignoreCase = true) }
+        fun fromValue(value: String): OrganizationRole =
+            entries.find { it.name.equals(value, ignoreCase = true) }
                 ?: throw IllegalArgumentException("Invalid organization role: $value")
-        }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/admin/OrganizationType.kt
@@ -7,7 +7,7 @@ package com.nextup.core.domain.admin
  */
 enum class OrganizationType(
     val displayName: String,
-    val description: String
+    val description: String,
 ) {
     /**
      * 협회 (최상위 조직)
@@ -22,7 +22,8 @@ enum class OrganizationType(
     /**
      * 팀 (리그 하위 조직)
      */
-    TEAM("팀", "리그에 속한 팀");
+    TEAM("팀", "리그에 속한 팀"),
+    ;
 
     companion object {
         /**
@@ -32,9 +33,8 @@ enum class OrganizationType(
          * @return OrganizationType
          * @throws IllegalArgumentException 유효하지 않은 값인 경우
          */
-        fun fromValue(value: String): OrganizationType {
-            return entries.find { it.name.equals(value, ignoreCase = true) }
+        fun fromValue(value: String): OrganizationType =
+            entries.find { it.name.equals(value, ignoreCase = true) }
                 ?: throw IllegalArgumentException("Invalid organization type: $value")
-        }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/association/Association.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/association/Association.kt
@@ -14,36 +14,28 @@ import jakarta.persistence.*
     name = "associations",
     indexes = [
         Index(name = "idx_associations_region", columnList = "region"),
-        Index(name = "idx_associations_is_active", columnList = "is_active")
-    ]
+        Index(name = "idx_associations_is_active", columnList = "is_active"),
+    ],
 )
 class Association(
     @Column(nullable = false, length = 100)
     val name: String,
-
     @Column(length = 20)
     val abbreviation: String? = null,
-
     @Column(length = 50)
     val region: String? = null,
-
     @Column(length = 500)
     var description: String? = null,
-
     @Column(length = 255)
     var logoUrl: String? = null,
-
     @Column(length = 255)
     var websiteUrl: String? = null,
-
     @Column(name = "is_active", nullable = false)
     var isActive: Boolean = true,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     fun deactivate() {
         this.isActive = false
     }
@@ -55,7 +47,7 @@ class Association(
     fun updateInfo(
         description: String? = this.description,
         logoUrl: String? = this.logoUrl,
-        websiteUrl: String? = this.websiteUrl
+        websiteUrl: String? = this.websiteUrl,
     ) {
         this.description = description
         this.logoUrl = logoUrl

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/auth/RefreshToken.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/auth/RefreshToken.kt
@@ -16,33 +16,26 @@ import java.time.Instant
     indexes = [
         Index(name = "idx_refresh_token_user", columnList = "user_id"),
         Index(name = "idx_refresh_token_token", columnList = "token", unique = true),
-        Index(name = "idx_refresh_token_expires", columnList = "expires_at")
-    ]
+        Index(name = "idx_refresh_token_expires", columnList = "expires_at"),
+    ],
 )
 class RefreshToken private constructor(
     @Column(name = "user_id", nullable = false)
     val userId: Long,
-
     @Column(nullable = false, unique = true, length = 500)
     val token: String,
-
     @Column(name = "expires_at", nullable = false)
     val expiresAt: Instant,
-
     @Column(name = "is_revoked", nullable = false)
     var isRevoked: Boolean = false,
-
     @Column(name = "device_info", length = 255)
     val deviceInfo: String? = null,
-
     @Column(name = "ip_address", length = 45)
     val ipAddress: String? = null,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     /**
      * 토큰이 만료되었는지 확인합니다.
      */
@@ -85,8 +78,7 @@ class RefreshToken private constructor(
 
     override fun hashCode(): Int = id.hashCode()
 
-    override fun toString(): String =
-        "RefreshToken(id=$id, userId=$userId, isRevoked=$isRevoked, expiresAt=$expiresAt)"
+    override fun toString(): String = "RefreshToken(id=$id, userId=$userId, isRevoked=$isRevoked, expiresAt=$expiresAt)"
 
     companion object {
         /**
@@ -105,7 +97,7 @@ class RefreshToken private constructor(
             token: String,
             expiresAt: Instant,
             deviceInfo: String? = null,
-            ipAddress: String? = null
+            ipAddress: String? = null,
         ): RefreshToken {
             require(token.isNotBlank()) { "Token cannot be blank" }
             require(expiresAt.isAfter(Instant.now())) {
@@ -117,7 +109,7 @@ class RefreshToken private constructor(
                 token = token,
                 expiresAt = expiresAt,
                 deviceInfo = deviceInfo,
-                ipAddress = ipAddress
+                ipAddress = ipAddress,
             )
         }
     }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/Competition.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/Competition.kt
@@ -18,48 +18,37 @@ import java.time.LocalDate
         Index(name = "idx_competitions_league", columnList = "league_id"),
         Index(name = "idx_competitions_year_season", columnList = "year, season"),
         Index(name = "idx_competitions_dates", columnList = "start_date, end_date"),
-        Index(name = "idx_competitions_status", columnList = "status")
-    ]
+        Index(name = "idx_competitions_status", columnList = "status"),
+    ],
 )
 class Competition(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "league_id", nullable = false)
     val league: League,
-
     @Column(nullable = false, length = 100)
     val name: String,
-
     @Column(nullable = false)
     val year: Int,
-
     @Column(nullable = false)
     val season: Int = 1,
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     val type: CompetitionType = CompetitionType.LEAGUE,
-
     @Column(name = "start_date", nullable = false)
     val startDate: LocalDate,
-
     @Column(name = "end_date")
     var endDate: LocalDate? = null,
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     var status: CompetitionStatus = CompetitionStatus.SCHEDULED,
-
     @Column(length = 500)
     var description: String? = null,
-
     @Column(name = "max_teams")
     val maxTeams: Int? = null,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     /**
      * 대회를 시작합니다.
      */
@@ -107,10 +96,12 @@ class Competition(
 /**
  * 대회 상태
  */
-enum class CompetitionStatus(val displayName: String) {
+enum class CompetitionStatus(
+    val displayName: String,
+) {
     SCHEDULED("예정"),
     IN_PROGRESS("진행 중"),
     COMPLETED("완료"),
     CANCELLED("취소"),
-    POSTPONED("연기")
+    POSTPONED("연기"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/CompetitionType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/CompetitionType.kt
@@ -3,10 +3,12 @@ package com.nextup.core.domain.competition
 /**
  * 대회 유형
  */
-enum class CompetitionType(val displayName: String) {
+enum class CompetitionType(
+    val displayName: String,
+) {
     LEAGUE("리그"),
     TOURNAMENT("토너먼트"),
     PLAYOFF("플레이오프"),
     CHAMPIONSHIP("챔피언십"),
-    FRIENDLY("친선")
+    FRIENDLY("친선"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Base.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Base.kt
@@ -7,5 +7,5 @@ enum class Base {
     FIRST,
     SECOND,
     THIRD,
-    HOME
+    HOME,
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
@@ -15,19 +15,17 @@ import java.math.RoundingMode
 @Table(
     name = "batting_records",
     indexes = [
-        Index(name = "idx_batting_records_game_player", columnList = "game_player_id")
-    ]
+        Index(name = "idx_batting_records_game_player", columnList = "game_player_id"),
+    ],
 )
 class BattingRecord(
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_player_id", nullable = false, unique = true)
     val gamePlayer: GamePlayer,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     // 기본 타격 기록
     @Column(name = "plate_appearances", nullable = false)
     var plateAppearances: Int = 0
@@ -134,11 +132,12 @@ class BattingRecord(
      * 타수가 0이면 .000
      */
     val battingAverage: BigDecimal
-        get() = if (atBats == 0) {
-            BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
-        } else {
-            BigDecimal(hits).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (atBats == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(hits).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
+            }
 
     /**
      * 출루율 (OBP) = (안타 + 볼넷 + 사구) / (타수 + 볼넷 + 사구 + 희생플라이)
@@ -158,11 +157,12 @@ class BattingRecord(
      * 장타율 (SLG) = 총 루타 / 타수
      */
     val sluggingPercentage: BigDecimal
-        get() = if (atBats == 0) {
-            BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
-        } else {
-            BigDecimal(totalBases).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (atBats == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(totalBases).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
+            }
 
     /**
      * OPS = 출루율 + 장타율
@@ -191,7 +191,7 @@ class BattingRecord(
     fun recordPlateAppearance(
         result: PlateAppearanceResult,
         runsBattedIn: Int = 0,
-        runsScored: Boolean = false
+        runsScored: Boolean = false,
     ) {
         require(runsBattedIn >= 0) { "타점은 0 이상이어야 합니다." }
 
@@ -233,7 +233,10 @@ class BattingRecord(
      * 타석 결과에 따른 기록을 자동으로 갱신합니다 (BoxScore 계산용).
      * recordPlateAppearance와 유사하지만 더 명시적인 API를 제공합니다.
      */
-    fun applyPlateAppearanceResult(result: PlateAppearanceResult, rbis: Int = 0) {
+    fun applyPlateAppearanceResult(
+        result: PlateAppearanceResult,
+        rbis: Int = 0,
+    ) {
         require(rbis >= 0) { "타점은 0 이상이어야 합니다." }
 
         plateAppearances++
@@ -257,7 +260,7 @@ class BattingRecord(
                 atBats++
                 hits++
                 homeRuns++
-                runs++  // 홈런은 타자 자신도 득점
+                runs++ // 홈런은 타자 자신도 득점
             }
             PlateAppearanceResult.STRIKEOUT -> {
                 atBats++
@@ -267,7 +270,8 @@ class BattingRecord(
             PlateAppearanceResult.FLY_OUT,
             PlateAppearanceResult.LINE_OUT,
             PlateAppearanceResult.FIELDERS_CHOICE,
-            PlateAppearanceResult.ERROR -> {
+            PlateAppearanceResult.ERROR,
+            -> {
                 atBats++
             }
             PlateAppearanceResult.WALK -> {
@@ -286,7 +290,8 @@ class BattingRecord(
                 sacrificeBunts++
             }
             PlateAppearanceResult.DOUBLE_PLAY,
-            PlateAppearanceResult.TRIPLE_PLAY -> {
+            PlateAppearanceResult.TRIPLE_PLAY,
+            -> {
                 atBats++
                 groundedIntoDoublePlays++
             }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -19,56 +19,42 @@ import java.time.LocalDateTime
         Index(name = "idx_games_competition", columnList = "competition_id"),
         Index(name = "idx_games_scheduled_at", columnList = "scheduled_at"),
         Index(name = "idx_games_status", columnList = "status"),
-        Index(name = "idx_games_competition_date", columnList = "competition_id, scheduled_at")
-    ]
+        Index(name = "idx_games_competition_date", columnList = "competition_id, scheduled_at"),
+    ],
 )
 class Game(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "competition_id", nullable = false)
     val competition: Competition,
-
     @Column(name = "scheduled_at", nullable = false)
     var scheduledAt: LocalDateTime,
-
     @Column(length = 100)
     var location: String? = null,
-
     @Column(name = "field_name", length = 100)
     var fieldName: String? = null,
-
     @Column(name = "game_number")
     var gameNumber: Int? = null,
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     var status: GameStatus = GameStatus.SCHEDULED,
-
     @Column(name = "current_inning")
     var currentInning: Int = 0,
-
     @Column(name = "is_top_inning")
     var isTopInning: Boolean = true,
-
     @Column(name = "total_innings")
     var totalInnings: Int = 9,
-
     @Column(name = "started_at")
     var startedAt: LocalDateTime? = null,
-
     @Column(name = "ended_at")
     var endedAt: LocalDateTime? = null,
-
     @Column(length = 500)
     var note: String? = null,
-
     @Embedded
     var gameState: GameState = GameState(),
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     /**
      * 경기를 시작합니다.
      */
@@ -133,7 +119,10 @@ class Game(
     /**
      * 경기를 연기합니다.
      */
-    fun postpone(newScheduledAt: LocalDateTime, reason: String? = null) {
+    fun postpone(
+        newScheduledAt: LocalDateTime,
+        reason: String? = null,
+    ) {
         require(status == GameStatus.SCHEDULED) { "예정 상태의 경기만 연기할 수 있습니다." }
         status = GameStatus.POSTPONED
         scheduledAt = newScheduledAt
@@ -199,7 +188,10 @@ class Game(
     /**
      * 주자를 설정합니다.
      */
-    fun setRunner(base: Base, playerId: Long?) {
+    fun setRunner(
+        base: Base,
+        playerId: Long?,
+    ) {
         require(status.isOngoing()) { "진행 중인 경기만 주자를 설정할 수 있습니다." }
         gameState.setRunner(base, playerId)
     }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -1,0 +1,148 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * 경기 이벤트 엔티티
+ *
+ * 경기 중 발생하는 모든 이벤트를 기록합니다.
+ */
+@Entity
+@Table(
+    name = "game_events",
+    indexes = [
+        Index(name = "idx_game_events_game", columnList = "game_id"),
+        Index(name = "idx_game_events_game_inning", columnList = "game_id, inning, is_top_inning"),
+        Index(name = "idx_game_events_timestamp", columnList = "event_timestamp")
+    ]
+)
+class GameEvent(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    val game: Game,
+
+    @Column(nullable = false)
+    val inning: Int,
+
+    @Column(name = "is_top_inning", nullable = false)
+    val isTopInning: Boolean,
+
+    @Column(name = "out_count_before", nullable = false)
+    val outCountBefore: Int,
+
+    @Column(name = "out_count_after", nullable = false)
+    val outCountAfter: Int,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 30)
+    val eventType: GameEventType,
+
+    @Column(nullable = false, length = 500)
+    val description: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batter_id")
+    val batter: GamePlayer? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pitcher_id")
+    val pitcher: GamePlayer? = null,
+
+    @Column(name = "runners_before_json", columnDefinition = "TEXT")
+    val runnersBeforeJson: String? = null,
+
+    @Column(name = "runners_after_json", columnDefinition = "TEXT")
+    val runnersAfterJson: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "plate_appearance_result", length = 30)
+    val plateAppearanceResult: PlateAppearanceResult? = null,
+
+    @Column(name = "runs_scored", nullable = false)
+    val runsScored: Int = 0,
+
+    @Column(nullable = false)
+    val rbis: Int = 0,
+
+    @Column(name = "event_timestamp", nullable = false)
+    val eventTimestamp: Instant = Instant.now(),
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+) : BaseTimeEntity() {
+
+    companion object {
+        /**
+         * 타석 결과 이벤트를 생성합니다.
+         */
+        fun createPlateAppearance(
+            game: Game,
+            batter: GamePlayer,
+            pitcher: GamePlayer,
+            result: PlateAppearanceResult,
+            description: String,
+            outCountBefore: Int,
+            outCountAfter: Int,
+            runnersBeforeJson: String?,
+            runnersAfterJson: String?,
+            runsScored: Int = 0,
+            rbis: Int = 0
+        ): GameEvent {
+            return GameEvent(
+                game = game,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                outCountBefore = outCountBefore,
+                outCountAfter = outCountAfter,
+                eventType = GameEventType.PLATE_APPEARANCE,
+                description = description,
+                batter = batter,
+                pitcher = pitcher,
+                runnersBeforeJson = runnersBeforeJson,
+                runnersAfterJson = runnersAfterJson,
+                plateAppearanceResult = result,
+                runsScored = runsScored,
+                rbis = rbis
+            )
+        }
+
+        /**
+         * 이닝 전환 이벤트를 생성합니다.
+         */
+        fun createInningChange(
+            game: Game,
+            description: String
+        ): GameEvent {
+            return GameEvent(
+                game = game,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                outCountBefore = 3,
+                outCountAfter = 0,
+                eventType = GameEventType.INNING_CHANGE,
+                description = description
+            )
+        }
+
+        /**
+         * 경기 상태 변경 이벤트를 생성합니다.
+         */
+        fun createGameStatus(
+            game: Game,
+            description: String
+        ): GameEvent {
+            return GameEvent(
+                game = game,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                outCountBefore = game.gameState.outs,
+                outCountAfter = game.gameState.outs,
+                eventType = GameEventType.GAME_STATUS,
+                description = description
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -15,65 +15,49 @@ import java.time.Instant
     indexes = [
         Index(name = "idx_game_events_game", columnList = "game_id"),
         Index(name = "idx_game_events_game_inning", columnList = "game_id, inning, is_top_inning"),
-        Index(name = "idx_game_events_timestamp", columnList = "event_timestamp")
-    ]
+        Index(name = "idx_game_events_timestamp", columnList = "event_timestamp"),
+    ],
 )
 class GameEvent(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id", nullable = false)
     val game: Game,
-
     @Column(nullable = false)
     val inning: Int,
-
     @Column(name = "is_top_inning", nullable = false)
     val isTopInning: Boolean,
-
     @Column(name = "out_count_before", nullable = false)
     val outCountBefore: Int,
-
     @Column(name = "out_count_after", nullable = false)
     val outCountAfter: Int,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "event_type", nullable = false, length = 30)
     val eventType: GameEventType,
-
     @Column(nullable = false, length = 500)
     val description: String,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "batter_id")
     val batter: GamePlayer? = null,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pitcher_id")
     val pitcher: GamePlayer? = null,
-
     @Column(name = "runners_before_json", columnDefinition = "TEXT")
     val runnersBeforeJson: String? = null,
-
     @Column(name = "runners_after_json", columnDefinition = "TEXT")
     val runnersAfterJson: String? = null,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "plate_appearance_result", length = 30)
     val plateAppearanceResult: PlateAppearanceResult? = null,
-
     @Column(name = "runs_scored", nullable = false)
     val runsScored: Int = 0,
-
     @Column(nullable = false)
     val rbis: Int = 0,
-
     @Column(name = "event_timestamp", nullable = false)
     val eventTimestamp: Instant = Instant.now(),
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     companion object {
         /**
          * 타석 결과 이벤트를 생성합니다.
@@ -89,9 +73,9 @@ class GameEvent(
             runnersBeforeJson: String?,
             runnersAfterJson: String?,
             runsScored: Int = 0,
-            rbis: Int = 0
-        ): GameEvent {
-            return GameEvent(
+            rbis: Int = 0,
+        ): GameEvent =
+            GameEvent(
                 game = game,
                 inning = game.currentInning,
                 isTopInning = game.isTopInning,
@@ -105,44 +89,41 @@ class GameEvent(
                 runnersAfterJson = runnersAfterJson,
                 plateAppearanceResult = result,
                 runsScored = runsScored,
-                rbis = rbis
+                rbis = rbis,
             )
-        }
 
         /**
          * 이닝 전환 이벤트를 생성합니다.
          */
         fun createInningChange(
             game: Game,
-            description: String
-        ): GameEvent {
-            return GameEvent(
+            description: String,
+        ): GameEvent =
+            GameEvent(
                 game = game,
                 inning = game.currentInning,
                 isTopInning = game.isTopInning,
                 outCountBefore = 3,
                 outCountAfter = 0,
                 eventType = GameEventType.INNING_CHANGE,
-                description = description
+                description = description,
             )
-        }
 
         /**
          * 경기 상태 변경 이벤트를 생성합니다.
          */
         fun createGameStatus(
             game: Game,
-            description: String
-        ): GameEvent {
-            return GameEvent(
+            description: String,
+        ): GameEvent =
+            GameEvent(
                 game = game,
                 inning = game.currentInning,
                 isTopInning = game.isTopInning,
                 outCountBefore = game.gameState.outs,
                 outCountAfter = game.gameState.outs,
                 eventType = GameEventType.GAME_STATUS,
-                description = description
+                description = description,
             )
-        }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
@@ -3,11 +3,13 @@ package com.nextup.core.domain.game
 /**
  * 경기 이벤트 타입
  */
-enum class GameEventType(val displayName: String) {
+enum class GameEventType(
+    val displayName: String,
+) {
     PLATE_APPEARANCE("타석 결과"),
     BASE_RUNNING("주루 플레이"),
     SUBSTITUTION("선수 교체"),
     PITCHING_CHANGE("투수 교체"),
     INNING_CHANGE("이닝 전환"),
-    GAME_STATUS("경기 상태 변경")
+    GAME_STATUS("경기 상태 변경"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
@@ -1,0 +1,13 @@
+package com.nextup.core.domain.game
+
+/**
+ * 경기 이벤트 타입
+ */
+enum class GameEventType(val displayName: String) {
+    PLATE_APPEARANCE("타석 결과"),
+    BASE_RUNNING("주루 플레이"),
+    SUBSTITUTION("선수 교체"),
+    PITCHING_CHANGE("투수 교체"),
+    INNING_CHANGE("이닝 전환"),
+    GAME_STATUS("경기 상태 변경")
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GamePlayer.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GamePlayer.kt
@@ -18,39 +18,33 @@ import jakarta.persistence.*
         Index(name = "idx_game_players_game_team", columnList = "game_team_id"),
         Index(name = "idx_game_players_player", columnList = "player_id"),
         Index(name = "idx_game_players_batting_order", columnList = "game_team_id, batting_order"),
-        Index(name = "idx_game_players_position", columnList = "game_team_id, position")
+        Index(name = "idx_game_players_position", columnList = "game_team_id, position"),
     ],
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_game_players_game_team_player",
-            columnNames = ["game_team_id", "player_id"]
-        )
-    ]
+            columnNames = ["game_team_id", "player_id"],
+        ),
+    ],
 )
 class GamePlayer(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_team_id", nullable = false)
     val gameTeam: GameTeam,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id", nullable = false)
     val player: Player,
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
     var position: Position,
-
     @Column(name = "batting_order")
     var battingOrder: Int? = null,
-
     @Column(name = "back_number")
     var backNumber: Int? = null,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     @Column(name = "is_starter", nullable = false)
     var isStarter: Boolean = true
         protected set
@@ -96,7 +90,11 @@ class GamePlayer(
     /**
      * 교체 선수로 출전합니다.
      */
-    fun enterAsSubstitute(inning: Int, newPosition: Position, newBattingOrder: Int?) {
+    fun enterAsSubstitute(
+        inning: Int,
+        newPosition: Position,
+        newBattingOrder: Int?,
+    ) {
         require(inning >= 1) { "이닝은 1 이상이어야 합니다." }
         this.isStarter = false
         this.isCurrentlyPlaying = true
@@ -158,18 +156,19 @@ class GamePlayer(
             player: Player,
             position: Position,
             battingOrder: Int?,
-            backNumber: Int? = null
-        ): GamePlayer = GamePlayer(
-            gameTeam = gameTeam,
-            player = player,
-            position = position,
-            battingOrder = battingOrder,
-            backNumber = backNumber
-        ).apply {
-            this.isStarter = true
-            this.isCurrentlyPlaying = true
-            this.entryInning = 1
-        }
+            backNumber: Int? = null,
+        ): GamePlayer =
+            GamePlayer(
+                gameTeam = gameTeam,
+                player = player,
+                position = position,
+                battingOrder = battingOrder,
+                backNumber = backNumber,
+            ).apply {
+                this.isStarter = true
+                this.isCurrentlyPlaying = true
+                this.entryInning = 1
+            }
 
         /**
          * 대기 선수(벤치)를 생성합니다.
@@ -178,16 +177,17 @@ class GamePlayer(
             gameTeam: GameTeam,
             player: Player,
             position: Position,
-            backNumber: Int? = null
-        ): GamePlayer = GamePlayer(
-            gameTeam = gameTeam,
-            player = player,
-            position = position,
-            battingOrder = null,
-            backNumber = backNumber
-        ).apply {
-            this.isStarter = false
-            this.isCurrentlyPlaying = false
-        }
+            backNumber: Int? = null,
+        ): GamePlayer =
+            GamePlayer(
+                gameTeam = gameTeam,
+                player = player,
+                position = position,
+                battingOrder = null,
+                backNumber = backNumber,
+            ).apply {
+                this.isStarter = false
+                this.isCurrentlyPlaying = false
+            }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameResult.kt
@@ -3,7 +3,9 @@ package com.nextup.core.domain.game
 /**
  * 경기 결과
  */
-enum class GameResult(val displayName: String) {
+enum class GameResult(
+    val displayName: String,
+) {
     /** 승리 */
     WIN("승"),
 
@@ -14,5 +16,5 @@ enum class GameResult(val displayName: String) {
     DRAW("무"),
 
     /** 미결정 (경기 진행 중 또는 예정) */
-    UNDECIDED("미정")
+    UNDECIDED("미정"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
@@ -15,33 +15,24 @@ import jakarta.persistence.Embeddable
 class GameState(
     @Column(name = "outs")
     var outs: Int = 0,
-
     @Column(name = "balls")
     var balls: Int = 0,
-
     @Column(name = "strikes")
     var strikes: Int = 0,
-
     @Column(name = "runner_on_first_id")
     var runnerOnFirstId: Long? = null,
-
     @Column(name = "runner_on_second_id")
     var runnerOnSecondId: Long? = null,
-
     @Column(name = "runner_on_third_id")
     var runnerOnThirdId: Long? = null,
-
     @Column(name = "home_batting_order")
     var homeBattingOrder: Int = 1,
-
     @Column(name = "away_batting_order")
     var awayBattingOrder: Int = 1,
-
     @Column(name = "current_pitcher_id")
     var currentPitcherId: Long? = null,
-
     @Column(name = "current_batter_id")
-    var currentBatterId: Long? = null
+    var currentBatterId: Long? = null,
 ) {
     init {
         require(outs in 0..3) { "아웃 카운트는 0-3 사이여야 합니다: $outs" }
@@ -92,7 +83,10 @@ class GameState(
     /**
      * 주자를 설정합니다.
      */
-    fun setRunner(base: Base, playerId: Long?) {
+    fun setRunner(
+        base: Base,
+        playerId: Long?,
+    ) {
         when (base) {
             Base.FIRST -> runnerOnFirstId = playerId
             Base.SECOND -> runnerOnSecondId = playerId
@@ -104,14 +98,13 @@ class GameState(
     /**
      * 특정 베이스의 주자를 반환합니다.
      */
-    fun getRunner(base: Base): Long? {
-        return when (base) {
+    fun getRunner(base: Base): Long? =
+        when (base) {
             Base.FIRST -> runnerOnFirstId
             Base.SECOND -> runnerOnSecondId
             Base.THIRD -> runnerOnThirdId
             Base.HOME -> null
         }
-    }
 
     /**
      * 모든 베이스를 클리어합니다 (3아웃 시).
@@ -147,16 +140,12 @@ class GameState(
     /**
      * 주자가 있는지 확인합니다.
      */
-    fun hasRunner(base: Base): Boolean {
-        return getRunner(base) != null
-    }
+    fun hasRunner(base: Base): Boolean = getRunner(base) != null
 
     /**
      * 만루 상태인지 확인합니다.
      */
-    fun isBasesLoaded(): Boolean {
-        return runnerOnFirstId != null && runnerOnSecondId != null && runnerOnThirdId != null
-    }
+    fun isBasesLoaded(): Boolean = runnerOnFirstId != null && runnerOnSecondId != null && runnerOnThirdId != null
 
     /**
      * 현재 볼카운트 문자열을 반환합니다 (예: "2B-1S").

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameStatus.kt
@@ -3,7 +3,10 @@ package com.nextup.core.domain.game
 /**
  * 경기 상태
  */
-enum class GameStatus(val displayName: String, val description: String) {
+enum class GameStatus(
+    val displayName: String,
+    val description: String,
+) {
     /** 경기 예정 */
     SCHEDULED("예정", "경기가 예정된 상태"),
 
@@ -23,7 +26,8 @@ enum class GameStatus(val displayName: String, val description: String) {
     FORFEITED("몰수", "몰수 처리된 경기"),
 
     /** 콜드게임 */
-    CALLED("콜드게임", "점수차 또는 기상 조건으로 조기 종료된 경기");
+    CALLED("콜드게임", "점수차 또는 기상 조건으로 조기 종료된 경기"),
+    ;
 
     /**
      * 경기가 시작 가능한 상태인지 확인합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameTeam.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameTeam.kt
@@ -16,37 +16,33 @@ import jakarta.persistence.*
     indexes = [
         Index(name = "idx_game_teams_game", columnList = "game_id"),
         Index(name = "idx_game_teams_team", columnList = "team_id"),
-        Index(name = "idx_game_teams_result", columnList = "result")
+        Index(name = "idx_game_teams_result", columnList = "result"),
     ],
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_game_teams_game_home_away",
-            columnNames = ["game_id", "home_away"]
+            columnNames = ["game_id", "home_away"],
         ),
         UniqueConstraint(
             name = "uk_game_teams_game_team",
-            columnNames = ["game_id", "team_id"]
-        )
-    ]
+            columnNames = ["game_id", "team_id"],
+        ),
+    ],
 )
 class GameTeam(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id", nullable = false)
     val game: Game,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
     val team: Team,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "home_away", nullable = false, length = 10)
     val homeAway: HomeAway,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     @Column(name = "total_score", nullable = false)
     var totalScore: Int = 0
         protected set
@@ -109,7 +105,10 @@ class GameTeam(
     /**
      * 이닝 점수를 기록합니다.
      */
-    fun recordInningScore(inning: Int, runs: Int) {
+    fun recordInningScore(
+        inning: Int,
+        runs: Int,
+    ) {
         require(inning >= 1) { "이닝은 1 이상이어야 합니다." }
         require(runs >= 0) { "점수는 0 이상이어야 합니다." }
 
@@ -127,7 +126,10 @@ class GameTeam(
     /**
      * 특정 이닝에 득점을 추가합니다 (BoxScore 계산용).
      */
-    fun addRunInInning(inning: Int, runs: Int = 1) {
+    fun addRunInInning(
+        inning: Int,
+        runs: Int = 1,
+    ) {
         require(inning >= 1) { "이닝은 1 이상이어야 합니다." }
         require(runs >= 0) { "점수는 0 이상이어야 합니다." }
 
@@ -164,7 +166,11 @@ class GameTeam(
     /**
      * 점수를 업데이트합니다.
      */
-    fun updateScore(totalScore: Int, totalHits: Int, totalErrors: Int) {
+    fun updateScore(
+        totalScore: Int,
+        totalHits: Int,
+        totalErrors: Int,
+    ) {
         require(totalScore >= 0) { "점수는 0 이상이어야 합니다." }
         require(totalHits >= 0) { "안타 수는 0 이상이어야 합니다." }
         require(totalErrors >= 0) { "실책 수는 0 이상이어야 합니다." }
@@ -177,7 +183,5 @@ class GameTeam(
     /**
      * 경기 결과 표시 문자열을 반환합니다 (예: "5 - 3 승").
      */
-    fun getScoreDisplay(opponentScore: Int): String {
-        return "$totalScore - $opponentScore ${result.displayName}"
-    }
+    fun getScoreDisplay(opponentScore: Int): String = "$totalScore - $opponentScore ${result.displayName}"
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/HomeAway.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/HomeAway.kt
@@ -3,12 +3,16 @@ package com.nextup.core.domain.game
 /**
  * 홈/원정 구분
  */
-enum class HomeAway(val displayName: String, val isHome: Boolean) {
+enum class HomeAway(
+    val displayName: String,
+    val isHome: Boolean,
+) {
     /** 홈팀 (후공) */
     HOME("홈", true),
 
     /** 원정팀 (선공) */
-    AWAY("원정", false);
+    AWAY("원정", false),
+    ;
 
     /**
      * 반대편을 반환합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupEntry.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupEntry.kt
@@ -17,42 +17,36 @@ import jakarta.persistence.*
     indexes = [
         Index(name = "idx_lineup_entries_submission", columnList = "submission_id"),
         Index(name = "idx_lineup_entries_player", columnList = "player_id"),
-        Index(name = "idx_lineup_entries_batting_order", columnList = "submission_id, batting_order")
+        Index(name = "idx_lineup_entries_batting_order", columnList = "submission_id, batting_order"),
     ],
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_lineup_entries_submission_player",
-            columnNames = ["submission_id", "player_id"]
+            columnNames = ["submission_id", "player_id"],
         ),
         UniqueConstraint(
             name = "uk_lineup_entries_submission_batting_order",
-            columnNames = ["submission_id", "batting_order"]
-        )
-    ]
+            columnNames = ["submission_id", "batting_order"],
+        ),
+    ],
 )
 class LineupEntry(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "submission_id", nullable = false)
     val submission: LineupSubmission,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id", nullable = false)
     val player: Player,
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
     val position: Position,
-
     @Column(name = "batting_order")
     val battingOrder: Int?,
-
     @Column(name = "back_number")
     val backNumber: Int?,
-
     @Column(name = "is_starter", nullable = false)
     val isStarter: Boolean = true,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity()

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupSubmission.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupSubmission.kt
@@ -19,33 +19,29 @@ import java.time.Instant
         Index(name = "idx_lineup_submissions_game", columnList = "game_id"),
         Index(name = "idx_lineup_submissions_team", columnList = "team_id"),
         Index(name = "idx_lineup_submissions_status", columnList = "status"),
-        Index(name = "idx_lineup_submissions_submitted_by", columnList = "submitted_by_id")
+        Index(name = "idx_lineup_submissions_submitted_by", columnList = "submitted_by_id"),
     ],
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_lineup_submissions_game_team",
-            columnNames = ["game_id", "team_id"]
-        )
-    ]
+            columnNames = ["game_id", "team_id"],
+        ),
+    ],
 )
 class LineupSubmission private constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id", nullable = false)
     val game: Game,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
     val team: Team,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "submitted_by_id", nullable = false)
     val submittedBy: User,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     var status: LineupSubmissionStatus = LineupSubmissionStatus.DRAFT
@@ -77,7 +73,7 @@ class LineupSubmission private constructor(
         mappedBy = "submission",
         cascade = [CascadeType.ALL],
         orphanRemoval = true,
-        fetch = FetchType.LAZY
+        fetch = FetchType.LAZY,
     )
     private val _entries: MutableList<LineupEntry> = mutableListOf()
 
@@ -112,7 +108,10 @@ class LineupSubmission private constructor(
     /**
      * 기록원이 라인업을 반려합니다.
      */
-    fun reject(scorer: User, reason: String) {
+    fun reject(
+        scorer: User,
+        reason: String,
+    ) {
         require(status.canReject()) {
             "제출된 상태의 라인업만 반려할 수 있습니다. 현재 상태: ${status.displayName}"
         }
@@ -149,11 +148,12 @@ class LineupSubmission private constructor(
         fun create(
             game: Game,
             team: Team,
-            submittedBy: User
-        ): LineupSubmission = LineupSubmission(
-            game = game,
-            team = team,
-            submittedBy = submittedBy
-        )
+            submittedBy: User,
+        ): LineupSubmission =
+            LineupSubmission(
+                game = game,
+                team = team,
+                submittedBy = submittedBy,
+            )
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupSubmissionStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupSubmissionStatus.kt
@@ -5,7 +5,9 @@ package com.nextup.core.domain.game
  *
  * 감독의 라인업 작성부터 기록원 확인까지의 워크플로우를 나타냅니다.
  */
-enum class LineupSubmissionStatus(val displayName: String) {
+enum class LineupSubmissionStatus(
+    val displayName: String,
+) {
     /**
      * 작성 중 - 감독이 라인업을 작성 중인 상태
      */
@@ -24,7 +26,8 @@ enum class LineupSubmissionStatus(val displayName: String) {
     /**
      * 반려됨 - 기록원이 라인업을 반려한 상태
      */
-    REJECTED("반려됨");
+    REJECTED("반려됨"),
+    ;
 
     /**
      * 제출 가능한 상태인지 확인합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingDecision.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingDecision.kt
@@ -8,14 +8,15 @@ package com.nextup.core.domain.game
 enum class PitchingDecision(
     val displayName: String,
     val abbreviation: String,
-    val description: String
+    val description: String,
 ) {
     WIN("승", "W", "승리투수"),
     LOSS("패", "L", "패전투수"),
     SAVE("세이브", "S", "세이브"),
     HOLD("홀드", "H", "홀드"),
     BLOWN_SAVE("블론세이브", "BS", "세이브 실패"),
-    NONE("없음", "-", "결정 없음");
+    NONE("없음", "-", "결정 없음"),
+    ;
 
     /**
      * 승리 결정인지 확인합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
@@ -16,19 +16,17 @@ import java.math.RoundingMode
     name = "pitching_records",
     indexes = [
         Index(name = "idx_pitching_records_game_player", columnList = "game_player_id"),
-        Index(name = "idx_pitching_records_decision", columnList = "decision")
-    ]
+        Index(name = "idx_pitching_records_decision", columnList = "decision"),
+    ],
 )
 class PitchingRecord(
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_player_id", nullable = false, unique = true)
     val gamePlayer: GamePlayer,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     /**
      * 이닝 수를 아웃 카운트로 저장 (5.1이닝 = 16 outs)
      */
@@ -124,72 +122,78 @@ class PitchingRecord(
      * 이닝이 0이면 0.00
      */
     val earnedRunAverage: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(earnedRuns)
-                .multiply(BigDecimal(9))
-                .divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(earnedRuns)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * WHIP = (피안타 + 볼넷) / 이닝
      */
     val whip: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(hitsAllowed + walksAllowed).divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(hitsAllowed + walksAllowed).divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * 9이닝당 삼진 (K/9) = (삼진 / 이닝) * 9
      */
     val strikeoutsPer9: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(strikeouts)
-                .multiply(BigDecimal(9))
-                .divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(strikeouts)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * 9이닝당 볼넷 (BB/9) = (볼넷 / 이닝) * 9
      */
     val walksPer9: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(walksAllowed)
-                .multiply(BigDecimal(9))
-                .divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(walksAllowed)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * 삼진/볼넷 비율 (K/BB)
      */
     val strikeoutToWalkRatio: BigDecimal
-        get() = if (walksAllowed == 0) {
-            if (strikeouts == 0) BigDecimal.ZERO else BigDecimal(strikeouts)
-        } else {
-            BigDecimal(strikeouts).divide(BigDecimal(walksAllowed), 2, RoundingMode.HALF_UP)
-        }.setScale(2, RoundingMode.HALF_UP)
+        get() =
+            if (walksAllowed == 0) {
+                if (strikeouts == 0) BigDecimal.ZERO else BigDecimal(strikeouts)
+            } else {
+                BigDecimal(strikeouts).divide(BigDecimal(walksAllowed), 2, RoundingMode.HALF_UP)
+            }.setScale(2, RoundingMode.HALF_UP)
 
     /**
      * 스트라이크 비율 (투구 수 대비 스트라이크)
      */
     val strikePercentage: BigDecimal?
-        get() = if (pitchesThrown == null || strikesThrown == null || pitchesThrown == 0) {
-            null
-        } else {
-            BigDecimal(strikesThrown!!)
-                .divide(BigDecimal(pitchesThrown!!), 3, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (pitchesThrown == null || strikesThrown == null || pitchesThrown == 0) {
+                null
+            } else {
+                BigDecimal(strikesThrown!!)
+                    .divide(BigDecimal(pitchesThrown!!), 3, RoundingMode.HALF_UP)
+            }
 
     /**
      * 비자책 실점 = 실점 - 자책점
@@ -219,7 +223,11 @@ class PitchingRecord(
     /**
      * 피안타를 기록합니다.
      */
-    fun recordHit(isHomeRun: Boolean = false, runsScored: Int = 0, earnedRuns: Int = 0) {
+    fun recordHit(
+        isHomeRun: Boolean = false,
+        runsScored: Int = 0,
+        earnedRuns: Int = 0,
+    ) {
         require(earnedRuns <= runsScored) {
             "자책점($earnedRuns)이 실점($runsScored)보다 클 수 없습니다."
         }
@@ -276,7 +284,10 @@ class PitchingRecord(
     /**
      * 투구 수를 기록합니다.
      */
-    fun recordPitchCount(totalPitches: Int, strikes: Int) {
+    fun recordPitchCount(
+        totalPitches: Int,
+        strikes: Int,
+    ) {
         require(strikes <= totalPitches) {
             "스트라이크 수($strikes)가 총 투구 수($totalPitches)보다 클 수 없습니다."
         }
@@ -356,7 +367,8 @@ class PitchingRecord(
         when (result) {
             PlateAppearanceResult.SINGLE,
             PlateAppearanceResult.DOUBLE,
-            PlateAppearanceResult.TRIPLE -> {
+            PlateAppearanceResult.TRIPLE,
+            -> {
                 hitsAllowed++
             }
             PlateAppearanceResult.HOME_RUN -> {
@@ -367,7 +379,8 @@ class PitchingRecord(
                 strikeouts++
             }
             PlateAppearanceResult.WALK,
-            PlateAppearanceResult.INTENTIONAL_WALK -> {
+            PlateAppearanceResult.INTENTIONAL_WALK,
+            -> {
                 walksAllowed++
             }
             PlateAppearanceResult.HIT_BY_PITCH -> {
@@ -412,7 +425,7 @@ class PitchingRecord(
         }
         if (pitchesThrown != null && strikesThrown != null) {
             require(strikesThrown!! <= pitchesThrown!!) {
-                "스트라이크 수(${strikesThrown})가 총 투구 수(${pitchesThrown})보다 클 수 없습니다."
+                "스트라이크 수($strikesThrown)가 총 투구 수($pitchesThrown)보다 클 수 없습니다."
             }
         }
         if (isStartingPitcher && decision == PitchingDecision.WIN) {
@@ -426,7 +439,10 @@ class PitchingRecord(
         /**
          * 경기 출전 선수의 투수 기록을 생성합니다.
          */
-        fun create(gamePlayer: GamePlayer, isStartingPitcher: Boolean = false): PitchingRecord =
+        fun create(
+            gamePlayer: GamePlayer,
+            isStartingPitcher: Boolean = false,
+        ): PitchingRecord =
             PitchingRecord(gamePlayer = gamePlayer).apply {
                 this.isStartingPitcher = isStartingPitcher
             }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PlateAppearanceResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PlateAppearanceResult.kt
@@ -10,7 +10,7 @@ enum class PlateAppearanceResult(
     val displayName: String,
     val description: String,
     val isAtBat: Boolean,
-    val isHit: Boolean
+    val isHit: Boolean,
 ) {
     // 안타 (Hit) - 타수 O, 안타 O
     SINGLE("1루타", "안타로 1루에 진루", true, true),
@@ -34,7 +34,8 @@ enum class PlateAppearanceResult(
     HIT_BY_PITCH("사구", "몸에 맞는 공으로 출루", false, false),
     SACRIFICE_BUNT("희생번트", "희생번트로 아웃", false, false),
     SACRIFICE_FLY("희생플라이", "희생플라이로 아웃", false, false),
-    INTERFERENCE("방해", "수비 방해로 출루", false, false);
+    INTERFERENCE("방해", "수비 방해로 출루", false, false),
+    ;
 
     /**
      * 단타인지 확인합니다.
@@ -100,11 +101,12 @@ enum class PlateAppearanceResult(
      * 루타 수를 반환합니다 (안타가 아니면 0).
      */
     val totalBases: Int
-        get() = when (this) {
-            SINGLE -> 1
-            DOUBLE -> 2
-            TRIPLE -> 3
-            HOME_RUN -> 4
-            else -> 0
-        }
+        get() =
+            when (this) {
+                SINGLE -> 1
+                DOUBLE -> 2
+                TRIPLE -> 3
+                HOME_RUN -> 4
+                else -> 0
+            }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/league/League.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/league/League.kt
@@ -15,40 +15,31 @@ import jakarta.persistence.*
     name = "leagues",
     indexes = [
         Index(name = "idx_leagues_association", columnList = "association_id"),
-        Index(name = "idx_leagues_is_active", columnList = "is_active")
-    ]
+        Index(name = "idx_leagues_is_active", columnList = "is_active"),
+    ],
 )
 class League(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "association_id", nullable = false)
     val association: Association,
-
     @Column(nullable = false, length = 100)
     val name: String,
-
     @Column(length = 20)
     val abbreviation: String? = null,
-
     @Column(nullable = false)
     val foundedYear: Int,
-
     @Column(name = "division_level")
     val divisionLevel: Int? = null,
-
     @Column(length = 500)
     var description: String? = null,
-
     @Column(length = 255)
     var logoUrl: String? = null,
-
     @Column(name = "is_active", nullable = false)
     var isActive: Boolean = true,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     fun deactivate() {
         this.isActive = false
     }
@@ -59,7 +50,7 @@ class League(
 
     fun updateInfo(
         description: String? = this.description,
-        logoUrl: String? = this.logoUrl
+        logoUrl: String? = this.logoUrl,
     ) {
         this.description = description
         this.logoUrl = logoUrl

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/player/CareerType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/player/CareerType.kt
@@ -5,7 +5,10 @@ package com.nextup.core.domain.player
  *
  * 선출(선수 출신) 여부 판별의 기초 데이터로 사용됩니다.
  */
-enum class CareerType(val displayName: String, val isProfessional: Boolean) {
+enum class CareerType(
+    val displayName: String,
+    val isProfessional: Boolean,
+) {
     /** KBO 프로야구 */
     KBO("KBO 프로", true),
 
@@ -37,5 +40,5 @@ enum class CareerType(val displayName: String, val isProfessional: Boolean) {
     AMATEUR("사회인", false),
 
     /** 군 야구단 */
-    MILITARY("군", false)
+    MILITARY("군", false),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/player/ContractType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/player/ContractType.kt
@@ -1,10 +1,12 @@
 package com.nextup.core.domain.player
 
-enum class ContractType(val displayName: String) {
+enum class ContractType(
+    val displayName: String,
+) {
     REGULAR("정규 계약"),
     MINOR_LEAGUE("마이너리그"),
     LOAN("임대"),
     FREE_AGENT("FA 계약"),
     ROOKIE("신인"),
-    FOREIGN("외국인 선수")
+    FOREIGN("외국인 선수"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/player/Player.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/player/Player.kt
@@ -15,54 +15,41 @@ import java.time.LocalDate
     name = "players",
     indexes = [
         Index(name = "idx_players_name", columnList = "name"),
-        Index(name = "idx_players_birth_date", columnList = "birth_date")
-    ]
+        Index(name = "idx_players_birth_date", columnList = "birth_date"),
+    ],
 )
 class Player(
     @Column(nullable = false, length = 50)
     val name: String,
-
     @Column(name = "birth_date")
     val birthDate: LocalDate? = null,
-
     @Column(length = 50)
     val birthPlace: String? = null,
-
     @Column(length = 50)
     val nationality: String? = null,
-
     @Column
     var height: Int? = null,
-
     @Column
     var weight: Int? = null,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "throwing_hand", length = 10)
     var throwingHand: ThrowingHand? = null,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "batting_hand", length = 10)
     var battingHand: BattingHand? = null,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "primary_position", nullable = false, length = 30)
     var primaryPosition: Position,
-
     @Column(name = "debut_year")
     var debutYear: Int? = null,
-
     @Column(name = "retirement_year")
     var retirementYear: Int? = null,
-
     @Column(name = "profile_image_url", length = 255)
     var profileImageUrl: String? = null,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     val isActive: Boolean
         get() = retirementYear == null
 
@@ -74,7 +61,7 @@ class Player(
 
     fun updatePhysicalInfo(
         height: Int? = this.height,
-        weight: Int? = this.weight
+        weight: Int? = this.weight,
     ) {
         this.height = height
         this.weight = weight
@@ -87,13 +74,12 @@ class Player(
     /**
      * 선수의 나이를 계산합니다.
      */
-    fun calculateAge(baseDate: LocalDate = LocalDate.now()): Int? {
-        return birthDate?.let {
+    fun calculateAge(baseDate: LocalDate = LocalDate.now()): Int? =
+        birthDate?.let {
             var age = baseDate.year - it.year
             if (baseDate.dayOfYear < it.dayOfYear) {
                 age--
             }
             age
         }
-    }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/player/PlayerCareer.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/player/PlayerCareer.kt
@@ -16,38 +16,30 @@ import java.time.LocalDate
     indexes = [
         Index(name = "idx_player_careers_player", columnList = "player_id"),
         Index(name = "idx_player_careers_type", columnList = "career_type"),
-        Index(name = "idx_player_careers_dates", columnList = "player_id, start_date, end_date")
-    ]
+        Index(name = "idx_player_careers_dates", columnList = "player_id, start_date, end_date"),
+    ],
 )
 class PlayerCareer(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id", nullable = false)
     val player: Player,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "career_type", nullable = false, length = 20)
     val type: CareerType,
-
     @Column(nullable = false, length = 100)
     val organization: String,
-
     @Column(name = "start_date", nullable = false)
     val startDate: LocalDate,
-
     @Column(name = "end_date")
     var endDate: LocalDate? = null,
-
     @Column(length = 50)
     val position: String? = null,
-
     @Column(length = 500)
     var description: String? = null,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     /**
      * 현재 활동 중인 경력인지 확인합니다.
      */
@@ -71,9 +63,8 @@ class PlayerCareer(
     /**
      * 특정 날짜에 이 경력이 활성 상태였는지 확인합니다.
      */
-    fun isActiveAt(date: LocalDate): Boolean {
-        return !startDate.isAfter(date) && (endDate == null || !endDate!!.isBefore(date))
-    }
+    fun isActiveAt(date: LocalDate): Boolean =
+        !startDate.isAfter(date) && (endDate == null || !endDate!!.isBefore(date))
 
     /**
      * 경력 기간(년)을 계산합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/player/PlayerTeamHistory.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/player/PlayerTeamHistory.kt
@@ -25,44 +25,35 @@ import java.time.temporal.ChronoUnit
         Index(name = "idx_pth_team_dates", columnList = "team_id, start_date, end_date"),
         Index(name = "idx_pth_current", columnList = "player_id, end_date"),
         Index(name = "idx_pth_status", columnList = "status"),
-        Index(name = "idx_pth_player_status", columnList = "player_id, status")
-    ]
+        Index(name = "idx_pth_player_status", columnList = "player_id, status"),
+    ],
 )
 class PlayerTeamHistory(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id", nullable = false)
     val player: Player,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
     val team: Team,
-
     @Column(name = "start_date", nullable = false)
     val startDate: LocalDate,
-
     @Column(name = "end_date")
     var endDate: LocalDate? = null,
-
     @Column(name = "uniform_number")
     var uniformNumber: Int? = null,
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
     var position: Position,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "contract_type", nullable = false, length = 20)
     var contractType: ContractType = ContractType.REGULAR,
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     var status: PlayerTeamStatus = PlayerTeamStatus.ACTIVE,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     val isCurrentAffiliation: Boolean
         get() = endDate == null
 
@@ -124,9 +115,8 @@ class PlayerTeamHistory(
         this.position = newPosition
     }
 
-    fun isActiveAt(date: LocalDate): Boolean {
-        return !startDate.isAfter(date) && (endDate == null || !endDate!!.isBefore(date))
-    }
+    fun isActiveAt(date: LocalDate): Boolean =
+        !startDate.isAfter(date) && (endDate == null || !endDate!!.isBefore(date))
 
     fun overlaps(other: PlayerTeamHistory): Boolean {
         if (this.player.id != other.player.id) return false

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/player/PlayerTeamStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/player/PlayerTeamStatus.kt
@@ -7,8 +7,10 @@ package com.nextup.core.domain.player
  * - INACTIVE: 비활동 상태 (부상, 휴식 등)
  * - TRANSFERRED: 다른 팀으로 이적
  */
-enum class PlayerTeamStatus(val displayName: String) {
+enum class PlayerTeamStatus(
+    val displayName: String,
+) {
     ACTIVE("활동중"),
     INACTIVE("비활동"),
-    TRANSFERRED("이적")
+    TRANSFERRED("이적"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/player/Position.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/player/Position.kt
@@ -1,6 +1,10 @@
 package com.nextup.core.domain.player
 
-enum class Position(val displayName: String, val abbreviation: String, val category: PositionCategory) {
+enum class Position(
+    val displayName: String,
+    val abbreviation: String,
+    val category: PositionCategory,
+) {
     // Pitcher
     STARTING_PITCHER("선발투수", "SP", PositionCategory.PITCHER),
     RELIEF_PITCHER("중간계투", "RP", PositionCategory.PITCHER),
@@ -21,13 +25,15 @@ enum class Position(val displayName: String, val abbreviation: String, val categ
     RIGHT_FIELD("우익수", "RF", PositionCategory.OUTFIELD),
 
     // Designated Hitter
-    DESIGNATED_HITTER("지명타자", "DH", PositionCategory.DESIGNATED_HITTER);
+    DESIGNATED_HITTER("지명타자", "DH", PositionCategory.DESIGNATED_HITTER),
 }
 
-enum class PositionCategory(val displayName: String) {
+enum class PositionCategory(
+    val displayName: String,
+) {
     PITCHER("투수"),
     CATCHER("포수"),
     INFIELD("내야수"),
     OUTFIELD("외야수"),
-    DESIGNATED_HITTER("지명타자")
+    DESIGNATED_HITTER("지명타자"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/player/ThrowingHand.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/player/ThrowingHand.kt
@@ -1,13 +1,17 @@
 package com.nextup.core.domain.player
 
-enum class ThrowingHand(val displayName: String) {
+enum class ThrowingHand(
+    val displayName: String,
+) {
     LEFT("좌투"),
     RIGHT("우투"),
-    SWITCH("양투")
+    SWITCH("양투"),
 }
 
-enum class BattingHand(val displayName: String) {
+enum class BattingHand(
+    val displayName: String,
+) {
     LEFT("좌타"),
     RIGHT("우타"),
-    SWITCH("양타")
+    SWITCH("양타"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
@@ -18,19 +18,17 @@ import java.math.RoundingMode
 @Table(
     name = "career_batting_stats",
     indexes = [
-        Index(name = "idx_career_batting_stats_player", columnList = "player_id")
-    ]
+        Index(name = "idx_career_batting_stats_player", columnList = "player_id"),
+    ],
 )
 class CareerBattingStats(
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id", nullable = false, unique = true)
     val player: Player,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     // 시즌 수
     @Column(name = "seasons_played", nullable = false)
     var seasonsPlayed: Int = 0
@@ -147,11 +145,12 @@ class CareerBattingStats(
      * 타수가 0이면 .000
      */
     val battingAverage: BigDecimal
-        get() = if (atBats == 0) {
-            BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
-        } else {
-            BigDecimal(hits).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (atBats == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(hits).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
+            }
 
     /**
      * 출루율 (OBP) = (안타 + 볼넷 + 사구) / (타수 + 볼넷 + 사구 + 희생플라이)
@@ -171,11 +170,12 @@ class CareerBattingStats(
      * 장타율 (SLG) = 총 루타 / 타수
      */
     val sluggingPercentage: BigDecimal
-        get() = if (atBats == 0) {
-            BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
-        } else {
-            BigDecimal(totalBases).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (atBats == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(totalBases).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
+            }
 
     /**
      * OPS = 출루율 + 장타율

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
@@ -18,19 +18,17 @@ import java.math.RoundingMode
 @Table(
     name = "career_pitching_stats",
     indexes = [
-        Index(name = "idx_career_pitching_stats_player", columnList = "player_id")
-    ]
+        Index(name = "idx_career_pitching_stats_player", columnList = "player_id"),
+    ],
 )
 class CareerPitchingStats(
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id", nullable = false, unique = true)
     val player: Player,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     // 시즌 수
     @Column(name = "seasons_played", nullable = false)
     var seasonsPlayed: Int = 0
@@ -149,72 +147,78 @@ class CareerPitchingStats(
      * 이닝이 0이면 0.00
      */
     val earnedRunAverage: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(earnedRuns)
-                .multiply(BigDecimal(9))
-                .divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(earnedRuns)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * WHIP = (피안타 + 볼넷) / 이닝
      */
     val whip: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(hitsAllowed + walksAllowed).divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(hitsAllowed + walksAllowed).divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * 9이닝당 삼진 (K/9) = (삼진 / 이닝) * 9
      */
     val strikeoutsPer9: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(strikeouts)
-                .multiply(BigDecimal(9))
-                .divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(strikeouts)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * 9이닝당 볼넷 (BB/9) = (볼넷 / 이닝) * 9
      */
     val walksPer9: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(walksAllowed)
-                .multiply(BigDecimal(9))
-                .divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(walksAllowed)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * 삼진/볼넷 비율 (K/BB)
      */
     val strikeoutToWalkRatio: BigDecimal
-        get() = if (walksAllowed == 0) {
-            if (strikeouts == 0) BigDecimal.ZERO else BigDecimal(strikeouts)
-        } else {
-            BigDecimal(strikeouts).divide(BigDecimal(walksAllowed), 2, RoundingMode.HALF_UP)
-        }.setScale(2, RoundingMode.HALF_UP)
+        get() =
+            if (walksAllowed == 0) {
+                if (strikeouts == 0) BigDecimal.ZERO else BigDecimal(strikeouts)
+            } else {
+                BigDecimal(strikeouts).divide(BigDecimal(walksAllowed), 2, RoundingMode.HALF_UP)
+            }.setScale(2, RoundingMode.HALF_UP)
 
     /**
      * 스트라이크 비율 (투구 수 대비 스트라이크)
      */
     val strikePercentage: BigDecimal?
-        get() = if (pitchesThrown == null || strikesThrown == null || pitchesThrown == 0) {
-            null
-        } else {
-            BigDecimal(strikesThrown!!)
-                .divide(BigDecimal(pitchesThrown!!), 3, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (pitchesThrown == null || strikesThrown == null || pitchesThrown == 0) {
+                null
+            } else {
+                BigDecimal(strikesThrown!!)
+                    .divide(BigDecimal(pitchesThrown!!), 3, RoundingMode.HALF_UP)
+            }
 
     /**
      * 비자책 실점 = 실점 - 자책점
@@ -300,7 +304,7 @@ class CareerPitchingStats(
             throw StatsValidationException("자책점($earnedRuns)이 실점($runsAllowed)보다 클 수 없습니다.")
         }
         if (pitchesThrown != null && strikesThrown != null && strikesThrown!! > pitchesThrown!!) {
-            throw StatsValidationException("스트라이크 수(${strikesThrown})가 총 투구 수(${pitchesThrown})보다 클 수 없습니다.")
+            throw StatsValidationException("스트라이크 수($strikesThrown)가 총 투구 수($pitchesThrown)보다 클 수 없습니다.")
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
@@ -20,28 +20,25 @@ import java.math.RoundingMode
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_season_batting_stats_player_year",
-            columnNames = ["player_id", "year"]
-        )
+            columnNames = ["player_id", "year"],
+        ),
     ],
     indexes = [
         Index(name = "idx_season_batting_stats_player", columnList = "player_id"),
         Index(name = "idx_season_batting_stats_year", columnList = "year"),
-        Index(name = "idx_season_batting_stats_games", columnList = "games_played")
-    ]
+        Index(name = "idx_season_batting_stats_games", columnList = "games_played"),
+    ],
 )
 class SeasonBattingStats(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id", nullable = false)
     val player: Player,
-
     @Column(nullable = false)
     val year: Int,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     // 출전 경기 수
     @Column(name = "games_played", nullable = false)
     var gamesPlayed: Int = 0
@@ -153,11 +150,12 @@ class SeasonBattingStats(
      * 타수가 0이면 .000
      */
     val battingAverage: BigDecimal
-        get() = if (atBats == 0) {
-            BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
-        } else {
-            BigDecimal(hits).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (atBats == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(hits).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
+            }
 
     /**
      * 출루율 (OBP) = (안타 + 볼넷 + 사구) / (타수 + 볼넷 + 사구 + 희생플라이)
@@ -177,11 +175,12 @@ class SeasonBattingStats(
      * 장타율 (SLG) = 총 루타 / 타수
      */
     val sluggingPercentage: BigDecimal
-        get() = if (atBats == 0) {
-            BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
-        } else {
-            BigDecimal(totalBases).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (atBats == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(totalBases).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
+            }
 
     /**
      * OPS = 출루율 + 장타율
@@ -250,7 +249,10 @@ class SeasonBattingStats(
         /**
          * 선수의 시즌 타격 통계를 생성합니다.
          */
-        fun create(player: Player, year: Int): SeasonBattingStats {
+        fun create(
+            player: Player,
+            year: Int,
+        ): SeasonBattingStats {
             if (year <= 0) {
                 throw StatsValidationException("연도는 양수여야 합니다.")
             }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
@@ -20,28 +20,25 @@ import java.math.RoundingMode
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_season_pitching_stats_player_year",
-            columnNames = ["player_id", "year"]
-        )
+            columnNames = ["player_id", "year"],
+        ),
     ],
     indexes = [
         Index(name = "idx_season_pitching_stats_player", columnList = "player_id"),
         Index(name = "idx_season_pitching_stats_year", columnList = "year"),
-        Index(name = "idx_season_pitching_stats_games", columnList = "games_played")
-    ]
+        Index(name = "idx_season_pitching_stats_games", columnList = "games_played"),
+    ],
 )
 class SeasonPitchingStats(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id", nullable = false)
     val player: Player,
-
     @Column(nullable = false)
     val year: Int,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     // 출전 경기 수
     @Column(name = "games_played", nullable = false)
     var gamesPlayed: Int = 0
@@ -155,72 +152,78 @@ class SeasonPitchingStats(
      * 이닝이 0이면 0.00
      */
     val earnedRunAverage: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(earnedRuns)
-                .multiply(BigDecimal(9))
-                .divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(earnedRuns)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * WHIP = (피안타 + 볼넷) / 이닝
      */
     val whip: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(hitsAllowed + walksAllowed).divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(hitsAllowed + walksAllowed).divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * 9이닝당 삼진 (K/9) = (삼진 / 이닝) * 9
      */
     val strikeoutsPer9: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(strikeouts)
-                .multiply(BigDecimal(9))
-                .divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(strikeouts)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * 9이닝당 볼넷 (BB/9) = (볼넷 / 이닝) * 9
      */
     val walksPer9: BigDecimal
-        get() = if (inningsPitchedOuts == 0) {
-            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
-        } else {
-            val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
-            BigDecimal(walksAllowed)
-                .multiply(BigDecimal(9))
-                .divide(innings, 2, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (inningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(walksAllowed)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
 
     /**
      * 삼진/볼넷 비율 (K/BB)
      */
     val strikeoutToWalkRatio: BigDecimal
-        get() = if (walksAllowed == 0) {
-            if (strikeouts == 0) BigDecimal.ZERO else BigDecimal(strikeouts)
-        } else {
-            BigDecimal(strikeouts).divide(BigDecimal(walksAllowed), 2, RoundingMode.HALF_UP)
-        }.setScale(2, RoundingMode.HALF_UP)
+        get() =
+            if (walksAllowed == 0) {
+                if (strikeouts == 0) BigDecimal.ZERO else BigDecimal(strikeouts)
+            } else {
+                BigDecimal(strikeouts).divide(BigDecimal(walksAllowed), 2, RoundingMode.HALF_UP)
+            }.setScale(2, RoundingMode.HALF_UP)
 
     /**
      * 스트라이크 비율 (투구 수 대비 스트라이크)
      */
     val strikePercentage: BigDecimal?
-        get() = if (pitchesThrown == null || strikesThrown == null || pitchesThrown == 0) {
-            null
-        } else {
-            BigDecimal(strikesThrown!!)
-                .divide(BigDecimal(pitchesThrown!!), 3, RoundingMode.HALF_UP)
-        }
+        get() =
+            if (pitchesThrown == null || strikesThrown == null || pitchesThrown == 0) {
+                null
+            } else {
+                BigDecimal(strikesThrown!!)
+                    .divide(BigDecimal(pitchesThrown!!), 3, RoundingMode.HALF_UP)
+            }
 
     /**
      * 비자책 실점 = 실점 - 자책점
@@ -296,7 +299,7 @@ class SeasonPitchingStats(
             throw StatsValidationException("자책점($earnedRuns)이 실점($runsAllowed)보다 클 수 없습니다.")
         }
         if (pitchesThrown != null && strikesThrown != null && strikesThrown!! > pitchesThrown!!) {
-            throw StatsValidationException("스트라이크 수(${strikesThrown})가 총 투구 수(${pitchesThrown})보다 클 수 없습니다.")
+            throw StatsValidationException("스트라이크 수($strikesThrown)가 총 투구 수($pitchesThrown)보다 클 수 없습니다.")
         }
     }
 
@@ -304,7 +307,10 @@ class SeasonPitchingStats(
         /**
          * 선수의 시즌 투수 통계를 생성합니다.
          */
-        fun create(player: Player, year: Int): SeasonPitchingStats {
+        fun create(
+            player: Player,
+            year: Int,
+        ): SeasonPitchingStats {
             if (year <= 0) {
                 throw StatsValidationException("연도는 양수여야 합니다.")
             }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/team/Team.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/team/Team.kt
@@ -14,43 +14,33 @@ import jakarta.persistence.*
     name = "teams",
     indexes = [
         Index(name = "idx_teams_league_id", columnList = "league_id"),
-        Index(name = "idx_teams_is_active", columnList = "is_active")
-    ]
+        Index(name = "idx_teams_is_active", columnList = "is_active"),
+    ],
 )
 class Team(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "league_id", nullable = false)
     val league: League,
-
     @Column(nullable = false, length = 100)
     val name: String,
-
     @Column(length = 20)
     val abbreviation: String? = null,
-
     @Column(nullable = false, length = 100)
     val city: String,
-
     @Column(nullable = false)
     val foundedYear: Int,
-
     @Column(length = 255)
     var logoUrl: String? = null,
-
     @Column(length = 50)
     var primaryColor: String? = null,
-
     @Column(length = 50)
     var secondaryColor: String? = null,
-
     @Column(name = "is_active", nullable = false)
     var isActive: Boolean = true,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     val fullName: String
         get() = "$city $name"
 
@@ -65,7 +55,7 @@ class Team(
     fun updateInfo(
         logoUrl: String? = this.logoUrl,
         primaryColor: String? = this.primaryColor,
-        secondaryColor: String? = this.secondaryColor
+        secondaryColor: String? = this.secondaryColor,
     ) {
         this.logoUrl = logoUrl
         this.primaryColor = primaryColor

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/user/OAuthAccount.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/user/OAuthAccount.kt
@@ -16,37 +16,31 @@ import java.time.Instant
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_oauth_provider_id",
-            columnNames = ["provider", "oauth_id"]
-        )
+            columnNames = ["provider", "oauth_id"],
+        ),
     ],
     indexes = [
         Index(name = "idx_oauth_user", columnList = "user_id"),
-        Index(name = "idx_oauth_provider", columnList = "provider")
-    ]
+        Index(name = "idx_oauth_provider", columnList = "provider"),
+    ],
 )
 class OAuthAccount private constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     val user: User,
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     val provider: OAuthProvider,
-
     @Column(name = "oauth_id", nullable = false, length = 100)
     val oauthId: String,
-
     @Column(length = 100)
     val email: String? = null,
-
     @Column(name = "connected_at", nullable = false)
     val connectedAt: Instant = Instant.now(),
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     companion object {
         /**
          * OAuthAccount를 생성합니다.
@@ -62,7 +56,7 @@ class OAuthAccount private constructor(
             user: User,
             provider: OAuthProvider,
             oauthId: String,
-            email: String? = null
+            email: String? = null,
         ): OAuthAccount {
             require(provider != OAuthProvider.LOCAL) {
                 "LOCAL은 OAuthAccount로 관리하지 않습니다."
@@ -74,7 +68,7 @@ class OAuthAccount private constructor(
                 user = user,
                 provider = provider,
                 oauthId = oauthId,
-                email = email
+                email = email,
             )
         }
     }
@@ -88,6 +82,5 @@ class OAuthAccount private constructor(
 
     override fun hashCode(): Int = id.hashCode()
 
-    override fun toString(): String =
-        "OAuthAccount(id=$id, provider=$provider, oauthId=$oauthId, userId=${user.id})"
+    override fun toString(): String = "OAuthAccount(id=$id, provider=$provider, oauthId=$oauthId, userId=${user.id})"
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/user/OAuthProvider.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/user/OAuthProvider.kt
@@ -3,7 +3,9 @@ package com.nextup.core.domain.user
 /**
  * OAuth 제공자
  */
-enum class OAuthProvider(val displayName: String) {
+enum class OAuthProvider(
+    val displayName: String,
+) {
     /** 일반 회원가입 (OAuth 미사용) */
     LOCAL("일반"),
 
@@ -17,5 +19,5 @@ enum class OAuthProvider(val displayName: String) {
     NAVER("네이버"),
 
     /** 애플 로그인 */
-    APPLE("애플")
+    APPLE("애플"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/user/Role.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/user/Role.kt
@@ -3,7 +3,10 @@ package com.nextup.core.domain.user
 /**
  * 사용자 권한
  */
-enum class Role(val displayName: String, val description: String) {
+enum class Role(
+    val displayName: String,
+    val description: String,
+) {
     /** 시스템 관리자 - 전체 시스템 관리 */
     ADMIN("관리자", "시스템 전체 관리 권한"),
 
@@ -23,5 +26,5 @@ enum class Role(val displayName: String, val description: String) {
     PLAYER("선수", "본인 기록 조회 및 프로필 관리"),
 
     /** 일반 사용자 - 조회만 가능 */
-    USER("사용자", "기본 조회 권한")
+    USER("사용자", "기본 조회 권한"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/user/User.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/user/User.kt
@@ -16,38 +16,31 @@ import jakarta.persistence.*
     name = "users",
     indexes = [
         Index(name = "idx_users_email", columnList = "email", unique = true),
-        Index(name = "idx_users_player", columnList = "player_id")
-    ]
+        Index(name = "idx_users_player", columnList = "player_id"),
+    ],
 )
 class User private constructor(
     @Column(nullable = false, unique = true, length = 100)
     val email: String,
-
     @Column(length = 255)
     var password: String? = null,
-
     @Column(nullable = false, length = 50)
     var nickname: String,
-
     @Column(name = "profile_image_url", length = 255)
     var profileImageUrl: String? = null,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")
     var player: Player? = null,
-
     @Column(name = "is_active", nullable = false)
     var isActive: Boolean = true,
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L
+    val id: Long = 0L,
 ) : BaseTimeEntity() {
-
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
         name = "user_roles",
-        joinColumns = [JoinColumn(name = "user_id")]
+        joinColumns = [JoinColumn(name = "user_id")],
     )
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false, length = 30)
@@ -57,7 +50,7 @@ class User private constructor(
         mappedBy = "user",
         cascade = [CascadeType.ALL],
         orphanRemoval = true,
-        fetch = FetchType.LAZY
+        fetch = FetchType.LAZY,
     )
     private val _oauthAccounts: MutableList<OAuthAccount> = mutableListOf()
 
@@ -115,7 +108,7 @@ class User private constructor(
     fun addOAuthAccount(
         provider: OAuthProvider,
         oauthId: String,
-        email: String? = null
+        email: String? = null,
     ): OAuthAccount {
         require(!hasOAuthProvider(provider)) {
             "이미 ${provider.displayName} 계정이 연결되어 있습니다."
@@ -141,14 +134,12 @@ class User private constructor(
     /**
      * 특정 OAuth 제공자가 연동되어 있는지 확인합니다.
      */
-    fun hasOAuthProvider(provider: OAuthProvider): Boolean =
-        _oauthAccounts.any { it.provider == provider }
+    fun hasOAuthProvider(provider: OAuthProvider): Boolean = _oauthAccounts.any { it.provider == provider }
 
     /**
      * 특정 OAuth 제공자의 연동 정보를 조회합니다.
      */
-    fun getOAuthAccount(provider: OAuthProvider): OAuthAccount? =
-        _oauthAccounts.find { it.provider == provider }
+    fun getOAuthAccount(provider: OAuthProvider): OAuthAccount? = _oauthAccounts.find { it.provider == provider }
 
     /**
      * 인증 수단을 제거할 수 있는지 확인합니다.
@@ -181,7 +172,7 @@ class User private constructor(
      */
     fun updateProfile(
         nickname: String = this.nickname,
-        profileImageUrl: String? = this.profileImageUrl
+        profileImageUrl: String? = this.profileImageUrl,
     ) {
         this.nickname = nickname
         this.profileImageUrl = profileImageUrl
@@ -230,8 +221,7 @@ class User private constructor(
 
     override fun hashCode(): Int = id.hashCode()
 
-    override fun toString(): String =
-        "User(id=$id, email=$email, nickname=$nickname, isActive=$isActive)"
+    override fun toString(): String = "User(id=$id, email=$email, nickname=$nickname, isActive=$isActive)"
 
     companion object {
         /**
@@ -240,7 +230,7 @@ class User private constructor(
         fun createLocalUser(
             email: String,
             encodedPassword: String,
-            nickname: String
+            nickname: String,
         ): User {
             require(email.isNotBlank()) { "이메일은 비어있을 수 없습니다." }
             require(encodedPassword.isNotBlank()) { "비밀번호는 비어있을 수 없습니다." }
@@ -249,7 +239,7 @@ class User private constructor(
             return User(
                 email = email,
                 password = encodedPassword,
-                nickname = nickname
+                nickname = nickname,
             )
         }
 
@@ -268,7 +258,7 @@ class User private constructor(
             nickname: String,
             provider: OAuthProvider,
             oauthId: String,
-            profileImageUrl: String? = null
+            profileImageUrl: String? = null,
         ): User {
             require(email.isNotBlank()) { "이메일은 비어있을 수 없습니다." }
             require(nickname.isNotBlank()) { "닉네임은 비어있을 수 없습니다." }
@@ -277,7 +267,7 @@ class User private constructor(
             return User(
                 email = email,
                 nickname = nickname,
-                profileImageUrl = profileImageUrl
+                profileImageUrl = profileImageUrl,
             ).apply {
                 addOAuthAccount(provider, oauthId, email)
             }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/AssociationRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/AssociationRepositoryPort.kt
@@ -1,14 +1,12 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.association.Association
-import java.util.Optional
 
 /**
  * Association Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface AssociationRepositoryPort {
-
     fun save(association: Association): Association
 
     fun findAll(): List<Association>

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BattingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BattingRecordRepositoryPort.kt
@@ -2,14 +2,12 @@ package com.nextup.core.port.repository
 
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.GamePlayer
-import java.util.Optional
 
 /**
  * BattingRecord Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface BattingRecordRepositoryPort {
-
     fun save(battingRecord: BattingRecord): BattingRecord
 
     fun findAll(): List<BattingRecord>
@@ -41,22 +39,34 @@ interface BattingRecordRepositoryPort {
     /**
      * 선수의 최근 N경기 타격 기록을 조회합니다.
      */
-    fun findRecentByPlayerId(playerId: Long, limit: Int): List<BattingRecord>
+    fun findRecentByPlayerId(
+        playerId: Long,
+        limit: Int,
+    ): List<BattingRecord>
 
     /**
      * 팀의 특정 경기 타격 기록을 조회합니다.
      */
-    fun findAllByTeamIdAndGameId(teamId: Long, gameId: Long): List<BattingRecord>
+    fun findAllByTeamIdAndGameId(
+        teamId: Long,
+        gameId: Long,
+    ): List<BattingRecord>
 
     /**
      * 경기에서 최소 타석 수 이상인 타격 기록을 조회합니다.
      */
-    fun findByGameIdAndMinPlateAppearances(gameId: Long, minPlateAppearances: Int): List<BattingRecord>
+    fun findByGameIdAndMinPlateAppearances(
+        gameId: Long,
+        minPlateAppearances: Int,
+    ): List<BattingRecord>
 
     /**
      * 타율 상위 N명을 조회합니다 (최소 타수 조건).
      */
-    fun findTopByBattingAverage(minAtBats: Int, limit: Int): List<BattingRecord>
+    fun findTopByBattingAverage(
+        minAtBats: Int,
+        limit: Int,
+    ): List<BattingRecord>
 
     /**
      * 홈런 상위 N명을 조회합니다.
@@ -71,5 +81,8 @@ interface BattingRecordRepositoryPort {
     /**
      * 선수의 특정 연도 타격 기록을 조회합니다.
      */
-    fun findAllByPlayerIdAndYear(playerId: Long, year: Int): List<BattingRecord>
+    fun findAllByPlayerIdAndYear(
+        playerId: Long,
+        year: Int,
+    ): List<BattingRecord>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CareerBattingStatsRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CareerBattingStatsRepositoryPort.kt
@@ -1,14 +1,12 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.stats.CareerBattingStats
-import java.util.Optional
 
 /**
  * CareerBattingStats Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface CareerBattingStatsRepositoryPort {
-
     fun save(careerBattingStats: CareerBattingStats): CareerBattingStats
 
     fun findAll(): List<CareerBattingStats>
@@ -25,7 +23,10 @@ interface CareerBattingStatsRepositoryPort {
     /**
      * 통산 타율 상위 N명을 조회합니다 (최소 타수 조건).
      */
-    fun findTopByBattingAverage(minAtBats: Int, limit: Int): List<CareerBattingStats>
+    fun findTopByBattingAverage(
+        minAtBats: Int,
+        limit: Int,
+    ): List<CareerBattingStats>
 
     /**
      * 통산 홈런 상위 N명을 조회합니다.
@@ -50,10 +51,16 @@ interface CareerBattingStatsRepositoryPort {
     /**
      * 통산 OPS 상위 N명을 조회합니다 (최소 타석 조건).
      */
-    fun findTopByOps(minPlateAppearances: Int, limit: Int): List<CareerBattingStats>
+    fun findTopByOps(
+        minPlateAppearances: Int,
+        limit: Int,
+    ): List<CareerBattingStats>
 
     /**
      * 통산 장타율 상위 N명을 조회합니다 (최소 타수 조건).
      */
-    fun findTopBySluggingPercentage(minAtBats: Int, limit: Int): List<CareerBattingStats>
+    fun findTopBySluggingPercentage(
+        minAtBats: Int,
+        limit: Int,
+    ): List<CareerBattingStats>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CareerPitchingStatsRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CareerPitchingStatsRepositoryPort.kt
@@ -1,14 +1,12 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.stats.CareerPitchingStats
-import java.util.Optional
 
 /**
  * CareerPitchingStats Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface CareerPitchingStatsRepositoryPort {
-
     fun save(careerPitchingStats: CareerPitchingStats): CareerPitchingStats
 
     fun findAll(): List<CareerPitchingStats>
@@ -26,7 +24,10 @@ interface CareerPitchingStatsRepositoryPort {
      * 통산 ERA 상위 N명을 조회합니다 (최소 이닝 조건).
      * ERA는 낮을수록 좋으므로 ASC 정렬합니다.
      */
-    fun findTopByEra(minInningsPitchedOuts: Int, limit: Int): List<CareerPitchingStats>
+    fun findTopByEra(
+        minInningsPitchedOuts: Int,
+        limit: Int,
+    ): List<CareerPitchingStats>
 
     /**
      * 통산 승수 상위 N명을 조회합니다.
@@ -47,7 +48,10 @@ interface CareerPitchingStatsRepositoryPort {
      * 통산 WHIP 상위 N명을 조회합니다 (최소 이닝 조건).
      * WHIP는 낮을수록 좋으므로 ASC 정렬합니다.
      */
-    fun findTopByWhip(minInningsPitchedOuts: Int, limit: Int): List<CareerPitchingStats>
+    fun findTopByWhip(
+        minInningsPitchedOuts: Int,
+        limit: Int,
+    ): List<CareerPitchingStats>
 
     /**
      * 통산 이닝 상위 N명을 조회합니다.
@@ -57,5 +61,8 @@ interface CareerPitchingStatsRepositoryPort {
     /**
      * 통산 삼진/볼넷 비율 상위 N명을 조회합니다 (최소 이닝 및 볼넷 조건).
      */
-    fun findTopByStrikeoutToWalkRatio(minInningsPitchedOuts: Int, limit: Int): List<CareerPitchingStats>
+    fun findTopByStrikeoutToWalkRatio(
+        minInningsPitchedOuts: Int,
+        limit: Int,
+    ): List<CareerPitchingStats>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionRepositoryPort.kt
@@ -2,14 +2,12 @@ package com.nextup.core.port.repository
 
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
-import java.util.Optional
 
 /**
  * Competition Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface CompetitionRepositoryPort {
-
     fun save(competition: Competition): Competition
 
     fun findAll(): List<Competition>
@@ -30,7 +28,11 @@ interface CompetitionRepositoryPort {
     /**
      * 리그 + 연도 + 시즌으로 대회 조회
      */
-    fun findByLeagueIdAndYearAndSeason(leagueId: Long, year: Int, season: Int): Competition?
+    fun findByLeagueIdAndYearAndSeason(
+        leagueId: Long,
+        year: Int,
+        season: Int,
+    ): Competition?
 
     /**
      * 특정 상태의 대회 목록 조회

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
@@ -1,0 +1,19 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.game.GameEvent
+
+/**
+ * GameEvent Repository Port
+ */
+interface GameEventRepositoryPort {
+
+    fun save(gameEvent: GameEvent): GameEvent
+
+    fun findByIdOrNull(id: Long): GameEvent?
+
+    fun findAllByGameId(gameId: Long): List<GameEvent>
+
+    fun findAllByGameIdOrderByEventTimestamp(gameId: Long): List<GameEvent>
+
+    fun delete(gameEvent: GameEvent)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
@@ -6,7 +6,6 @@ import com.nextup.core.domain.game.GameEvent
  * GameEvent Repository Port
  */
 interface GameEventRepositoryPort {
-
     fun save(gameEvent: GameEvent): GameEvent
 
     fun findByIdOrNull(id: Long): GameEvent?

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GamePlayerRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GamePlayerRepositoryPort.kt
@@ -1,14 +1,12 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.game.GamePlayer
-import java.util.Optional
 
 /**
  * GamePlayer Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface GamePlayerRepositoryPort {
-
     fun save(gamePlayer: GamePlayer): GamePlayer
 
     fun findAll(): List<GamePlayer>
@@ -22,7 +20,10 @@ interface GamePlayerRepositoryPort {
     /**
      * 경기 ID와 선수 ID로 GamePlayer를 조회합니다.
      */
-    fun findByGameIdAndPlayerId(gameId: Long, playerId: Long): GamePlayer?
+    fun findByGameIdAndPlayerId(
+        gameId: Long,
+        playerId: Long,
+    ): GamePlayer?
 
     /**
      * 경기 ID로 모든 GamePlayer를 조회합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
@@ -1,0 +1,20 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.game.Game
+
+/**
+ * Game Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface GameRepositoryPort {
+
+    fun save(game: Game): Game
+
+    fun findAll(): List<Game>
+
+    fun findByIdOrNull(id: Long): Game?
+
+    fun delete(game: Game)
+
+    fun deleteById(id: Long)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
@@ -7,7 +7,6 @@ import com.nextup.core.domain.game.Game
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface GameRepositoryPort {
-
     fun save(game: Game): Game
 
     fun findAll(): List<Game>

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/LeagueRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/LeagueRepositoryPort.kt
@@ -1,14 +1,12 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.league.League
-import java.util.Optional
 
 /**
  * League Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface LeagueRepositoryPort {
-
     fun save(league: League): League
 
     fun findAll(): List<League>
@@ -39,12 +37,18 @@ interface LeagueRepositoryPort {
     /**
      * 협회 내에서 리그 이름 존재 여부를 확인합니다.
      */
-    fun existsByAssociationIdAndName(associationId: Long, name: String): Boolean
+    fun existsByAssociationIdAndName(
+        associationId: Long,
+        name: String,
+    ): Boolean
 
     /**
      * 협회 내에서 리그 이름으로 조회합니다.
      */
-    fun findByAssociationIdAndName(associationId: Long, name: String): League?
+    fun findByAssociationIdAndName(
+        associationId: Long,
+        name: String,
+    ): League?
 
     /**
      * 부 레벨(divisionLevel)별로 리그를 조회합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/OAuthAccountRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/OAuthAccountRepositoryPort.kt
@@ -8,18 +8,26 @@ import com.nextup.core.domain.user.OAuthProvider
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface OAuthAccountRepositoryPort {
-
     fun save(oAuthAccount: OAuthAccount): OAuthAccount
 
     fun delete(oAuthAccount: OAuthAccount)
 
-    fun findByProviderAndOauthId(provider: OAuthProvider, oauthId: String): OAuthAccount?
+    fun findByProviderAndOauthId(
+        provider: OAuthProvider,
+        oauthId: String,
+    ): OAuthAccount?
 
-    fun existsByProviderAndOauthId(provider: OAuthProvider, oauthId: String): Boolean
+    fun existsByProviderAndOauthId(
+        provider: OAuthProvider,
+        oauthId: String,
+    ): Boolean
 
     fun findAllByUserId(userId: Long): List<OAuthAccount>
 
-    fun findByUserIdAndProvider(userId: Long, provider: OAuthProvider): OAuthAccount?
+    fun findByUserIdAndProvider(
+        userId: Long,
+        provider: OAuthProvider,
+    ): OAuthAccount?
 
     fun findProvidersByUserId(userId: Long): List<OAuthProvider>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/OrganizationAdminRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/OrganizationAdminRepositoryPort.kt
@@ -4,14 +4,12 @@ import com.nextup.core.domain.admin.OrganizationAdmin
 import com.nextup.core.domain.admin.OrganizationRole
 import com.nextup.core.domain.admin.OrganizationType
 import com.nextup.core.domain.user.User
-import java.util.Optional
 
 /**
  * OrganizationAdmin Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface OrganizationAdminRepositoryPort {
-
     fun save(organizationAdmin: OrganizationAdmin): OrganizationAdmin
 
     fun findAll(): List<OrganizationAdmin>
@@ -42,7 +40,7 @@ interface OrganizationAdminRepositoryPort {
      */
     fun findByOrganizationTypeAndOrganizationId(
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): List<OrganizationAdmin>
 
     /**
@@ -50,7 +48,7 @@ interface OrganizationAdminRepositoryPort {
      */
     fun findActiveByOrganizationTypeAndOrganizationId(
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): List<OrganizationAdmin>
 
     /**
@@ -59,7 +57,7 @@ interface OrganizationAdminRepositoryPort {
     fun findByUserAndOrganizationTypeAndOrganizationId(
         user: User,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): OrganizationAdmin?
 
     /**
@@ -68,7 +66,7 @@ interface OrganizationAdminRepositoryPort {
     fun findByUserIdAndOrganizationTypeAndOrganizationId(
         userId: Long,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): OrganizationAdmin?
 
     /**
@@ -77,7 +75,7 @@ interface OrganizationAdminRepositoryPort {
     fun existsByUserAndOrganizationTypeAndOrganizationId(
         user: User,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): Boolean
 
     /**
@@ -86,7 +84,7 @@ interface OrganizationAdminRepositoryPort {
     fun existsByUserIdAndOrganizationTypeAndOrganizationId(
         userId: Long,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): Boolean
 
     /**
@@ -95,7 +93,7 @@ interface OrganizationAdminRepositoryPort {
     fun existsActiveByUserIdAndOrganizationTypeAndOrganizationId(
         userId: Long,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): Boolean
 
     /**
@@ -103,7 +101,7 @@ interface OrganizationAdminRepositoryPort {
      */
     fun findByUserIdAndOrganizationType(
         userId: Long,
-        organizationType: OrganizationType
+        organizationType: OrganizationType,
     ): List<OrganizationAdmin>
 
     /**
@@ -111,7 +109,7 @@ interface OrganizationAdminRepositoryPort {
      */
     fun findActiveByUserIdAndOrganizationType(
         userId: Long,
-        organizationType: OrganizationType
+        organizationType: OrganizationType,
     ): List<OrganizationAdmin>
 
     /**
@@ -120,7 +118,7 @@ interface OrganizationAdminRepositoryPort {
     fun findByOrganizationAndRole(
         organizationType: OrganizationType,
         organizationId: Long,
-        role: OrganizationRole
+        role: OrganizationRole,
     ): List<OrganizationAdmin>
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchingRecordRepositoryPort.kt
@@ -3,14 +3,12 @@ package com.nextup.core.port.repository
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.PitchingDecision
 import com.nextup.core.domain.game.PitchingRecord
-import java.util.Optional
 
 /**
  * PitchingRecord Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface PitchingRecordRepositoryPort {
-
     fun save(pitchingRecord: PitchingRecord): PitchingRecord
 
     fun findAll(): List<PitchingRecord>
@@ -42,12 +40,18 @@ interface PitchingRecordRepositoryPort {
     /**
      * 선수의 최근 N경기 투수 기록을 조회합니다.
      */
-    fun findRecentByPlayerId(playerId: Long, limit: Int): List<PitchingRecord>
+    fun findRecentByPlayerId(
+        playerId: Long,
+        limit: Int,
+    ): List<PitchingRecord>
 
     /**
      * 팀의 특정 경기 투수 기록을 조회합니다.
      */
-    fun findAllByTeamIdAndGameId(teamId: Long, gameId: Long): List<PitchingRecord>
+    fun findAllByTeamIdAndGameId(
+        teamId: Long,
+        gameId: Long,
+    ): List<PitchingRecord>
 
     /**
      * 경기의 선발 투수 기록을 조회합니다.
@@ -82,7 +86,10 @@ interface PitchingRecordRepositoryPort {
     /**
      * ERA 상위 N명을 조회합니다 (최소 이닝 조건).
      */
-    fun findTopByEarnedRunAverage(minInningsPitchedOuts: Int, limit: Int): List<PitchingRecord>
+    fun findTopByEarnedRunAverage(
+        minInningsPitchedOuts: Int,
+        limit: Int,
+    ): List<PitchingRecord>
 
     /**
      * 삼진 상위 N명을 조회합니다.
@@ -102,5 +109,8 @@ interface PitchingRecordRepositoryPort {
     /**
      * 선수의 특정 연도 투수 기록을 조회합니다.
      */
-    fun findAllByPlayerIdAndYear(playerId: Long, year: Int): List<PitchingRecord>
+    fun findAllByPlayerIdAndYear(
+        playerId: Long,
+        year: Int,
+    ): List<PitchingRecord>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PlayerRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PlayerRepositoryPort.kt
@@ -2,14 +2,12 @@ package com.nextup.core.port.repository
 
 import com.nextup.core.domain.player.Player
 import java.time.LocalDate
-import java.util.Optional
 
 /**
  * Player Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface PlayerRepositoryPort {
-
     fun save(player: Player): Player
 
     fun findAll(): List<Player>
@@ -30,5 +28,8 @@ interface PlayerRepositoryPort {
 
     fun findCurrentPlayersByTeamId(teamId: Long): List<Player>
 
-    fun findPlayersByTeamIdAtDate(teamId: Long, date: LocalDate): List<Player>
+    fun findPlayersByTeamIdAtDate(
+        teamId: Long,
+        date: LocalDate,
+    ): List<Player>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PlayerTeamHistoryRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PlayerTeamHistoryRepositoryPort.kt
@@ -9,7 +9,6 @@ import java.time.LocalDate
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface PlayerTeamHistoryRepositoryPort {
-
     fun save(playerTeamHistory: PlayerTeamHistory): PlayerTeamHistory
 
     fun findAll(): List<PlayerTeamHistory>
@@ -30,7 +29,10 @@ interface PlayerTeamHistoryRepositoryPort {
 
     fun findByPlayerIdWithDetails(playerId: Long): List<PlayerTeamHistory>
 
-    fun findByTeamIdAtDate(teamId: Long, date: LocalDate): List<PlayerTeamHistory>
+    fun findByTeamIdAtDate(
+        teamId: Long,
+        date: LocalDate,
+    ): List<PlayerTeamHistory>
 
     // ===== 신규 메서드 (Issue #37) =====
 
@@ -49,7 +51,10 @@ interface PlayerTeamHistoryRepositoryPort {
      * @param leagueId 리그 ID
      * @return 해당 리그 내 활성 소속 이력 (없으면 null)
      */
-    fun findActiveByPlayerIdAndLeagueId(playerId: Long, leagueId: Long): PlayerTeamHistory?
+    fun findActiveByPlayerIdAndLeagueId(
+        playerId: Long,
+        leagueId: Long,
+    ): PlayerTeamHistory?
 
     /**
      * 선수가 특정 리그에 활성 소속되어 있는지 확인합니다.
@@ -58,7 +63,10 @@ interface PlayerTeamHistoryRepositoryPort {
      * @param leagueId 리그 ID
      * @return 활성 소속 여부
      */
-    fun existsActiveByPlayerIdAndLeagueId(playerId: Long, leagueId: Long): Boolean
+    fun existsActiveByPlayerIdAndLeagueId(
+        playerId: Long,
+        leagueId: Long,
+    ): Boolean
 
     /**
      * 특정 상태의 소속 이력을 조회합니다.
@@ -67,7 +75,10 @@ interface PlayerTeamHistoryRepositoryPort {
      * @param status 소속 상태
      * @return 해당 상태의 소속 이력 목록
      */
-    fun findByPlayerIdAndStatus(playerId: Long, status: PlayerTeamStatus): List<PlayerTeamHistory>
+    fun findByPlayerIdAndStatus(
+        playerId: Long,
+        status: PlayerTeamStatus,
+    ): List<PlayerTeamHistory>
 
     /**
      * 팀의 활성 선수 목록을 조회합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/RefreshTokenRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/RefreshTokenRepositoryPort.kt
@@ -2,14 +2,12 @@ package com.nextup.core.port.repository
 
 import com.nextup.core.domain.auth.RefreshToken
 import java.time.Instant
-import java.util.Optional
 
 /**
  * RefreshToken Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface RefreshTokenRepositoryPort {
-
     fun save(refreshToken: RefreshToken): RefreshToken
 
     fun findAll(): List<RefreshToken>
@@ -41,7 +39,10 @@ interface RefreshTokenRepositoryPort {
      * @param now 현재 시간
      * @return 유효한 RefreshToken 목록
      */
-    fun findValidTokensByUserId(userId: Long, now: Instant = Instant.now()): List<RefreshToken>
+    fun findValidTokensByUserId(
+        userId: Long,
+        now: Instant = Instant.now(),
+    ): List<RefreshToken>
 
     /**
      * 사용자의 모든 RefreshToken을 폐기합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonBattingStatsRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonBattingStatsRepositoryPort.kt
@@ -1,14 +1,12 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.stats.SeasonBattingStats
-import java.util.Optional
 
 /**
  * SeasonBattingStats Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface SeasonBattingStatsRepositoryPort {
-
     fun save(seasonBattingStats: SeasonBattingStats): SeasonBattingStats
 
     fun findAll(): List<SeasonBattingStats>
@@ -20,7 +18,10 @@ interface SeasonBattingStatsRepositoryPort {
     /**
      * 선수 ID와 연도로 시즌 타격 통계를 조회합니다.
      */
-    fun findByPlayerIdAndYear(playerId: Long, year: Int): SeasonBattingStats?
+    fun findByPlayerIdAndYear(
+        playerId: Long,
+        year: Int,
+    ): SeasonBattingStats?
 
     /**
      * 선수 ID로 모든 시즌 타격 통계를 조회합니다.
@@ -35,20 +36,34 @@ interface SeasonBattingStatsRepositoryPort {
     /**
      * 타율 상위 N명을 조회합니다 (최소 타수 조건).
      */
-    fun findTopByBattingAverage(year: Int, minAtBats: Int, limit: Int): List<SeasonBattingStats>
+    fun findTopByBattingAverage(
+        year: Int,
+        minAtBats: Int,
+        limit: Int,
+    ): List<SeasonBattingStats>
 
     /**
      * 홈런 상위 N명을 조회합니다.
      */
-    fun findTopByHomeRuns(year: Int, limit: Int): List<SeasonBattingStats>
+    fun findTopByHomeRuns(
+        year: Int,
+        limit: Int,
+    ): List<SeasonBattingStats>
 
     /**
      * 타점 상위 N명을 조회합니다.
      */
-    fun findTopByRunsBattedIn(year: Int, limit: Int): List<SeasonBattingStats>
+    fun findTopByRunsBattedIn(
+        year: Int,
+        limit: Int,
+    ): List<SeasonBattingStats>
 
     /**
      * OPS 상위 N명을 조회합니다 (최소 타석 조건).
      */
-    fun findTopByOps(year: Int, minPlateAppearances: Int, limit: Int): List<SeasonBattingStats>
+    fun findTopByOps(
+        year: Int,
+        minPlateAppearances: Int,
+        limit: Int,
+    ): List<SeasonBattingStats>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonPitchingStatsRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonPitchingStatsRepositoryPort.kt
@@ -1,14 +1,12 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.stats.SeasonPitchingStats
-import java.util.Optional
 
 /**
  * SeasonPitchingStats Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface SeasonPitchingStatsRepositoryPort {
-
     fun save(seasonPitchingStats: SeasonPitchingStats): SeasonPitchingStats
 
     fun findAll(): List<SeasonPitchingStats>
@@ -20,7 +18,10 @@ interface SeasonPitchingStatsRepositoryPort {
     /**
      * 선수 ID와 연도로 시즌 투수 통계를 조회합니다.
      */
-    fun findByPlayerIdAndYear(playerId: Long, year: Int): SeasonPitchingStats?
+    fun findByPlayerIdAndYear(
+        playerId: Long,
+        year: Int,
+    ): SeasonPitchingStats?
 
     /**
      * 선수 ID로 모든 시즌 투수 통계를 조회합니다.
@@ -36,26 +37,43 @@ interface SeasonPitchingStatsRepositoryPort {
      * ERA 상위 N명을 조회합니다 (최소 이닝 조건).
      * ERA는 낮을수록 좋으므로 ASC 정렬합니다.
      */
-    fun findTopByEra(year: Int, minInningsPitchedOuts: Int, limit: Int): List<SeasonPitchingStats>
+    fun findTopByEra(
+        year: Int,
+        minInningsPitchedOuts: Int,
+        limit: Int,
+    ): List<SeasonPitchingStats>
 
     /**
      * 승수 상위 N명을 조회합니다.
      */
-    fun findTopByWins(year: Int, limit: Int): List<SeasonPitchingStats>
+    fun findTopByWins(
+        year: Int,
+        limit: Int,
+    ): List<SeasonPitchingStats>
 
     /**
      * 삼진 상위 N명을 조회합니다.
      */
-    fun findTopByStrikeouts(year: Int, limit: Int): List<SeasonPitchingStats>
+    fun findTopByStrikeouts(
+        year: Int,
+        limit: Int,
+    ): List<SeasonPitchingStats>
 
     /**
      * 세이브 상위 N명을 조회합니다.
      */
-    fun findTopBySaves(year: Int, limit: Int): List<SeasonPitchingStats>
+    fun findTopBySaves(
+        year: Int,
+        limit: Int,
+    ): List<SeasonPitchingStats>
 
     /**
      * WHIP 상위 N명을 조회합니다 (최소 이닝 조건).
      * WHIP는 낮을수록 좋으므로 ASC 정렬합니다.
      */
-    fun findTopByWhip(year: Int, minInningsPitchedOuts: Int, limit: Int): List<SeasonPitchingStats>
+    fun findTopByWhip(
+        year: Int,
+        minInningsPitchedOuts: Int,
+        limit: Int,
+    ): List<SeasonPitchingStats>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamRepositoryPort.kt
@@ -1,14 +1,12 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.team.Team
-import java.util.Optional
 
 /**
  * Team Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface TeamRepositoryPort {
-
     fun save(team: Team): Team
 
     fun findAll(): List<Team>

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/UserRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/UserRepositoryPort.kt
@@ -4,14 +4,12 @@ import com.nextup.core.domain.user.Role
 import com.nextup.core.domain.user.User
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import java.util.Optional
 
 /**
  * User Repository Port
  * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
  */
 interface UserRepositoryPort {
-
     fun save(user: User): User
 
     fun findByIdOrNull(id: Long): User?
@@ -26,13 +24,25 @@ interface UserRepositoryPort {
 
     fun findAllActive(pageable: Pageable): Page<User>
 
-    fun findAllByIsActive(isActive: Boolean, pageable: Pageable): Page<User>
+    fun findAllByIsActive(
+        isActive: Boolean,
+        pageable: Pageable,
+    ): Page<User>
 
-    fun searchByKeyword(keyword: String, pageable: Pageable): Page<User>
+    fun searchByKeyword(
+        keyword: String,
+        pageable: Pageable,
+    ): Page<User>
 
-    fun findAllByRole(role: Role, pageable: Pageable): Page<User>
+    fun findAllByRole(
+        role: Role,
+        pageable: Pageable,
+    ): Page<User>
 
-    fun findAllByRolesIn(roles: Set<Role>, pageable: Pageable): Page<User>
+    fun findAllByRolesIn(
+        roles: Set<Role>,
+        pageable: Pageable,
+    ): Page<User>
 
     fun findByPlayerId(playerId: Long): User?
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/admin/OrganizationAdminService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/admin/OrganizationAdminService.kt
@@ -20,9 +20,8 @@ import org.springframework.transaction.annotation.Transactional
 class OrganizationAdminService(
     private val organizationAdminRepository: OrganizationAdminRepositoryPort,
     private val userRepository: UserRepositoryPort,
-    private val teamRepository: TeamRepositoryPort
+    private val teamRepository: TeamRepositoryPort,
 ) {
-
     /**
      * 관리자를 할당합니다.
      *
@@ -42,21 +41,25 @@ class OrganizationAdminService(
         organizationType: OrganizationType,
         organizationId: Long,
         role: OrganizationRole,
-        assignedBy: Long? = null
+        assignedBy: Long? = null,
     ): OrganizationAdmin {
         // 사용자 존재 확인
-        val user = userRepository.findByIdOrNull(userId)
-            ?: throw UserNotFoundException(userId)
+        val user =
+            userRepository.findByIdOrNull(userId)
+                ?: throw UserNotFoundException(userId)
 
         // 이미 할당되어 있는지 확인
-        val existing = organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-            userId, organizationType, organizationId
-        )
+        val existing =
+            organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                userId,
+                organizationType,
+                organizationId,
+            )
         if (existing != null) {
             throw OrganizationAdminAlreadyExistsException(
                 organizationType.name,
                 organizationId,
-                userId
+                userId,
             )
         }
 
@@ -66,13 +69,14 @@ class OrganizationAdminService(
         }
 
         // 관리자 생성
-        val admin = OrganizationAdmin.create(
-            user = user,
-            organizationType = organizationType,
-            organizationId = organizationId,
-            role = role,
-            assignedBy = assignedBy
-        )
+        val admin =
+            OrganizationAdmin.create(
+                user = user,
+                organizationType = organizationType,
+                organizationId = organizationId,
+                role = role,
+                assignedBy = assignedBy,
+            )
 
         return organizationAdminRepository.save(admin)
     }
@@ -85,22 +89,28 @@ class OrganizationAdminService(
      * @throws SameLeagueConflictException 같은 리그 내 다른 팀의 관리자인 경우
      * @throws TeamNotFoundException 팀을 찾을 수 없는 경우
      */
-    private fun validateSameLeagueConflict(userId: Long, newTeamId: Long) {
+    private fun validateSameLeagueConflict(
+        userId: Long,
+        newTeamId: Long,
+    ) {
         // 새 팀의 리그 ID 조회
-        val newTeam = teamRepository.findByIdWithLeague(newTeamId)
-            ?: throw TeamNotFoundException(newTeamId)
+        val newTeam =
+            teamRepository.findByIdWithLeague(newTeamId)
+                ?: throw TeamNotFoundException(newTeamId)
         val newTeamLeagueId = newTeam.league.id
 
         // 사용자의 활성화된 팀 관리자 권한 조회
-        val existingTeamAdmins = organizationAdminRepository.findActiveByUserIdAndOrganizationType(
-            userId,
-            OrganizationType.TEAM
-        )
+        val existingTeamAdmins =
+            organizationAdminRepository.findActiveByUserIdAndOrganizationType(
+                userId,
+                OrganizationType.TEAM,
+            )
 
         // 같은 리그 내 다른 팀의 관리자인지 확인
         for (admin in existingTeamAdmins) {
-            val existingTeam = teamRepository.findByIdWithLeague(admin.organizationId)
-                ?: continue
+            val existingTeam =
+                teamRepository.findByIdWithLeague(admin.organizationId)
+                    ?: continue
 
             val existingTeamLeagueId = existingTeam.league.id
 
@@ -108,7 +118,7 @@ class OrganizationAdminService(
                 throw SameLeagueConflictException(
                     leagueId = newTeamLeagueId,
                     existingTeamId = admin.organizationId,
-                    newTeamId = newTeamId
+                    newTeamId = newTeamId,
                 )
             }
         }
@@ -126,15 +136,18 @@ class OrganizationAdminService(
     fun removeAdmin(
         userId: Long,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ) {
-        val admin = organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-            userId, organizationType, organizationId
-        ) ?: throw OrganizationAdminNotFoundException(
-            organizationType.name,
-            organizationId,
-            userId
-        )
+        val admin =
+            organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                userId,
+                organizationType,
+                organizationId,
+            ) ?: throw OrganizationAdminNotFoundException(
+                organizationType.name,
+                organizationId,
+                userId,
+            )
 
         admin.deactivate()
     }
@@ -148,13 +161,12 @@ class OrganizationAdminService(
      */
     fun getAdminsByOrganization(
         organizationType: OrganizationType,
-        organizationId: Long
-    ): List<OrganizationAdmin> {
-        return organizationAdminRepository.findActiveByOrganizationTypeAndOrganizationId(
+        organizationId: Long,
+    ): List<OrganizationAdmin> =
+        organizationAdminRepository.findActiveByOrganizationTypeAndOrganizationId(
             organizationType,
-            organizationId
+            organizationId,
         )
-    }
 
     /**
      * 특정 사용자가 관리하는 모든 조직을 조회합니다.
@@ -162,9 +174,8 @@ class OrganizationAdminService(
      * @param userId 사용자 ID
      * @return 관리하는 조직 목록 (활성화된 것만)
      */
-    fun getOrganizationsByUser(userId: Long): List<OrganizationAdmin> {
-        return organizationAdminRepository.findActiveByUserId(userId)
-    }
+    fun getOrganizationsByUser(userId: Long): List<OrganizationAdmin> =
+        organizationAdminRepository.findActiveByUserId(userId)
 
     /**
      * 관리자의 역할을 변경합니다.
@@ -182,15 +193,18 @@ class OrganizationAdminService(
         userId: Long,
         organizationType: OrganizationType,
         organizationId: Long,
-        newRole: OrganizationRole
+        newRole: OrganizationRole,
     ): OrganizationAdmin {
-        val admin = organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-            userId, organizationType, organizationId
-        ) ?: throw OrganizationAdminNotFoundException(
-            organizationType.name,
-            organizationId,
-            userId
-        )
+        val admin =
+            organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
+                userId,
+                organizationType,
+                organizationId,
+            ) ?: throw OrganizationAdminNotFoundException(
+                organizationType.name,
+                organizationId,
+                userId,
+            )
 
         if (!admin.isActive) {
             throw OrganizationAdminDeactivatedException(admin.id)
@@ -211,14 +225,13 @@ class OrganizationAdminService(
     fun hasPermission(
         userId: Long,
         organizationType: OrganizationType,
-        organizationId: Long
-    ): Boolean {
-        return organizationAdminRepository.existsActiveByUserIdAndOrganizationTypeAndOrganizationId(
+        organizationId: Long,
+    ): Boolean =
+        organizationAdminRepository.existsActiveByUserIdAndOrganizationTypeAndOrganizationId(
             userId,
             organizationType,
-            organizationId
+            organizationId,
         )
-    }
 
     /**
      * ID로 관리자를 조회합니다.
@@ -227,8 +240,7 @@ class OrganizationAdminService(
      * @return OrganizationAdmin
      * @throws OrganizationAdminNotFoundByIdException 관리자를 찾을 수 없는 경우
      */
-    fun getById(id: Long): OrganizationAdmin {
-        return organizationAdminRepository.findByIdOrNull(id)
+    fun getById(id: Long): OrganizationAdmin =
+        organizationAdminRepository.findByIdOrNull(id)
             ?: throw OrganizationAdminNotFoundByIdException(id)
-    }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/association/AssociationService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/association/AssociationService.kt
@@ -15,9 +15,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class AssociationService(
-    private val associationRepository: AssociationRepositoryPort
+    private val associationRepository: AssociationRepositoryPort,
 ) {
-
     /**
      * 협회를 생성합니다.
      */
@@ -28,21 +27,22 @@ class AssociationService(
         region: String? = null,
         description: String? = null,
         logoUrl: String? = null,
-        websiteUrl: String? = null
+        websiteUrl: String? = null,
     ): Association {
         // 이름 중복 체크
         if (associationRepository.existsByName(name)) {
             throw AssociationNameDuplicateException(name)
         }
 
-        val association = Association(
-            name = name,
-            abbreviation = abbreviation,
-            region = region,
-            description = description,
-            logoUrl = logoUrl,
-            websiteUrl = websiteUrl
-        )
+        val association =
+            Association(
+                name = name,
+                abbreviation = abbreviation,
+                region = region,
+                description = description,
+                logoUrl = logoUrl,
+                websiteUrl = websiteUrl,
+            )
 
         return associationRepository.save(association)
     }
@@ -50,31 +50,24 @@ class AssociationService(
     /**
      * ID로 협회를 조회합니다.
      */
-    fun getById(id: Long): Association {
-        return associationRepository.findByIdOrNull(id)
+    fun getById(id: Long): Association =
+        associationRepository.findByIdOrNull(id)
             ?: throw AssociationNotFoundException(id)
-    }
 
     /**
      * 활성화된 모든 협회를 조회합니다.
      */
-    fun getAllActive(): List<Association> {
-        return associationRepository.findAllActive()
-    }
+    fun getAllActive(): List<Association> = associationRepository.findAllActive()
 
     /**
      * 모든 협회를 조회합니다 (관리자용).
      */
-    fun getAll(): List<Association> {
-        return associationRepository.findAll()
-    }
+    fun getAll(): List<Association> = associationRepository.findAll()
 
     /**
      * 지역별 활성화된 협회를 조회합니다.
      */
-    fun getActiveByRegion(region: String): List<Association> {
-        return associationRepository.findActiveByRegion(region)
-    }
+    fun getActiveByRegion(region: String): List<Association> = associationRepository.findActiveByRegion(region)
 
     /**
      * 협회 정보를 수정합니다.
@@ -84,13 +77,13 @@ class AssociationService(
         id: Long,
         description: String? = null,
         logoUrl: String? = null,
-        websiteUrl: String? = null
+        websiteUrl: String? = null,
     ): Association {
         val association = getById(id)
         association.updateInfo(
             description = description,
             logoUrl = logoUrl,
-            websiteUrl = websiteUrl
+            websiteUrl = websiteUrl,
         )
         return association
     }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/competition/CompetitionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/competition/CompetitionService.kt
@@ -21,9 +21,8 @@ import java.time.LocalDate
 @Transactional(readOnly = true)
 class CompetitionService(
     private val competitionRepository: CompetitionRepositoryPort,
-    private val leagueRepository: LeagueRepositoryPort
+    private val leagueRepository: LeagueRepositoryPort,
 ) {
-
     /**
      * 대회를 생성합니다.
      */
@@ -37,30 +36,32 @@ class CompetitionService(
         startDate: LocalDate,
         endDate: LocalDate? = null,
         description: String? = null,
-        maxTeams: Int? = null
+        maxTeams: Int? = null,
     ): Competition {
         // 리그 존재 확인
-        val league = leagueRepository.findByIdOrNull(leagueId)
-            ?: throw LeagueNotFoundException(leagueId)
+        val league =
+            leagueRepository.findByIdOrNull(leagueId)
+                ?: throw LeagueNotFoundException(leagueId)
 
         // 동일한 리그, 연도, 시즌의 대회가 이미 존재하는지 확인
         competitionRepository.findByLeagueIdAndYearAndSeason(leagueId, year, season)?.let {
             throw InvalidCompetitionStateException(
-                "Competition already exists for league $leagueId, year $year, season $season"
+                "Competition already exists for league $leagueId, year $year, season $season",
             )
         }
 
-        val competition = Competition(
-            league = league,
-            name = name,
-            year = year,
-            season = season,
-            type = type,
-            startDate = startDate,
-            endDate = endDate,
-            description = description,
-            maxTeams = maxTeams
-        )
+        val competition =
+            Competition(
+                league = league,
+                name = name,
+                year = year,
+                season = season,
+                type = type,
+                startDate = startDate,
+                endDate = endDate,
+                description = description,
+                maxTeams = maxTeams,
+            )
 
         return competitionRepository.save(competition)
     }
@@ -68,46 +69,36 @@ class CompetitionService(
     /**
      * ID로 대회를 조회합니다.
      */
-    fun getById(id: Long): Competition {
-        return competitionRepository.findByIdOrNull(id)
+    fun getById(id: Long): Competition =
+        competitionRepository.findByIdOrNull(id)
             ?: throw CompetitionNotFoundException(id)
-    }
 
     /**
      * ID로 대회를 조회합니다 (League 함께 조회).
      */
-    fun getByIdWithLeague(id: Long): Competition {
-        return competitionRepository.findByIdWithLeague(id)
+    fun getByIdWithLeague(id: Long): Competition =
+        competitionRepository.findByIdWithLeague(id)
             ?: throw CompetitionNotFoundException(id)
-    }
 
     /**
      * 모든 대회를 조회합니다.
      */
-    fun getAll(): List<Competition> {
-        return competitionRepository.findAll()
-    }
+    fun getAll(): List<Competition> = competitionRepository.findAll()
 
     /**
      * 리그별 대회 목록을 조회합니다.
      */
-    fun getByLeagueId(leagueId: Long): List<Competition> {
-        return competitionRepository.findByLeagueId(leagueId)
-    }
+    fun getByLeagueId(leagueId: Long): List<Competition> = competitionRepository.findByLeagueId(leagueId)
 
     /**
      * 진행 중인 대회 목록을 조회합니다.
      */
-    fun getInProgress(): List<Competition> {
-        return competitionRepository.findInProgressCompetitions()
-    }
+    fun getInProgress(): List<Competition> = competitionRepository.findInProgressCompetitions()
 
     /**
      * 특정 상태의 대회 목록을 조회합니다.
      */
-    fun getByStatus(status: CompetitionStatus): List<Competition> {
-        return competitionRepository.findByStatus(status)
-    }
+    fun getByStatus(status: CompetitionStatus): List<Competition> = competitionRepository.findByStatus(status)
 
     /**
      * 대회 정보를 수정합니다.
@@ -116,7 +107,7 @@ class CompetitionService(
     fun update(
         id: Long,
         description: String?,
-        endDate: LocalDate?
+        endDate: LocalDate?,
     ): Competition {
         val competition = getById(id)
 
@@ -144,7 +135,10 @@ class CompetitionService(
      * 대회를 완료합니다.
      */
     @Transactional
-    fun complete(id: Long, endDate: LocalDate = LocalDate.now()): Competition {
+    fun complete(
+        id: Long,
+        endDate: LocalDate = LocalDate.now(),
+    ): Competition {
         val competition = getById(id)
         try {
             competition.complete(endDate)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/BattingRecordService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/BattingRecordService.kt
@@ -19,16 +19,16 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class BattingRecordService(
     private val battingRecordRepository: BattingRecordRepositoryPort,
-    private val gamePlayerRepository: GamePlayerRepositoryPort
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
-
     /**
      * 타격 기록을 생성합니다.
      */
     @Transactional
     fun createRecord(gamePlayerId: Long): BattingRecord {
-        val gamePlayer = gamePlayerRepository.findByIdOrNull(gamePlayerId)
-            ?: throw GamePlayerNotFoundException(gamePlayerId)
+        val gamePlayer =
+            gamePlayerRepository.findByIdOrNull(gamePlayerId)
+                ?: throw GamePlayerNotFoundException(gamePlayerId)
 
         // 중복 체크
         battingRecordRepository.findByGamePlayer(gamePlayer)?.let {
@@ -42,10 +42,9 @@ class BattingRecordService(
     /**
      * GamePlayer ID로 타격 기록을 조회합니다.
      */
-    fun getByGamePlayerId(gamePlayerId: Long): BattingRecord {
-        return battingRecordRepository.findByGamePlayerId(gamePlayerId)
+    fun getByGamePlayerId(gamePlayerId: Long): BattingRecord =
+        battingRecordRepository.findByGamePlayerId(gamePlayerId)
             ?: throw BattingRecordNotFoundException(gamePlayerId)
-    }
 
     /**
      * 타석 결과를 기록합니다.
@@ -55,7 +54,7 @@ class BattingRecordService(
         gamePlayerId: Long,
         result: PlateAppearanceResult,
         runsBattedIn: Int = 0,
-        runsScored: Boolean = false
+        runsScored: Boolean = false,
     ) {
         val battingRecord = getByGamePlayerId(gamePlayerId)
         battingRecord.recordPlateAppearance(result, runsBattedIn, runsScored)
@@ -91,14 +90,10 @@ class BattingRecordService(
     /**
      * 경기 ID로 모든 타격 기록을 조회합니다.
      */
-    fun getAllByGameId(gameId: Long): List<BattingRecord> {
-        return battingRecordRepository.findAllByGameId(gameId)
-    }
+    fun getAllByGameId(gameId: Long): List<BattingRecord> = battingRecordRepository.findAllByGameId(gameId)
 
     /**
      * 선수 ID로 모든 타격 기록을 조회합니다.
      */
-    fun getAllByPlayerId(playerId: Long): List<BattingRecord> {
-        return battingRecordRepository.findAllByPlayerId(playerId)
-    }
+    fun getAllByPlayerId(playerId: Long): List<BattingRecord> = battingRecordRepository.findAllByPlayerId(playerId)
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/BoxScoreService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/BoxScoreService.kt
@@ -31,6 +31,6 @@ interface BoxScoreService {
         result: PlateAppearanceResult,
         rbis: Int,
         runsScored: List<Long>,
-        inning: Int
+        inning: Int,
     )
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
@@ -1,0 +1,47 @@
+package com.nextup.core.service.game
+
+import com.nextup.core.domain.game.Game
+import com.nextup.core.service.game.dto.GameEndReason
+import com.nextup.core.service.game.dto.PlateAppearanceRequest
+
+/**
+ * 기록원 전용 경기 기록 서비스 인터페이스
+ *
+ * 실시간 경기 기록 입력을 위한 서비스입니다.
+ */
+interface GameScorerService {
+
+    /**
+     * 경기를 시작합니다.
+     *
+     * @param gameId 경기 ID
+     * @return 시작된 경기
+     */
+    fun startGame(gameId: Long): Game
+
+    /**
+     * 타석 결과를 기록합니다.
+     *
+     * @param gameId 경기 ID
+     * @param request 타석 결과 요청
+     * @return 업데이트된 경기
+     */
+    fun recordPlateAppearance(gameId: Long, request: PlateAppearanceRequest): Game
+
+    /**
+     * 반 이닝을 진행합니다 (공수 교대).
+     *
+     * @param gameId 경기 ID
+     * @return 다음 이닝으로 진행된 경기
+     */
+    fun advanceHalfInning(gameId: Long): Game
+
+    /**
+     * 경기를 종료합니다.
+     *
+     * @param gameId 경기 ID
+     * @param reason 종료 사유
+     * @return 종료된 경기
+     */
+    fun endGame(gameId: Long, reason: GameEndReason): Game
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
@@ -10,7 +10,6 @@ import com.nextup.core.service.game.dto.PlateAppearanceRequest
  * 실시간 경기 기록 입력을 위한 서비스입니다.
  */
 interface GameScorerService {
-
     /**
      * 경기를 시작합니다.
      *
@@ -26,7 +25,10 @@ interface GameScorerService {
      * @param request 타석 결과 요청
      * @return 업데이트된 경기
      */
-    fun recordPlateAppearance(gameId: Long, request: PlateAppearanceRequest): Game
+    fun recordPlateAppearance(
+        gameId: Long,
+        request: PlateAppearanceRequest,
+    ): Game
 
     /**
      * 반 이닝을 진행합니다 (공수 교대).
@@ -43,5 +45,8 @@ interface GameScorerService {
      * @param reason 종료 사유
      * @return 종료된 경기
      */
-    fun endGame(gameId: Long, reason: GameEndReason): Game
+    fun endGame(
+        gameId: Long,
+        reason: GameEndReason,
+    ): Game
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/PitchingRecordService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/PitchingRecordService.kt
@@ -18,16 +18,19 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class PitchingRecordService(
     private val pitchingRecordRepository: PitchingRecordRepositoryPort,
-    private val gamePlayerRepository: GamePlayerRepositoryPort
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
-
     /**
      * 투수 기록을 생성합니다.
      */
     @Transactional
-    fun createRecord(gamePlayerId: Long, isStartingPitcher: Boolean = false): PitchingRecord {
-        val gamePlayer = gamePlayerRepository.findByIdOrNull(gamePlayerId)
-            ?: throw GamePlayerNotFoundException(gamePlayerId)
+    fun createRecord(
+        gamePlayerId: Long,
+        isStartingPitcher: Boolean = false,
+    ): PitchingRecord {
+        val gamePlayer =
+            gamePlayerRepository.findByIdOrNull(gamePlayerId)
+                ?: throw GamePlayerNotFoundException(gamePlayerId)
 
         // 중복 체크
         pitchingRecordRepository.findByGamePlayer(gamePlayer)?.let {
@@ -41,16 +44,18 @@ class PitchingRecordService(
     /**
      * GamePlayer ID로 투수 기록을 조회합니다.
      */
-    fun getByGamePlayerId(gamePlayerId: Long): PitchingRecord {
-        return pitchingRecordRepository.findByGamePlayerId(gamePlayerId)
+    fun getByGamePlayerId(gamePlayerId: Long): PitchingRecord =
+        pitchingRecordRepository.findByGamePlayerId(gamePlayerId)
             ?: throw PitchingRecordNotFoundException(gamePlayerId)
-    }
 
     /**
      * 아웃을 기록합니다.
      */
     @Transactional
-    fun recordOut(gamePlayerId: Long, isStrikeout: Boolean = false) {
+    fun recordOut(
+        gamePlayerId: Long,
+        isStrikeout: Boolean = false,
+    ) {
         val pitchingRecord = getByGamePlayerId(gamePlayerId)
         pitchingRecord.recordOut(isStrikeout)
     }
@@ -63,7 +68,7 @@ class PitchingRecordService(
         gamePlayerId: Long,
         isHomeRun: Boolean = false,
         runsScored: Int = 0,
-        earnedRuns: Int = 0
+        earnedRuns: Int = 0,
     ) {
         val pitchingRecord = getByGamePlayerId(gamePlayerId)
         pitchingRecord.recordHit(isHomeRun, runsScored, earnedRuns)
@@ -91,7 +96,10 @@ class PitchingRecordService(
      * 실점을 기록합니다 (주루 중 득점 등).
      */
     @Transactional
-    fun recordRun(gamePlayerId: Long, isEarned: Boolean = true) {
+    fun recordRun(
+        gamePlayerId: Long,
+        isEarned: Boolean = true,
+    ) {
         val pitchingRecord = getByGamePlayerId(gamePlayerId)
         pitchingRecord.recordRun(isEarned)
     }
@@ -118,7 +126,11 @@ class PitchingRecordService(
      * 투구 수를 기록합니다.
      */
     @Transactional
-    fun recordPitchCount(gamePlayerId: Long, totalPitches: Int, strikes: Int) {
+    fun recordPitchCount(
+        gamePlayerId: Long,
+        totalPitches: Int,
+        strikes: Int,
+    ) {
         val pitchingRecord = getByGamePlayerId(gamePlayerId)
         pitchingRecord.recordPitchCount(totalPitches, strikes)
     }
@@ -171,28 +183,22 @@ class PitchingRecordService(
     /**
      * 경기의 선발 투수 기록을 조회합니다.
      */
-    fun getStartingPitchersByGameId(gameId: Long): List<PitchingRecord> {
-        return pitchingRecordRepository.findStartingPitchersByGameId(gameId)
-    }
+    fun getStartingPitchersByGameId(gameId: Long): List<PitchingRecord> =
+        pitchingRecordRepository.findStartingPitchersByGameId(gameId)
 
     /**
      * 경기의 구원 투수 기록을 조회합니다.
      */
-    fun getReliefPitchersByGameId(gameId: Long): List<PitchingRecord> {
-        return pitchingRecordRepository.findReliefPitchersByGameId(gameId)
-    }
+    fun getReliefPitchersByGameId(gameId: Long): List<PitchingRecord> =
+        pitchingRecordRepository.findReliefPitchersByGameId(gameId)
 
     /**
      * 경기 ID로 모든 투수 기록을 조회합니다.
      */
-    fun getAllByGameId(gameId: Long): List<PitchingRecord> {
-        return pitchingRecordRepository.findAllByGameId(gameId)
-    }
+    fun getAllByGameId(gameId: Long): List<PitchingRecord> = pitchingRecordRepository.findAllByGameId(gameId)
 
     /**
      * 선수 ID로 모든 투수 기록을 조회합니다.
      */
-    fun getAllByPlayerId(playerId: Long): List<PitchingRecord> {
-        return pitchingRecordRepository.findAllByPlayerId(playerId)
-    }
+    fun getAllByPlayerId(playerId: Long): List<PitchingRecord> = pitchingRecordRepository.findAllByPlayerId(playerId)
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/BoxScoreDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/BoxScoreDto.kt
@@ -11,7 +11,7 @@ data class BoxScoreDto(
     val homeTeam: TeamBoxScoreDto,
     val awayTeam: TeamBoxScoreDto,
     val currentInning: String,
-    val gameStatus: String
+    val gameStatus: String,
 )
 
 /**
@@ -25,7 +25,7 @@ data class TeamBoxScoreDto(
     val hits: Int,
     val errors: Int,
     val batters: List<BatterLineDto>,
-    val pitchers: List<PitcherLineDto>
+    val pitchers: List<PitcherLineDto>,
 )
 
 /**
@@ -43,12 +43,10 @@ data class BatterLineDto(
     val rbis: Int,
     val walks: Int,
     val strikeouts: Int,
-    val avg: String
+    val avg: String,
 ) {
     companion object {
-        fun formatAverage(average: BigDecimal): String {
-            return average.setScale(3, RoundingMode.HALF_UP).toString()
-        }
+        fun formatAverage(average: BigDecimal): String = average.setScale(3, RoundingMode.HALF_UP).toString()
     }
 }
 
@@ -66,11 +64,9 @@ data class PitcherLineDto(
     val strikeouts: Int,
     val homeRuns: Int,
     val decision: String?,
-    val era: String
+    val era: String,
 ) {
     companion object {
-        fun formatERA(era: BigDecimal): String {
-            return era.setScale(2, RoundingMode.HALF_UP).toString()
-        }
+        fun formatERA(era: BigDecimal): String = era.setScale(2, RoundingMode.HALF_UP).toString()
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/GameEndReason.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/GameEndReason.kt
@@ -3,7 +3,10 @@ package com.nextup.core.service.game.dto
 /**
  * 경기 종료 사유
  */
-enum class GameEndReason(val displayName: String, val description: String) {
+enum class GameEndReason(
+    val displayName: String,
+    val description: String,
+) {
     /** 정규 이닝 종료 */
     REGULATION("정규 종료", "정규 이닝 완료로 경기 종료"),
 
@@ -17,5 +20,5 @@ enum class GameEndReason(val displayName: String, val description: String) {
     FORFEIT("몰수", "몰수 처리"),
 
     /** 기타 */
-    OTHER("기타", "기타 사유로 경기 종료");
+    OTHER("기타", "기타 사유로 경기 종료"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/GameEndReason.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/GameEndReason.kt
@@ -1,0 +1,21 @@
+package com.nextup.core.service.game.dto
+
+/**
+ * 경기 종료 사유
+ */
+enum class GameEndReason(val displayName: String, val description: String) {
+    /** 정규 이닝 종료 */
+    REGULATION("정규 종료", "정규 이닝 완료로 경기 종료"),
+
+    /** 콜드게임 (점수 차이) */
+    MERCY_RULE("콜드게임 (점수차)", "점수 차이로 인한 콜드게임"),
+
+    /** 콜드게임 (기상 조건) */
+    WEATHER("콜드게임 (날씨)", "기상 조건으로 인한 콜드게임"),
+
+    /** 몰수 */
+    FORFEIT("몰수", "몰수 처리"),
+
+    /** 기타 */
+    OTHER("기타", "기타 사유로 경기 종료");
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/PlateAppearanceRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/PlateAppearanceRequest.kt
@@ -20,7 +20,7 @@ data class PlateAppearanceRequest(
     val runnerMovements: List<RunnerMovement> = emptyList(),
     val rbis: Int? = null,
     val balls: Int = 0,
-    val strikes: Int = 0
+    val strikes: Int = 0,
 ) {
     init {
         require(balls in 0..4) { "볼 카운트는 0-4 사이여야 합니다: $balls" }
@@ -33,14 +33,10 @@ data class PlateAppearanceRequest(
     /**
      * 득점한 주자 수를 계산합니다.
      */
-    fun calculateRunsScored(): Int {
-        return runnerMovements.count { it.isScored }
-    }
+    fun calculateRunsScored(): Int = runnerMovements.count { it.isScored }
 
     /**
      * 실제 타점을 계산합니다 (rbis가 null이면 자동 계산).
      */
-    fun getActualRbis(): Int {
-        return rbis ?: calculateRunsScored()
-    }
+    fun getActualRbis(): Int = rbis ?: calculateRunsScored()
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/PlateAppearanceRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/PlateAppearanceRequest.kt
@@ -1,0 +1,46 @@
+package com.nextup.core.service.game.dto
+
+import com.nextup.core.domain.game.PlateAppearanceResult
+
+/**
+ * 타석 결과 입력 요청 DTO
+ *
+ * @property batterId 타자 ID (GamePlayer ID)
+ * @property pitcherId 투수 ID (GamePlayer ID)
+ * @property result 타석 결과
+ * @property runnerMovements 주자 이동 목록 (옵션)
+ * @property rbis 타점 수 (옵션, 자동 계산 가능)
+ * @property balls 최종 볼 카운트 (옵션)
+ * @property strikes 최종 스트라이크 카운트 (옵션)
+ */
+data class PlateAppearanceRequest(
+    val batterId: Long,
+    val pitcherId: Long,
+    val result: PlateAppearanceResult,
+    val runnerMovements: List<RunnerMovement> = emptyList(),
+    val rbis: Int? = null,
+    val balls: Int = 0,
+    val strikes: Int = 0
+) {
+    init {
+        require(balls in 0..4) { "볼 카운트는 0-4 사이여야 합니다: $balls" }
+        require(strikes in 0..3) { "스트라이크 카운트는 0-3 사이여야 합니다: $strikes" }
+        rbis?.let {
+            require(it >= 0) { "타점은 0 이상이어야 합니다: $it" }
+        }
+    }
+
+    /**
+     * 득점한 주자 수를 계산합니다.
+     */
+    fun calculateRunsScored(): Int {
+        return runnerMovements.count { it.isScored }
+    }
+
+    /**
+     * 실제 타점을 계산합니다 (rbis가 null이면 자동 계산).
+     */
+    fun getActualRbis(): Int {
+        return rbis ?: calculateRunsScored()
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/RunnerMovement.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/RunnerMovement.kt
@@ -14,7 +14,7 @@ data class RunnerMovement(
     val runnerId: Long,
     val fromBase: Base,
     val toBase: Base,
-    val isOut: Boolean = false
+    val isOut: Boolean = false,
 ) {
     /**
      * 득점 여부를 확인합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/RunnerMovement.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/RunnerMovement.kt
@@ -1,0 +1,24 @@
+package com.nextup.core.service.game.dto
+
+import com.nextup.core.domain.game.Base
+
+/**
+ * 주자 이동 정보
+ *
+ * @property runnerId 주자 ID (GamePlayer ID)
+ * @property fromBase 출발 베이스
+ * @property toBase 도착 베이스
+ * @property isOut 아웃 여부
+ */
+data class RunnerMovement(
+    val runnerId: Long,
+    val fromBase: Base,
+    val toBase: Base,
+    val isOut: Boolean = false
+) {
+    /**
+     * 득점 여부를 확인합니다.
+     */
+    val isScored: Boolean
+        get() = toBase == Base.HOME && !isOut
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/league/LeagueService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/league/LeagueService.kt
@@ -18,9 +18,8 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class LeagueService(
     private val leagueRepository: LeagueRepositoryPort,
-    private val associationRepository: AssociationRepositoryPort
+    private val associationRepository: AssociationRepositoryPort,
 ) {
-
     /**
      * 리그를 생성합니다.
      */
@@ -32,25 +31,27 @@ class LeagueService(
         foundedYear: Int,
         divisionLevel: Int? = null,
         description: String? = null,
-        logoUrl: String? = null
+        logoUrl: String? = null,
     ): League {
-        val association = associationRepository.findByIdOrNull(associationId)
-            ?: throw AssociationNotFoundException(associationId)
+        val association =
+            associationRepository.findByIdOrNull(associationId)
+                ?: throw AssociationNotFoundException(associationId)
 
         // 협회 내 이름 중복 체크
         if (leagueRepository.existsByAssociationIdAndName(associationId, name)) {
             throw LeagueNameDuplicateException(associationId, name)
         }
 
-        val league = League(
-            association = association,
-            name = name,
-            abbreviation = abbreviation,
-            foundedYear = foundedYear,
-            divisionLevel = divisionLevel,
-            description = description,
-            logoUrl = logoUrl
-        )
+        val league =
+            League(
+                association = association,
+                name = name,
+                abbreviation = abbreviation,
+                foundedYear = foundedYear,
+                divisionLevel = divisionLevel,
+                description = description,
+                logoUrl = logoUrl,
+            )
 
         return leagueRepository.save(league)
     }
@@ -58,38 +59,30 @@ class LeagueService(
     /**
      * ID로 리그를 조회합니다.
      */
-    fun getById(id: Long): League {
-        return leagueRepository.findByIdOrNull(id)
+    fun getById(id: Long): League =
+        leagueRepository.findByIdOrNull(id)
             ?: throw LeagueNotFoundException(id)
-    }
 
     /**
      * 활성화된 모든 리그를 조회합니다.
      */
-    fun getAllActive(): List<League> {
-        return leagueRepository.findAllActive()
-    }
+    fun getAllActive(): List<League> = leagueRepository.findAllActive()
 
     /**
      * 모든 리그를 조회합니다 (관리자용).
      */
-    fun getAll(): List<League> {
-        return leagueRepository.findAll()
-    }
+    fun getAll(): List<League> = leagueRepository.findAll()
 
     /**
      * 협회별 활성화된 리그를 조회합니다.
      */
-    fun getActiveByAssociationId(associationId: Long): List<League> {
-        return leagueRepository.findActiveByAssociationId(associationId)
-    }
+    fun getActiveByAssociationId(associationId: Long): List<League> =
+        leagueRepository.findActiveByAssociationId(associationId)
 
     /**
      * 협회별 모든 리그를 조회합니다 (관리자용).
      */
-    fun getByAssociationId(associationId: Long): List<League> {
-        return leagueRepository.findByAssociationId(associationId)
-    }
+    fun getByAssociationId(associationId: Long): List<League> = leagueRepository.findByAssociationId(associationId)
 
     /**
      * 리그 정보를 수정합니다.
@@ -98,12 +91,12 @@ class LeagueService(
     fun update(
         id: Long,
         description: String? = null,
-        logoUrl: String? = null
+        logoUrl: String? = null,
     ): League {
         val league = getById(id)
         league.updateInfo(
             description = description,
-            logoUrl = logoUrl
+            logoUrl = logoUrl,
         )
         return league
     }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/player/PlayerTeamService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/player/PlayerTeamService.kt
@@ -22,9 +22,8 @@ import java.time.LocalDate
 class PlayerTeamService(
     private val playerTeamHistoryRepository: PlayerTeamHistoryRepositoryPort,
     private val playerRepository: PlayerRepositoryPort,
-    private val teamRepository: TeamRepositoryPort
+    private val teamRepository: TeamRepositoryPort,
 ) {
-
     // ========== CREATE ==========
 
     /**
@@ -48,13 +47,15 @@ class PlayerTeamService(
         startDate: LocalDate,
         position: Position,
         uniformNumber: Int? = null,
-        contractType: ContractType = ContractType.REGULAR
+        contractType: ContractType = ContractType.REGULAR,
     ): PlayerTeamHistory {
-        val player = playerRepository.findByIdOrNull(playerId)
-            ?: throw PlayerNotFoundException(playerId)
+        val player =
+            playerRepository.findByIdOrNull(playerId)
+                ?: throw PlayerNotFoundException(playerId)
 
-        val team = teamRepository.findByIdWithLeague(teamId)
-            ?: throw TeamNotFoundException(teamId)
+        val team =
+            teamRepository.findByIdWithLeague(teamId)
+                ?: throw TeamNotFoundException(teamId)
 
         val leagueId = team.league.id
 
@@ -63,15 +64,16 @@ class PlayerTeamService(
             throw PlayerAlreadyInLeagueException(playerId, leagueId)
         }
 
-        val affiliation = PlayerTeamHistory(
-            player = player,
-            team = team,
-            startDate = startDate,
-            position = position,
-            uniformNumber = uniformNumber,
-            contractType = contractType,
-            status = PlayerTeamStatus.ACTIVE
-        )
+        val affiliation =
+            PlayerTeamHistory(
+                player = player,
+                team = team,
+                startDate = startDate,
+                position = position,
+                uniformNumber = uniformNumber,
+                contractType = contractType,
+                status = PlayerTeamStatus.ACTIVE,
+            )
 
         return playerTeamHistoryRepository.save(affiliation)
     }
@@ -89,7 +91,7 @@ class PlayerTeamService(
     @Transactional
     fun endAffiliation(
         affiliationId: Long,
-        endDate: LocalDate
+        endDate: LocalDate,
     ): PlayerTeamHistory {
         val affiliation = findAffiliationById(affiliationId)
         affiliation.deactivate(endDate)
@@ -120,16 +122,19 @@ class PlayerTeamService(
         transferDate: LocalDate,
         newPosition: Position,
         newUniformNumber: Int? = null,
-        newContractType: ContractType = ContractType.REGULAR
+        newContractType: ContractType = ContractType.REGULAR,
     ): PlayerTeamHistory {
-        val player = playerRepository.findByIdOrNull(playerId)
-            ?: throw PlayerNotFoundException(playerId)
+        val player =
+            playerRepository.findByIdOrNull(playerId)
+                ?: throw PlayerNotFoundException(playerId)
 
-        val fromTeam = teamRepository.findByIdWithLeague(fromTeamId)
-            ?: throw TeamNotFoundException(fromTeamId)
+        val fromTeam =
+            teamRepository.findByIdWithLeague(fromTeamId)
+                ?: throw TeamNotFoundException(fromTeamId)
 
-        val toTeam = teamRepository.findByIdWithLeague(toTeamId)
-            ?: throw TeamNotFoundException(toTeamId)
+        val toTeam =
+            teamRepository.findByIdWithLeague(toTeamId)
+                ?: throw TeamNotFoundException(toTeamId)
 
         // 같은 리그 내 이적만 허용
         val fromLeagueId = fromTeam.league.id
@@ -137,27 +142,29 @@ class PlayerTeamService(
 
         if (fromLeagueId != toLeagueId) {
             throw PlayerTransferNotAllowedException(
-                "선수는 같은 리그 내에서만 이적할 수 있습니다. (From: League $fromLeagueId, To: League $toLeagueId)"
+                "선수는 같은 리그 내에서만 이적할 수 있습니다. (From: League $fromLeagueId, To: League $toLeagueId)",
             )
         }
 
         // 현재 소속 이력 조회
-        val currentAffiliation = playerTeamHistoryRepository.findActiveByPlayerIdAndLeagueId(playerId, fromLeagueId)
-            ?: throw PlayerNotInTeamException(playerId, fromTeamId)
+        val currentAffiliation =
+            playerTeamHistoryRepository.findActiveByPlayerIdAndLeagueId(playerId, fromLeagueId)
+                ?: throw PlayerNotInTeamException(playerId, fromTeamId)
 
         // 기존 소속 TRANSFERRED 처리
         currentAffiliation.transfer(transferDate)
 
         // 새 팀으로 소속 생성
-        val newAffiliation = PlayerTeamHistory(
-            player = player,
-            team = toTeam,
-            startDate = transferDate,
-            position = newPosition,
-            uniformNumber = newUniformNumber,
-            contractType = newContractType,
-            status = PlayerTeamStatus.ACTIVE
-        )
+        val newAffiliation =
+            PlayerTeamHistory(
+                player = player,
+                team = toTeam,
+                startDate = transferDate,
+                position = newPosition,
+                uniformNumber = newUniformNumber,
+                contractType = newContractType,
+                status = PlayerTeamStatus.ACTIVE,
+            )
 
         return playerTeamHistoryRepository.save(newAffiliation)
     }
@@ -172,7 +179,7 @@ class PlayerTeamService(
     @Transactional
     fun changeUniformNumber(
         affiliationId: Long,
-        uniformNumber: Int
+        uniformNumber: Int,
     ): PlayerTeamHistory {
         val affiliation = findAffiliationById(affiliationId)
         affiliation.changeUniformNumber(uniformNumber)
@@ -189,7 +196,7 @@ class PlayerTeamService(
     @Transactional
     fun changePosition(
         affiliationId: Long,
-        position: Position
+        position: Position,
     ): PlayerTeamHistory {
         val affiliation = findAffiliationById(affiliationId)
         affiliation.changePosition(position)
@@ -233,7 +240,10 @@ class PlayerTeamService(
      * @param date 기준 날짜
      * @return 해당 날짜의 팀 로스터
      */
-    fun getTeamRosterAtDate(teamId: Long, date: LocalDate): List<PlayerTeamHistory> {
+    fun getTeamRosterAtDate(
+        teamId: Long,
+        date: LocalDate,
+    ): List<PlayerTeamHistory> {
         // 팀 존재 여부 확인
         teamRepository.findByIdWithLeague(teamId)
             ?: throw TeamNotFoundException(teamId)
@@ -260,8 +270,7 @@ class PlayerTeamService(
     /**
      * ID로 소속 이력을 조회합니다.
      */
-    private fun findAffiliationById(id: Long): PlayerTeamHistory {
-        return playerTeamHistoryRepository.findByIdOrNull(id)
+    private fun findAffiliationById(id: Long): PlayerTeamHistory =
+        playerTeamHistoryRepository.findByIdOrNull(id)
             ?: throw PlayerTeamHistoryNotFoundException(id)
-    }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/PlayerStatsService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/PlayerStatsService.kt
@@ -29,9 +29,8 @@ class PlayerStatsService(
     private val careerBattingStatsRepository: CareerBattingStatsRepositoryPort,
     private val careerPitchingStatsRepository: CareerPitchingStatsRepositoryPort,
     private val battingRecordRepository: BattingRecordRepositoryPort,
-    private val pitchingRecordRepository: PitchingRecordRepositoryPort
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
 ) {
-
     // ========== 조회 메서드 ==========
 
     /**
@@ -39,54 +38,54 @@ class PlayerStatsService(
      *
      * @throws IllegalArgumentException 통계가 존재하지 않을 때
      */
-    fun getSeasonBattingStats(playerId: Long, year: Int): SeasonBattingStats {
-        return seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year)
+    fun getSeasonBattingStats(
+        playerId: Long,
+        year: Int,
+    ): SeasonBattingStats =
+        seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year)
             ?: throw IllegalArgumentException("선수 ID $playerId 의 ${year}년도 타격 통계가 존재하지 않습니다.")
-    }
 
     /**
      * 시즌 투수 통계를 조회합니다.
      *
      * @throws IllegalArgumentException 통계가 존재하지 않을 때
      */
-    fun getSeasonPitchingStats(playerId: Long, year: Int): SeasonPitchingStats {
-        return seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year)
+    fun getSeasonPitchingStats(
+        playerId: Long,
+        year: Int,
+    ): SeasonPitchingStats =
+        seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year)
             ?: throw IllegalArgumentException("선수 ID $playerId 의 ${year}년도 투수 통계가 존재하지 않습니다.")
-    }
 
     /**
      * 통산 타격 통계를 조회합니다.
      *
      * @throws IllegalArgumentException 통계가 존재하지 않을 때
      */
-    fun getCareerBattingStats(playerId: Long): CareerBattingStats {
-        return careerBattingStatsRepository.findByPlayerId(playerId)
+    fun getCareerBattingStats(playerId: Long): CareerBattingStats =
+        careerBattingStatsRepository.findByPlayerId(playerId)
             ?: throw IllegalArgumentException("선수 ID $playerId 의 통산 타격 통계가 존재하지 않습니다.")
-    }
 
     /**
      * 통산 투수 통계를 조회합니다.
      *
      * @throws IllegalArgumentException 통계가 존재하지 않을 때
      */
-    fun getCareerPitchingStats(playerId: Long): CareerPitchingStats {
-        return careerPitchingStatsRepository.findByPlayerId(playerId)
+    fun getCareerPitchingStats(playerId: Long): CareerPitchingStats =
+        careerPitchingStatsRepository.findByPlayerId(playerId)
             ?: throw IllegalArgumentException("선수 ID $playerId 의 통산 투수 통계가 존재하지 않습니다.")
-    }
 
     /**
      * 선수의 모든 시즌 타격 통계를 조회합니다.
      */
-    fun getAllSeasonBattingStats(playerId: Long): List<SeasonBattingStats> {
-        return seasonBattingStatsRepository.findAllByPlayerId(playerId)
-    }
+    fun getAllSeasonBattingStats(playerId: Long): List<SeasonBattingStats> =
+        seasonBattingStatsRepository.findAllByPlayerId(playerId)
 
     /**
      * 선수의 모든 시즌 투수 통계를 조회합니다.
      */
-    fun getAllSeasonPitchingStats(playerId: Long): List<SeasonPitchingStats> {
-        return seasonPitchingStatsRepository.findAllByPlayerId(playerId)
-    }
+    fun getAllSeasonPitchingStats(playerId: Long): List<SeasonPitchingStats> =
+        seasonPitchingStatsRepository.findAllByPlayerId(playerId)
 
     // ========== 통계 갱신 메서드 ==========
 
@@ -97,12 +96,16 @@ class PlayerStatsService(
      * @return 갱신된 시즌 타격 통계
      */
     @Transactional
-    fun updatePlayerBattingStats(playerId: Long, year: Int): SeasonBattingStats {
+    fun updatePlayerBattingStats(
+        playerId: Long,
+        year: Int,
+    ): SeasonBattingStats {
         val player = findPlayer(playerId)
 
         // 시즌 통계 조회 또는 생성
-        val seasonStats = seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year)
-            ?: SeasonBattingStats.create(player, year)
+        val seasonStats =
+            seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year)
+                ?: SeasonBattingStats.create(player, year)
 
         // 기존 통계 초기화 (새로 계산하기 위해)
         resetSeasonBattingStats(seasonStats)
@@ -128,12 +131,16 @@ class PlayerStatsService(
      * @return 갱신된 시즌 투수 통계
      */
     @Transactional
-    fun updatePlayerPitchingStats(playerId: Long, year: Int): SeasonPitchingStats {
+    fun updatePlayerPitchingStats(
+        playerId: Long,
+        year: Int,
+    ): SeasonPitchingStats {
         val player = findPlayer(playerId)
 
         // 시즌 통계 조회 또는 생성
-        val seasonStats = seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year)
-            ?: SeasonPitchingStats.create(player, year)
+        val seasonStats =
+            seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year)
+                ?: SeasonPitchingStats.create(player, year)
 
         // 기존 통계 초기화 (새로 계산하기 위해)
         resetSeasonPitchingStats(seasonStats)
@@ -163,8 +170,9 @@ class PlayerStatsService(
         val player = findPlayer(playerId)
 
         // 통산 통계 조회 또는 생성
-        val careerStats = careerBattingStatsRepository.findByPlayerId(playerId)
-            ?: CareerBattingStats.create(player)
+        val careerStats =
+            careerBattingStatsRepository.findByPlayerId(playerId)
+                ?: CareerBattingStats.create(player)
 
         // 기존 통계 초기화 (새로 계산하기 위해)
         resetCareerBattingStats(careerStats)
@@ -178,10 +186,11 @@ class PlayerStatsService(
         }
 
         // 시즌 수 계산 (년도별 그룹핑)
-        val seasons = battingRecords
-            .map { record -> record.gamePlayer.gameTeam.game.scheduledAt.year }
-            .distinct()
-            .size
+        val seasons =
+            battingRecords
+                .map { record -> record.gamePlayer.gameTeam.game.scheduledAt.year }
+                .distinct()
+                .size
 
         // 시즌 수 업데이트
         repeat(seasons - careerStats.seasonsPlayed) {
@@ -205,8 +214,9 @@ class PlayerStatsService(
         val player = findPlayer(playerId)
 
         // 통산 통계 조회 또는 생성
-        val careerStats = careerPitchingStatsRepository.findByPlayerId(playerId)
-            ?: CareerPitchingStats.create(player)
+        val careerStats =
+            careerPitchingStatsRepository.findByPlayerId(playerId)
+                ?: CareerPitchingStats.create(player)
 
         // 기존 통계 초기화 (새로 계산하기 위해)
         resetCareerPitchingStats(careerStats)
@@ -220,10 +230,11 @@ class PlayerStatsService(
         }
 
         // 시즌 수 계산 (년도별 그룹핑)
-        val seasons = pitchingRecords
-            .map { record -> record.gamePlayer.gameTeam.game.scheduledAt.year }
-            .distinct()
-            .size
+        val seasons =
+            pitchingRecords
+                .map { record -> record.gamePlayer.gameTeam.game.scheduledAt.year }
+                .distinct()
+                .size
 
         // 시즌 수 업데이트
         repeat(seasons - careerStats.seasonsPlayed) {
@@ -250,15 +261,14 @@ class PlayerStatsService(
         year: Int,
         category: BattingCategory,
         minAtBats: Int = 50,
-        limit: Int = 10
-    ): List<SeasonBattingStats> {
-        return when (category) {
+        limit: Int = 10,
+    ): List<SeasonBattingStats> =
+        when (category) {
             BattingCategory.AVG -> seasonBattingStatsRepository.findTopByBattingAverage(year, minAtBats, limit)
             BattingCategory.HR -> seasonBattingStatsRepository.findTopByHomeRuns(year, limit)
             BattingCategory.RBI -> seasonBattingStatsRepository.findTopByRunsBattedIn(year, limit)
             BattingCategory.OPS -> seasonBattingStatsRepository.findTopByOps(year, minAtBats, limit)
         }
-    }
 
     /**
      * 시즌 투수 리더보드를 조회합니다.
@@ -272,7 +282,7 @@ class PlayerStatsService(
         year: Int,
         category: PitchingCategory,
         minInnings: Int = 15,
-        limit: Int = 10
+        limit: Int = 10,
     ): List<SeasonPitchingStats> {
         val minInningsPitchedOuts = minInnings * 3
 
@@ -287,10 +297,9 @@ class PlayerStatsService(
 
     // ========== 헬퍼 메서드 ==========
 
-    private fun findPlayer(playerId: Long): Player {
-        return playerRepository.findByIdOrNull(playerId)
+    private fun findPlayer(playerId: Long): Player =
+        playerRepository.findByIdOrNull(playerId)
             ?: throw IllegalArgumentException("선수 ID $playerId 를 찾을 수 없습니다.")
-    }
 
     /**
      * 시즌 타격 통계를 초기화합니다 (Reflection 사용하여 protected setter 접근).
@@ -299,10 +308,24 @@ class PlayerStatsService(
         val clazz = SeasonBattingStats::class.java
 
         listOf(
-            "gamesPlayed", "plateAppearances", "atBats", "hits", "doubles", "triples",
-            "homeRuns", "runs", "runsBattedIn", "walks", "intentionalWalks", "hitByPitch",
-            "strikeouts", "sacrificeBunts", "sacrificeFlies", "stolenBases", "caughtStealing",
-            "groundedIntoDoublePlays"
+            "gamesPlayed",
+            "plateAppearances",
+            "atBats",
+            "hits",
+            "doubles",
+            "triples",
+            "homeRuns",
+            "runs",
+            "runsBattedIn",
+            "walks",
+            "intentionalWalks",
+            "hitByPitch",
+            "strikeouts",
+            "sacrificeBunts",
+            "sacrificeFlies",
+            "stolenBases",
+            "caughtStealing",
+            "groundedIntoDoublePlays",
         ).forEach { fieldName ->
             val field = clazz.getDeclaredField(fieldName)
             field.isAccessible = true
@@ -317,9 +340,24 @@ class PlayerStatsService(
         val clazz = SeasonPitchingStats::class.java
 
         listOf(
-            "gamesPlayed", "gamesStarted", "inningsPitchedOuts", "wins", "losses", "saves",
-            "holds", "blownSaves", "earnedRuns", "runsAllowed", "hitsAllowed", "walksAllowed",
-            "strikeouts", "homeRunsAllowed", "hitBatsmen", "wildPitches", "balks", "battersFaced"
+            "gamesPlayed",
+            "gamesStarted",
+            "inningsPitchedOuts",
+            "wins",
+            "losses",
+            "saves",
+            "holds",
+            "blownSaves",
+            "earnedRuns",
+            "runsAllowed",
+            "hitsAllowed",
+            "walksAllowed",
+            "strikeouts",
+            "homeRunsAllowed",
+            "hitBatsmen",
+            "wildPitches",
+            "balks",
+            "battersFaced",
         ).forEach { fieldName ->
             val field = clazz.getDeclaredField(fieldName)
             field.isAccessible = true
@@ -341,10 +379,25 @@ class PlayerStatsService(
         val clazz = CareerBattingStats::class.java
 
         listOf(
-            "seasonsPlayed", "gamesPlayed", "plateAppearances", "atBats", "hits", "doubles", "triples",
-            "homeRuns", "runs", "runsBattedIn", "walks", "intentionalWalks", "hitByPitch",
-            "strikeouts", "sacrificeBunts", "sacrificeFlies", "stolenBases", "caughtStealing",
-            "groundedIntoDoublePlays"
+            "seasonsPlayed",
+            "gamesPlayed",
+            "plateAppearances",
+            "atBats",
+            "hits",
+            "doubles",
+            "triples",
+            "homeRuns",
+            "runs",
+            "runsBattedIn",
+            "walks",
+            "intentionalWalks",
+            "hitByPitch",
+            "strikeouts",
+            "sacrificeBunts",
+            "sacrificeFlies",
+            "stolenBases",
+            "caughtStealing",
+            "groundedIntoDoublePlays",
         ).forEach { fieldName ->
             val field = clazz.getDeclaredField(fieldName)
             field.isAccessible = true
@@ -359,10 +412,25 @@ class PlayerStatsService(
         val clazz = CareerPitchingStats::class.java
 
         listOf(
-            "seasonsPlayed", "gamesPlayed", "gamesStarted", "inningsPitchedOuts", "wins", "losses",
-            "saves", "holds", "blownSaves", "earnedRuns", "runsAllowed", "hitsAllowed",
-            "walksAllowed", "strikeouts", "homeRunsAllowed", "hitBatsmen", "wildPitches",
-            "balks", "battersFaced"
+            "seasonsPlayed",
+            "gamesPlayed",
+            "gamesStarted",
+            "inningsPitchedOuts",
+            "wins",
+            "losses",
+            "saves",
+            "holds",
+            "blownSaves",
+            "earnedRuns",
+            "runsAllowed",
+            "hitsAllowed",
+            "walksAllowed",
+            "strikeouts",
+            "homeRunsAllowed",
+            "hitBatsmen",
+            "wildPitches",
+            "balks",
+            "battersFaced",
         ).forEach { fieldName ->
             val field = clazz.getDeclaredField(fieldName)
             field.isAccessible = true
@@ -382,19 +450,19 @@ class PlayerStatsService(
  * 타격 통계 카테고리
  */
 enum class BattingCategory {
-    AVG,  // 타율
-    HR,   // 홈런
-    RBI,  // 타점
-    OPS   // OPS
+    AVG, // 타율
+    HR, // 홈런
+    RBI, // 타점
+    OPS, // OPS
 }
 
 /**
  * 투수 통계 카테고리
  */
 enum class PitchingCategory {
-    ERA,        // 자책점
-    WINS,       // 승수
+    ERA, // 자책점
+    WINS, // 승수
     STRIKEOUTS, // 삼진
-    SAVES,      // 세이브
-    WHIP        // WHIP
+    SAVES, // 세이브
+    WHIP, // WHIP
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/user/UserService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/user/UserService.kt
@@ -20,9 +20,8 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class UserService(
     private val userRepository: UserRepositoryPort,
-    private val oauthAccountRepository: OAuthAccountRepositoryPort
+    private val oauthAccountRepository: OAuthAccountRepositoryPort,
 ) {
-
     // ========== CREATE ==========
 
     /**
@@ -32,15 +31,16 @@ class UserService(
     fun createLocalUser(
         email: String,
         encodedPassword: String,
-        nickname: String
+        nickname: String,
     ): User {
         validateEmailNotDuplicate(email)
 
-        val user = User.createLocalUser(
-            email = email,
-            encodedPassword = encodedPassword,
-            nickname = nickname
-        )
+        val user =
+            User.createLocalUser(
+                email = email,
+                encodedPassword = encodedPassword,
+                nickname = nickname,
+            )
 
         return userRepository.save(user)
     }
@@ -56,7 +56,7 @@ class UserService(
         nickname: String,
         provider: OAuthProvider,
         oauthId: String,
-        profileImageUrl: String? = null
+        profileImageUrl: String? = null,
     ): Pair<User, Boolean> {
         // 이미 연동된 OAuth 계정이 있는지 확인
         val existingOAuth = oauthAccountRepository.findByProviderAndOauthId(provider, oauthId)
@@ -76,13 +76,14 @@ class UserService(
         }
 
         // 신규 사용자 생성
-        val newUser = User.createOAuthUser(
-            email = email,
-            nickname = nickname,
-            provider = provider,
-            oauthId = oauthId,
-            profileImageUrl = profileImageUrl
-        )
+        val newUser =
+            User.createOAuthUser(
+                email = email,
+                nickname = nickname,
+                provider = provider,
+                oauthId = oauthId,
+                profileImageUrl = profileImageUrl,
+            )
 
         return Pair(userRepository.save(newUser), true)
     }
@@ -92,10 +93,9 @@ class UserService(
     /**
      * ID로 사용자를 조회합니다.
      */
-    fun getById(id: Long): User {
-        return userRepository.findByIdOrNull(id)
+    fun getById(id: Long): User =
+        userRepository.findByIdOrNull(id)
             ?: throw UserNotFoundException(id)
-    }
 
     /**
      * 활성 사용자를 ID로 조회합니다.
@@ -111,59 +111,56 @@ class UserService(
     /**
      * 이메일로 사용자를 조회합니다.
      */
-    fun getByEmail(email: String): User {
-        return userRepository.findByEmail(email)
+    fun getByEmail(email: String): User =
+        userRepository.findByEmail(email)
             ?: throw UserNotFoundByEmailException(email)
-    }
 
     /**
      * 이메일로 사용자를 조회합니다 (없으면 null).
      */
-    fun findByEmail(email: String): User? {
-        return userRepository.findByEmail(email)
-    }
+    fun findByEmail(email: String): User? = userRepository.findByEmail(email)
 
     /**
      * OAuth 정보로 사용자를 조회합니다.
      */
-    fun findByOAuth(provider: OAuthProvider, oauthId: String): User? {
-        return oauthAccountRepository.findByProviderAndOauthId(provider, oauthId)?.user
-    }
+    fun findByOAuth(
+        provider: OAuthProvider,
+        oauthId: String,
+    ): User? = oauthAccountRepository.findByProviderAndOauthId(provider, oauthId)?.user
 
     /**
      * 활성화된 모든 사용자를 페이징으로 조회합니다.
      */
-    fun getAllActive(pageable: Pageable): Page<User> {
-        return userRepository.findAllActive(pageable)
-    }
+    fun getAllActive(pageable: Pageable): Page<User> = userRepository.findAllActive(pageable)
 
     /**
      * 모든 사용자를 페이징으로 조회합니다 (관리자용).
      */
-    fun getAll(pageable: Pageable): Page<User> {
-        return userRepository.findAllByIsActive(true, pageable)
-    }
+    fun getAll(pageable: Pageable): Page<User> = userRepository.findAllByIsActive(true, pageable)
 
     /**
      * 활성 상태별로 사용자를 조회합니다 (관리자용).
      */
-    fun getAllByStatus(isActive: Boolean, pageable: Pageable): Page<User> {
-        return userRepository.findAllByIsActive(isActive, pageable)
-    }
+    fun getAllByStatus(
+        isActive: Boolean,
+        pageable: Pageable,
+    ): Page<User> = userRepository.findAllByIsActive(isActive, pageable)
 
     /**
      * 키워드로 사용자를 검색합니다 (관리자용).
      */
-    fun search(keyword: String, pageable: Pageable): Page<User> {
-        return userRepository.searchByKeyword(keyword, pageable)
-    }
+    fun search(
+        keyword: String,
+        pageable: Pageable,
+    ): Page<User> = userRepository.searchByKeyword(keyword, pageable)
 
     /**
      * 역할별로 사용자를 조회합니다 (관리자용).
      */
-    fun getAllByRole(role: Role, pageable: Pageable): Page<User> {
-        return userRepository.findAllByRole(role, pageable)
-    }
+    fun getAllByRole(
+        role: Role,
+        pageable: Pageable,
+    ): Page<User> = userRepository.findAllByRole(role, pageable)
 
     // ========== UPDATE ==========
 
@@ -174,13 +171,13 @@ class UserService(
     fun updateProfile(
         userId: Long,
         nickname: String? = null,
-        profileImageUrl: String? = null
+        profileImageUrl: String? = null,
     ): User {
         val user = getActiveById(userId)
 
         user.updateProfile(
             nickname = nickname ?: user.nickname,
-            profileImageUrl = profileImageUrl
+            profileImageUrl = profileImageUrl,
         )
 
         return user
@@ -190,7 +187,10 @@ class UserService(
      * 비밀번호를 변경합니다.
      */
     @Transactional
-    fun changePassword(userId: Long, encodedPassword: String): User {
+    fun changePassword(
+        userId: Long,
+        encodedPassword: String,
+    ): User {
         val user = getActiveById(userId)
         user.changePassword(encodedPassword)
         return user
@@ -200,7 +200,10 @@ class UserService(
      * 역할을 추가합니다 (관리자용).
      */
     @Transactional
-    fun addRole(userId: Long, role: Role): User {
+    fun addRole(
+        userId: Long,
+        role: Role,
+    ): User {
         val user = getById(userId)
         user.addRole(role)
         return user
@@ -210,7 +213,10 @@ class UserService(
      * 역할을 제거합니다 (관리자용).
      */
     @Transactional
-    fun removeRole(userId: Long, role: Role): User {
+    fun removeRole(
+        userId: Long,
+        role: Role,
+    ): User {
         val user = getById(userId)
         user.removeRole(role)
         return user
@@ -226,7 +232,7 @@ class UserService(
         userId: Long,
         provider: OAuthProvider,
         oauthId: String,
-        email: String? = null
+        email: String? = null,
     ): User {
         val user = getActiveById(userId)
 
@@ -244,7 +250,10 @@ class UserService(
      * OAuth 계정 연동을 해제합니다.
      */
     @Transactional
-    fun unlinkOAuthAccount(userId: Long, provider: OAuthProvider): User {
+    fun unlinkOAuthAccount(
+        userId: Long,
+        provider: OAuthProvider,
+    ): User {
         val user = getActiveById(userId)
 
         if (!user.canRemoveAuthMethod()) {
@@ -258,9 +267,7 @@ class UserService(
     /**
      * 사용자의 연동된 OAuth Provider 목록을 조회합니다.
      */
-    fun getLinkedProviders(userId: Long): List<OAuthProvider> {
-        return oauthAccountRepository.findProvidersByUserId(userId)
-    }
+    fun getLinkedProviders(userId: Long): List<OAuthProvider> = oauthAccountRepository.findProvidersByUserId(userId)
 
     // ========== 상태 변경 ==========
 
@@ -298,7 +305,5 @@ class UserService(
     /**
      * 이메일 존재 여부를 확인합니다.
      */
-    fun existsByEmail(email: String): Boolean {
-        return userRepository.existsByEmail(email)
-    }
+    fun existsByEmail(email: String): Boolean = userRepository.existsByEmail(email)
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationAdminTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationAdminTest.kt
@@ -9,23 +9,22 @@ import org.junit.jupiter.api.assertThrows
 
 @DisplayName("OrganizationAdmin 테스트")
 class OrganizationAdminTest {
-
     @Nested
     @DisplayName("create 팩토리 메서드")
     inner class Create {
-
         @Test
         fun `should create organization admin successfully`() {
             // given
             val user = createUser()
 
             // when
-            val admin = OrganizationAdmin.create(
-                user = user,
-                organizationType = OrganizationType.ASSOCIATION,
-                organizationId = 1L,
-                role = OrganizationRole.ADMIN
-            )
+            val admin =
+                OrganizationAdmin.create(
+                    user = user,
+                    organizationType = OrganizationType.ASSOCIATION,
+                    organizationId = 1L,
+                    role = OrganizationRole.ADMIN,
+                )
 
             // then
             assertThat(admin.user).isEqualTo(user)
@@ -43,13 +42,14 @@ class OrganizationAdminTest {
             val assignedByUserId = 100L
 
             // when
-            val admin = OrganizationAdmin.create(
-                user = user,
-                organizationType = OrganizationType.LEAGUE,
-                organizationId = 2L,
-                role = OrganizationRole.MANAGER,
-                assignedBy = assignedByUserId
-            )
+            val admin =
+                OrganizationAdmin.create(
+                    user = user,
+                    organizationType = OrganizationType.LEAGUE,
+                    organizationId = 2L,
+                    role = OrganizationRole.MANAGER,
+                    assignedBy = assignedByUserId,
+                )
 
             // then
             assertThat(admin.assignedBy).isEqualTo(assignedByUserId)
@@ -66,7 +66,7 @@ class OrganizationAdminTest {
                     user = user,
                     organizationType = OrganizationType.TEAM,
                     organizationId = 0L,
-                    role = OrganizationRole.SCORER
+                    role = OrganizationRole.SCORER,
                 )
             }
         }
@@ -82,7 +82,7 @@ class OrganizationAdminTest {
                     user = user,
                     organizationType = OrganizationType.TEAM,
                     organizationId = -1L,
-                    role = OrganizationRole.SCORER
+                    role = OrganizationRole.SCORER,
                 )
             }
         }
@@ -91,17 +91,17 @@ class OrganizationAdminTest {
     @Nested
     @DisplayName("createAssociationAdmin 팩토리 메서드")
     inner class CreateAssociationAdmin {
-
         @Test
         fun `should create association admin with default role`() {
             // given
             val user = createUser()
 
             // when
-            val admin = OrganizationAdmin.createAssociationAdmin(
-                user = user,
-                associationId = 1L
-            )
+            val admin =
+                OrganizationAdmin.createAssociationAdmin(
+                    user = user,
+                    associationId = 1L,
+                )
 
             // then
             assertThat(admin.organizationType).isEqualTo(OrganizationType.ASSOCIATION)
@@ -115,11 +115,12 @@ class OrganizationAdminTest {
             val user = createUser()
 
             // when
-            val admin = OrganizationAdmin.createAssociationAdmin(
-                user = user,
-                associationId = 1L,
-                role = OrganizationRole.MANAGER
-            )
+            val admin =
+                OrganizationAdmin.createAssociationAdmin(
+                    user = user,
+                    associationId = 1L,
+                    role = OrganizationRole.MANAGER,
+                )
 
             // then
             assertThat(admin.role).isEqualTo(OrganizationRole.MANAGER)
@@ -129,17 +130,17 @@ class OrganizationAdminTest {
     @Nested
     @DisplayName("createLeagueAdmin 팩토리 메서드")
     inner class CreateLeagueAdmin {
-
         @Test
         fun `should create league admin with default role`() {
             // given
             val user = createUser()
 
             // when
-            val admin = OrganizationAdmin.createLeagueAdmin(
-                user = user,
-                leagueId = 2L
-            )
+            val admin =
+                OrganizationAdmin.createLeagueAdmin(
+                    user = user,
+                    leagueId = 2L,
+                )
 
             // then
             assertThat(admin.organizationType).isEqualTo(OrganizationType.LEAGUE)
@@ -153,11 +154,12 @@ class OrganizationAdminTest {
             val user = createUser()
 
             // when
-            val admin = OrganizationAdmin.createLeagueAdmin(
-                user = user,
-                leagueId = 2L,
-                assignedBy = 99L
-            )
+            val admin =
+                OrganizationAdmin.createLeagueAdmin(
+                    user = user,
+                    leagueId = 2L,
+                    assignedBy = 99L,
+                )
 
             // then
             assertThat(admin.assignedBy).isEqualTo(99L)
@@ -167,17 +169,17 @@ class OrganizationAdminTest {
     @Nested
     @DisplayName("createTeamAdmin 팩토리 메서드")
     inner class CreateTeamAdmin {
-
         @Test
         fun `should create team admin with default role`() {
             // given
             val user = createUser()
 
             // when
-            val admin = OrganizationAdmin.createTeamAdmin(
-                user = user,
-                teamId = 3L
-            )
+            val admin =
+                OrganizationAdmin.createTeamAdmin(
+                    user = user,
+                    teamId = 3L,
+                )
 
             // then
             assertThat(admin.organizationType).isEqualTo(OrganizationType.TEAM)
@@ -191,11 +193,12 @@ class OrganizationAdminTest {
             val user = createUser()
 
             // when
-            val admin = OrganizationAdmin.createTeamAdmin(
-                user = user,
-                teamId = 3L,
-                role = OrganizationRole.SCORER
-            )
+            val admin =
+                OrganizationAdmin.createTeamAdmin(
+                    user = user,
+                    teamId = 3L,
+                    role = OrganizationRole.SCORER,
+                )
 
             // then
             assertThat(admin.role).isEqualTo(OrganizationRole.SCORER)
@@ -205,7 +208,6 @@ class OrganizationAdminTest {
     @Nested
     @DisplayName("changeRole 메서드")
     inner class ChangeRole {
-
         @Test
         fun `should change role successfully when active`() {
             // given
@@ -234,7 +236,6 @@ class OrganizationAdminTest {
     @Nested
     @DisplayName("activate/deactivate 메서드")
     inner class ActivateDeactivate {
-
         @Test
         fun `should deactivate admin successfully`() {
             // given
@@ -264,7 +265,6 @@ class OrganizationAdminTest {
     @Nested
     @DisplayName("hasRoleOrHigher 메서드")
     inner class HasRoleOrHigher {
-
         @Test
         fun `should return true when admin has higher role`() {
             // given
@@ -308,7 +308,6 @@ class OrganizationAdminTest {
     @Nested
     @DisplayName("조직 유형 프로퍼티")
     inner class OrganizationTypeProperties {
-
         @Test
         fun `should return true for isAssociationAdmin when type is ASSOCIATION`() {
             // given
@@ -346,7 +345,6 @@ class OrganizationAdminTest {
     @Nested
     @DisplayName("equals/hashCode")
     inner class EqualsHashCode {
-
         @Test
         fun `should be equal when same instance`() {
             // given
@@ -409,7 +407,6 @@ class OrganizationAdminTest {
     @Nested
     @DisplayName("toString")
     inner class ToString {
-
         @Test
         fun `should return readable string representation`() {
             // given
@@ -430,32 +427,30 @@ class OrganizationAdminTest {
 
     // Helper methods
 
-    private fun createUser(): User {
-        return User.createLocalUser(
+    private fun createUser(): User =
+        User.createLocalUser(
             email = "test@example.com",
             encodedPassword = "password",
-            nickname = "테스터"
+            nickname = "테스터",
         )
-    }
 
     private fun createAdmin(
         organizationType: OrganizationType = OrganizationType.ASSOCIATION,
         organizationId: Long = 1L,
-        role: OrganizationRole = OrganizationRole.ADMIN
-    ): OrganizationAdmin {
-        return OrganizationAdmin.create(
+        role: OrganizationRole = OrganizationRole.ADMIN,
+    ): OrganizationAdmin =
+        OrganizationAdmin.create(
             user = createUser(),
             organizationType = organizationType,
             organizationId = organizationId,
-            role = role
+            role = role,
         )
-    }
 
     private fun createAdminWithId(
         id: Long,
         organizationType: OrganizationType = OrganizationType.ASSOCIATION,
         organizationId: Long = 1L,
-        role: OrganizationRole = OrganizationRole.ADMIN
+        role: OrganizationRole = OrganizationRole.ADMIN,
     ): OrganizationAdmin {
         val admin = createAdmin(organizationType, organizationId, role)
         val idField = OrganizationAdmin::class.java.getDeclaredField("id")

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationRoleTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationRoleTest.kt
@@ -10,11 +10,9 @@ import org.junit.jupiter.params.provider.CsvSource
 
 @DisplayName("OrganizationRole 테스트")
 class OrganizationRoleTest {
-
     @Nested
     @DisplayName("enum 값")
     inner class EnumValues {
-
         @Test
         fun `should have correct ADMIN properties`() {
             // given
@@ -52,7 +50,6 @@ class OrganizationRoleTest {
     @Nested
     @DisplayName("isHigherThan 메서드")
     inner class IsHigherThan {
-
         @Test
         fun `ADMIN should be higher than MANAGER`() {
             assertThat(OrganizationRole.ADMIN.isHigherThan(OrganizationRole.MANAGER)).isTrue()
@@ -89,7 +86,6 @@ class OrganizationRoleTest {
     @Nested
     @DisplayName("isHigherOrEqual 메서드")
     inner class IsHigherOrEqual {
-
         @Test
         fun `ADMIN should be higher or equal to all roles`() {
             assertThat(OrganizationRole.ADMIN.isHigherOrEqual(OrganizationRole.ADMIN)).isTrue()
@@ -115,7 +111,6 @@ class OrganizationRoleTest {
     @Nested
     @DisplayName("fromValue 메서드")
     inner class FromValue {
-
         @ParameterizedTest
         @CsvSource(
             "ADMIN, ADMIN",
@@ -124,9 +119,12 @@ class OrganizationRoleTest {
             "MANAGER, MANAGER",
             "manager, MANAGER",
             "SCORER, SCORER",
-            "scorer, SCORER"
+            "scorer, SCORER",
         )
-        fun `should return correct role for valid values`(input: String, expected: OrganizationRole) {
+        fun `should return correct role for valid values`(
+            input: String,
+            expected: OrganizationRole,
+        ) {
             // when
             val result = OrganizationRole.fromValue(input)
 
@@ -137,9 +135,10 @@ class OrganizationRoleTest {
         @Test
         fun `should throw exception for invalid value`() {
             // when & then
-            val exception = assertThrows<IllegalArgumentException> {
-                OrganizationRole.fromValue("INVALID")
-            }
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    OrganizationRole.fromValue("INVALID")
+                }
             assertThat(exception.message).contains("Invalid organization role")
         }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationTypeTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/admin/OrganizationTypeTest.kt
@@ -10,11 +10,9 @@ import org.junit.jupiter.params.provider.CsvSource
 
 @DisplayName("OrganizationType 테스트")
 class OrganizationTypeTest {
-
     @Nested
     @DisplayName("enum 값")
     inner class EnumValues {
-
         @Test
         fun `should have correct ASSOCIATION properties`() {
             // given
@@ -49,7 +47,6 @@ class OrganizationTypeTest {
     @Nested
     @DisplayName("fromValue 메서드")
     inner class FromValue {
-
         @ParameterizedTest
         @CsvSource(
             "ASSOCIATION, ASSOCIATION",
@@ -60,9 +57,12 @@ class OrganizationTypeTest {
             "League, LEAGUE",
             "TEAM, TEAM",
             "team, TEAM",
-            "Team, TEAM"
+            "Team, TEAM",
         )
-        fun `should return correct type for valid values`(input: String, expected: OrganizationType) {
+        fun `should return correct type for valid values`(
+            input: String,
+            expected: OrganizationType,
+        ) {
             // when
             val result = OrganizationType.fromValue(input)
 
@@ -73,9 +73,10 @@ class OrganizationTypeTest {
         @Test
         fun `should throw exception for invalid value`() {
             // when & then
-            val exception = assertThrows<IllegalArgumentException> {
-                OrganizationType.fromValue("INVALID")
-            }
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    OrganizationType.fromValue("INVALID")
+                }
             assertThat(exception.message).contains("Invalid organization type")
         }
 
@@ -91,7 +92,6 @@ class OrganizationTypeTest {
     @Nested
     @DisplayName("전체 enum 값")
     inner class AllValues {
-
         @Test
         fun `should have exactly three types`() {
             // when
@@ -102,7 +102,7 @@ class OrganizationTypeTest {
             assertThat(allTypes).containsExactly(
                 OrganizationType.ASSOCIATION,
                 OrganizationType.LEAGUE,
-                OrganizationType.TEAM
+                OrganizationType.TEAM,
             )
         }
     }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/association/AssociationTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/association/AssociationTest.kt
@@ -7,23 +7,20 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("Association 엔티티 테스트")
 class AssociationTest {
-
-    private fun createAssociation(isActive: Boolean = true): Association {
-        return Association(
+    private fun createAssociation(isActive: Boolean = true): Association =
+        Association(
             name = "서울시야구협회",
             abbreviation = "SBA",
             region = "서울",
             description = "서울 지역 사회인 야구 협회",
             logoUrl = "https://example.com/logo.png",
             websiteUrl = "https://example.com",
-            isActive = isActive
+            isActive = isActive,
         )
-    }
 
     @Nested
     @DisplayName("활성화/비활성화")
     inner class ActivationTests {
-
         @Test
         fun `협회를 비활성화할 수 있다`() {
             // given
@@ -52,7 +49,6 @@ class AssociationTest {
     @Nested
     @DisplayName("정보 업데이트")
     inner class UpdateInfoTests {
-
         @Test
         fun `설명을 업데이트할 수 있다`() {
             // given
@@ -101,7 +97,7 @@ class AssociationTest {
             association.updateInfo(
                 description = "새로운 설명",
                 logoUrl = "https://example.com/updated.png",
-                websiteUrl = "https://updated-website.com"
+                websiteUrl = "https://updated-website.com",
             )
 
             // then
@@ -114,14 +110,14 @@ class AssociationTest {
     @Nested
     @DisplayName("기본 속성")
     inner class PropertyTests {
-
         @Test
         fun `협회 생성 시 기본값으로 활성 상태이다`() {
             // given & when
-            val association = Association(
-                name = "테스트 협회",
-                region = "테스트"
-            )
+            val association =
+                Association(
+                    name = "테스트 협회",
+                    region = "테스트",
+                )
 
             // then
             assertThat(association.isActive).isTrue()

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/auth/RefreshTokenTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/auth/RefreshTokenTest.kt
@@ -10,11 +10,9 @@ import java.time.temporal.ChronoUnit
 
 @DisplayName("RefreshToken Entity")
 class RefreshTokenTest {
-
     @Nested
     @DisplayName("create()")
     inner class Create {
-
         @Test
         fun `should create RefreshToken with valid parameters`() {
             // given
@@ -23,11 +21,12 @@ class RefreshTokenTest {
             val expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
 
             // when
-            val refreshToken = RefreshToken.create(
-                userId = userId,
-                token = token,
-                expiresAt = expiresAt
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = userId,
+                    token = token,
+                    expiresAt = expiresAt,
+                )
 
             // then
             assertThat(refreshToken.userId).isEqualTo(userId)
@@ -48,13 +47,14 @@ class RefreshTokenTest {
             val ipAddress = "192.168.1.1"
 
             // when
-            val refreshToken = RefreshToken.create(
-                userId = userId,
-                token = token,
-                expiresAt = expiresAt,
-                deviceInfo = deviceInfo,
-                ipAddress = ipAddress
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = userId,
+                    token = token,
+                    expiresAt = expiresAt,
+                    deviceInfo = deviceInfo,
+                    ipAddress = ipAddress,
+                )
 
             // then
             assertThat(refreshToken.deviceInfo).isEqualTo(deviceInfo)
@@ -72,10 +72,9 @@ class RefreshTokenTest {
                 RefreshToken.create(
                     userId = userId,
                     token = "   ",
-                    expiresAt = expiresAt
+                    expiresAt = expiresAt,
                 )
-            }
-                .isInstanceOf(IllegalArgumentException::class.java)
+            }.isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("Token cannot be blank")
         }
 
@@ -91,10 +90,9 @@ class RefreshTokenTest {
                 RefreshToken.create(
                     userId = userId,
                     token = token,
-                    expiresAt = expiresAt
+                    expiresAt = expiresAt,
                 )
-            }
-                .isInstanceOf(IllegalArgumentException::class.java)
+            }.isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("Expiration time must be in the future")
         }
     }
@@ -102,15 +100,15 @@ class RefreshTokenTest {
     @Nested
     @DisplayName("isExpired")
     inner class IsExpired {
-
         @Test
         fun `should return false when token is not expired`() {
             // given
-            val refreshToken = RefreshToken.create(
-                userId = 1L,
-                token = "test-token",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
 
             // when & then
             assertThat(refreshToken.isExpired).isFalse()
@@ -126,16 +124,20 @@ class RefreshTokenTest {
         }
     }
 
-    private fun createExpiredRefreshToken(userId: Long, token: String): RefreshToken {
-        val constructor = RefreshToken::class.java.getDeclaredConstructor(
-            Long::class.java,
-            String::class.java,
-            Instant::class.java,
-            Boolean::class.java,
-            String::class.java,
-            String::class.java,
-            Long::class.java
-        )
+    private fun createExpiredRefreshToken(
+        userId: Long,
+        token: String,
+    ): RefreshToken {
+        val constructor =
+            RefreshToken::class.java.getDeclaredConstructor(
+                Long::class.java,
+                String::class.java,
+                Instant::class.java,
+                Boolean::class.java,
+                String::class.java,
+                String::class.java,
+                Long::class.java,
+            )
         constructor.isAccessible = true
         return constructor.newInstance(
             userId,
@@ -144,22 +146,22 @@ class RefreshTokenTest {
             false,
             null,
             null,
-            0L
+            0L,
         )
     }
 
     @Nested
     @DisplayName("isValid")
     inner class IsValid {
-
         @Test
         fun `should return true when token is not expired and not revoked`() {
             // given
-            val refreshToken = RefreshToken.create(
-                userId = 1L,
-                token = "test-token",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
 
             // when & then
             assertThat(refreshToken.isValid).isTrue()
@@ -168,11 +170,12 @@ class RefreshTokenTest {
         @Test
         fun `should return false when token is revoked`() {
             // given
-            val refreshToken = RefreshToken.create(
-                userId = 1L,
-                token = "test-token",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
             refreshToken.revoke()
 
             // when & then
@@ -192,15 +195,15 @@ class RefreshTokenTest {
     @Nested
     @DisplayName("revoke()")
     inner class Revoke {
-
         @Test
         fun `should revoke token`() {
             // given
-            val refreshToken = RefreshToken.create(
-                userId = 1L,
-                token = "test-token",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
 
             // when
             refreshToken.revoke()
@@ -212,11 +215,12 @@ class RefreshTokenTest {
         @Test
         fun `should not change state when already revoked`() {
             // given
-            val refreshToken = RefreshToken.create(
-                userId = 1L,
-                token = "test-token",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
             refreshToken.revoke()
 
             // when
@@ -230,15 +234,15 @@ class RefreshTokenTest {
     @Nested
     @DisplayName("validate()")
     inner class Validate {
-
         @Test
         fun `should not throw when token is valid`() {
             // given
-            val refreshToken = RefreshToken.create(
-                userId = 1L,
-                token = "test-token",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
 
             // when & then
             refreshToken.validate() // should not throw
@@ -247,11 +251,12 @@ class RefreshTokenTest {
         @Test
         fun `should throw when token is revoked`() {
             // given
-            val refreshToken = RefreshToken.create(
-                userId = 1L,
-                token = "test-token",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
             refreshToken.revoke()
 
             // when & then
@@ -275,15 +280,15 @@ class RefreshTokenTest {
     @Nested
     @DisplayName("equals() and hashCode()")
     inner class EqualsAndHashCode {
-
         @Test
         fun `should be equal when same reference`() {
             // given
-            val refreshToken = RefreshToken.create(
-                userId = 1L,
-                token = "test-token",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
 
             // when & then
             assertThat(refreshToken).isEqualTo(refreshToken)
@@ -292,16 +297,18 @@ class RefreshTokenTest {
         @Test
         fun `should not be equal when id is 0`() {
             // given
-            val token1 = RefreshToken.create(
-                userId = 1L,
-                token = "test-token-1",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
-            val token2 = RefreshToken.create(
-                userId = 1L,
-                token = "test-token-2",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val token1 =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token-1",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
+            val token2 =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token-2",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
 
             // when & then
             assertThat(token1).isNotEqualTo(token2)
@@ -310,11 +317,12 @@ class RefreshTokenTest {
         @Test
         fun `should not be equal to different type`() {
             // given
-            val refreshToken = RefreshToken.create(
-                userId = 1L,
-                token = "test-token",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
 
             // when & then
             assertThat(refreshToken).isNotEqualTo("string")
@@ -324,15 +332,15 @@ class RefreshTokenTest {
     @Nested
     @DisplayName("toString()")
     inner class ToString {
-
         @Test
         fun `should return readable string representation`() {
             // given
-            val refreshToken = RefreshToken.create(
-                userId = 1L,
-                token = "test-token",
-                expiresAt = Instant.now().plus(7, ChronoUnit.DAYS)
-            )
+            val refreshToken =
+                RefreshToken.create(
+                    userId = 1L,
+                    token = "test-token",
+                    expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+                )
 
             // when
             val result = refreshToken.toString()

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/CompetitionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/CompetitionTest.kt
@@ -12,32 +12,33 @@ import java.time.LocalDate
 
 @DisplayName("Competition 엔티티 테스트")
 class CompetitionTest {
-
     private lateinit var association: Association
     private lateinit var league: League
 
     @BeforeEach
     fun setUp() {
-        association = Association(
-            name = "서울시야구협회",
-            abbreviation = "SBA",
-            region = "서울"
-        )
-        league = League(
-            association = association,
-            name = "1부 리그",
-            abbreviation = "1st",
-            foundedYear = 2020,
-            divisionLevel = 1
-        )
+        association =
+            Association(
+                name = "서울시야구협회",
+                abbreviation = "SBA",
+                region = "서울",
+            )
+        league =
+            League(
+                association = association,
+                name = "1부 리그",
+                abbreviation = "1st",
+                foundedYear = 2020,
+                divisionLevel = 1,
+            )
     }
 
     private fun createCompetition(
         status: CompetitionStatus = CompetitionStatus.SCHEDULED,
         startDate: LocalDate = LocalDate.of(2025, 3, 1),
-        endDate: LocalDate? = null
-    ): Competition {
-        return Competition(
+        endDate: LocalDate? = null,
+    ): Competition =
+        Competition(
             league = league,
             name = "2025 춘계대회",
             year = 2025,
@@ -45,14 +46,12 @@ class CompetitionTest {
             type = CompetitionType.LEAGUE,
             startDate = startDate,
             endDate = endDate,
-            status = status
+            status = status,
         )
-    }
 
     @Nested
     @DisplayName("대회 시작")
     inner class Start {
-
         @Test
         fun `예정된 대회를 시작할 수 있다`() {
             // given
@@ -90,7 +89,6 @@ class CompetitionTest {
     @Nested
     @DisplayName("대회 완료")
     inner class Complete {
-
         @Test
         fun `진행 중인 대회를 완료할 수 있다`() {
             // given
@@ -119,10 +117,11 @@ class CompetitionTest {
         @Test
         fun `종료일이 시작일보다 이전이면 완료할 수 없다`() {
             // given
-            val competition = createCompetition(
-                status = CompetitionStatus.IN_PROGRESS,
-                startDate = LocalDate.of(2025, 3, 1)
-            )
+            val competition =
+                createCompetition(
+                    status = CompetitionStatus.IN_PROGRESS,
+                    startDate = LocalDate.of(2025, 3, 1),
+                )
 
             // when & then
             assertThatThrownBy { competition.complete(LocalDate.of(2025, 2, 1)) }
@@ -134,7 +133,6 @@ class CompetitionTest {
     @Nested
     @DisplayName("대회 취소")
     inner class Cancel {
-
         @Test
         fun `예정된 대회를 취소할 수 있다`() {
             // given
@@ -174,7 +172,6 @@ class CompetitionTest {
     @Nested
     @DisplayName("활성 상태 확인")
     inner class IsActive {
-
         @Test
         fun `진행 중인 대회는 활성 상태이다`() {
             // given
@@ -206,15 +203,15 @@ class CompetitionTest {
     @Nested
     @DisplayName("특정 날짜 활성 상태 확인")
     inner class IsActiveAt {
-
         @Test
         fun `진행 중인 대회의 시작일과 종료일 사이 날짜는 활성이다`() {
             // given
-            val competition = createCompetition(
-                status = CompetitionStatus.IN_PROGRESS,
-                startDate = LocalDate.of(2025, 3, 1),
-                endDate = LocalDate.of(2025, 6, 30)
-            )
+            val competition =
+                createCompetition(
+                    status = CompetitionStatus.IN_PROGRESS,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    endDate = LocalDate.of(2025, 6, 30),
+                )
 
             // then
             assertThat(competition.isActiveAt(LocalDate.of(2025, 4, 15))).isTrue()
@@ -223,10 +220,11 @@ class CompetitionTest {
         @Test
         fun `대회 시작일 이전 날짜는 활성이 아니다`() {
             // given
-            val competition = createCompetition(
-                status = CompetitionStatus.IN_PROGRESS,
-                startDate = LocalDate.of(2025, 3, 1)
-            )
+            val competition =
+                createCompetition(
+                    status = CompetitionStatus.IN_PROGRESS,
+                    startDate = LocalDate.of(2025, 3, 1),
+                )
 
             // then
             assertThat(competition.isActiveAt(LocalDate.of(2025, 2, 28))).isFalse()

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
@@ -11,7 +11,6 @@ import java.math.BigDecimal
 
 @DisplayName("BattingRecord")
 class BattingRecordTest {
-
     private lateinit var gamePlayer: GamePlayer
     private lateinit var battingRecord: BattingRecord
 
@@ -24,7 +23,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("타석 결과 기록")
     inner class RecordPlateAppearanceTest {
-
         @Test
         fun `단타를 기록하면 타석, 타수, 안타가 증가한다`() {
             // when
@@ -167,7 +165,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("도루 기록")
     inner class StolenBaseTest {
-
         @Test
         fun `도루 성공을 기록할 수 있다`() {
             // when
@@ -190,7 +187,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("득점 기록")
     inner class RunTest {
-
         @Test
         fun `득점을 별도로 기록할 수 있다`() {
             // when
@@ -204,7 +200,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("계산된 속성")
     inner class CalculatedPropertiesTest {
-
         @Test
         fun `singles는 안타에서 장타를 뺀 값이다`() {
             // given
@@ -265,7 +260,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("타율 계산")
     inner class BattingAverageTest {
-
         @Test
         fun `타수가 0이면 타율은 0이다`() {
             // when
@@ -302,7 +296,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("출루율 계산")
     inner class OnBasePercentageTest {
-
         @Test
         fun `분모가 0이면 출루율은 0이다`() {
             // then
@@ -327,7 +320,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("장타율 계산")
     inner class SluggingPercentageTest {
-
         @Test
         fun `타수가 0이면 장타율은 0이다`() {
             // then
@@ -351,7 +343,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("OPS 계산")
     inner class OpsTest {
-
         @Test
         fun `OPS는 출루율 + 장타율이다`() {
             // given: 간단한 예시 - 4타수 2안타(단타 2개)
@@ -370,7 +361,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("도루 성공률 계산")
     inner class StolenBasePercentageTest {
-
         @Test
         fun `도루 시도가 없으면 0이다`() {
             // then
@@ -393,7 +383,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("유효성 검증")
     inner class ValidationTest {
-
         @Test
         fun `정상적인 기록은 검증에 통과한다`() {
             // given
@@ -409,7 +398,6 @@ class BattingRecordTest {
     @Nested
     @DisplayName("applyPlateAppearanceResult - BoxScore 자동 계산")
     inner class ApplyPlateAppearanceResultTest {
-
         @Test
         fun `단타를 적용하면 타석, 타수, 안타가 증가한다`() {
             // when

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
@@ -1,0 +1,245 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.team.Team
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameEvent")
+class GameEventTest {
+
+    private lateinit var game: Game
+    private lateinit var batter: GamePlayer
+    private lateinit var pitcher: GamePlayer
+
+    @BeforeEach
+    fun setUp() {
+        game = createGame()
+        batter = mockk(relaxed = true)
+        pitcher = mockk(relaxed = true)
+    }
+
+    @Nested
+    @DisplayName("createPlateAppearance")
+    inner class CreatePlateAppearance {
+
+        @Test
+        fun `should create plate appearance event with single`() {
+            // given
+            val result = PlateAppearanceResult.SINGLE
+
+            // when
+            val event = GameEvent.createPlateAppearance(
+                game = game,
+                batter = batter,
+                pitcher = pitcher,
+                result = result,
+                description = "우전 안타",
+                outCountBefore = 0,
+                outCountAfter = 0,
+                runnersBeforeJson = null,
+                runnersAfterJson = """{"first": 1}""",
+                runsScored = 0,
+                rbis = 0
+            )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.PLATE_APPEARANCE)
+            assertThat(event.plateAppearanceResult).isEqualTo(PlateAppearanceResult.SINGLE)
+            assertThat(event.description).isEqualTo("우전 안타")
+            assertThat(event.inning).isEqualTo(game.currentInning)
+            assertThat(event.isTopInning).isEqualTo(game.isTopInning)
+            assertThat(event.outCountBefore).isEqualTo(0)
+            assertThat(event.outCountAfter).isEqualTo(0)
+            assertThat(event.runsScored).isEqualTo(0)
+            assertThat(event.rbis).isEqualTo(0)
+        }
+
+        @Test
+        fun `should create plate appearance event with home run and runs scored`() {
+            // given
+            val result = PlateAppearanceResult.HOME_RUN
+
+            // when
+            val event = GameEvent.createPlateAppearance(
+                game = game,
+                batter = batter,
+                pitcher = pitcher,
+                result = result,
+                description = "3점 홈런",
+                outCountBefore = 1,
+                outCountAfter = 1,
+                runnersBeforeJson = """{"first": 1, "second": 2}""",
+                runnersAfterJson = null,
+                runsScored = 3,
+                rbis = 3
+            )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.PLATE_APPEARANCE)
+            assertThat(event.plateAppearanceResult).isEqualTo(PlateAppearanceResult.HOME_RUN)
+            assertThat(event.runsScored).isEqualTo(3)
+            assertThat(event.rbis).isEqualTo(3)
+        }
+
+        @Test
+        fun `should create plate appearance event with strikeout and out increase`() {
+            // given
+            val result = PlateAppearanceResult.STRIKEOUT
+
+            // when
+            val event = GameEvent.createPlateAppearance(
+                game = game,
+                batter = batter,
+                pitcher = pitcher,
+                result = result,
+                description = "헛스윙 삼진",
+                outCountBefore = 1,
+                outCountAfter = 2,
+                runnersBeforeJson = null,
+                runnersAfterJson = null,
+                runsScored = 0,
+                rbis = 0
+            )
+
+            // then
+            assertThat(event.outCountBefore).isEqualTo(1)
+            assertThat(event.outCountAfter).isEqualTo(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("createInningChange")
+    inner class CreateInningChange {
+
+        @Test
+        fun `should create inning change event`() {
+            // when
+            val event = GameEvent.createInningChange(
+                game = game,
+                description = "1회초 종료"
+            )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.INNING_CHANGE)
+            assertThat(event.description).isEqualTo("1회초 종료")
+            assertThat(event.outCountBefore).isEqualTo(3)
+            assertThat(event.outCountAfter).isEqualTo(0)
+            assertThat(event.batter).isNull()
+            assertThat(event.pitcher).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("createGameStatus")
+    inner class CreateGameStatus {
+
+        @Test
+        fun `should create game status event for game start`() {
+            // when
+            val event = GameEvent.createGameStatus(
+                game = game,
+                description = "경기 시작"
+            )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.GAME_STATUS)
+            assertThat(event.description).isEqualTo("경기 시작")
+            assertThat(event.inning).isEqualTo(game.currentInning)
+        }
+
+        @Test
+        fun `should create game status event for game end`() {
+            // given
+            game.currentInning = 9
+            game.isTopInning = false
+
+            // when
+            val event = GameEvent.createGameStatus(
+                game = game,
+                description = "경기 종료"
+            )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.GAME_STATUS)
+            assertThat(event.description).isEqualTo("경기 종료")
+            assertThat(event.inning).isEqualTo(9)
+            assertThat(event.isTopInning).isFalse()
+        }
+    }
+
+    private fun createGame(): Game {
+        val association = Association(
+            name = "서울시야구협회",
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+
+        val league = League(
+            association = association,
+            name = "1부 리그",
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+
+        val competition = Competition(
+            league = league,
+            name = "2025 춘계대회",
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            endDate = LocalDate.of(2025, 6, 30),
+            status = CompetitionStatus.IN_PROGRESS,
+            description = null,
+            maxTeams = null
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+
+        return Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실구장",
+            fieldName = "1구장",
+            gameNumber = 1,
+            status = GameStatus.IN_PROGRESS,
+            currentInning = 1,
+            isTopInning = true,
+            totalInnings = 9,
+            gameState = GameState()
+        ).apply {
+            val idField = Game::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
@@ -5,9 +5,6 @@ import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
-import com.nextup.core.domain.player.Player
-import com.nextup.core.domain.team.Team
-import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -19,7 +16,6 @@ import java.time.LocalDateTime
 
 @DisplayName("GameEvent")
 class GameEventTest {
-
     private lateinit var game: Game
     private lateinit var batter: GamePlayer
     private lateinit var pitcher: GamePlayer
@@ -34,26 +30,26 @@ class GameEventTest {
     @Nested
     @DisplayName("createPlateAppearance")
     inner class CreatePlateAppearance {
-
         @Test
         fun `should create plate appearance event with single`() {
             // given
             val result = PlateAppearanceResult.SINGLE
 
             // when
-            val event = GameEvent.createPlateAppearance(
-                game = game,
-                batter = batter,
-                pitcher = pitcher,
-                result = result,
-                description = "우전 안타",
-                outCountBefore = 0,
-                outCountAfter = 0,
-                runnersBeforeJson = null,
-                runnersAfterJson = """{"first": 1}""",
-                runsScored = 0,
-                rbis = 0
-            )
+            val event =
+                GameEvent.createPlateAppearance(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = result,
+                    description = "우전 안타",
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runnersAfterJson = """{"first": 1}""",
+                    runsScored = 0,
+                    rbis = 0,
+                )
 
             // then
             assertThat(event.eventType).isEqualTo(GameEventType.PLATE_APPEARANCE)
@@ -73,19 +69,20 @@ class GameEventTest {
             val result = PlateAppearanceResult.HOME_RUN
 
             // when
-            val event = GameEvent.createPlateAppearance(
-                game = game,
-                batter = batter,
-                pitcher = pitcher,
-                result = result,
-                description = "3점 홈런",
-                outCountBefore = 1,
-                outCountAfter = 1,
-                runnersBeforeJson = """{"first": 1, "second": 2}""",
-                runnersAfterJson = null,
-                runsScored = 3,
-                rbis = 3
-            )
+            val event =
+                GameEvent.createPlateAppearance(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = result,
+                    description = "3점 홈런",
+                    outCountBefore = 1,
+                    outCountAfter = 1,
+                    runnersBeforeJson = """{"first": 1, "second": 2}""",
+                    runnersAfterJson = null,
+                    runsScored = 3,
+                    rbis = 3,
+                )
 
             // then
             assertThat(event.eventType).isEqualTo(GameEventType.PLATE_APPEARANCE)
@@ -100,19 +97,20 @@ class GameEventTest {
             val result = PlateAppearanceResult.STRIKEOUT
 
             // when
-            val event = GameEvent.createPlateAppearance(
-                game = game,
-                batter = batter,
-                pitcher = pitcher,
-                result = result,
-                description = "헛스윙 삼진",
-                outCountBefore = 1,
-                outCountAfter = 2,
-                runnersBeforeJson = null,
-                runnersAfterJson = null,
-                runsScored = 0,
-                rbis = 0
-            )
+            val event =
+                GameEvent.createPlateAppearance(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = result,
+                    description = "헛스윙 삼진",
+                    outCountBefore = 1,
+                    outCountAfter = 2,
+                    runnersBeforeJson = null,
+                    runnersAfterJson = null,
+                    runsScored = 0,
+                    rbis = 0,
+                )
 
             // then
             assertThat(event.outCountBefore).isEqualTo(1)
@@ -123,14 +121,14 @@ class GameEventTest {
     @Nested
     @DisplayName("createInningChange")
     inner class CreateInningChange {
-
         @Test
         fun `should create inning change event`() {
             // when
-            val event = GameEvent.createInningChange(
-                game = game,
-                description = "1회초 종료"
-            )
+            val event =
+                GameEvent.createInningChange(
+                    game = game,
+                    description = "1회초 종료",
+                )
 
             // then
             assertThat(event.eventType).isEqualTo(GameEventType.INNING_CHANGE)
@@ -145,14 +143,14 @@ class GameEventTest {
     @Nested
     @DisplayName("createGameStatus")
     inner class CreateGameStatus {
-
         @Test
         fun `should create game status event for game start`() {
             // when
-            val event = GameEvent.createGameStatus(
-                game = game,
-                description = "경기 시작"
-            )
+            val event =
+                GameEvent.createGameStatus(
+                    game = game,
+                    description = "경기 시작",
+                )
 
             // then
             assertThat(event.eventType).isEqualTo(GameEventType.GAME_STATUS)
@@ -167,10 +165,11 @@ class GameEventTest {
             game.isTopInning = false
 
             // when
-            val event = GameEvent.createGameStatus(
-                game = game,
-                description = "경기 종료"
-            )
+            val event =
+                GameEvent.createGameStatus(
+                    game = game,
+                    description = "경기 종료",
+                )
 
             // then
             assertThat(event.eventType).isEqualTo(GameEventType.GAME_STATUS)
@@ -181,49 +180,52 @@ class GameEventTest {
     }
 
     private fun createGame(): Game {
-        val association = Association(
-            name = "서울시야구협회",
-            abbreviation = null,
-            region = "서울",
-            description = null,
-            logoUrl = null,
-            websiteUrl = null
-        ).apply {
-            val idField = Association::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, 1L)
-        }
+        val association =
+            Association(
+                name = "서울시야구협회",
+                abbreviation = null,
+                region = "서울",
+                description = null,
+                logoUrl = null,
+                websiteUrl = null,
+            ).apply {
+                val idField = Association::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
 
-        val league = League(
-            association = association,
-            name = "1부 리그",
-            abbreviation = null,
-            foundedYear = 2020,
-            divisionLevel = 1,
-            description = null,
-            logoUrl = null
-        ).apply {
-            val idField = League::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, 1L)
-        }
+        val league =
+            League(
+                association = association,
+                name = "1부 리그",
+                abbreviation = null,
+                foundedYear = 2020,
+                divisionLevel = 1,
+                description = null,
+                logoUrl = null,
+            ).apply {
+                val idField = League::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
 
-        val competition = Competition(
-            league = league,
-            name = "2025 춘계대회",
-            year = 2025,
-            season = 1,
-            type = CompetitionType.LEAGUE,
-            startDate = LocalDate.of(2025, 3, 1),
-            endDate = LocalDate.of(2025, 6, 30),
-            status = CompetitionStatus.IN_PROGRESS,
-            description = null,
-            maxTeams = null
-        ).apply {
-            val idField = Competition::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, 1L)
-        }
+        val competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                endDate = LocalDate.of(2025, 6, 30),
+                status = CompetitionStatus.IN_PROGRESS,
+                description = null,
+                maxTeams = null,
+            ).apply {
+                val idField = Competition::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
 
         return Game(
             competition = competition,
@@ -235,7 +237,7 @@ class GameEventTest {
             currentInning = 1,
             isTopInning = true,
             totalInnings = 9,
-            gameState = GameState()
+            gameState = GameState(),
         ).apply {
             val idField = Game::class.java.getDeclaredField("id")
             idField.isAccessible = true

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameStateTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameStateTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 
 class GameStateTest {
-
     @Test
     fun `should create GameState with default values`() {
         // when
@@ -269,11 +268,12 @@ class GameStateTest {
     @Test
     fun `should clear runner by setting null`() {
         // given
-        val gameState = GameState(
-            runnerOnFirstId = 100L,
-            runnerOnSecondId = 200L,
-            runnerOnThirdId = 300L
-        )
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnSecondId = 200L,
+                runnerOnThirdId = 300L,
+            )
 
         // when
         gameState.setRunner(Base.FIRST, null)
@@ -302,11 +302,12 @@ class GameStateTest {
     @Test
     fun `should get runner from base`() {
         // given
-        val gameState = GameState(
-            runnerOnFirstId = 100L,
-            runnerOnSecondId = 200L,
-            runnerOnThirdId = 300L
-        )
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnSecondId = 200L,
+                runnerOnThirdId = 300L,
+            )
 
         // when & then
         assertThat(gameState.getRunner(Base.FIRST)).isEqualTo(100L)
@@ -318,11 +319,12 @@ class GameStateTest {
     @Test
     fun `should clear all bases`() {
         // given
-        val gameState = GameState(
-            runnerOnFirstId = 100L,
-            runnerOnSecondId = 200L,
-            runnerOnThirdId = 300L
-        )
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnSecondId = 200L,
+                runnerOnThirdId = 300L,
+            )
 
         // when
         gameState.clearBases()
@@ -386,14 +388,15 @@ class GameStateTest {
     @Test
     fun `should reset for new inning`() {
         // given
-        val gameState = GameState(
-            outs = 2,
-            balls = 3,
-            strikes = 2,
-            runnerOnFirstId = 100L,
-            runnerOnSecondId = 200L,
-            runnerOnThirdId = 300L
-        )
+        val gameState =
+            GameState(
+                outs = 2,
+                balls = 3,
+                strikes = 2,
+                runnerOnFirstId = 100L,
+                runnerOnSecondId = 200L,
+                runnerOnThirdId = 300L,
+            )
 
         // when
         gameState.resetForNewInning()
@@ -410,11 +413,12 @@ class GameStateTest {
     @Test
     fun `should check if runner exists on base`() {
         // given
-        val gameState = GameState(
-            runnerOnFirstId = 100L,
-            runnerOnSecondId = null,
-            runnerOnThirdId = 300L
-        )
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnSecondId = null,
+                runnerOnThirdId = 300L,
+            )
 
         // when & then
         assertThat(gameState.hasRunner(Base.FIRST)).isTrue()
@@ -426,11 +430,12 @@ class GameStateTest {
     @Test
     fun `should check if bases loaded`() {
         // given
-        val gameState = GameState(
-            runnerOnFirstId = 100L,
-            runnerOnSecondId = 200L,
-            runnerOnThirdId = 300L
-        )
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnSecondId = 200L,
+                runnerOnThirdId = 300L,
+            )
 
         // when & then
         assertThat(gameState.isBasesLoaded()).isTrue()
@@ -439,11 +444,12 @@ class GameStateTest {
     @Test
     fun `should return false when bases not loaded`() {
         // given
-        val gameState = GameState(
-            runnerOnFirstId = 100L,
-            runnerOnSecondId = null,
-            runnerOnThirdId = 300L
-        )
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnSecondId = null,
+                runnerOnThirdId = 300L,
+            )
 
         // when & then
         assertThat(gameState.isBasesLoaded()).isFalse()

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTeamTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTeamTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("GameTeam")
 class GameTeamTest {
-
     private lateinit var game: Game
     private lateinit var team: Team
     private lateinit var gameTeam: GameTeam
@@ -20,17 +19,17 @@ class GameTeamTest {
     fun setup() {
         game = mockk<Game>(relaxed = true)
         team = mockk<Team>(relaxed = true)
-        gameTeam = GameTeam(
-            game = game,
-            team = team,
-            homeAway = HomeAway.HOME
-        )
+        gameTeam =
+            GameTeam(
+                game = game,
+                team = team,
+                homeAway = HomeAway.HOME,
+            )
     }
 
     @Nested
     @DisplayName("점수 추가")
     inner class AddScoreTest {
-
         @Test
         fun `점수를 추가할 수 있다`() {
             // when
@@ -63,7 +62,6 @@ class GameTeamTest {
     @Nested
     @DisplayName("안타 추가")
     inner class AddHitTest {
-
         @Test
         fun `안타를 추가할 수 있다`() {
             // when
@@ -88,7 +86,6 @@ class GameTeamTest {
     @Nested
     @DisplayName("실책 추가")
     inner class AddErrorTest {
-
         @Test
         fun `실책을 추가할 수 있다`() {
             // when
@@ -112,7 +109,6 @@ class GameTeamTest {
     @Nested
     @DisplayName("이닝별 점수 기록")
     inner class RecordInningScoreTest {
-
         @Test
         fun `이닝별 점수를 기록할 수 있다`() {
             // when
@@ -169,7 +165,6 @@ class GameTeamTest {
     @Nested
     @DisplayName("addRunInInning - 이닝별 득점 추가 (BoxScore)")
     inner class AddRunInInningTest {
-
         @Test
         fun `특정 이닝에 득점을 추가할 수 있다`() {
             // when
@@ -260,7 +255,6 @@ class GameTeamTest {
     @Nested
     @DisplayName("이닝 점수 조회")
     inner class GetInningScoreTest {
-
         @Test
         fun `기록되지 않은 이닝은 0점이다`() {
             // when
@@ -286,7 +280,6 @@ class GameTeamTest {
     @Nested
     @DisplayName("경기 결과 업데이트")
     inner class UpdateResultTest {
-
         @Test
         fun `경기 결과를 업데이트할 수 있다`() {
             // when
@@ -300,7 +293,6 @@ class GameTeamTest {
     @Nested
     @DisplayName("점수 업데이트")
     inner class UpdateScoreTest {
-
         @Test
         fun `전체 점수를 한 번에 업데이트할 수 있다`() {
             // when

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -16,37 +16,35 @@ import java.time.LocalDateTime
 
 @DisplayName("Game 엔티티 테스트")
 class GameTest {
-
     private lateinit var competition: Competition
 
     @BeforeEach
     fun setUp() {
         val association = Association(name = "서울시야구협회", region = "서울")
         val league = League(association = association, name = "1부 리그", foundedYear = 2020)
-        competition = Competition(
-            league = league,
-            name = "2025 춘계대회",
-            year = 2025,
-            season = 1,
-            type = CompetitionType.LEAGUE,
-            startDate = LocalDate.of(2025, 3, 1),
-            status = CompetitionStatus.IN_PROGRESS
-        )
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+            )
     }
 
-    private fun createGame(status: GameStatus = GameStatus.SCHEDULED): Game {
-        return Game(
+    private fun createGame(status: GameStatus = GameStatus.SCHEDULED): Game =
+        Game(
             competition = competition,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실야구장",
-            status = status
+            status = status,
         )
-    }
 
     @Nested
     @DisplayName("경기 시작")
     inner class Start {
-
         @Test
         fun `예정된 경기를 시작할 수 있다`() {
             // given
@@ -76,14 +74,14 @@ class GameTest {
     @Nested
     @DisplayName("이닝 진행")
     inner class NextHalfInning {
-
         @Test
         fun `초에서 말로 진행한다`() {
             // given
-            val game = createGame(status = GameStatus.IN_PROGRESS).apply {
-                currentInning = 1
-                isTopInning = true
-            }
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 1
+                    isTopInning = true
+                }
 
             // when
             game.nextHalfInning()
@@ -96,10 +94,11 @@ class GameTest {
         @Test
         fun `말에서 다음 이닝 초로 진행한다`() {
             // given
-            val game = createGame(status = GameStatus.IN_PROGRESS).apply {
-                currentInning = 1
-                isTopInning = false
-            }
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 1
+                    isTopInning = false
+                }
 
             // when
             game.nextHalfInning()
@@ -123,7 +122,6 @@ class GameTest {
     @Nested
     @DisplayName("경기 종료")
     inner class Finish {
-
         @Test
         fun `진행 중인 경기를 종료할 수 있다`() {
             // given
@@ -151,7 +149,6 @@ class GameTest {
     @Nested
     @DisplayName("콜드게임")
     inner class CallGame {
-
         @Test
         fun `진행 중인 경기를 콜드게임 처리할 수 있다`() {
             // given
@@ -170,7 +167,6 @@ class GameTest {
     @Nested
     @DisplayName("경기 취소")
     inner class Cancel {
-
         @Test
         fun `예정된 경기를 취소할 수 있다`() {
             // given
@@ -198,7 +194,6 @@ class GameTest {
     @Nested
     @DisplayName("경기 연기")
     inner class Postpone {
-
         @Test
         fun `예정된 경기를 연기할 수 있다`() {
             // given
@@ -218,7 +213,6 @@ class GameTest {
     @Nested
     @DisplayName("몰수패")
     inner class Forfeit {
-
         @Test
         fun `예정된 경기를 몰수 처리할 수 있다`() {
             // given
@@ -236,7 +230,6 @@ class GameTest {
     @Nested
     @DisplayName("일정 변경")
     inner class Reschedule {
-
         @Test
         fun `연기된 경기를 재스케줄하면 예정 상태로 변경된다`() {
             // given
@@ -255,7 +248,6 @@ class GameTest {
     @Nested
     @DisplayName("이닝 표시")
     inner class InningDisplay {
-
         @Test
         fun `경기 전에는 '경기 전'을 반환한다`() {
             // given
@@ -268,10 +260,11 @@ class GameTest {
         @Test
         fun `1회초는 '1회초'를 반환한다`() {
             // given
-            val game = createGame().apply {
-                currentInning = 1
-                isTopInning = true
-            }
+            val game =
+                createGame().apply {
+                    currentInning = 1
+                    isTopInning = true
+                }
 
             // then
             assertThat(game.currentInningDisplay).isEqualTo("1회초")
@@ -280,10 +273,11 @@ class GameTest {
         @Test
         fun `5회말은 '5회말'을 반환한다`() {
             // given
-            val game = createGame().apply {
-                currentInning = 5
-                isTopInning = false
-            }
+            val game =
+                createGame().apply {
+                    currentInning = 5
+                    isTopInning = false
+                }
 
             // then
             assertThat(game.currentInningDisplay).isEqualTo("5회말")
@@ -293,14 +287,14 @@ class GameTest {
     @Nested
     @DisplayName("연장전 확인")
     inner class ExtraInning {
-
         @Test
         fun `9회까지는 연장전이 아니다`() {
             // given
-            val game = createGame().apply {
-                currentInning = 9
-                totalInnings = 9
-            }
+            val game =
+                createGame().apply {
+                    currentInning = 9
+                    totalInnings = 9
+                }
 
             // then
             assertThat(game.isExtraInning).isFalse()
@@ -309,10 +303,11 @@ class GameTest {
         @Test
         fun `10회 이상은 연장전이다`() {
             // given
-            val game = createGame().apply {
-                currentInning = 10
-                totalInnings = 9
-            }
+            val game =
+                createGame().apply {
+                    currentInning = 10
+                    totalInnings = 9
+                }
 
             // then
             assertThat(game.isExtraInning).isTrue()
@@ -322,7 +317,6 @@ class GameTest {
     @Nested
     @DisplayName("아웃 기록")
     inner class RecordOut {
-
         @Test
         fun `진행 중인 경기에서 아웃을 기록할 수 있다`() {
             // given
@@ -364,7 +358,6 @@ class GameTest {
     @Nested
     @DisplayName("타자 진행")
     inner class AdvanceBatter {
-
         @Test
         fun `진행 중인 경기에서 타순을 진행할 수 있다`() {
             // given
@@ -392,7 +385,6 @@ class GameTest {
     @Nested
     @DisplayName("주자 설정")
     inner class SetRunner {
-
         @Test
         fun `진행 중인 경기에서 주자를 설정할 수 있다`() {
             // given
@@ -420,7 +412,6 @@ class GameTest {
     @Nested
     @DisplayName("베이스 클리어")
     inner class ClearBases {
-
         @Test
         fun `진행 중인 경기에서 베이스를 클리어할 수 있다`() {
             // given
@@ -450,7 +441,6 @@ class GameTest {
     @Nested
     @DisplayName("볼카운트 리셋")
     inner class ResetCount {
-
         @Test
         fun `진행 중인 경기에서 볼카운트를 리셋할 수 있다`() {
             // given
@@ -478,7 +468,6 @@ class GameTest {
     @Nested
     @DisplayName("볼 추가")
     inner class AddBall {
-
         @Test
         fun `진행 중인 경기에서 볼을 추가할 수 있다`() {
             // given
@@ -521,7 +510,6 @@ class GameTest {
     @Nested
     @DisplayName("스트라이크 추가")
     inner class AddStrike {
-
         @Test
         fun `진행 중인 경기에서 스트라이크를 추가할 수 있다`() {
             // given

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupEntryTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupEntryTest.kt
@@ -18,7 +18,6 @@ import java.time.LocalDateTime
 
 @DisplayName("LineupEntry 엔티티 테스트")
 class LineupEntryTest {
-
     private lateinit var association: Association
     private lateinit var league: League
     private lateinit var competition: Competition
@@ -32,46 +31,51 @@ class LineupEntryTest {
     fun setUp() {
         association = Association(name = "서울시야구협회", region = "서울")
         league = League(association = association, name = "1부 리그", foundedYear = 2020)
-        competition = Competition(
-            league = league,
-            name = "2025 춘계대회",
-            year = 2025,
-            season = 1,
-            type = CompetitionType.LEAGUE,
-            startDate = LocalDate.of(2025, 3, 1),
-            status = CompetitionStatus.IN_PROGRESS
-        )
-        game = Game(
-            competition = competition,
-            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
-            location = "잠실야구장",
-            status = GameStatus.SCHEDULED
-        )
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+            )
+        game =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                location = "잠실야구장",
+                status = GameStatus.SCHEDULED,
+            )
         team = Team(league = league, name = "테스트팀", city = "서울", foundedYear = 2020)
-        user = User.createLocalUser(
-            email = "test@example.com",
-            encodedPassword = "encoded",
-            nickname = "감독"
-        )
+        user =
+            User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "encoded",
+                nickname = "감독",
+            )
         lineupSubmission = LineupSubmission.create(game = game, team = team, submittedBy = user)
-        player = Player(
-            name = "홍길동",
-            birthDate = LocalDate.of(1995, 1, 1),
-            primaryPosition = Position.FIRST_BASE
-        )
+        player =
+            Player(
+                name = "홍길동",
+                birthDate = LocalDate.of(1995, 1, 1),
+                primaryPosition = Position.FIRST_BASE,
+            )
     }
 
     @Test
     fun `선발 출전 선수로 LineupEntry를 생성할 수 있다`() {
         // when
-        val lineupEntry = LineupEntry(
-            submission = lineupSubmission,
-            player = player,
-            position = Position.FIRST_BASE,
-            battingOrder = 3,
-            backNumber = 10,
-            isStarter = true
-        )
+        val lineupEntry =
+            LineupEntry(
+                submission = lineupSubmission,
+                player = player,
+                position = Position.FIRST_BASE,
+                battingOrder = 3,
+                backNumber = 10,
+                isStarter = true,
+            )
 
         // then
         assertThat(lineupEntry.submission).isEqualTo(lineupSubmission)
@@ -85,14 +89,15 @@ class LineupEntryTest {
     @Test
     fun `교체 선수로 LineupEntry를 생성할 수 있다`() {
         // when
-        val lineupEntry = LineupEntry(
-            submission = lineupSubmission,
-            player = player,
-            position = Position.LEFT_FIELD,
-            battingOrder = null,
-            backNumber = 25,
-            isStarter = false
-        )
+        val lineupEntry =
+            LineupEntry(
+                submission = lineupSubmission,
+                player = player,
+                position = Position.LEFT_FIELD,
+                battingOrder = null,
+                backNumber = 25,
+                isStarter = false,
+            )
 
         // then
         assertThat(lineupEntry.isStarter).isFalse()
@@ -102,14 +107,15 @@ class LineupEntryTest {
     @Test
     fun `투수는 타순이 없을 수 있다`() {
         // when
-        val lineupEntry = LineupEntry(
-            submission = lineupSubmission,
-            player = player,
-            position = Position.STARTING_PITCHER,
-            battingOrder = null,
-            backNumber = 1,
-            isStarter = true
-        )
+        val lineupEntry =
+            LineupEntry(
+                submission = lineupSubmission,
+                player = player,
+                position = Position.STARTING_PITCHER,
+                battingOrder = null,
+                backNumber = 1,
+                isStarter = true,
+            )
 
         // then
         assertThat(lineupEntry.position).isEqualTo(Position.STARTING_PITCHER)
@@ -120,14 +126,15 @@ class LineupEntryTest {
     @Test
     fun `등번호가 없을 수 있다`() {
         // when
-        val lineupEntry = LineupEntry(
-            submission = lineupSubmission,
-            player = player,
-            position = Position.CENTER_FIELD,
-            battingOrder = 1,
-            backNumber = null,
-            isStarter = true
-        )
+        val lineupEntry =
+            LineupEntry(
+                submission = lineupSubmission,
+                player = player,
+                position = Position.CENTER_FIELD,
+                battingOrder = 1,
+                backNumber = null,
+                isStarter = true,
+            )
 
         // then
         assertThat(lineupEntry.backNumber).isNull()
@@ -136,14 +143,15 @@ class LineupEntryTest {
     @Test
     fun `지명타자로 LineupEntry를 생성할 수 있다`() {
         // when
-        val lineupEntry = LineupEntry(
-            submission = lineupSubmission,
-            player = player,
-            position = Position.DESIGNATED_HITTER,
-            battingOrder = 4,
-            backNumber = 44,
-            isStarter = true
-        )
+        val lineupEntry =
+            LineupEntry(
+                submission = lineupSubmission,
+                player = player,
+                position = Position.DESIGNATED_HITTER,
+                battingOrder = 4,
+                backNumber = 44,
+                isStarter = true,
+            )
 
         // then
         assertThat(lineupEntry.position).isEqualTo(Position.DESIGNATED_HITTER)
@@ -154,22 +162,24 @@ class LineupEntryTest {
     @Test
     fun `타순은 1번부터 9번까지 지정할 수 있다`() {
         // when
-        val lineupEntry1 = LineupEntry(
-            submission = lineupSubmission,
-            player = player,
-            position = Position.SHORTSTOP,
-            battingOrder = 1,
-            backNumber = 5,
-            isStarter = true
-        )
-        val lineupEntry9 = LineupEntry(
-            submission = lineupSubmission,
-            player = player,
-            position = Position.RIGHT_FIELD,
-            battingOrder = 9,
-            backNumber = 9,
-            isStarter = true
-        )
+        val lineupEntry1 =
+            LineupEntry(
+                submission = lineupSubmission,
+                player = player,
+                position = Position.SHORTSTOP,
+                battingOrder = 1,
+                backNumber = 5,
+                isStarter = true,
+            )
+        val lineupEntry9 =
+            LineupEntry(
+                submission = lineupSubmission,
+                player = player,
+                position = Position.RIGHT_FIELD,
+                battingOrder = 9,
+                backNumber = 9,
+                isStarter = true,
+            )
 
         // then
         assertThat(lineupEntry1.battingOrder).isEqualTo(1)
@@ -179,14 +189,15 @@ class LineupEntryTest {
     @Test
     fun `BaseTimeEntity를 상속하여 생성시간과 수정시간을 가진다`() {
         // when
-        val lineupEntry = LineupEntry(
-            submission = lineupSubmission,
-            player = player,
-            position = Position.CATCHER,
-            battingOrder = 2,
-            backNumber = 22,
-            isStarter = true
-        )
+        val lineupEntry =
+            LineupEntry(
+                submission = lineupSubmission,
+                player = player,
+                position = Position.CATCHER,
+                battingOrder = 2,
+                backNumber = 22,
+                isStarter = true,
+            )
 
         // then
         assertThat(lineupEntry.createdAt).isNotNull()

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupSubmissionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupSubmissionTest.kt
@@ -2,9 +2,7 @@ package com.nextup.core.domain.game
 
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.league.League
-import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.team.Team
-import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.User
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -12,7 +10,6 @@ import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
 
 class LineupSubmissionTest {
-
     @Test
     fun `should create lineup submission in DRAFT status`() {
         // given
@@ -52,9 +49,10 @@ class LineupSubmissionTest {
         val submission = createLineupSubmission().apply { submit() }
 
         // when & then
-        val exception = assertThrows<IllegalArgumentException> {
-            submission.submit()
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                submission.submit()
+            }
         assertThat(exception.message).contains("제출 가능한 상태가 아닙니다")
     }
 
@@ -80,9 +78,10 @@ class LineupSubmissionTest {
         val scorer = createScorer()
 
         // when & then
-        val exception = assertThrows<IllegalArgumentException> {
-            submission.confirm(scorer)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                submission.confirm(scorer)
+            }
         assertThat(exception.message).contains("제출된 상태의 라인업만 확인할 수 있습니다")
     }
 
@@ -109,19 +108,21 @@ class LineupSubmissionTest {
         val scorer = createScorer()
 
         // when & then
-        val exception = assertThrows<IllegalArgumentException> {
-            submission.reject(scorer, "반려 사유")
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                submission.reject(scorer, "반려 사유")
+            }
         assertThat(exception.message).contains("제출된 상태의 라인업만 반려할 수 있습니다")
     }
 
     @Test
     fun `should resubmit lineup when status is REJECTED`() {
         // given
-        val submission = createLineupSubmission().apply {
-            submit()
-            reject(createScorer(), "수정 필요")
-        }
+        val submission =
+            createLineupSubmission().apply {
+                submit()
+                reject(createScorer(), "수정 필요")
+            }
 
         // when
         submission.submit()
@@ -136,15 +137,17 @@ class LineupSubmissionTest {
     @Test
     fun `should not allow editing confirmed lineup`() {
         // given
-        val submission = createLineupSubmission().apply {
-            submit()
-            confirm(createScorer())
-        }
+        val submission =
+            createLineupSubmission().apply {
+                submit()
+                confirm(createScorer())
+            }
 
         // when & then
-        val exception = assertThrows<IllegalArgumentException> {
-            submission.submit()
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                submission.submit()
+            }
         assertThat(exception.message).contains("제출 가능한 상태가 아닙니다")
     }
 
@@ -152,46 +155,57 @@ class LineupSubmissionTest {
         LineupSubmission.create(createGame(), createTeam(), createManager())
 
     private fun createGame(): Game {
-        val association = com.nextup.core.domain.association.Association(
-            name = "서울시야구협회",
-            abbreviation = "서야협",
-            region = "서울"
-        )
-        val league = League(
-            association = association,
-            name = "서울시 리그",
-            foundedYear = 2020
-        )
-        val competition = Competition(
-            league = league,
-            name = "2024 시즌",
-            year = 2024,
-            startDate = java.time.LocalDate.now().minusDays(30),
-            endDate = java.time.LocalDate.now().plusDays(30)
-        )
+        val association =
+            com.nextup.core.domain.association.Association(
+                name = "서울시야구협회",
+                abbreviation = "서야협",
+                region = "서울",
+            )
+        val league =
+            League(
+                association = association,
+                name = "서울시 리그",
+                foundedYear = 2020,
+            )
+        val competition =
+            Competition(
+                league = league,
+                name = "2024 시즌",
+                year = 2024,
+                startDate =
+                    java.time.LocalDate
+                        .now()
+                        .minusDays(30),
+                endDate =
+                    java.time.LocalDate
+                        .now()
+                        .plusDays(30),
+            )
         return Game(
             competition = competition,
             scheduledAt = LocalDateTime.now().plusDays(1),
-            location = "서울야구장"
+            location = "서울야구장",
         )
     }
 
     private fun createTeam(): Team {
-        val association = com.nextup.core.domain.association.Association(
-            name = "서울시야구협회",
-            abbreviation = "서야협",
-            region = "서울"
-        )
-        val league = League(
-            association = association,
-            name = "서울시 리그",
-            foundedYear = 2020
-        )
+        val association =
+            com.nextup.core.domain.association.Association(
+                name = "서울시야구협회",
+                abbreviation = "서야협",
+                region = "서울",
+            )
+        val league =
+            League(
+                association = association,
+                name = "서울시 리그",
+                foundedYear = 2020,
+            )
         return Team(
             league = league,
             name = "Tigers",
             city = "서울",
-            foundedYear = 2020
+            foundedYear = 2020,
         )
     }
 
@@ -199,13 +213,13 @@ class LineupSubmissionTest {
         User.createLocalUser(
             email = "manager@test.com",
             encodedPassword = "encoded",
-            nickname = "감독"
+            nickname = "감독",
         )
 
     private fun createScorer(): User =
         User.createLocalUser(
             email = "scorer@test.com",
             encodedPassword = "encoded",
-            nickname = "기록원"
+            nickname = "기록원",
         )
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingDecisionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingDecisionTest.kt
@@ -7,11 +7,9 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("PitchingDecision")
 class PitchingDecisionTest {
-
     @Nested
     @DisplayName("승리 결정")
     inner class WinTest {
-
         @Test
         fun `WIN은 isWin이 true이다`() {
             assertThat(PitchingDecision.WIN.isWin).isTrue()
@@ -31,7 +29,6 @@ class PitchingDecisionTest {
     @Nested
     @DisplayName("패배 결정")
     inner class LossTest {
-
         @Test
         fun `LOSS는 isLoss가 true이다`() {
             assertThat(PitchingDecision.LOSS.isLoss).isTrue()
@@ -46,7 +43,6 @@ class PitchingDecisionTest {
     @Nested
     @DisplayName("세이브 결정")
     inner class SaveTest {
-
         @Test
         fun `SAVE는 isSave가 true이다`() {
             assertThat(PitchingDecision.SAVE.isSave).isTrue()
@@ -61,7 +57,6 @@ class PitchingDecisionTest {
     @Nested
     @DisplayName("홀드 결정")
     inner class HoldTest {
-
         @Test
         fun `HOLD는 isHold가 true이다`() {
             assertThat(PitchingDecision.HOLD.isHold).isTrue()
@@ -76,7 +71,6 @@ class PitchingDecisionTest {
     @Nested
     @DisplayName("블론세이브 결정")
     inner class BlownSaveTest {
-
         @Test
         fun `BLOWN_SAVE는 isBlownSave가 true이다`() {
             assertThat(PitchingDecision.BLOWN_SAVE.isBlownSave).isTrue()
@@ -91,7 +85,6 @@ class PitchingDecisionTest {
     @Nested
     @DisplayName("결정 없음")
     inner class NoneTest {
-
         @Test
         fun `NONE은 hasNoDecision이 true이다`() {
             assertThat(PitchingDecision.NONE.hasNoDecision).isTrue()
@@ -116,7 +109,6 @@ class PitchingDecisionTest {
     @Nested
     @DisplayName("구원 성공")
     inner class ReliefSuccessTest {
-
         @Test
         fun `WIN은 구원 성공이 아니다`() {
             assertThat(PitchingDecision.WIN.isReliefSuccess).isFalse()

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -11,7 +11,6 @@ import java.math.BigDecimal
 
 @DisplayName("PitchingRecord")
 class PitchingRecordTest {
-
     private lateinit var gamePlayer: GamePlayer
     private lateinit var pitchingRecord: PitchingRecord
 
@@ -24,7 +23,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("아웃 기록")
     inner class RecordOutTest {
-
         @Test
         fun `아웃을 기록하면 inningsPitchedOuts가 증가한다`() {
             // when
@@ -60,7 +58,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("피안타 기록")
     inner class RecordHitTest {
-
         @Test
         fun `피안타를 기록하면 hitsAllowed가 증가한다`() {
             // when
@@ -104,7 +101,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("볼넷 기록")
     inner class RecordWalkTest {
-
         @Test
         fun `볼넷을 기록하면 walksAllowed가 증가한다`() {
             // when
@@ -119,7 +115,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("사구 기록")
     inner class RecordHitByPitchTest {
-
         @Test
         fun `사구를 기록하면 hitBatsmen이 증가한다`() {
             // when
@@ -134,7 +129,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("실점 기록")
     inner class RecordRunTest {
-
         @Test
         fun `자책점을 기록하면 earnedRuns와 runsAllowed 모두 증가한다`() {
             // when
@@ -159,7 +153,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("와일드피치와 보크")
     inner class WildPitchAndBalkTest {
-
         @Test
         fun `와일드피치를 기록할 수 있다`() {
             // when
@@ -182,7 +175,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("투구 수 기록")
     inner class RecordPitchCountTest {
-
         @Test
         fun `투구 수를 기록할 수 있다`() {
             // when
@@ -206,7 +198,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("이닝 계산")
     inner class InningsCalculationTest {
-
         @Test
         fun `0아웃은 0이닝이다`() {
             assertThat(pitchingRecord.inningsPitchedDisplay).isEqualTo("0.0")
@@ -236,7 +227,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("ERA 계산")
     inner class EarnedRunAverageTest {
-
         @Test
         fun `이닝이 0이면 ERA는 0이다`() {
             assertThat(pitchingRecord.earnedRunAverage).isEqualTo(BigDecimal("0.00"))
@@ -269,7 +259,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("WHIP 계산")
     inner class WhipTest {
-
         @Test
         fun `이닝이 0이면 WHIP은 0이다`() {
             assertThat(pitchingRecord.whip).isEqualTo(BigDecimal("0.00"))
@@ -300,7 +289,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("K/9 계산")
     inner class StrikeoutsPer9Test {
-
         @Test
         fun `이닝이 0이면 9이닝당 삼진은 0이다`() {
             assertThat(pitchingRecord.strikeoutsPer9).isEqualTo(BigDecimal("0.00"))
@@ -320,7 +308,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("BB/9 계산")
     inner class WalksPer9Test {
-
         @Test
         fun `이닝이 0이면 9이닝당 볼넷은 0이다`() {
             assertThat(pitchingRecord.walksPer9).isEqualTo(BigDecimal("0.00"))
@@ -340,7 +327,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("K/BB 비율")
     inner class StrikeoutToWalkRatioTest {
-
         @Test
         fun `삼진과 볼넷이 모두 0이면 0이다`() {
             assertThat(pitchingRecord.strikeoutToWalkRatio).isEqualTo(BigDecimal("0.00"))
@@ -369,7 +355,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("스트라이크 비율")
     inner class StrikePercentageTest {
-
         @Test
         fun `투구 수가 없으면 null이다`() {
             assertThat(pitchingRecord.strikePercentage).isNull()
@@ -388,7 +373,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("비자책점 계산")
     inner class UnearnedRunsTest {
-
         @Test
         fun `비자책점 = 실점 - 자책점`() {
             // given
@@ -405,7 +389,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("선발 투수")
     inner class StartingPitcherTest {
-
         @Test
         fun `기본값은 선발투수가 아니다`() {
             assertThat(pitchingRecord.isStartingPitcher).isFalse()
@@ -433,7 +416,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("선발 승리 자격")
     inner class QualifiedForWinTest {
-
         @Test
         fun `선발투수가 아니면 자격이 없다`() {
             // given
@@ -467,7 +449,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("승/패/세이브/홀드 결정")
     inner class DecisionTest {
-
         @Test
         fun `기본 결정은 NONE이다`() {
             assertThat(pitchingRecord.decision).isEqualTo(PitchingDecision.NONE)
@@ -554,7 +535,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("유효성 검증")
     inner class ValidationTest {
-
         @Test
         fun `정상적인 기록은 검증에 통과한다`() {
             // given
@@ -578,7 +558,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("이닝 문자열 파싱")
     inner class ParseInningsToOutsTest {
-
         @Test
         fun `5_0을 15아웃으로 변환한다`() {
             assertThat(PitchingRecord.parseInningsToOuts("5.0")).isEqualTo(15)
@@ -610,7 +589,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("applyBatterFaced - BoxScore 자동 계산")
     inner class ApplyBatterFacedTest {
-
         @Test
         fun `단타를 적용하면 battersFaced와 hitsAllowed가 증가한다`() {
             // when
@@ -714,7 +692,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("recordOut - 아웃 카운트 기록")
     inner class RecordOutOnlyTest {
-
         @Test
         fun `recordOut()은 이닝 아웃만 증가시킨다`() {
             // when
@@ -728,7 +705,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("recordEarnedRun - 자책점 기록")
     inner class RecordEarnedRunTest {
-
         @Test
         fun `자책점을 기록하면 earnedRuns와 runsAllowed가 증가한다`() {
             // when
@@ -752,7 +728,6 @@ class PitchingRecordTest {
     @Nested
     @DisplayName("recordUnearnedRun - 비자책 실점 기록")
     inner class RecordUnearnedRunTest {
-
         @Test
         fun `비자책 실점을 기록하면 runsAllowed만 증가한다`() {
             // when

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PlateAppearanceResultTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PlateAppearanceResultTest.kt
@@ -9,15 +9,16 @@ import org.junit.jupiter.params.provider.EnumSource
 
 @DisplayName("PlateAppearanceResult")
 class PlateAppearanceResultTest {
-
     @Nested
     @DisplayName("isAtBat 속성")
     inner class IsAtBatTest {
-
         @ParameterizedTest
         @EnumSource(
             value = PlateAppearanceResult::class,
-            names = ["SINGLE", "DOUBLE", "TRIPLE", "HOME_RUN", "STRIKEOUT", "GROUND_OUT", "FLY_OUT", "LINE_OUT", "FIELDERS_CHOICE", "ERROR", "DOUBLE_PLAY", "TRIPLE_PLAY"]
+            names = [
+                "SINGLE", "DOUBLE", "TRIPLE", "HOME_RUN", "STRIKEOUT", "GROUND_OUT",
+                "FLY_OUT", "LINE_OUT", "FIELDERS_CHOICE", "ERROR", "DOUBLE_PLAY", "TRIPLE_PLAY",
+            ],
         )
         fun `타수에 포함되는 결과를 반환한다`(result: PlateAppearanceResult) {
             assertThat(result.isAtBat).isTrue()
@@ -26,7 +27,7 @@ class PlateAppearanceResultTest {
         @ParameterizedTest
         @EnumSource(
             value = PlateAppearanceResult::class,
-            names = ["WALK", "INTENTIONAL_WALK", "HIT_BY_PITCH", "SACRIFICE_BUNT", "SACRIFICE_FLY", "INTERFERENCE"]
+            names = ["WALK", "INTENTIONAL_WALK", "HIT_BY_PITCH", "SACRIFICE_BUNT", "SACRIFICE_FLY", "INTERFERENCE"],
         )
         fun `타수에 포함되지 않는 결과를 반환한다`(result: PlateAppearanceResult) {
             assertThat(result.isAtBat).isFalse()
@@ -36,11 +37,10 @@ class PlateAppearanceResultTest {
     @Nested
     @DisplayName("isHit 속성")
     inner class IsHitTest {
-
         @ParameterizedTest
         @EnumSource(
             value = PlateAppearanceResult::class,
-            names = ["SINGLE", "DOUBLE", "TRIPLE", "HOME_RUN"]
+            names = ["SINGLE", "DOUBLE", "TRIPLE", "HOME_RUN"],
         )
         fun `안타 결과를 반환한다`(result: PlateAppearanceResult) {
             assertThat(result.isHit).isTrue()
@@ -49,7 +49,7 @@ class PlateAppearanceResultTest {
         @ParameterizedTest
         @EnumSource(
             value = PlateAppearanceResult::class,
-            names = ["STRIKEOUT", "GROUND_OUT", "FLY_OUT", "WALK", "SACRIFICE_BUNT"]
+            names = ["STRIKEOUT", "GROUND_OUT", "FLY_OUT", "WALK", "SACRIFICE_BUNT"],
         )
         fun `안타가 아닌 결과를 반환한다`(result: PlateAppearanceResult) {
             assertThat(result.isHit).isFalse()
@@ -59,7 +59,6 @@ class PlateAppearanceResultTest {
     @Nested
     @DisplayName("totalBases 속성")
     inner class TotalBasesTest {
-
         @Test
         fun `단타는 1루타를 반환한다`() {
             assertThat(PlateAppearanceResult.SINGLE.totalBases).isEqualTo(1)
@@ -90,7 +89,6 @@ class PlateAppearanceResultTest {
     @Nested
     @DisplayName("장타 속성")
     inner class ExtraBaseHitTest {
-
         @Test
         fun `2루타는 장타이다`() {
             assertThat(PlateAppearanceResult.DOUBLE.isExtraBaseHit).isTrue()
@@ -115,11 +113,13 @@ class PlateAppearanceResultTest {
     @Nested
     @DisplayName("출루 속성")
     inner class IsOnBaseTest {
-
         @ParameterizedTest
         @EnumSource(
             value = PlateAppearanceResult::class,
-            names = ["SINGLE", "DOUBLE", "TRIPLE", "HOME_RUN", "WALK", "INTENTIONAL_WALK", "HIT_BY_PITCH", "FIELDERS_CHOICE", "ERROR", "INTERFERENCE"]
+            names = [
+                "SINGLE", "DOUBLE", "TRIPLE", "HOME_RUN", "WALK", "INTENTIONAL_WALK",
+                "HIT_BY_PITCH", "FIELDERS_CHOICE", "ERROR", "INTERFERENCE",
+            ],
         )
         fun `출루에 성공한 결과를 반환한다`(result: PlateAppearanceResult) {
             assertThat(result.isOnBase).isTrue()
@@ -128,7 +128,10 @@ class PlateAppearanceResultTest {
         @ParameterizedTest
         @EnumSource(
             value = PlateAppearanceResult::class,
-            names = ["STRIKEOUT", "GROUND_OUT", "FLY_OUT", "LINE_OUT", "SACRIFICE_BUNT", "SACRIFICE_FLY", "DOUBLE_PLAY", "TRIPLE_PLAY"]
+            names = [
+                "STRIKEOUT", "GROUND_OUT", "FLY_OUT", "LINE_OUT",
+                "SACRIFICE_BUNT", "SACRIFICE_FLY", "DOUBLE_PLAY", "TRIPLE_PLAY",
+            ],
         )
         fun `출루에 실패한 결과를 반환한다`(result: PlateAppearanceResult) {
             assertThat(result.isOnBase).isFalse()
@@ -138,7 +141,6 @@ class PlateAppearanceResultTest {
     @Nested
     @DisplayName("볼넷 관련 속성")
     inner class WalkTest {
-
         @Test
         fun `볼넷은 isWalk가 true이다`() {
             assertThat(PlateAppearanceResult.WALK.isWalk).isTrue()
@@ -158,7 +160,6 @@ class PlateAppearanceResultTest {
     @Nested
     @DisplayName("희생타 속성")
     inner class SacrificeTest {
-
         @Test
         fun `희생번트는 희생타이다`() {
             assertThat(PlateAppearanceResult.SACRIFICE_BUNT.isSacrifice).isTrue()

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/league/LeagueTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/league/LeagueTest.kt
@@ -9,20 +9,20 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("League 엔티티 테스트")
 class LeagueTest {
-
     private lateinit var association: Association
 
     @BeforeEach
     fun setUp() {
-        association = Association(
-            name = "서울시야구협회",
-            abbreviation = "SBA",
-            region = "서울"
-        )
+        association =
+            Association(
+                name = "서울시야구협회",
+                abbreviation = "SBA",
+                region = "서울",
+            )
     }
 
-    private fun createLeague(isActive: Boolean = true): League {
-        return League(
+    private fun createLeague(isActive: Boolean = true): League =
+        League(
             association = association,
             name = "1부 리그",
             abbreviation = "1st",
@@ -30,14 +30,12 @@ class LeagueTest {
             divisionLevel = 1,
             description = "최상위 리그",
             logoUrl = "https://example.com/logo.png",
-            isActive = isActive
+            isActive = isActive,
         )
-    }
 
     @Nested
     @DisplayName("활성화/비활성화")
     inner class ActivationTests {
-
         @Test
         fun `리그를 비활성화할 수 있다`() {
             // given
@@ -66,7 +64,6 @@ class LeagueTest {
     @Nested
     @DisplayName("정보 업데이트")
     inner class UpdateInfoTests {
-
         @Test
         fun `설명을 업데이트할 수 있다`() {
             // given
@@ -101,7 +98,7 @@ class LeagueTest {
             // when
             league.updateInfo(
                 description = "새로운 설명",
-                logoUrl = "https://example.com/updated.png"
+                logoUrl = "https://example.com/updated.png",
             )
 
             // then
@@ -113,16 +110,16 @@ class LeagueTest {
     @Nested
     @DisplayName("기본 속성")
     inner class PropertyTests {
-
         @Test
         fun `리그 생성 시 기본값으로 활성 상태이다`() {
             // given & when
-            val league = League(
-                association = association,
-                name = "테스트 리그",
-                foundedYear = 2025,
-                divisionLevel = 1
-            )
+            val league =
+                League(
+                    association = association,
+                    name = "테스트 리그",
+                    foundedYear = 2025,
+                    divisionLevel = 1,
+                )
 
             // then
             assertThat(league.isActive).isTrue()

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/player/PlayerCareerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/player/PlayerCareerTest.kt
@@ -10,36 +10,34 @@ import java.time.LocalDate
 
 @DisplayName("PlayerCareer 엔티티 테스트")
 class PlayerCareerTest {
-
     private lateinit var player: Player
 
     @BeforeEach
     fun setUp() {
-        player = Player(
-            name = "홍길동",
-            primaryPosition = Position.SHORTSTOP
-        )
+        player =
+            Player(
+                name = "홍길동",
+                primaryPosition = Position.SHORTSTOP,
+            )
     }
 
     private fun createCareer(
         type: CareerType = CareerType.UNIVERSITY,
         organization: String = "서울대학교",
         startDate: LocalDate = LocalDate.of(2015, 3, 1),
-        endDate: LocalDate? = null
-    ): PlayerCareer {
-        return PlayerCareer(
+        endDate: LocalDate? = null,
+    ): PlayerCareer =
+        PlayerCareer(
             player = player,
             type = type,
             organization = organization,
             startDate = startDate,
-            endDate = endDate
+            endDate = endDate,
         )
-    }
 
     @Nested
     @DisplayName("활동 상태 확인")
     inner class IsActive {
-
         @Test
         fun `종료일이 없으면 활동 중이다`() {
             // given
@@ -62,7 +60,6 @@ class PlayerCareerTest {
     @Nested
     @DisplayName("프로 경력 확인")
     inner class IsProfessional {
-
         @Test
         fun `KBO 경력은 프로 경력이다`() {
             // given
@@ -130,7 +127,6 @@ class PlayerCareerTest {
     @Nested
     @DisplayName("경력 종료")
     inner class EndCareer {
-
         @Test
         fun `경력을 종료할 수 있다`() {
             // given
@@ -159,14 +155,14 @@ class PlayerCareerTest {
     @Nested
     @DisplayName("특정 날짜 활동 여부 확인")
     inner class IsActiveAt {
-
         @Test
         fun `시작일 이전에는 활동 중이 아니다`() {
             // given
-            val career = createCareer(
-                startDate = LocalDate.of(2015, 3, 1),
-                endDate = LocalDate.of(2019, 2, 28)
-            )
+            val career =
+                createCareer(
+                    startDate = LocalDate.of(2015, 3, 1),
+                    endDate = LocalDate.of(2019, 2, 28),
+                )
 
             // then
             assertThat(career.isActiveAt(LocalDate.of(2014, 12, 31))).isFalse()
@@ -175,10 +171,11 @@ class PlayerCareerTest {
         @Test
         fun `시작일에는 활동 중이다`() {
             // given
-            val career = createCareer(
-                startDate = LocalDate.of(2015, 3, 1),
-                endDate = LocalDate.of(2019, 2, 28)
-            )
+            val career =
+                createCareer(
+                    startDate = LocalDate.of(2015, 3, 1),
+                    endDate = LocalDate.of(2019, 2, 28),
+                )
 
             // then
             assertThat(career.isActiveAt(LocalDate.of(2015, 3, 1))).isTrue()
@@ -187,10 +184,11 @@ class PlayerCareerTest {
         @Test
         fun `기간 중에는 활동 중이다`() {
             // given
-            val career = createCareer(
-                startDate = LocalDate.of(2015, 3, 1),
-                endDate = LocalDate.of(2019, 2, 28)
-            )
+            val career =
+                createCareer(
+                    startDate = LocalDate.of(2015, 3, 1),
+                    endDate = LocalDate.of(2019, 2, 28),
+                )
 
             // then
             assertThat(career.isActiveAt(LocalDate.of(2017, 6, 15))).isTrue()
@@ -199,10 +197,11 @@ class PlayerCareerTest {
         @Test
         fun `종료일에는 활동 중이다`() {
             // given
-            val career = createCareer(
-                startDate = LocalDate.of(2015, 3, 1),
-                endDate = LocalDate.of(2019, 2, 28)
-            )
+            val career =
+                createCareer(
+                    startDate = LocalDate.of(2015, 3, 1),
+                    endDate = LocalDate.of(2019, 2, 28),
+                )
 
             // then
             assertThat(career.isActiveAt(LocalDate.of(2019, 2, 28))).isTrue()
@@ -211,10 +210,11 @@ class PlayerCareerTest {
         @Test
         fun `종료일 이후에는 활동 중이 아니다`() {
             // given
-            val career = createCareer(
-                startDate = LocalDate.of(2015, 3, 1),
-                endDate = LocalDate.of(2019, 2, 28)
-            )
+            val career =
+                createCareer(
+                    startDate = LocalDate.of(2015, 3, 1),
+                    endDate = LocalDate.of(2019, 2, 28),
+                )
 
             // then
             assertThat(career.isActiveAt(LocalDate.of(2019, 3, 1))).isFalse()
@@ -223,10 +223,11 @@ class PlayerCareerTest {
         @Test
         fun `종료일이 없으면 현재까지 활동 중이다`() {
             // given
-            val career = createCareer(
-                startDate = LocalDate.of(2015, 3, 1),
-                endDate = null
-            )
+            val career =
+                createCareer(
+                    startDate = LocalDate.of(2015, 3, 1),
+                    endDate = null,
+                )
 
             // then
             assertThat(career.isActiveAt(LocalDate.of(2030, 12, 31))).isTrue()
@@ -236,14 +237,14 @@ class PlayerCareerTest {
     @Nested
     @DisplayName("경력 기간 계산")
     inner class CalculateYears {
-
         @Test
         fun `경력 기간을 년 단위로 계산한다`() {
             // given
-            val career = createCareer(
-                startDate = LocalDate.of(2015, 3, 1),
-                endDate = LocalDate.of(2019, 2, 28)
-            )
+            val career =
+                createCareer(
+                    startDate = LocalDate.of(2015, 3, 1),
+                    endDate = LocalDate.of(2019, 2, 28),
+                )
 
             // then
             assertThat(career.calculateYears()).isEqualTo(4)
@@ -252,10 +253,11 @@ class PlayerCareerTest {
         @Test
         fun `종료일이 없으면 기준일까지 계산한다`() {
             // given
-            val career = createCareer(
-                startDate = LocalDate.of(2015, 3, 1),
-                endDate = null
-            )
+            val career =
+                createCareer(
+                    startDate = LocalDate.of(2015, 3, 1),
+                    endDate = null,
+                )
             val baseDate = LocalDate.of(2024, 3, 1)
 
             // then

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/player/PlayerTeamHistoryTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/player/PlayerTeamHistoryTest.kt
@@ -13,39 +13,44 @@ import java.time.LocalDate
 
 @DisplayName("PlayerTeamHistory 엔티티 테스트")
 class PlayerTeamHistoryTest {
-
     private lateinit var player: Player
     private lateinit var team: Team
     private lateinit var otherTeam: Team
 
     @BeforeEach
     fun setUp() {
-        player = Player(
-            name = "홍길동",
-            primaryPosition = Position.SHORTSTOP
-        ).apply {
-            setId(this, 1L)
-        }
+        player =
+            Player(
+                name = "홍길동",
+                primaryPosition = Position.SHORTSTOP,
+            ).apply {
+                setId(this, 1L)
+            }
 
         val association = Association(name = "서울시야구협회", region = "서울")
         val league = League(association = association, name = "1부 리그", foundedYear = 2020)
 
-        team = Team(
-            league = league,
-            name = "타이거즈",
-            city = "서울",
-            foundedYear = 2015
-        )
+        team =
+            Team(
+                league = league,
+                name = "타이거즈",
+                city = "서울",
+                foundedYear = 2015,
+            )
 
-        otherTeam = Team(
-            league = league,
-            name = "라이온즈",
-            city = "부산",
-            foundedYear = 2016
-        )
+        otherTeam =
+            Team(
+                league = league,
+                name = "라이온즈",
+                city = "부산",
+                foundedYear = 2016,
+            )
     }
 
-    private fun setId(entity: Any, id: Long) {
+    private fun setId(
+        entity: Any,
+        id: Long,
+    ) {
         val idField = entity::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(entity, id)
@@ -55,22 +60,20 @@ class PlayerTeamHistoryTest {
         startDate: LocalDate = LocalDate.of(2020, 3, 1),
         endDate: LocalDate? = null,
         uniformNumber: Int? = 7,
-        position: Position = Position.SHORTSTOP
-    ): PlayerTeamHistory {
-        return PlayerTeamHistory(
+        position: Position = Position.SHORTSTOP,
+    ): PlayerTeamHistory =
+        PlayerTeamHistory(
             player = player,
             team = team,
             startDate = startDate,
             endDate = endDate,
             uniformNumber = uniformNumber,
-            position = position
+            position = position,
         )
-    }
 
     @Nested
     @DisplayName("현재 소속 확인")
     inner class IsCurrentAffiliation {
-
         @Test
         fun `종료일이 없으면 현재 소속이다`() {
             // given
@@ -93,14 +96,14 @@ class PlayerTeamHistoryTest {
     @Nested
     @DisplayName("소속 기간 계산")
     inner class DurationInDays {
-
         @Test
         fun `소속 기간을 일 단위로 계산한다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 1, 1),
-                endDate = LocalDate.of(2020, 1, 11)
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                    endDate = LocalDate.of(2020, 1, 11),
+                )
 
             // then
             assertThat(history.durationInDays).isEqualTo(10)
@@ -119,7 +122,6 @@ class PlayerTeamHistoryTest {
     @Nested
     @DisplayName("소속 종료")
     inner class EndAffiliation {
-
         @Test
         fun `소속을 종료할 수 있다`() {
             // given
@@ -148,7 +150,6 @@ class PlayerTeamHistoryTest {
     @Nested
     @DisplayName("등번호 변경")
     inner class ChangeUniformNumber {
-
         @Test
         fun `등번호를 변경할 수 있다`() {
             // given
@@ -165,7 +166,6 @@ class PlayerTeamHistoryTest {
     @Nested
     @DisplayName("포지션 변경")
     inner class ChangePosition {
-
         @Test
         fun `포지션을 변경할 수 있다`() {
             // given
@@ -182,14 +182,14 @@ class PlayerTeamHistoryTest {
     @Nested
     @DisplayName("특정 날짜 활동 여부 확인")
     inner class IsActiveAt {
-
         @Test
         fun `시작일 이전에는 활동 중이 아니다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 3, 1),
-                endDate = LocalDate.of(2023, 12, 31)
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 3, 1),
+                    endDate = LocalDate.of(2023, 12, 31),
+                )
 
             // then
             assertThat(history.isActiveAt(LocalDate.of(2020, 2, 28))).isFalse()
@@ -198,10 +198,11 @@ class PlayerTeamHistoryTest {
         @Test
         fun `기간 중에는 활동 중이다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 3, 1),
-                endDate = LocalDate.of(2023, 12, 31)
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 3, 1),
+                    endDate = LocalDate.of(2023, 12, 31),
+                )
 
             // then
             assertThat(history.isActiveAt(LocalDate.of(2022, 6, 15))).isTrue()
@@ -210,10 +211,11 @@ class PlayerTeamHistoryTest {
         @Test
         fun `종료일 이후에는 활동 중이 아니다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 3, 1),
-                endDate = LocalDate.of(2023, 12, 31)
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 3, 1),
+                    endDate = LocalDate.of(2023, 12, 31),
+                )
 
             // then
             assertThat(history.isActiveAt(LocalDate.of(2024, 1, 1))).isFalse()
@@ -222,10 +224,11 @@ class PlayerTeamHistoryTest {
         @Test
         fun `종료일이 없으면 현재까지 활동 중이다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 3, 1),
-                endDate = null
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 3, 1),
+                    endDate = null,
+                )
 
             // then
             assertThat(history.isActiveAt(LocalDate.of(2030, 12, 31))).isTrue()
@@ -235,13 +238,13 @@ class PlayerTeamHistoryTest {
     @Nested
     @DisplayName("이적 처리")
     inner class Transfer {
-
         @Test
         fun `ACTIVE 상태에서 이적할 수 있다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 1, 1)
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                )
 
             // when
             history.transfer(LocalDate.of(2023, 6, 30))
@@ -254,9 +257,10 @@ class PlayerTeamHistoryTest {
         @Test
         fun `ACTIVE 상태가 아니면 이적할 수 없다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 1, 1)
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                )
             history.deactivate(LocalDate.of(2023, 1, 1))
 
             // when & then
@@ -268,9 +272,10 @@ class PlayerTeamHistoryTest {
         @Test
         fun `이적일이 시작일보다 이전이면 예외가 발생한다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 1, 1)
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                )
 
             // when & then
             assertThatThrownBy { history.transfer(LocalDate.of(2019, 12, 31)) }
@@ -282,13 +287,13 @@ class PlayerTeamHistoryTest {
     @Nested
     @DisplayName("비활동 처리")
     inner class Deactivate {
-
         @Test
         fun `ACTIVE 상태에서 비활동 처리할 수 있다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 1, 1)
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                )
 
             // when
             history.deactivate(LocalDate.of(2023, 6, 30))
@@ -301,9 +306,10 @@ class PlayerTeamHistoryTest {
         @Test
         fun `ACTIVE 상태가 아니면 비활동 처리할 수 없다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 1, 1)
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                )
             history.transfer(LocalDate.of(2023, 1, 1))
 
             // when & then
@@ -315,9 +321,10 @@ class PlayerTeamHistoryTest {
         @Test
         fun `비활동일이 시작일보다 이전이면 예외가 발생한다`() {
             // given
-            val history = createHistory(
-                startDate = LocalDate.of(2020, 1, 1)
-            )
+            val history =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                )
 
             // when & then
             assertThatThrownBy { history.deactivate(LocalDate.of(2019, 12, 31)) }
@@ -329,7 +336,6 @@ class PlayerTeamHistoryTest {
     @Nested
     @DisplayName("활성 상태 확인")
     inner class IsActive {
-
         @Test
         fun `ACTIVE 상태면 true를 반환한다`() {
             // given
@@ -363,21 +369,22 @@ class PlayerTeamHistoryTest {
     @Nested
     @DisplayName("기간 중복 확인")
     inner class Overlaps {
-
         @Test
         fun `같은 선수의 기간이 겹치면 true를 반환한다`() {
             // given
-            val history1 = createHistory(
-                startDate = LocalDate.of(2020, 1, 1),
-                endDate = LocalDate.of(2021, 12, 31)
-            )
-            val history2 = PlayerTeamHistory(
-                player = player,
-                team = otherTeam,
-                startDate = LocalDate.of(2021, 6, 1),
-                endDate = LocalDate.of(2022, 12, 31),
-                position = Position.SHORTSTOP
-            )
+            val history1 =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                    endDate = LocalDate.of(2021, 12, 31),
+                )
+            val history2 =
+                PlayerTeamHistory(
+                    player = player,
+                    team = otherTeam,
+                    startDate = LocalDate.of(2021, 6, 1),
+                    endDate = LocalDate.of(2022, 12, 31),
+                    position = Position.SHORTSTOP,
+                )
 
             // then
             assertThat(history1.overlaps(history2)).isTrue()
@@ -386,17 +393,19 @@ class PlayerTeamHistoryTest {
         @Test
         fun `같은 선수의 기간이 겹치지 않으면 false를 반환한다`() {
             // given
-            val history1 = createHistory(
-                startDate = LocalDate.of(2020, 1, 1),
-                endDate = LocalDate.of(2021, 12, 31)
-            )
-            val history2 = PlayerTeamHistory(
-                player = player,
-                team = otherTeam,
-                startDate = LocalDate.of(2022, 1, 1),
-                endDate = LocalDate.of(2023, 12, 31),
-                position = Position.SHORTSTOP
-            )
+            val history1 =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                    endDate = LocalDate.of(2021, 12, 31),
+                )
+            val history2 =
+                PlayerTeamHistory(
+                    player = player,
+                    team = otherTeam,
+                    startDate = LocalDate.of(2022, 1, 1),
+                    endDate = LocalDate.of(2023, 12, 31),
+                    position = Position.SHORTSTOP,
+                )
 
             // then
             assertThat(history1.overlaps(history2)).isFalse()
@@ -405,17 +414,19 @@ class PlayerTeamHistoryTest {
         @Test
         fun `종료일이 없는 경우도 중복 확인이 가능하다`() {
             // given
-            val history1 = createHistory(
-                startDate = LocalDate.of(2020, 1, 1),
-                endDate = null
-            )
-            val history2 = PlayerTeamHistory(
-                player = player,
-                team = otherTeam,
-                startDate = LocalDate.of(2022, 1, 1),
-                endDate = null,
-                position = Position.SHORTSTOP
-            )
+            val history1 =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                    endDate = null,
+                )
+            val history2 =
+                PlayerTeamHistory(
+                    player = player,
+                    team = otherTeam,
+                    startDate = LocalDate.of(2022, 1, 1),
+                    endDate = null,
+                    position = Position.SHORTSTOP,
+                )
 
             // then
             assertThat(history1.overlaps(history2)).isTrue()
@@ -424,20 +435,23 @@ class PlayerTeamHistoryTest {
         @Test
         fun `다른 선수의 기간은 중복되지 않는다`() {
             // given
-            val otherPlayer = Player(name = "김철수", primaryPosition = Position.CATCHER).apply {
-                setId(this, 2L)
-            }
-            val history1 = createHistory(
-                startDate = LocalDate.of(2020, 1, 1),
-                endDate = LocalDate.of(2021, 12, 31)
-            )
-            val history2 = PlayerTeamHistory(
-                player = otherPlayer,
-                team = team,
-                startDate = LocalDate.of(2020, 6, 1),
-                endDate = LocalDate.of(2022, 12, 31),
-                position = Position.CATCHER
-            )
+            val otherPlayer =
+                Player(name = "김철수", primaryPosition = Position.CATCHER).apply {
+                    setId(this, 2L)
+                }
+            val history1 =
+                createHistory(
+                    startDate = LocalDate.of(2020, 1, 1),
+                    endDate = LocalDate.of(2021, 12, 31),
+                )
+            val history2 =
+                PlayerTeamHistory(
+                    player = otherPlayer,
+                    team = team,
+                    startDate = LocalDate.of(2020, 6, 1),
+                    endDate = LocalDate.of(2022, 12, 31),
+                    position = Position.CATCHER,
+                )
 
             // then
             assertThat(history1.overlaps(history2)).isFalse()

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/player/PlayerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/player/PlayerTest.kt
@@ -9,26 +9,23 @@ import java.time.LocalDate
 
 @DisplayName("Player 엔티티 테스트")
 class PlayerTest {
-
     private fun createPlayer(
         name: String = "홍길동",
         birthDate: LocalDate? = LocalDate.of(1995, 5, 15),
         debutYear: Int? = 2018,
-        retirementYear: Int? = null
-    ): Player {
-        return Player(
+        retirementYear: Int? = null,
+    ): Player =
+        Player(
             name = name,
             birthDate = birthDate,
             primaryPosition = Position.SHORTSTOP,
             debutYear = debutYear,
-            retirementYear = retirementYear
+            retirementYear = retirementYear,
         )
-    }
 
     @Nested
     @DisplayName("은퇴 처리")
     inner class Retire {
-
         @Test
         fun `현역 선수를 은퇴 처리할 수 있다`() {
             // given
@@ -68,7 +65,6 @@ class PlayerTest {
     @Nested
     @DisplayName("신체 정보 수정")
     inner class UpdatePhysicalInfo {
-
         @Test
         fun `키와 몸무게를 수정할 수 있다`() {
             // given
@@ -85,9 +81,10 @@ class PlayerTest {
         @Test
         fun `키만 수정할 수 있다`() {
             // given
-            val player = createPlayer().apply {
-                updatePhysicalInfo(height = 180, weight = 75)
-            }
+            val player =
+                createPlayer().apply {
+                    updatePhysicalInfo(height = 180, weight = 75)
+                }
 
             // when
             player.updatePhysicalInfo(height = 183)
@@ -101,7 +98,6 @@ class PlayerTest {
     @Nested
     @DisplayName("프로필 수정")
     inner class UpdateProfile {
-
         @Test
         fun `프로필 이미지 URL을 수정할 수 있다`() {
             // given
@@ -117,9 +113,10 @@ class PlayerTest {
         @Test
         fun `프로필 이미지를 null로 설정할 수 있다`() {
             // given
-            val player = createPlayer().apply {
-                updateProfile("https://example.com/profile.jpg")
-            }
+            val player =
+                createPlayer().apply {
+                    updateProfile("https://example.com/profile.jpg")
+                }
 
             // when
             player.updateProfile(null)
@@ -132,7 +129,6 @@ class PlayerTest {
     @Nested
     @DisplayName("나이 계산")
     inner class CalculateAge {
-
         @Test
         fun `생년월일로 나이를 계산할 수 있다`() {
             // given
@@ -175,7 +171,6 @@ class PlayerTest {
     @Nested
     @DisplayName("활동 상태 확인")
     inner class IsActive {
-
         @Test
         fun `은퇴하지 않은 선수는 현역이다`() {
             // given

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerBattingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerBattingStatsTest.kt
@@ -17,19 +17,18 @@ import java.math.BigDecimal
 
 @DisplayName("CareerBattingStats 테스트")
 class CareerBattingStatsTest {
-
-    private val testPlayer = Player(
-        name = "홍길동",
-        primaryPosition = Position.CATCHER,
-        throwingHand = ThrowingHand.RIGHT,
-        battingHand = BattingHand.RIGHT,
-        id = 1L
-    )
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
 
     @Nested
     @DisplayName("통산 타격 통계 생성")
     inner class Create {
-
         @Test
         fun `should create career batting stats successfully`() {
             // when
@@ -47,15 +46,15 @@ class CareerBattingStatsTest {
     @Nested
     @DisplayName("경기 기록 누적")
     inner class AddGameRecord {
-
         @Test
         fun `should accumulate single game record correctly`() {
             // given
             val stats = CareerBattingStats.create(testPlayer)
             val gamePlayer = mockk<GamePlayer>()
-            val record = BattingRecord.create(gamePlayer).apply {
-                setStats(pa = 5, ab = 4, h = 2, doubles = 1, bb = 1, so = 1, runs = 1, rbi = 1)
-            }
+            val record =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 5, ab = 4, h = 2, doubles = 1, bb = 1, so = 1, runs = 1, rbi = 1)
+                }
 
             // when
             stats.addGameRecord(record)
@@ -79,19 +78,22 @@ class CareerBattingStatsTest {
             val gamePlayer = mockk<GamePlayer>()
 
             // Game 1: 4타수 2안타 1홈런
-            val record1 = BattingRecord.create(gamePlayer).apply {
-                setStats(pa = 4, ab = 4, h = 2, hr = 1, runs = 2, rbi = 2)
-            }
+            val record1 =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 4, ab = 4, h = 2, hr = 1, runs = 2, rbi = 2)
+                }
 
             // Game 2: 3타수 1안타 1볼넷
-            val record2 = BattingRecord.create(gamePlayer).apply {
-                setStats(pa = 4, ab = 3, h = 1, bb = 1, runs = 0, rbi = 0)
-            }
+            val record2 =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 4, ab = 3, h = 1, bb = 1, runs = 0, rbi = 0)
+                }
 
             // Game 3: 5타수 3안타 (2루타 1개, 3루타 1개)
-            val record3 = BattingRecord.create(gamePlayer).apply {
-                setStats(pa = 5, ab = 5, h = 3, doubles = 1, triples = 1, runs = 1, rbi = 2)
-            }
+            val record3 =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 5, ab = 5, h = 3, doubles = 1, triples = 1, runs = 1, rbi = 2)
+                }
 
             // when
             stats.addGameRecord(record1)
@@ -115,7 +117,6 @@ class CareerBattingStatsTest {
     @Nested
     @DisplayName("시즌 추가")
     inner class AddSeason {
-
         @Test
         fun `should increment seasons played`() {
             // given
@@ -133,7 +134,6 @@ class CareerBattingStatsTest {
     @Nested
     @DisplayName("계산 속성 검증")
     inner class CalculatedProperties {
-
         @Test
         fun `should calculate batting average correctly`() {
             // given: 10타수 3안타 = .300
@@ -321,12 +321,19 @@ class CareerBattingStatsTest {
     @Nested
     @DisplayName("유효성 검증")
     inner class Validation {
-
         @Test
         fun `should validate successfully with valid stats`() {
             // given
             val stats = CareerBattingStats.create(testPlayer)
-            setStatsDirectly(stats, seasonsPlayed = 3, gamesPlayed = 100, pa = 400, atBats = 350, hits = 100, doubles = 20)
+            setStatsDirectly(
+                stats,
+                seasonsPlayed = 3,
+                gamesPlayed = 100,
+                pa = 400,
+                atBats = 350,
+                hits = 100,
+                doubles = 20
+            )
 
             // when & then
             stats.validate() // Should not throw
@@ -406,7 +413,7 @@ class CareerBattingStatsTest {
         hbp: Int = 0,
         so: Int = 0,
         runs: Int = 0,
-        rbi: Int = 0
+        rbi: Int = 0,
     ) {
         setField("plateAppearances", pa)
         setField("atBats", ab)
@@ -421,7 +428,10 @@ class CareerBattingStatsTest {
         setField("runsBattedIn", rbi)
     }
 
-    private fun BattingRecord.setField(fieldName: String, value: Int) {
+    private fun BattingRecord.setField(
+        fieldName: String,
+        value: Int,
+    ) {
         val field = BattingRecord::class.java.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(this, value)
@@ -443,7 +453,7 @@ class CareerBattingStatsTest {
         sacrificeBunts: Int = 0,
         sacrificeFlies: Int = 0,
         stolenBases: Int = 0,
-        caughtStealing: Int = 0
+        caughtStealing: Int = 0,
     ) {
         val clazz = CareerBattingStats::class.java
         setField(clazz, stats, "seasonsPlayed", seasonsPlayed)
@@ -463,7 +473,12 @@ class CareerBattingStatsTest {
         setField(clazz, stats, "caughtStealing", caughtStealing)
     }
 
-    private fun setField(clazz: Class<*>, obj: Any, fieldName: String, value: Int) {
+    private fun setField(
+        clazz: Class<*>,
+        obj: Any,
+        fieldName: String,
+        value: Int,
+    ) {
         val field = clazz.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(obj, value)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerPitchingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerPitchingStatsTest.kt
@@ -18,19 +18,18 @@ import java.math.BigDecimal
 
 @DisplayName("CareerPitchingStats 테스트")
 class CareerPitchingStatsTest {
-
-    private val testPlayer = Player(
-        name = "박찬호",
-        primaryPosition = Position.STARTING_PITCHER,
-        throwingHand = ThrowingHand.RIGHT,
-        battingHand = BattingHand.RIGHT,
-        id = 1L
-    )
+    private val testPlayer =
+        Player(
+            name = "박찬호",
+            primaryPosition = Position.STARTING_PITCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
 
     @Nested
     @DisplayName("통산 투수 통계 생성")
     inner class Create {
-
         @Test
         fun `should create career pitching stats successfully`() {
             // when
@@ -48,24 +47,24 @@ class CareerPitchingStatsTest {
     @Nested
     @DisplayName("경기 기록 누적")
     inner class AddGameRecord {
-
         @Test
         fun `should accumulate single game record for starting pitcher correctly`() {
             // given
             val stats = CareerPitchingStats.create(testPlayer)
             val gamePlayer = mockk<GamePlayer>()
-            val record = PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
-                setStats(
-                    inningsPitchedOuts = 18,
-                    earnedRuns = 2,
-                    runsAllowed = 2,
-                    hitsAllowed = 5,
-                    walksAllowed = 2,
-                    strikeouts = 7,
-                    battersFaced = 25,
-                    decision = PitchingDecision.WIN
-                )
-            }
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 2,
+                        runsAllowed = 2,
+                        hitsAllowed = 5,
+                        walksAllowed = 2,
+                        strikeouts = 7,
+                        battersFaced = 25,
+                        decision = PitchingDecision.WIN,
+                    )
+                }
 
             // when
             stats.addGameRecord(record)
@@ -89,18 +88,19 @@ class CareerPitchingStatsTest {
             // given
             val stats = CareerPitchingStats.create(testPlayer)
             val gamePlayer = mockk<GamePlayer>()
-            val record = PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
-                setStats(
-                    inningsPitchedOuts = 6,
-                    earnedRuns = 0,
-                    runsAllowed = 0,
-                    hitsAllowed = 1,
-                    walksAllowed = 0,
-                    strikeouts = 3,
-                    battersFaced = 7,
-                    decision = PitchingDecision.SAVE
-                )
-            }
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
+                    setStats(
+                        inningsPitchedOuts = 6,
+                        earnedRuns = 0,
+                        runsAllowed = 0,
+                        hitsAllowed = 1,
+                        walksAllowed = 0,
+                        strikeouts = 3,
+                        battersFaced = 7,
+                        decision = PitchingDecision.SAVE,
+                    )
+                }
 
             // when
             stats.addGameRecord(record)
@@ -119,60 +119,64 @@ class CareerPitchingStatsTest {
             val gamePlayer = mockk<GamePlayer>()
 
             // Game 1: 선발 6이닝 승리
-            val record1 = PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
-                setStats(
-                    inningsPitchedOuts = 18,
-                    earnedRuns = 2,
-                    runsAllowed = 2,
-                    hitsAllowed = 5,
-                    walksAllowed = 2,
-                    strikeouts = 6,
-                    battersFaced = 24,
-                    decision = PitchingDecision.WIN
-                )
-            }
+            val record1 =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 2,
+                        runsAllowed = 2,
+                        hitsAllowed = 5,
+                        walksAllowed = 2,
+                        strikeouts = 6,
+                        battersFaced = 24,
+                        decision = PitchingDecision.WIN,
+                    )
+                }
 
             // Game 2: 선발 7이닝 패배
-            val record2 = PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
-                setStats(
-                    inningsPitchedOuts = 21,
-                    earnedRuns = 4,
-                    runsAllowed = 4,
-                    hitsAllowed = 8,
-                    walksAllowed = 1,
-                    strikeouts = 5,
-                    battersFaced = 28,
-                    decision = PitchingDecision.LOSS
-                )
-            }
+            val record2 =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 21,
+                        earnedRuns = 4,
+                        runsAllowed = 4,
+                        hitsAllowed = 8,
+                        walksAllowed = 1,
+                        strikeouts = 5,
+                        battersFaced = 28,
+                        decision = PitchingDecision.LOSS,
+                    )
+                }
 
             // Game 3: 중계 2이닝 홀드
-            val record3 = PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
-                setStats(
-                    inningsPitchedOuts = 6,
-                    earnedRuns = 0,
-                    runsAllowed = 0,
-                    hitsAllowed = 1,
-                    walksAllowed = 1,
-                    strikeouts = 2,
-                    battersFaced = 7,
-                    decision = PitchingDecision.HOLD
-                )
-            }
+            val record3 =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
+                    setStats(
+                        inningsPitchedOuts = 6,
+                        earnedRuns = 0,
+                        runsAllowed = 0,
+                        hitsAllowed = 1,
+                        walksAllowed = 1,
+                        strikeouts = 2,
+                        battersFaced = 7,
+                        decision = PitchingDecision.HOLD,
+                    )
+                }
 
             // Game 4: 중계 1이닝 블론세이브
-            val record4 = PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
-                setStats(
-                    inningsPitchedOuts = 3,
-                    earnedRuns = 2,
-                    runsAllowed = 2,
-                    hitsAllowed = 3,
-                    walksAllowed = 1,
-                    strikeouts = 1,
-                    battersFaced = 6,
-                    decision = PitchingDecision.BLOWN_SAVE
-                )
-            }
+            val record4 =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
+                    setStats(
+                        inningsPitchedOuts = 3,
+                        earnedRuns = 2,
+                        runsAllowed = 2,
+                        hitsAllowed = 3,
+                        walksAllowed = 1,
+                        strikeouts = 1,
+                        battersFaced = 6,
+                        decision = PitchingDecision.BLOWN_SAVE,
+                    )
+                }
 
             // when
             stats.addGameRecord(record1)
@@ -198,20 +202,22 @@ class CareerPitchingStatsTest {
             // given
             val stats = CareerPitchingStats.create(testPlayer)
             val gamePlayer = mockk<GamePlayer>()
-            val record1 = PitchingRecord.create(gamePlayer).apply {
-                setStats(
-                    inningsPitchedOuts = 18,
-                    pitchesThrown = 95,
-                    strikesThrown = 63
-                )
-            }
-            val record2 = PitchingRecord.create(gamePlayer).apply {
-                setStats(
-                    inningsPitchedOuts = 18,
-                    pitchesThrown = 90,
-                    strikesThrown = 60
-                )
-            }
+            val record1 =
+                PitchingRecord.create(gamePlayer).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        pitchesThrown = 95,
+                        strikesThrown = 63,
+                    )
+                }
+            val record2 =
+                PitchingRecord.create(gamePlayer).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        pitchesThrown = 90,
+                        strikesThrown = 60,
+                    )
+                }
 
             // when
             stats.addGameRecord(record1)
@@ -227,9 +233,10 @@ class CareerPitchingStatsTest {
             // given
             val stats = CareerPitchingStats.create(testPlayer)
             val gamePlayer = mockk<GamePlayer>()
-            val record = PitchingRecord.create(gamePlayer).apply {
-                setStats(inningsPitchedOuts = 18)
-            }
+            val record =
+                PitchingRecord.create(gamePlayer).apply {
+                    setStats(inningsPitchedOuts = 18)
+                }
 
             // when
             stats.addGameRecord(record)
@@ -244,12 +251,13 @@ class CareerPitchingStatsTest {
             // given
             val stats = CareerPitchingStats.create(testPlayer)
             val gamePlayer = mockk<GamePlayer>()
-            val record = PitchingRecord.create(gamePlayer).apply {
-                setStats(
-                    inningsPitchedOuts = 6,
-                    decision = PitchingDecision.NONE
-                )
-            }
+            val record =
+                PitchingRecord.create(gamePlayer).apply {
+                    setStats(
+                        inningsPitchedOuts = 6,
+                        decision = PitchingDecision.NONE,
+                    )
+                }
 
             // when
             stats.addGameRecord(record)
@@ -266,7 +274,6 @@ class CareerPitchingStatsTest {
     @Nested
     @DisplayName("시즌 추가")
     inner class AddSeason {
-
         @Test
         fun `should increment seasons played`() {
             // given
@@ -285,7 +292,6 @@ class CareerPitchingStatsTest {
     @Nested
     @DisplayName("계산 속성 검증")
     inner class CalculatedProperties {
-
         @Test
         fun `should calculate ERA correctly`() {
             // given: 18 outs (6이닝), 3자책 => ERA = (3/6)*9 = 4.50
@@ -557,7 +563,6 @@ class CareerPitchingStatsTest {
     @Nested
     @DisplayName("유효성 검증")
     inner class Validation {
-
         @Test
         fun `should validate successfully with valid stats`() {
             // given
@@ -569,7 +574,7 @@ class CareerPitchingStatsTest {
                 gamesStarted = 30,
                 inningsPitchedOuts = 600,
                 earnedRuns = 50,
-                runsAllowed = 60
+                runsAllowed = 60,
             )
 
             // when & then
@@ -658,7 +663,7 @@ class CareerPitchingStatsTest {
         battersFaced: Int = 0,
         decision: PitchingDecision = PitchingDecision.NONE,
         pitchesThrown: Int? = null,
-        strikesThrown: Int? = null
+        strikesThrown: Int? = null,
     ) {
         setField("inningsPitchedOuts", inningsPitchedOuts)
         setField("earnedRuns", earnedRuns)
@@ -672,7 +677,10 @@ class CareerPitchingStatsTest {
         setField("strikesThrown", strikesThrown)
     }
 
-    private fun PitchingRecord.setField(fieldName: String, value: Any?) {
+    private fun PitchingRecord.setField(
+        fieldName: String,
+        value: Any?,
+    ) {
         val field = PitchingRecord::class.java.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(this, value)
@@ -692,7 +700,7 @@ class CareerPitchingStatsTest {
         walksAllowed: Int = 0,
         strikeouts: Int = 0,
         pitchesThrown: Int? = null,
-        strikesThrown: Int? = null
+        strikesThrown: Int? = null,
     ) {
         val clazz = CareerPitchingStats::class.java
         setField(clazz, stats, "seasonsPlayed", seasonsPlayed)
@@ -710,7 +718,12 @@ class CareerPitchingStatsTest {
         setField(clazz, stats, "strikesThrown", strikesThrown)
     }
 
-    private fun setField(clazz: Class<*>, obj: Any, fieldName: String, value: Any?) {
+    private fun setField(
+        clazz: Class<*>,
+        obj: Any,
+        fieldName: String,
+        value: Any?,
+    ) {
         val field = clazz.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(obj, value)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonBattingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonBattingStatsTest.kt
@@ -7,7 +7,6 @@ import com.nextup.core.domain.player.BattingHand
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.player.ThrowingHand
-import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -18,19 +17,18 @@ import java.math.BigDecimal
 
 @DisplayName("SeasonBattingStats 테스트")
 class SeasonBattingStatsTest {
-
-    private val testPlayer = Player(
-        name = "홍길동",
-        primaryPosition = Position.CATCHER,
-        throwingHand = ThrowingHand.RIGHT,
-        battingHand = BattingHand.RIGHT,
-        id = 1L
-    )
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
 
     @Nested
     @DisplayName("시즌 타격 통계 생성")
     inner class Create {
-
         @Test
         fun `should create season batting stats successfully`() {
             // when
@@ -56,46 +54,46 @@ class SeasonBattingStatsTest {
     @Nested
     @DisplayName("경기 기록 누적")
     inner class AddGameRecord {
-
         @Test
         fun `should accumulate single game record correctly`() {
             // given
             val stats = SeasonBattingStats.create(testPlayer, 2024)
             val gamePlayer = mockk<GamePlayer>()
-            val record = BattingRecord.create(gamePlayer).apply {
-                // 4타수 2안타 (2루타 1개) 1볼넷 1삼진
-                val field = BattingRecord::class.java.getDeclaredField("plateAppearances")
-                field.isAccessible = true
-                field.set(this, 5)
+            val record =
+                BattingRecord.create(gamePlayer).apply {
+                    // 4타수 2안타 (2루타 1개) 1볼넷 1삼진
+                    val field = BattingRecord::class.java.getDeclaredField("plateAppearances")
+                    field.isAccessible = true
+                    field.set(this, 5)
 
-                val atBatsField = BattingRecord::class.java.getDeclaredField("atBats")
-                atBatsField.isAccessible = true
-                atBatsField.set(this, 4)
+                    val atBatsField = BattingRecord::class.java.getDeclaredField("atBats")
+                    atBatsField.isAccessible = true
+                    atBatsField.set(this, 4)
 
-                val hitsField = BattingRecord::class.java.getDeclaredField("hits")
-                hitsField.isAccessible = true
-                hitsField.set(this, 2)
+                    val hitsField = BattingRecord::class.java.getDeclaredField("hits")
+                    hitsField.isAccessible = true
+                    hitsField.set(this, 2)
 
-                val doublesField = BattingRecord::class.java.getDeclaredField("doubles")
-                doublesField.isAccessible = true
-                doublesField.set(this, 1)
+                    val doublesField = BattingRecord::class.java.getDeclaredField("doubles")
+                    doublesField.isAccessible = true
+                    doublesField.set(this, 1)
 
-                val walksField = BattingRecord::class.java.getDeclaredField("walks")
-                walksField.isAccessible = true
-                walksField.set(this, 1)
+                    val walksField = BattingRecord::class.java.getDeclaredField("walks")
+                    walksField.isAccessible = true
+                    walksField.set(this, 1)
 
-                val strikeoutsField = BattingRecord::class.java.getDeclaredField("strikeouts")
-                strikeoutsField.isAccessible = true
-                strikeoutsField.set(this, 1)
+                    val strikeoutsField = BattingRecord::class.java.getDeclaredField("strikeouts")
+                    strikeoutsField.isAccessible = true
+                    strikeoutsField.set(this, 1)
 
-                val runsField = BattingRecord::class.java.getDeclaredField("runs")
-                runsField.isAccessible = true
-                runsField.set(this, 1)
+                    val runsField = BattingRecord::class.java.getDeclaredField("runs")
+                    runsField.isAccessible = true
+                    runsField.set(this, 1)
 
-                val rbiField = BattingRecord::class.java.getDeclaredField("runsBattedIn")
-                rbiField.isAccessible = true
-                rbiField.set(this, 1)
-            }
+                    val rbiField = BattingRecord::class.java.getDeclaredField("runsBattedIn")
+                    rbiField.isAccessible = true
+                    rbiField.set(this, 1)
+                }
 
             // when
             stats.addGameRecord(record)
@@ -119,19 +117,22 @@ class SeasonBattingStatsTest {
             val gamePlayer = mockk<GamePlayer>()
 
             // Game 1: 4타수 2안타 1홈런
-            val record1 = BattingRecord.create(gamePlayer).apply {
-                setStats(pa = 4, ab = 4, h = 2, hr = 1, runs = 2, rbi = 2)
-            }
+            val record1 =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 4, ab = 4, h = 2, hr = 1, runs = 2, rbi = 2)
+                }
 
             // Game 2: 3타수 1안타 1볼넷
-            val record2 = BattingRecord.create(gamePlayer).apply {
-                setStats(pa = 4, ab = 3, h = 1, bb = 1, runs = 0, rbi = 0)
-            }
+            val record2 =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 4, ab = 3, h = 1, bb = 1, runs = 0, rbi = 0)
+                }
 
             // Game 3: 5타수 3안타 (2루타 1개, 3루타 1개)
-            val record3 = BattingRecord.create(gamePlayer).apply {
-                setStats(pa = 5, ab = 5, h = 3, doubles = 1, triples = 1, runs = 1, rbi = 2)
-            }
+            val record3 =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 5, ab = 5, h = 3, doubles = 1, triples = 1, runs = 1, rbi = 2)
+                }
 
             // when
             stats.addGameRecord(record1)
@@ -155,7 +156,6 @@ class SeasonBattingStatsTest {
     @Nested
     @DisplayName("계산 속성 검증")
     inner class CalculatedProperties {
-
         @Test
         fun `should calculate batting average correctly`() {
             // given: 10타수 3안타 = .300
@@ -270,7 +270,6 @@ class SeasonBattingStatsTest {
     @Nested
     @DisplayName("유효성 검증")
     inner class Validation {
-
         @Test
         fun `should validate successfully with valid stats`() {
             // given
@@ -342,7 +341,7 @@ class SeasonBattingStatsTest {
         bb: Int = 0,
         hbp: Int = 0,
         runs: Int = 0,
-        rbi: Int = 0
+        rbi: Int = 0,
     ) {
         setField("plateAppearances", pa)
         setField("atBats", ab)
@@ -356,7 +355,10 @@ class SeasonBattingStatsTest {
         setField("runsBattedIn", rbi)
     }
 
-    private fun BattingRecord.setField(fieldName: String, value: Int) {
+    private fun BattingRecord.setField(
+        fieldName: String,
+        value: Int,
+    ) {
         val field = BattingRecord::class.java.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(this, value)
@@ -374,7 +376,7 @@ class SeasonBattingStatsTest {
         walks: Int = 0,
         hbp: Int = 0,
         stolenBases: Int = 0,
-        caughtStealing: Int = 0
+        caughtStealing: Int = 0,
     ) {
         val clazz = SeasonBattingStats::class.java
         setField(clazz, stats, "gamesPlayed", gamesPlayed)
@@ -390,7 +392,12 @@ class SeasonBattingStatsTest {
         setField(clazz, stats, "caughtStealing", caughtStealing)
     }
 
-    private fun setField(clazz: Class<*>, obj: Any, fieldName: String, value: Int) {
+    private fun setField(
+        clazz: Class<*>,
+        obj: Any,
+        fieldName: String,
+        value: Int,
+    ) {
         val field = clazz.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(obj, value)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonPitchingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonPitchingStatsTest.kt
@@ -18,19 +18,18 @@ import java.math.BigDecimal
 
 @DisplayName("SeasonPitchingStats 테스트")
 class SeasonPitchingStatsTest {
-
-    private val testPlayer = Player(
-        name = "박찬호",
-        primaryPosition = Position.STARTING_PITCHER,
-        throwingHand = ThrowingHand.RIGHT,
-        battingHand = BattingHand.RIGHT,
-        id = 1L
-    )
+    private val testPlayer =
+        Player(
+            name = "박찬호",
+            primaryPosition = Position.STARTING_PITCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
 
     @Nested
     @DisplayName("시즌 투수 통계 생성")
     inner class Create {
-
         @Test
         fun `should create season pitching stats successfully`() {
             // when
@@ -56,25 +55,25 @@ class SeasonPitchingStatsTest {
     @Nested
     @DisplayName("경기 기록 누적")
     inner class AddGameRecord {
-
         @Test
         fun `should accumulate single game record for starting pitcher correctly`() {
             // given
             val stats = SeasonPitchingStats.create(testPlayer, 2024)
             val gamePlayer = mockk<GamePlayer>()
-            val record = PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
-                // 6이닝 (18 outs), 2실점, 2자책, 5피안타, 2볼넷, 7삼진
-                setStats(
-                    inningsPitchedOuts = 18,
-                    earnedRuns = 2,
-                    runsAllowed = 2,
-                    hitsAllowed = 5,
-                    walksAllowed = 2,
-                    strikeouts = 7,
-                    battersFaced = 25,
-                    decision = PitchingDecision.WIN
-                )
-            }
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    // 6이닝 (18 outs), 2실점, 2자책, 5피안타, 2볼넷, 7삼진
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 2,
+                        runsAllowed = 2,
+                        hitsAllowed = 5,
+                        walksAllowed = 2,
+                        strikeouts = 7,
+                        battersFaced = 25,
+                        decision = PitchingDecision.WIN,
+                    )
+                }
 
             // when
             stats.addGameRecord(record)
@@ -98,19 +97,20 @@ class SeasonPitchingStatsTest {
             // given
             val stats = SeasonPitchingStats.create(testPlayer, 2024)
             val gamePlayer = mockk<GamePlayer>()
-            val record = PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
-                // 2이닝 (6 outs), 0실점, 세이브
-                setStats(
-                    inningsPitchedOuts = 6,
-                    earnedRuns = 0,
-                    runsAllowed = 0,
-                    hitsAllowed = 1,
-                    walksAllowed = 0,
-                    strikeouts = 3,
-                    battersFaced = 7,
-                    decision = PitchingDecision.SAVE
-                )
-            }
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
+                    // 2이닝 (6 outs), 0실점, 세이브
+                    setStats(
+                        inningsPitchedOuts = 6,
+                        earnedRuns = 0,
+                        runsAllowed = 0,
+                        hitsAllowed = 1,
+                        walksAllowed = 0,
+                        strikeouts = 3,
+                        battersFaced = 7,
+                        decision = PitchingDecision.SAVE,
+                    )
+                }
 
             // when
             stats.addGameRecord(record)
@@ -129,46 +129,49 @@ class SeasonPitchingStatsTest {
             val gamePlayer = mockk<GamePlayer>()
 
             // Game 1: 선발 6이닝 승리
-            val record1 = PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
-                setStats(
-                    inningsPitchedOuts = 18,
-                    earnedRuns = 2,
-                    runsAllowed = 2,
-                    hitsAllowed = 5,
-                    walksAllowed = 2,
-                    strikeouts = 6,
-                    battersFaced = 24,
-                    decision = PitchingDecision.WIN
-                )
-            }
+            val record1 =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 2,
+                        runsAllowed = 2,
+                        hitsAllowed = 5,
+                        walksAllowed = 2,
+                        strikeouts = 6,
+                        battersFaced = 24,
+                        decision = PitchingDecision.WIN,
+                    )
+                }
 
             // Game 2: 선발 7이닝 패배
-            val record2 = PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
-                setStats(
-                    inningsPitchedOuts = 21,
-                    earnedRuns = 4,
-                    runsAllowed = 4,
-                    hitsAllowed = 8,
-                    walksAllowed = 1,
-                    strikeouts = 5,
-                    battersFaced = 28,
-                    decision = PitchingDecision.LOSS
-                )
-            }
+            val record2 =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 21,
+                        earnedRuns = 4,
+                        runsAllowed = 4,
+                        hitsAllowed = 8,
+                        walksAllowed = 1,
+                        strikeouts = 5,
+                        battersFaced = 28,
+                        decision = PitchingDecision.LOSS,
+                    )
+                }
 
             // Game 3: 중계 2이닝 홀드
-            val record3 = PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
-                setStats(
-                    inningsPitchedOuts = 6,
-                    earnedRuns = 0,
-                    runsAllowed = 0,
-                    hitsAllowed = 1,
-                    walksAllowed = 1,
-                    strikeouts = 2,
-                    battersFaced = 7,
-                    decision = PitchingDecision.HOLD
-                )
-            }
+            val record3 =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
+                    setStats(
+                        inningsPitchedOuts = 6,
+                        earnedRuns = 0,
+                        runsAllowed = 0,
+                        hitsAllowed = 1,
+                        walksAllowed = 1,
+                        strikeouts = 2,
+                        battersFaced = 7,
+                        decision = PitchingDecision.HOLD,
+                    )
+                }
 
             // when
             stats.addGameRecord(record1)
@@ -192,13 +195,14 @@ class SeasonPitchingStatsTest {
             // given
             val stats = SeasonPitchingStats.create(testPlayer, 2024)
             val gamePlayer = mockk<GamePlayer>()
-            val record = PitchingRecord.create(gamePlayer).apply {
-                setStats(
-                    inningsPitchedOuts = 18,
-                    pitchesThrown = 95,
-                    strikesThrown = 63
-                )
-            }
+            val record =
+                PitchingRecord.create(gamePlayer).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        pitchesThrown = 95,
+                        strikesThrown = 63,
+                    )
+                }
 
             // when
             stats.addGameRecord(record)
@@ -212,7 +216,6 @@ class SeasonPitchingStatsTest {
     @Nested
     @DisplayName("계산 속성 검증")
     inner class CalculatedProperties {
-
         @Test
         fun `should calculate ERA correctly`() {
             // given: 18 outs (6이닝), 3자책 => ERA = (3/6)*9 = 4.50
@@ -359,7 +362,6 @@ class SeasonPitchingStatsTest {
     @Nested
     @DisplayName("유효성 검증")
     inner class Validation {
-
         @Test
         fun `should validate successfully with valid stats`() {
             // given
@@ -370,7 +372,7 @@ class SeasonPitchingStatsTest {
                 gamesStarted = 5,
                 inningsPitchedOuts = 60,
                 earnedRuns = 10,
-                runsAllowed = 12
+                runsAllowed = 12,
             )
 
             // when & then
@@ -438,7 +440,7 @@ class SeasonPitchingStatsTest {
         battersFaced: Int = 0,
         decision: PitchingDecision = PitchingDecision.NONE,
         pitchesThrown: Int? = null,
-        strikesThrown: Int? = null
+        strikesThrown: Int? = null,
     ) {
         setField("inningsPitchedOuts", inningsPitchedOuts)
         setField("earnedRuns", earnedRuns)
@@ -452,7 +454,10 @@ class SeasonPitchingStatsTest {
         setField("strikesThrown", strikesThrown)
     }
 
-    private fun PitchingRecord.setField(fieldName: String, value: Any?) {
+    private fun PitchingRecord.setField(
+        fieldName: String,
+        value: Any?,
+    ) {
         val field = PitchingRecord::class.java.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(this, value)
@@ -471,7 +476,7 @@ class SeasonPitchingStatsTest {
         walksAllowed: Int = 0,
         strikeouts: Int = 0,
         pitchesThrown: Int? = null,
-        strikesThrown: Int? = null
+        strikesThrown: Int? = null,
     ) {
         val clazz = SeasonPitchingStats::class.java
         setField(clazz, stats, "gamesPlayed", gamesPlayed)
@@ -488,7 +493,12 @@ class SeasonPitchingStatsTest {
         setField(clazz, stats, "strikesThrown", strikesThrown)
     }
 
-    private fun setField(clazz: Class<*>, obj: Any, fieldName: String, value: Any?) {
+    private fun setField(
+        clazz: Class<*>,
+        obj: Any,
+        fieldName: String,
+        value: Any?,
+    ) {
         val field = clazz.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(obj, value)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("Team 엔티티 테스트")
 class TeamTest {
-
     private lateinit var league: League
 
     @BeforeEach
@@ -22,21 +21,19 @@ class TeamTest {
     private fun createTeam(
         name: String = "타이거즈",
         city: String = "서울",
-        isActive: Boolean = true
-    ): Team {
-        return Team(
+        isActive: Boolean = true,
+    ): Team =
+        Team(
             league = league,
             name = name,
             city = city,
             foundedYear = 2015,
-            isActive = isActive
+            isActive = isActive,
         )
-    }
 
     @Nested
     @DisplayName("전체 이름")
     inner class FullName {
-
         @Test
         fun `도시명과 팀명을 합쳐서 반환한다`() {
             // given
@@ -50,7 +47,6 @@ class TeamTest {
     @Nested
     @DisplayName("비활성화")
     inner class Deactivate {
-
         @Test
         fun `팀을 비활성화할 수 있다`() {
             // given
@@ -67,7 +63,6 @@ class TeamTest {
     @Nested
     @DisplayName("활성화")
     inner class Activate {
-
         @Test
         fun `팀을 활성화할 수 있다`() {
             // given
@@ -84,7 +79,6 @@ class TeamTest {
     @Nested
     @DisplayName("정보 수정")
     inner class UpdateInfo {
-
         @Test
         fun `모든 정보를 수정할 수 있다`() {
             // given
@@ -94,7 +88,7 @@ class TeamTest {
             team.updateInfo(
                 logoUrl = "https://example.com/logo.png",
                 primaryColor = "#FF0000",
-                secondaryColor = "#FFFFFF"
+                secondaryColor = "#FFFFFF",
             )
 
             // then
@@ -106,13 +100,14 @@ class TeamTest {
         @Test
         fun `일부 정보만 수정할 수 있다`() {
             // given
-            val team = createTeam().apply {
-                updateInfo(
-                    logoUrl = "https://example.com/old-logo.png",
-                    primaryColor = "#0000FF",
-                    secondaryColor = "#000000"
-                )
-            }
+            val team =
+                createTeam().apply {
+                    updateInfo(
+                        logoUrl = "https://example.com/old-logo.png",
+                        primaryColor = "#0000FF",
+                        secondaryColor = "#000000",
+                    )
+                }
 
             // when
             team.updateInfo(primaryColor = "#FF0000")
@@ -126,9 +121,10 @@ class TeamTest {
         @Test
         fun `정보를 null로 설정할 수 있다`() {
             // given
-            val team = createTeam().apply {
-                updateInfo(logoUrl = "https://example.com/logo.png")
-            }
+            val team =
+                createTeam().apply {
+                    updateInfo(logoUrl = "https://example.com/logo.png")
+                }
 
             // when
             team.updateInfo(logoUrl = null)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/user/OAuthAccountTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/user/OAuthAccountTest.kt
@@ -8,31 +8,29 @@ import org.junit.jupiter.api.assertThrows
 
 @DisplayName("OAuthAccount 테스트")
 class OAuthAccountTest {
-
-    private fun createTestUser(): User {
-        return User.createLocalUser(
+    private fun createTestUser(): User =
+        User.createLocalUser(
             email = "test@example.com",
             encodedPassword = "password",
-            nickname = "테스터"
+            nickname = "테스터",
         )
-    }
 
     @Nested
     @DisplayName("OAuth 계정 생성")
     inner class Create {
-
         @Test
         fun `should create oauth account successfully`() {
             // given
             val user = createTestUser()
 
             // when
-            val account = OAuthAccount.create(
-                user = user,
-                provider = OAuthProvider.KAKAO,
-                oauthId = "kakao_12345",
-                email = "kakao@example.com"
-            )
+            val account =
+                OAuthAccount.create(
+                    user = user,
+                    provider = OAuthProvider.KAKAO,
+                    oauthId = "kakao_12345",
+                    email = "kakao@example.com",
+                )
 
             // then
             assertThat(account.user).isEqualTo(user)
@@ -48,11 +46,12 @@ class OAuthAccountTest {
             val user = createTestUser()
 
             // when
-            val account = OAuthAccount.create(
-                user = user,
-                provider = OAuthProvider.GOOGLE,
-                oauthId = "google_12345"
-            )
+            val account =
+                OAuthAccount.create(
+                    user = user,
+                    provider = OAuthProvider.GOOGLE,
+                    oauthId = "google_12345",
+                )
 
             // then
             assertThat(account.email).isNull()
@@ -68,7 +67,7 @@ class OAuthAccountTest {
                 OAuthAccount.create(
                     user = user,
                     provider = OAuthProvider.LOCAL,
-                    oauthId = "local_123"
+                    oauthId = "local_123",
                 )
             }
         }
@@ -83,7 +82,7 @@ class OAuthAccountTest {
                 OAuthAccount.create(
                     user = user,
                     provider = OAuthProvider.KAKAO,
-                    oauthId = ""
+                    oauthId = "",
                 )
             }
         }
@@ -98,7 +97,7 @@ class OAuthAccountTest {
                 OAuthAccount.create(
                     user = user,
                     provider = OAuthProvider.NAVER,
-                    oauthId = "   "
+                    oauthId = "   ",
                 )
             }
         }
@@ -107,25 +106,26 @@ class OAuthAccountTest {
     @Nested
     @DisplayName("OAuth Provider 종류")
     inner class ProviderTypes {
-
         @Test
         fun `should create account for each provider`() {
             // given
             val user = createTestUser()
-            val providers = listOf(
-                OAuthProvider.KAKAO,
-                OAuthProvider.GOOGLE,
-                OAuthProvider.NAVER,
-                OAuthProvider.APPLE
-            )
+            val providers =
+                listOf(
+                    OAuthProvider.KAKAO,
+                    OAuthProvider.GOOGLE,
+                    OAuthProvider.NAVER,
+                    OAuthProvider.APPLE,
+                )
 
             // when & then
             providers.forEach { provider ->
-                val account = OAuthAccount.create(
-                    user = user,
-                    provider = provider,
-                    oauthId = "${provider.name.lowercase()}_123"
-                )
+                val account =
+                    OAuthAccount.create(
+                        user = user,
+                        provider = provider,
+                        oauthId = "${provider.name.lowercase()}_123",
+                    )
                 assertThat(account.provider).isEqualTo(provider)
             }
         }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/user/UserTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/user/UserTest.kt
@@ -8,19 +8,18 @@ import org.junit.jupiter.api.assertThrows
 
 @DisplayName("User 테스트")
 class UserTest {
-
     @Nested
     @DisplayName("LOCAL 사용자 생성")
     inner class CreateLocalUser {
-
         @Test
         fun `should create local user successfully`() {
             // when
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "encoded_password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "encoded_password",
+                    nickname = "테스터",
+                )
 
             // then
             assertThat(user.email).isEqualTo("test@example.com")
@@ -39,7 +38,7 @@ class UserTest {
                 User.createLocalUser(
                     email = "",
                     encodedPassword = "password",
-                    nickname = "테스터"
+                    nickname = "테스터",
                 )
             }
         }
@@ -51,7 +50,7 @@ class UserTest {
                 User.createLocalUser(
                     email = "test@example.com",
                     encodedPassword = "",
-                    nickname = "테스터"
+                    nickname = "테스터",
                 )
             }
         }
@@ -63,7 +62,7 @@ class UserTest {
                 User.createLocalUser(
                     email = "test@example.com",
                     encodedPassword = "password",
-                    nickname = ""
+                    nickname = "",
                 )
             }
         }
@@ -72,17 +71,17 @@ class UserTest {
     @Nested
     @DisplayName("OAuth 사용자 생성")
     inner class CreateOAuthUser {
-
         @Test
         fun `should create oauth user successfully`() {
             // when
-            val user = User.createOAuthUser(
-                email = "oauth@example.com",
-                nickname = "OAuth테스터",
-                provider = OAuthProvider.KAKAO,
-                oauthId = "kakao_12345",
-                profileImageUrl = "http://example.com/profile.jpg"
-            )
+            val user =
+                User.createOAuthUser(
+                    email = "oauth@example.com",
+                    nickname = "OAuth테스터",
+                    provider = OAuthProvider.KAKAO,
+                    oauthId = "kakao_12345",
+                    profileImageUrl = "http://example.com/profile.jpg",
+                )
 
             // then
             assertThat(user.email).isEqualTo("oauth@example.com")
@@ -103,7 +102,7 @@ class UserTest {
                     email = "test@example.com",
                     nickname = "테스터",
                     provider = OAuthProvider.LOCAL,
-                    oauthId = "local_123"
+                    oauthId = "local_123",
                 )
             }
         }
@@ -112,15 +111,15 @@ class UserTest {
     @Nested
     @DisplayName("OAuth 계정 연동")
     inner class OAuthAccountLink {
-
         @Test
         fun `should add oauth account to local user`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
 
             // when
             user.addOAuthAccount(OAuthProvider.GOOGLE, "google_123", "google@example.com")
@@ -134,11 +133,12 @@ class UserTest {
         @Test
         fun `should add multiple oauth accounts`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
 
             // when
             user.addOAuthAccount(OAuthProvider.KAKAO, "kakao_123")
@@ -153,12 +153,13 @@ class UserTest {
         @Test
         fun `should throw exception when adding duplicate provider`() {
             // given
-            val user = User.createOAuthUser(
-                email = "test@example.com",
-                nickname = "테스터",
-                provider = OAuthProvider.KAKAO,
-                oauthId = "kakao_123"
-            )
+            val user =
+                User.createOAuthUser(
+                    email = "test@example.com",
+                    nickname = "테스터",
+                    provider = OAuthProvider.KAKAO,
+                    oauthId = "kakao_123",
+                )
 
             // when & then
             assertThrows<IllegalArgumentException> {
@@ -169,11 +170,12 @@ class UserTest {
         @Test
         fun `should remove oauth account when multiple auth methods exist`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
             user.addOAuthAccount(OAuthProvider.KAKAO, "kakao_123")
             user.addOAuthAccount(OAuthProvider.GOOGLE, "google_123")
 
@@ -189,12 +191,13 @@ class UserTest {
         @Test
         fun `should throw exception when removing last auth method`() {
             // given
-            val user = User.createOAuthUser(
-                email = "test@example.com",
-                nickname = "테스터",
-                provider = OAuthProvider.KAKAO,
-                oauthId = "kakao_123"
-            )
+            val user =
+                User.createOAuthUser(
+                    email = "test@example.com",
+                    nickname = "테스터",
+                    provider = OAuthProvider.KAKAO,
+                    oauthId = "kakao_123",
+                )
 
             // when & then
             assertThrows<IllegalArgumentException> {
@@ -206,15 +209,15 @@ class UserTest {
     @Nested
     @DisplayName("인증 수단 관리")
     inner class AuthMethodManagement {
-
         @Test
         fun `should allow removing auth method when multiple exist`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
             user.addOAuthAccount(OAuthProvider.KAKAO, "kakao_123")
 
             // when & then
@@ -224,11 +227,12 @@ class UserTest {
         @Test
         fun `should not allow removing last auth method`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
 
             // when & then
             assertThat(user.canRemoveAuthMethod()).isFalse()
@@ -237,11 +241,12 @@ class UserTest {
         @Test
         fun `should remove password when oauth account exists`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
             user.addOAuthAccount(OAuthProvider.KAKAO, "kakao_123")
 
             // when
@@ -255,11 +260,12 @@ class UserTest {
         @Test
         fun `should throw exception when removing password without oauth`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
 
             // when & then
             assertThrows<IllegalArgumentException> {
@@ -271,15 +277,15 @@ class UserTest {
     @Nested
     @DisplayName("역할 관리")
     inner class RoleManagement {
-
         @Test
         fun `should add role successfully`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
 
             // when
             user.addRole(Role.ADMIN)
@@ -292,11 +298,12 @@ class UserTest {
         @Test
         fun `should remove role successfully`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
             user.addRole(Role.SCORER)
 
             // when
@@ -309,11 +316,12 @@ class UserTest {
         @Test
         fun `should throw exception when removing USER role`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
 
             // when & then
             assertThrows<IllegalArgumentException> {
@@ -325,20 +333,20 @@ class UserTest {
     @Nested
     @DisplayName("프로필 업데이트")
     inner class ProfileUpdate {
-
         @Test
         fun `should update profile successfully`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "원래닉네임"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "원래닉네임",
+                )
 
             // when
             user.updateProfile(
                 nickname = "새닉네임",
-                profileImageUrl = "http://example.com/new-profile.jpg"
+                profileImageUrl = "http://example.com/new-profile.jpg",
             )
 
             // then
@@ -349,11 +357,12 @@ class UserTest {
         @Test
         fun `should change password successfully`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "old_password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "old_password",
+                    nickname = "테스터",
+                )
 
             // when
             user.changePassword("new_password")
@@ -366,15 +375,15 @@ class UserTest {
     @Nested
     @DisplayName("계정 상태 관리")
     inner class AccountStatus {
-
         @Test
         fun `should deactivate account`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
 
             // when
             user.deactivate()
@@ -386,11 +395,12 @@ class UserTest {
         @Test
         fun `should activate account`() {
             // given
-            val user = User.createLocalUser(
-                email = "test@example.com",
-                encodedPassword = "password",
-                nickname = "테스터"
-            )
+            val user =
+                User.createLocalUser(
+                    email = "test@example.com",
+                    encodedPassword = "password",
+                    nickname = "테스터",
+                )
             user.deactivate()
 
             // when

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/admin/OrganizationAdminServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/admin/OrganizationAdminServiceTest.kt
@@ -8,8 +8,8 @@ import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.team.Team
 import com.nextup.core.domain.user.User
-import com.nextup.core.port.repository.TeamRepositoryPort
 import com.nextup.core.port.repository.OrganizationAdminRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
 import com.nextup.core.port.repository.UserRepositoryPort
 import io.mockk.every
 import io.mockk.mockk
@@ -24,7 +24,6 @@ import java.util.*
 
 @DisplayName("OrganizationAdminService")
 class OrganizationAdminServiceTest {
-
     private lateinit var organizationAdminRepository: OrganizationAdminRepositoryPort
     private lateinit var userRepository: UserRepositoryPort
     private lateinit var teamRepository: TeamRepositoryPort
@@ -35,17 +34,17 @@ class OrganizationAdminServiceTest {
         organizationAdminRepository = mockk()
         userRepository = mockk()
         teamRepository = mockk()
-        organizationAdminService = OrganizationAdminService(
-            organizationAdminRepository,
-            userRepository,
-            teamRepository
-        )
+        organizationAdminService =
+            OrganizationAdminService(
+                organizationAdminRepository,
+                userRepository,
+                teamRepository,
+            )
     }
 
     @Nested
     @DisplayName("assignAdmin")
     inner class AssignAdmin {
-
         @Test
         fun `관리자를 할당할 수 있다`() {
             // given
@@ -58,18 +57,21 @@ class OrganizationAdminServiceTest {
             every { userRepository.findByIdOrNull(userId) } returns user
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, organizationType, organizationId
+                    userId,
+                    organizationType,
+                    organizationId,
                 )
             } returns null
             every { organizationAdminRepository.save(any()) } answers { firstArg() }
 
             // when
-            val admin = organizationAdminService.assignAdmin(
-                userId = userId,
-                organizationType = organizationType,
-                organizationId = organizationId,
-                role = role
-            )
+            val admin =
+                organizationAdminService.assignAdmin(
+                    userId = userId,
+                    organizationType = organizationType,
+                    organizationId = organizationId,
+                    role = role,
+                )
 
             // then
             assertThat(admin.user.id).isEqualTo(userId)
@@ -92,7 +94,7 @@ class OrganizationAdminServiceTest {
                     userId = userId,
                     organizationType = OrganizationType.ASSOCIATION,
                     organizationId = 1L,
-                    role = OrganizationRole.ADMIN
+                    role = OrganizationRole.ADMIN,
                 )
             }.isInstanceOf(UserNotFoundException::class.java)
         }
@@ -109,7 +111,9 @@ class OrganizationAdminServiceTest {
             every { userRepository.findByIdOrNull(userId) } returns user
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, organizationType, organizationId
+                    userId,
+                    organizationType,
+                    organizationId,
                 )
             } returns existingAdmin
 
@@ -119,7 +123,7 @@ class OrganizationAdminServiceTest {
                     userId = userId,
                     organizationType = organizationType,
                     organizationId = organizationId,
-                    role = OrganizationRole.MANAGER
+                    role = OrganizationRole.MANAGER,
                 )
             }.isInstanceOf(OrganizationAdminAlreadyExistsException::class.java)
         }
@@ -143,13 +147,16 @@ class OrganizationAdminServiceTest {
             every { userRepository.findByIdOrNull(userId) } returns user
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, OrganizationType.TEAM, team2Id
+                    userId,
+                    OrganizationType.TEAM,
+                    team2Id,
                 )
             } returns null
             every { teamRepository.findByIdWithLeague(team2Id) } returns team2
             every {
                 organizationAdminRepository.findActiveByUserIdAndOrganizationType(
-                    userId, OrganizationType.TEAM
+                    userId,
+                    OrganizationType.TEAM,
                 )
             } returns listOf(existingAdmin)
             every { teamRepository.findByIdWithLeague(team1Id) } returns team1
@@ -160,7 +167,7 @@ class OrganizationAdminServiceTest {
                     userId = userId,
                     organizationType = OrganizationType.TEAM,
                     organizationId = team2Id,
-                    role = OrganizationRole.ADMIN
+                    role = OrganizationRole.ADMIN,
                 )
             }.isInstanceOf(SameLeagueConflictException::class.java)
                 .hasMessageContaining("leagueId=$leagueId")
@@ -189,25 +196,29 @@ class OrganizationAdminServiceTest {
             every { userRepository.findByIdOrNull(userId) } returns user
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, OrganizationType.TEAM, team2Id
+                    userId,
+                    OrganizationType.TEAM,
+                    team2Id,
                 )
             } returns null
             every { teamRepository.findByIdWithLeague(team2Id) } returns team2
             every {
                 organizationAdminRepository.findActiveByUserIdAndOrganizationType(
-                    userId, OrganizationType.TEAM
+                    userId,
+                    OrganizationType.TEAM,
                 )
             } returns listOf(existingAdmin)
             every { teamRepository.findByIdWithLeague(team1Id) } returns team1
             every { organizationAdminRepository.save(any()) } answers { firstArg() }
 
             // when
-            val admin = organizationAdminService.assignAdmin(
-                userId = userId,
-                organizationType = OrganizationType.TEAM,
-                organizationId = team2Id,
-                role = OrganizationRole.ADMIN
-            )
+            val admin =
+                organizationAdminService.assignAdmin(
+                    userId = userId,
+                    organizationType = OrganizationType.TEAM,
+                    organizationId = team2Id,
+                    role = OrganizationRole.ADMIN,
+                )
 
             // then
             assertThat(admin.organizationId).isEqualTo(team2Id)
@@ -218,7 +229,6 @@ class OrganizationAdminServiceTest {
     @Nested
     @DisplayName("removeAdmin")
     inner class RemoveAdmin {
-
         @Test
         fun `관리자 권한을 해제할 수 있다`() {
             // given
@@ -230,7 +240,9 @@ class OrganizationAdminServiceTest {
 
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, organizationType, organizationId
+                    userId,
+                    organizationType,
+                    organizationId,
                 )
             } returns admin
 
@@ -247,7 +259,9 @@ class OrganizationAdminServiceTest {
             val userId = 1L
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, OrganizationType.ASSOCIATION, 1L
+                    userId,
+                    OrganizationType.ASSOCIATION,
+                    1L,
                 )
             } returns null
 
@@ -256,7 +270,7 @@ class OrganizationAdminServiceTest {
                 organizationAdminService.removeAdmin(
                     userId = userId,
                     organizationType = OrganizationType.ASSOCIATION,
-                    organizationId = 1L
+                    organizationId = 1L,
                 )
             }.isInstanceOf(OrganizationAdminNotFoundException::class.java)
         }
@@ -265,7 +279,6 @@ class OrganizationAdminServiceTest {
     @Nested
     @DisplayName("getAdminsByOrganization")
     inner class GetAdminsByOrganization {
-
         @Test
         fun `특정 조직의 관리자 목록을 조회할 수 있다`() {
             // given
@@ -278,7 +291,8 @@ class OrganizationAdminServiceTest {
 
             every {
                 organizationAdminRepository.findActiveByOrganizationTypeAndOrganizationId(
-                    organizationType, organizationId
+                    organizationType,
+                    organizationId,
                 )
             } returns listOf(admin1, admin2)
 
@@ -294,7 +308,6 @@ class OrganizationAdminServiceTest {
     @Nested
     @DisplayName("getOrganizationsByUser")
     inner class GetOrganizationsByUser {
-
         @Test
         fun `사용자가 관리하는 모든 조직을 조회할 수 있다`() {
             // given
@@ -312,7 +325,7 @@ class OrganizationAdminServiceTest {
             assertThat(organizations).hasSize(2)
             assertThat(organizations.map { it.organizationType }).containsExactlyInAnyOrder(
                 OrganizationType.ASSOCIATION,
-                OrganizationType.LEAGUE
+                OrganizationType.LEAGUE,
             )
         }
     }
@@ -320,7 +333,6 @@ class OrganizationAdminServiceTest {
     @Nested
     @DisplayName("changeRole")
     inner class ChangeRole {
-
         @Test
         fun `관리자 역할을 변경할 수 있다`() {
             // given
@@ -332,14 +344,20 @@ class OrganizationAdminServiceTest {
 
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, organizationType, organizationId
+                    userId,
+                    organizationType,
+                    organizationId,
                 )
             } returns admin
 
             // when
-            val updated = organizationAdminService.changeRole(
-                userId, organizationType, organizationId, OrganizationRole.MANAGER
-            )
+            val updated =
+                organizationAdminService.changeRole(
+                    userId,
+                    organizationType,
+                    organizationId,
+                    OrganizationRole.MANAGER,
+                )
 
             // then
             assertThat(updated.role).isEqualTo(OrganizationRole.MANAGER)
@@ -357,14 +375,19 @@ class OrganizationAdminServiceTest {
 
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, organizationType, organizationId
+                    userId,
+                    organizationType,
+                    organizationId,
                 )
             } returns admin
 
             // when & then
             assertThatThrownBy {
                 organizationAdminService.changeRole(
-                    userId, organizationType, organizationId, OrganizationRole.MANAGER
+                    userId,
+                    organizationType,
+                    organizationId,
+                    OrganizationRole.MANAGER,
                 )
             }.isInstanceOf(OrganizationAdminDeactivatedException::class.java)
         }
@@ -373,29 +396,38 @@ class OrganizationAdminServiceTest {
     @Nested
     @DisplayName("hasPermission")
     inner class HasPermission {
-
         @Test
         fun `사용자가 특정 조직에 대한 권한을 가지고 있는지 확인할 수 있다`() {
             // given
             val userId = 1L
             every {
                 organizationAdminRepository.existsActiveByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, OrganizationType.ASSOCIATION, 1L
+                    userId,
+                    OrganizationType.ASSOCIATION,
+                    1L,
                 )
             } returns true
             every {
                 organizationAdminRepository.existsActiveByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, OrganizationType.LEAGUE, 2L
+                    userId,
+                    OrganizationType.LEAGUE,
+                    2L,
                 )
             } returns false
 
             // when
-            val hasPermission = organizationAdminService.hasPermission(
-                userId, OrganizationType.ASSOCIATION, 1L
-            )
-            val noPermission = organizationAdminService.hasPermission(
-                userId, OrganizationType.LEAGUE, 2L
-            )
+            val hasPermission =
+                organizationAdminService.hasPermission(
+                    userId,
+                    OrganizationType.ASSOCIATION,
+                    1L,
+                )
+            val noPermission =
+                organizationAdminService.hasPermission(
+                    userId,
+                    OrganizationType.LEAGUE,
+                    2L,
+                )
 
             // then
             assertThat(hasPermission).isTrue()
@@ -406,7 +438,6 @@ class OrganizationAdminServiceTest {
     @Nested
     @DisplayName("getById")
     inner class GetById {
-
         @Test
         fun `ID로 관리자를 조회할 수 있다`() {
             // given
@@ -440,7 +471,6 @@ class OrganizationAdminServiceTest {
     @Nested
     @DisplayName("validateSameLeagueConflict edge cases")
     inner class ValidateSameLeagueConflictEdgeCases {
-
         @Test
         fun `새 팀을 찾을 수 없으면 TeamNotFoundException 발생`() {
             // given
@@ -451,7 +481,9 @@ class OrganizationAdminServiceTest {
             every { userRepository.findByIdOrNull(userId) } returns user
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, OrganizationType.TEAM, newTeamId
+                    userId,
+                    OrganizationType.TEAM,
+                    newTeamId,
                 )
             } returns null
             every { teamRepository.findByIdWithLeague(newTeamId) } returns null
@@ -462,7 +494,7 @@ class OrganizationAdminServiceTest {
                     userId = userId,
                     organizationType = OrganizationType.TEAM,
                     organizationId = newTeamId,
-                    role = OrganizationRole.ADMIN
+                    role = OrganizationRole.ADMIN,
                 )
             }.isInstanceOf(TeamNotFoundException::class.java)
         }
@@ -484,25 +516,29 @@ class OrganizationAdminServiceTest {
             every { userRepository.findByIdOrNull(userId) } returns user
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, OrganizationType.TEAM, newTeamId
+                    userId,
+                    OrganizationType.TEAM,
+                    newTeamId,
                 )
             } returns null
             every { teamRepository.findByIdWithLeague(newTeamId) } returns newTeam
             every {
                 organizationAdminRepository.findActiveByUserIdAndOrganizationType(
-                    userId, OrganizationType.TEAM
+                    userId,
+                    OrganizationType.TEAM,
                 )
             } returns listOf(existingAdmin)
             every { teamRepository.findByIdWithLeague(existingTeamId) } returns null
             every { organizationAdminRepository.save(any()) } answers { firstArg() }
 
             // when
-            val admin = organizationAdminService.assignAdmin(
-                userId = userId,
-                organizationType = OrganizationType.TEAM,
-                organizationId = newTeamId,
-                role = OrganizationRole.ADMIN
-            )
+            val admin =
+                organizationAdminService.assignAdmin(
+                    userId = userId,
+                    organizationType = OrganizationType.TEAM,
+                    organizationId = newTeamId,
+                    role = OrganizationRole.ADMIN,
+                )
 
             // then
             assertThat(admin.organizationId).isEqualTo(newTeamId)
@@ -513,21 +549,25 @@ class OrganizationAdminServiceTest {
     @Nested
     @DisplayName("changeRole edge cases")
     inner class ChangeRoleEdgeCases {
-
         @Test
         fun `존재하지 않는 관리자의 역할을 변경하면 예외가 발생한다`() {
             // given
             val userId = 1L
             every {
                 organizationAdminRepository.findByUserIdAndOrganizationTypeAndOrganizationId(
-                    userId, OrganizationType.ASSOCIATION, 1L
+                    userId,
+                    OrganizationType.ASSOCIATION,
+                    1L,
                 )
             } returns null
 
             // when & then
             assertThatThrownBy {
                 organizationAdminService.changeRole(
-                    userId, OrganizationType.ASSOCIATION, 1L, OrganizationRole.MANAGER
+                    userId,
+                    OrganizationType.ASSOCIATION,
+                    1L,
+                    OrganizationRole.MANAGER,
                 )
             }.isInstanceOf(OrganizationAdminNotFoundException::class.java)
         }
@@ -535,44 +575,62 @@ class OrganizationAdminServiceTest {
 
     // Helper methods
 
-    private fun createUser(id: Long, email: String): User {
-        val user = User.createLocalUser(
-            email = email,
-            encodedPassword = "password",
-            nickname = "Test User"
-        )
+    private fun createUser(
+        id: Long,
+        email: String,
+    ): User {
+        val user =
+            User.createLocalUser(
+                email = email,
+                encodedPassword = "password",
+                nickname = "Test User",
+            )
         setEntityId(user, id)
         return user
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
-        val association = Association(
-            name = name,
-            abbreviation = name.substring(0, 2),
-            region = "Seoul"
-        )
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association {
+        val association =
+            Association(
+                name = name,
+                abbreviation = name.substring(0, 2),
+                region = "Seoul",
+            )
         setEntityId(association, id)
         return association
     }
 
-    private fun createLeague(id: Long, name: String, association: Association): League {
-        val league = League(
-            association = association,
-            name = name,
-            abbreviation = name.substring(0, 2),
-            foundedYear = 2020
-        )
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association,
+    ): League {
+        val league =
+            League(
+                association = association,
+                name = name,
+                abbreviation = name.substring(0, 2),
+                foundedYear = 2020,
+            )
         setEntityId(league, id)
         return league
     }
 
-    private fun createTeam(id: Long, name: String, league: League): Team {
-        val team = Team(
-            league = league,
-            name = name,
-            city = "Seoul",
-            foundedYear = 2020
-        )
+    private fun createTeam(
+        id: Long,
+        name: String,
+        league: League,
+    ): Team {
+        val team =
+            Team(
+                league = league,
+                name = name,
+                city = "Seoul",
+                foundedYear = 2020,
+            )
         setEntityId(team, id)
         return team
     }
@@ -582,19 +640,23 @@ class OrganizationAdminServiceTest {
         user: User,
         organizationType: OrganizationType,
         organizationId: Long,
-        role: OrganizationRole = OrganizationRole.ADMIN
+        role: OrganizationRole = OrganizationRole.ADMIN,
     ): OrganizationAdmin {
-        val admin = OrganizationAdmin.create(
-            user = user,
-            organizationType = organizationType,
-            organizationId = organizationId,
-            role = role
-        )
+        val admin =
+            OrganizationAdmin.create(
+                user = user,
+                organizationType = organizationType,
+                organizationId = organizationId,
+                role = role,
+            )
         setEntityId(admin, id)
         return admin
     }
 
-    private fun setEntityId(entity: Any, id: Long) {
+    private fun setEntityId(
+        entity: Any,
+        id: Long,
+    ) {
         val idField = entity::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(entity, id)

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/association/AssociationServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/association/AssociationServiceTest.kt
@@ -13,11 +13,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.util.Optional
 
 @DisplayName("AssociationService")
 class AssociationServiceTest {
-
     private lateinit var associationRepository: AssociationRepositoryPort
     private lateinit var associationService: AssociationService
 
@@ -30,7 +28,6 @@ class AssociationServiceTest {
     @Nested
     @DisplayName("create")
     inner class Create {
-
         @Test
         fun `should create association successfully`() {
             // given
@@ -40,12 +37,13 @@ class AssociationServiceTest {
             every { associationRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = associationService.create(
-                name = name,
-                abbreviation = "서야협",
-                region = region,
-                description = "서울시 사회인 야구 협회"
-            )
+            val result =
+                associationService.create(
+                    name = name,
+                    abbreviation = "서야협",
+                    region = region,
+                    description = "서울시 사회인 야구 협회",
+                )
 
             // then
             assertThat(result.name).isEqualTo(name)
@@ -70,7 +68,6 @@ class AssociationServiceTest {
     @Nested
     @DisplayName("getById")
     inner class GetById {
-
         @Test
         fun `should return association when found`() {
             // given
@@ -102,14 +99,14 @@ class AssociationServiceTest {
     @Nested
     @DisplayName("getAllActive")
     inner class GetAllActive {
-
         @Test
         fun `should return only active associations`() {
             // given
-            val associations = listOf(
-                createAssociation(1L, "서울시야구협회"),
-                createAssociation(2L, "경기도야구협회")
-            )
+            val associations =
+                listOf(
+                    createAssociation(1L, "서울시야구협회"),
+                    createAssociation(2L, "경기도야구협회"),
+                )
             every { associationRepository.findAllActive() } returns associations
 
             // when
@@ -123,7 +120,6 @@ class AssociationServiceTest {
     @Nested
     @DisplayName("update")
     inner class Update {
-
         @Test
         fun `should update association info`() {
             // given
@@ -132,11 +128,12 @@ class AssociationServiceTest {
             every { associationRepository.findByIdOrNull(id) } returns association
 
             // when
-            val result = associationService.update(
-                id = id,
-                description = "새로운 설명",
-                logoUrl = "https://example.com/logo.png"
-            )
+            val result =
+                associationService.update(
+                    id = id,
+                    description = "새로운 설명",
+                    logoUrl = "https://example.com/logo.png",
+                )
 
             // then
             assertThat(result.description).isEqualTo("새로운 설명")
@@ -147,7 +144,6 @@ class AssociationServiceTest {
     @Nested
     @DisplayName("deactivate/activate")
     inner class DeactivateActivate {
-
         @Test
         fun `should deactivate association`() {
             // given
@@ -177,19 +173,21 @@ class AssociationServiceTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
-        return Association(
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association =
+        Association(
             name = name,
             abbreviation = null,
             region = "서울",
             description = null,
             logoUrl = null,
-            websiteUrl = null
+            websiteUrl = null,
         ).apply {
             // 테스트용으로 ID를 설정하기 위해 리플렉션 사용
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/competition/CompetitionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/competition/CompetitionServiceTest.kt
@@ -20,11 +20,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.util.Optional
 
 @DisplayName("CompetitionService")
 class CompetitionServiceTest {
-
     private lateinit var competitionRepository: CompetitionRepositoryPort
     private lateinit var leagueRepository: LeagueRepositoryPort
     private lateinit var competitionService: CompetitionService
@@ -39,7 +37,6 @@ class CompetitionServiceTest {
     @Nested
     @DisplayName("create")
     inner class Create {
-
         @Test
         fun `should create competition successfully`() {
             // given
@@ -56,15 +53,16 @@ class CompetitionServiceTest {
             every { competitionRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = competitionService.create(
-                leagueId = leagueId,
-                name = name,
-                year = year,
-                season = season,
-                type = CompetitionType.LEAGUE,
-                startDate = startDate,
-                description = "2025년 춘계 정규 리그"
-            )
+            val result =
+                competitionService.create(
+                    leagueId = leagueId,
+                    name = name,
+                    year = year,
+                    season = season,
+                    type = CompetitionType.LEAGUE,
+                    startDate = startDate,
+                    description = "2025년 춘계 정규 리그",
+                )
 
             // then
             assertThat(result.name).isEqualTo(name)
@@ -87,7 +85,7 @@ class CompetitionServiceTest {
                     leagueId = leagueId,
                     name = "2025 춘계대회",
                     year = 2025,
-                    startDate = LocalDate.of(2025, 3, 1)
+                    startDate = LocalDate.of(2025, 3, 1),
                 )
             }.isInstanceOf(LeagueNotFoundException::class.java)
         }
@@ -103,7 +101,8 @@ class CompetitionServiceTest {
             val existingCompetition = createCompetition(1L, league, "2025 춘계대회", year, season)
 
             every { leagueRepository.findByIdOrNull(leagueId) } returns league
-            every { competitionRepository.findByLeagueIdAndYearAndSeason(leagueId, year, season) } returns existingCompetition
+            every { competitionRepository.findByLeagueIdAndYearAndSeason(leagueId, year, season) } returns
+                existingCompetition
 
             // when & then
             assertThatThrownBy {
@@ -112,7 +111,7 @@ class CompetitionServiceTest {
                     name = "2025 춘계대회",
                     year = year,
                     season = season,
-                    startDate = LocalDate.of(2025, 3, 1)
+                    startDate = LocalDate.of(2025, 3, 1),
                 )
             }.isInstanceOf(InvalidCompetitionStateException::class.java)
         }
@@ -121,7 +120,6 @@ class CompetitionServiceTest {
     @Nested
     @DisplayName("getById")
     inner class GetById {
-
         @Test
         fun `should return competition when found`() {
             // given
@@ -155,16 +153,16 @@ class CompetitionServiceTest {
     @Nested
     @DisplayName("getInProgress")
     inner class GetInProgress {
-
         @Test
         fun `should return only in-progress competitions`() {
             // given
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
-            val competitions = listOf(
-                createCompetition(1L, league, "2025 춘계대회", 2025, 1).apply { start() },
-                createCompetition(2L, league, "2025 하계대회", 2025, 2).apply { start() }
-            )
+            val competitions =
+                listOf(
+                    createCompetition(1L, league, "2025 춘계대회", 2025, 1).apply { start() },
+                    createCompetition(2L, league, "2025 하계대회", 2025, 2).apply { start() },
+                )
             every { competitionRepository.findInProgressCompetitions() } returns competitions
 
             // when
@@ -179,17 +177,17 @@ class CompetitionServiceTest {
     @Nested
     @DisplayName("getByLeagueId")
     inner class GetByLeagueId {
-
         @Test
         fun `should return competitions by league`() {
             // given
             val leagueId = 1L
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(leagueId, "1부 리그", association)
-            val competitions = listOf(
-                createCompetition(1L, league, "2025 춘계대회", 2025, 1),
-                createCompetition(2L, league, "2025 하계대회", 2025, 2)
-            )
+            val competitions =
+                listOf(
+                    createCompetition(1L, league, "2025 춘계대회", 2025, 1),
+                    createCompetition(2L, league, "2025 하계대회", 2025, 2),
+                )
             every { competitionRepository.findByLeagueId(leagueId) } returns competitions
 
             // when
@@ -204,7 +202,6 @@ class CompetitionServiceTest {
     @Nested
     @DisplayName("start")
     inner class Start {
-
         @Test
         fun `should start scheduled competition`() {
             // given
@@ -240,7 +237,6 @@ class CompetitionServiceTest {
     @Nested
     @DisplayName("complete")
     inner class Complete {
-
         @Test
         fun `should complete in-progress competition`() {
             // given
@@ -278,7 +274,6 @@ class CompetitionServiceTest {
     @Nested
     @DisplayName("cancel")
     inner class Cancel {
-
         @Test
         fun `should cancel scheduled competition`() {
             // given
@@ -317,10 +312,11 @@ class CompetitionServiceTest {
             val id = 1L
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
-            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1).apply {
-                start()
-                complete()
-            }
+            val competition =
+                createCompetition(id, league, "2025 춘계대회", 2025, 1).apply {
+                    start()
+                    complete()
+                }
             every { competitionRepository.findByIdOrNull(id) } returns competition
 
             // when & then
@@ -330,45 +326,50 @@ class CompetitionServiceTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
-        return Association(
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association =
+        Association(
             name = name,
             abbreviation = null,
             region = "서울",
             description = null,
             logoUrl = null,
-            websiteUrl = null
+            websiteUrl = null,
         ).apply {
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
-    private fun createLeague(id: Long, name: String, association: Association): League {
-        return League(
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association,
+    ): League =
+        League(
             association = association,
             name = name,
             abbreviation = null,
             foundedYear = 2020,
             divisionLevel = 1,
             description = null,
-            logoUrl = null
+            logoUrl = null,
         ).apply {
             val idField = League::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
     private fun createCompetition(
         id: Long,
         league: League,
         name: String,
         year: Int,
-        season: Int
-    ): Competition {
-        return Competition(
+        season: Int,
+    ): Competition =
+        Competition(
             league = league,
             name = name,
             year = year,
@@ -377,11 +378,10 @@ class CompetitionServiceTest {
             startDate = LocalDate.of(year, 3, 1),
             endDate = null,
             description = null,
-            maxTeams = null
+            maxTeams = null,
         ).apply {
             val idField = Competition::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/BattingRecordServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/BattingRecordServiceTest.kt
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class BattingRecordServiceTest {
-
     private lateinit var battingRecordRepository: BattingRecordRepositoryPort
     private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var battingRecordService: BattingRecordService
@@ -29,10 +28,11 @@ class BattingRecordServiceTest {
     fun setUp() {
         battingRecordRepository = mockk()
         gamePlayerRepository = mockk()
-        battingRecordService = BattingRecordService(
-            battingRecordRepository = battingRecordRepository,
-            gamePlayerRepository = gamePlayerRepository
-        )
+        battingRecordService =
+            BattingRecordService(
+                battingRecordRepository = battingRecordRepository,
+                gamePlayerRepository = gamePlayerRepository,
+            )
 
         mockGamePlayer = mockk(relaxed = true)
         mockBattingRecord = mockk(relaxed = true)

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/PitchingRecordServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/PitchingRecordServiceTest.kt
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class PitchingRecordServiceTest {
-
     private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
     private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var pitchingRecordService: PitchingRecordService
@@ -28,10 +27,11 @@ class PitchingRecordServiceTest {
     fun setUp() {
         pitchingRecordRepository = mockk()
         gamePlayerRepository = mockk()
-        pitchingRecordService = PitchingRecordService(
-            pitchingRecordRepository = pitchingRecordRepository,
-            gamePlayerRepository = gamePlayerRepository
-        )
+        pitchingRecordService =
+            PitchingRecordService(
+                pitchingRecordRepository = pitchingRecordRepository,
+                gamePlayerRepository = gamePlayerRepository,
+            )
 
         mockGamePlayer = mockk(relaxed = true)
         mockPitchingRecord = mockk(relaxed = true)

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/league/LeagueServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/league/LeagueServiceTest.kt
@@ -16,11 +16,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.util.Optional
 
 @DisplayName("LeagueService")
 class LeagueServiceTest {
-
     private lateinit var leagueRepository: LeagueRepositoryPort
     private lateinit var associationRepository: AssociationRepositoryPort
     private lateinit var leagueService: LeagueService
@@ -35,7 +33,6 @@ class LeagueServiceTest {
     @Nested
     @DisplayName("create")
     inner class Create {
-
         @Test
         fun `should create league successfully`() {
             // given
@@ -49,14 +46,15 @@ class LeagueServiceTest {
             every { leagueRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = leagueService.create(
-                associationId = associationId,
-                name = name,
-                abbreviation = "1부",
-                foundedYear = foundedYear,
-                divisionLevel = 1,
-                description = "서울시야구협회 1부 리그"
-            )
+            val result =
+                leagueService.create(
+                    associationId = associationId,
+                    name = name,
+                    abbreviation = "1부",
+                    foundedYear = foundedYear,
+                    divisionLevel = 1,
+                    description = "서울시야구협회 1부 리그",
+                )
 
             // then
             assertThat(result.name).isEqualTo(name)
@@ -77,7 +75,7 @@ class LeagueServiceTest {
                 leagueService.create(
                     associationId = associationId,
                     name = "1부 리그",
-                    foundedYear = 2020
+                    foundedYear = 2020,
                 )
             }.isInstanceOf(AssociationNotFoundException::class.java)
         }
@@ -97,7 +95,7 @@ class LeagueServiceTest {
                 leagueService.create(
                     associationId = associationId,
                     name = name,
-                    foundedYear = 2020
+                    foundedYear = 2020,
                 )
             }.isInstanceOf(LeagueNameDuplicateException::class.java)
         }
@@ -106,7 +104,6 @@ class LeagueServiceTest {
     @Nested
     @DisplayName("getById")
     inner class GetById {
-
         @Test
         fun `should return league when found`() {
             // given
@@ -139,15 +136,15 @@ class LeagueServiceTest {
     @Nested
     @DisplayName("getAllActive")
     inner class GetAllActive {
-
         @Test
         fun `should return only active leagues`() {
             // given
             val association = createAssociation(1L, "서울시야구협회")
-            val leagues = listOf(
-                createLeague(1L, "1부 리그", association),
-                createLeague(2L, "2부 리그", association)
-            )
+            val leagues =
+                listOf(
+                    createLeague(1L, "1부 리그", association),
+                    createLeague(2L, "2부 리그", association),
+                )
             every { leagueRepository.findAllActive() } returns leagues
 
             // when
@@ -161,16 +158,16 @@ class LeagueServiceTest {
     @Nested
     @DisplayName("getActiveByAssociationId")
     inner class GetActiveByAssociationId {
-
         @Test
         fun `should return active leagues by association`() {
             // given
             val associationId = 1L
             val association = createAssociation(associationId, "서울시야구협회")
-            val leagues = listOf(
-                createLeague(1L, "1부 리그", association),
-                createLeague(2L, "2부 리그", association)
-            )
+            val leagues =
+                listOf(
+                    createLeague(1L, "1부 리그", association),
+                    createLeague(2L, "2부 리그", association),
+                )
             every { leagueRepository.findActiveByAssociationId(associationId) } returns leagues
 
             // when
@@ -185,7 +182,6 @@ class LeagueServiceTest {
     @Nested
     @DisplayName("update")
     inner class Update {
-
         @Test
         fun `should update league info`() {
             // given
@@ -195,11 +191,12 @@ class LeagueServiceTest {
             every { leagueRepository.findByIdOrNull(id) } returns league
 
             // when
-            val result = leagueService.update(
-                id = id,
-                description = "새로운 설명",
-                logoUrl = "https://example.com/logo.png"
-            )
+            val result =
+                leagueService.update(
+                    id = id,
+                    description = "새로운 설명",
+                    logoUrl = "https://example.com/logo.png",
+                )
 
             // then
             assertThat(result.description).isEqualTo("새로운 설명")
@@ -210,7 +207,6 @@ class LeagueServiceTest {
     @Nested
     @DisplayName("deactivate/activate")
     inner class DeactivateActivate {
-
         @Test
         fun `should deactivate league`() {
             // given
@@ -242,34 +238,39 @@ class LeagueServiceTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
-        return Association(
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association =
+        Association(
             name = name,
             abbreviation = null,
             region = "서울",
             description = null,
             logoUrl = null,
-            websiteUrl = null
+            websiteUrl = null,
         ).apply {
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
-    private fun createLeague(id: Long, name: String, association: Association): League {
-        return League(
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association,
+    ): League =
+        League(
             association = association,
             name = name,
             abbreviation = null,
             foundedYear = 2020,
             divisionLevel = 1,
             description = null,
-            logoUrl = null
+            logoUrl = null,
         ).apply {
             val idField = League::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/player/PlayerTeamServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/player/PlayerTeamServiceTest.kt
@@ -21,7 +21,6 @@ import java.time.LocalDate
 
 @DisplayName("PlayerTeamService")
 class PlayerTeamServiceTest {
-
     private lateinit var playerTeamHistoryRepository: PlayerTeamHistoryRepositoryPort
     private lateinit var playerRepository: PlayerRepositoryPort
     private lateinit var teamRepository: TeamRepositoryPort
@@ -32,17 +31,17 @@ class PlayerTeamServiceTest {
         playerTeamHistoryRepository = mockk()
         playerRepository = mockk()
         teamRepository = mockk()
-        playerTeamService = PlayerTeamService(
-            playerTeamHistoryRepository,
-            playerRepository,
-            teamRepository
-        )
+        playerTeamService =
+            PlayerTeamService(
+                playerTeamHistoryRepository,
+                playerRepository,
+                teamRepository,
+            )
     }
 
     @Nested
     @DisplayName("registerAffiliation")
     inner class RegisterAffiliation {
-
         @Test
         fun `should register player affiliation successfully`() {
             // given
@@ -62,14 +61,15 @@ class PlayerTeamServiceTest {
             every { playerTeamHistoryRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = playerTeamService.registerAffiliation(
-                playerId = playerId,
-                teamId = teamId,
-                startDate = startDate,
-                position = position,
-                uniformNumber = uniformNumber,
-                contractType = ContractType.REGULAR
-            )
+            val result =
+                playerTeamService.registerAffiliation(
+                    playerId = playerId,
+                    teamId = teamId,
+                    startDate = startDate,
+                    position = position,
+                    uniformNumber = uniformNumber,
+                    contractType = ContractType.REGULAR,
+                )
 
             // then
             assertThat(result.player.id).isEqualTo(playerId)
@@ -100,7 +100,7 @@ class PlayerTeamServiceTest {
                     playerId = playerId,
                     teamId = teamId,
                     startDate = LocalDate.now(),
-                    position = Position.STARTING_PITCHER
+                    position = Position.STARTING_PITCHER,
                 )
             }.isInstanceOf(PlayerAlreadyInLeagueException::class.java)
         }
@@ -121,12 +121,13 @@ class PlayerTeamServiceTest {
             every { playerTeamHistoryRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = playerTeamService.registerAffiliation(
-                playerId = playerId,
-                teamId = teamId,
-                startDate = LocalDate.now(),
-                position = Position.STARTING_PITCHER
-            )
+            val result =
+                playerTeamService.registerAffiliation(
+                    playerId = playerId,
+                    teamId = teamId,
+                    startDate = LocalDate.now(),
+                    position = Position.STARTING_PITCHER,
+                )
 
             // then
             assertThat(result.status).isEqualTo(PlayerTeamStatus.ACTIVE)
@@ -145,7 +146,7 @@ class PlayerTeamServiceTest {
                     playerId = playerId,
                     teamId = 1L,
                     startDate = LocalDate.now(),
-                    position = Position.STARTING_PITCHER
+                    position = Position.STARTING_PITCHER,
                 )
             }.isInstanceOf(PlayerNotFoundException::class.java)
         }
@@ -166,7 +167,7 @@ class PlayerTeamServiceTest {
                     playerId = playerId,
                     teamId = teamId,
                     startDate = LocalDate.now(),
-                    position = Position.STARTING_PITCHER
+                    position = Position.STARTING_PITCHER,
                 )
             }.isInstanceOf(TeamNotFoundException::class.java)
         }
@@ -175,7 +176,6 @@ class PlayerTeamServiceTest {
     @Nested
     @DisplayName("endAffiliation")
     inner class EndAffiliation {
-
         @Test
         fun `should end affiliation successfully`() {
             // given
@@ -209,7 +209,6 @@ class PlayerTeamServiceTest {
     @Nested
     @DisplayName("transferPlayer")
     inner class TransferPlayer {
-
         @Test
         fun `should transfer player within same league successfully`() {
             // given
@@ -227,19 +226,21 @@ class PlayerTeamServiceTest {
             every { playerRepository.findByIdOrNull(playerId) } returns player
             every { teamRepository.findByIdWithLeague(fromTeamId) } returns fromTeam
             every { teamRepository.findByIdWithLeague(toTeamId) } returns toTeam
-            every { playerTeamHistoryRepository.findActiveByPlayerIdAndLeagueId(playerId, leagueId) } returns currentAffiliation
+            every { playerTeamHistoryRepository.findActiveByPlayerIdAndLeagueId(playerId, leagueId) } returns
+                currentAffiliation
             every { playerTeamHistoryRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = playerTeamService.transferPlayer(
-                playerId = playerId,
-                fromTeamId = fromTeamId,
-                toTeamId = toTeamId,
-                transferDate = transferDate,
-                newPosition = Position.LEFT_FIELD,
-                newUniformNumber = 20,
-                newContractType = ContractType.REGULAR
-            )
+            val result =
+                playerTeamService.transferPlayer(
+                    playerId = playerId,
+                    fromTeamId = fromTeamId,
+                    toTeamId = toTeamId,
+                    transferDate = transferDate,
+                    newPosition = Position.LEFT_FIELD,
+                    newUniformNumber = 20,
+                    newContractType = ContractType.REGULAR,
+                )
 
             // then
             assertThat(result.player.id).isEqualTo(playerId)
@@ -276,7 +277,7 @@ class PlayerTeamServiceTest {
                     fromTeamId = fromTeamId,
                     toTeamId = toTeamId,
                     transferDate = LocalDate.now(),
-                    newPosition = Position.LEFT_FIELD
+                    newPosition = Position.LEFT_FIELD,
                 )
             }.isInstanceOf(PlayerTransferNotAllowedException::class.java)
                 .hasMessageContaining("같은 리그 내에서만 이적")
@@ -306,7 +307,7 @@ class PlayerTeamServiceTest {
                     fromTeamId = fromTeamId,
                     toTeamId = toTeamId,
                     transferDate = LocalDate.now(),
-                    newPosition = Position.LEFT_FIELD
+                    newPosition = Position.LEFT_FIELD,
                 )
             }.isInstanceOf(PlayerNotInTeamException::class.java)
         }
@@ -315,7 +316,6 @@ class PlayerTeamServiceTest {
     @Nested
     @DisplayName("getActiveAffiliationsByPlayer")
     inner class GetActiveAffiliationsByPlayer {
-
         @Test
         fun `should return active affiliations for player`() {
             // given
@@ -323,10 +323,11 @@ class PlayerTeamServiceTest {
             val player = createPlayer(playerId, "홍길동")
             val team1 = createTeam(1L, "서울 타이거즈", 1L)
             val team2 = createTeam(2L, "경기 라이온즈", 2L)
-            val affiliations = listOf(
-                createPlayerTeamHistory(1L, player, team1),
-                createPlayerTeamHistory(2L, player, team2)
-            )
+            val affiliations =
+                listOf(
+                    createPlayerTeamHistory(1L, player, team1),
+                    createPlayerTeamHistory(2L, player, team2),
+                )
 
             every { playerRepository.findByIdOrNull(playerId) } returns player
             every { playerTeamHistoryRepository.findActiveByPlayerId(playerId) } returns affiliations
@@ -355,7 +356,6 @@ class PlayerTeamServiceTest {
     @Nested
     @DisplayName("changeUniformNumber")
     inner class ChangeUniformNumber {
-
         @Test
         fun `should change uniform number successfully`() {
             // given
@@ -388,7 +388,6 @@ class PlayerTeamServiceTest {
     @Nested
     @DisplayName("changePosition")
     inner class ChangePosition {
-
         @Test
         fun `should change position successfully`() {
             // given
@@ -421,7 +420,6 @@ class PlayerTeamServiceTest {
     @Nested
     @DisplayName("getTeamRoster")
     inner class GetTeamRoster {
-
         @Test
         fun `should return team roster`() {
             // given
@@ -429,10 +427,11 @@ class PlayerTeamServiceTest {
             val team = createTeam(teamId, "서울 타이거즈", 1L)
             val player1 = createPlayer(1L, "홍길동")
             val player2 = createPlayer(2L, "김철수")
-            val affiliations = listOf(
-                createPlayerTeamHistory(1L, player1, team),
-                createPlayerTeamHistory(2L, player2, team)
-            )
+            val affiliations =
+                listOf(
+                    createPlayerTeamHistory(1L, player1, team),
+                    createPlayerTeamHistory(2L, player2, team),
+                )
 
             every { teamRepository.findByIdWithLeague(teamId) } returns team
             every { playerTeamHistoryRepository.findActiveByTeamId(teamId) } returns affiliations
@@ -461,7 +460,6 @@ class PlayerTeamServiceTest {
     @Nested
     @DisplayName("getTeamRosterAtDate")
     inner class GetTeamRosterAtDate {
-
         @Test
         fun `should return team roster at specific date`() {
             // given
@@ -470,10 +468,11 @@ class PlayerTeamServiceTest {
             val team = createTeam(teamId, "서울 타이거즈", 1L)
             val player1 = createPlayer(1L, "홍길동")
             val player2 = createPlayer(2L, "김철수")
-            val affiliations = listOf(
-                createPlayerTeamHistory(1L, player1, team),
-                createPlayerTeamHistory(2L, player2, team)
-            )
+            val affiliations =
+                listOf(
+                    createPlayerTeamHistory(1L, player1, team),
+                    createPlayerTeamHistory(2L, player2, team),
+                )
 
             every { teamRepository.findByIdWithLeague(teamId) } returns team
             every { playerTeamHistoryRepository.findByTeamIdAtDate(teamId, date) } returns affiliations
@@ -502,7 +501,6 @@ class PlayerTeamServiceTest {
     @Nested
     @DisplayName("getPlayerHistory")
     inner class GetPlayerHistory {
-
         @Test
         fun `should return player affiliation history`() {
             // given
@@ -510,10 +508,11 @@ class PlayerTeamServiceTest {
             val player = createPlayer(playerId, "홍길동")
             val team1 = createTeam(1L, "서울 타이거즈", 1L)
             val team2 = createTeam(2L, "경기 라이온즈", 2L)
-            val history = listOf(
-                createPlayerTeamHistory(1L, player, team1),
-                createPlayerTeamHistory(2L, player, team2)
-            )
+            val history =
+                listOf(
+                    createPlayerTeamHistory(1L, player, team1),
+                    createPlayerTeamHistory(2L, player, team2),
+                )
 
             every { playerRepository.findByIdOrNull(playerId) } returns player
             every { playerTeamHistoryRepository.findByPlayerIdWithDetails(playerId) } returns history
@@ -539,24 +538,30 @@ class PlayerTeamServiceTest {
         }
     }
 
-    private fun createPlayer(id: Long, name: String): Player {
-        return Player(
+    private fun createPlayer(
+        id: Long,
+        name: String,
+    ): Player =
+        Player(
             name = name,
-            primaryPosition = Position.STARTING_PITCHER
+            primaryPosition = Position.STARTING_PITCHER,
         ).apply {
             val idField = Player::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
-    private fun createTeam(id: Long, name: String, leagueId: Long): Team {
+    private fun createTeam(
+        id: Long,
+        name: String,
+        leagueId: Long,
+    ): Team {
         val league = createLeague(leagueId)
         return Team(
             league = league,
             name = name,
             city = "서울",
-            foundedYear = 2020
+            foundedYear = 2020,
         ).apply {
             val idField = Team::class.java.getDeclaredField("id")
             idField.isAccessible = true
@@ -569,7 +574,7 @@ class PlayerTeamServiceTest {
         return League(
             association = association,
             name = "서울리그",
-            foundedYear = 2020
+            foundedYear = 2020,
         ).apply {
             val idField = League::class.java.getDeclaredField("id")
             idField.isAccessible = true
@@ -577,33 +582,31 @@ class PlayerTeamServiceTest {
         }
     }
 
-    private fun createAssociation(id: Long): Association {
-        return Association(
+    private fun createAssociation(id: Long): Association =
+        Association(
             name = "서울협회",
-            region = "서울"
+            region = "서울",
         ).apply {
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
     private fun createPlayerTeamHistory(
         id: Long,
         player: Player = createPlayer(1L, "홍길동"),
-        team: Team = createTeam(1L, "서울 타이거즈", 1L)
-    ): PlayerTeamHistory {
-        return PlayerTeamHistory(
+        team: Team = createTeam(1L, "서울 타이거즈", 1L),
+    ): PlayerTeamHistory =
+        PlayerTeamHistory(
             player = player,
             team = team,
             startDate = LocalDate.now(),
             position = Position.STARTING_PITCHER,
             contractType = ContractType.REGULAR,
-            status = PlayerTeamStatus.ACTIVE
+            status = PlayerTeamStatus.ACTIVE,
         ).apply {
             val idField = PlayerTeamHistory::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stats/PlayerStatsServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stats/PlayerStatsServiceTest.kt
@@ -14,11 +14,11 @@ import com.nextup.core.domain.stats.CareerBattingStats
 import com.nextup.core.domain.stats.CareerPitchingStats
 import com.nextup.core.domain.stats.SeasonBattingStats
 import com.nextup.core.domain.stats.SeasonPitchingStats
-import com.nextup.core.port.repository.PlayerRepositoryPort
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
-import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import io.mockk.every
@@ -30,12 +30,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.time.ZonedDateTime
-import java.util.Optional
 
 @DisplayName("PlayerStatsService 테스트")
 class PlayerStatsServiceTest {
-
     private lateinit var playerStatsService: PlayerStatsService
     private lateinit var playerRepository: PlayerRepositoryPort
     private lateinit var seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort
@@ -45,13 +42,14 @@ class PlayerStatsServiceTest {
     private lateinit var battingRecordRepository: BattingRecordRepositoryPort
     private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
 
-    private val testPlayer = Player(
-        name = "홍길동",
-        primaryPosition = Position.CATCHER,
-        throwingHand = ThrowingHand.RIGHT,
-        battingHand = BattingHand.RIGHT,
-        id = 1L
-    )
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
 
     private val playerId = 1L
     private val year = 2024
@@ -66,21 +64,21 @@ class PlayerStatsServiceTest {
         battingRecordRepository = mockk()
         pitchingRecordRepository = mockk()
 
-        playerStatsService = PlayerStatsService(
-            playerRepository,
-            seasonBattingStatsRepository,
-            seasonPitchingStatsRepository,
-            careerBattingStatsRepository,
-            careerPitchingStatsRepository,
-            battingRecordRepository,
-            pitchingRecordRepository
-        )
+        playerStatsService =
+            PlayerStatsService(
+                playerRepository,
+                seasonBattingStatsRepository,
+                seasonPitchingStatsRepository,
+                careerBattingStatsRepository,
+                careerPitchingStatsRepository,
+                battingRecordRepository,
+                pitchingRecordRepository,
+            )
     }
 
     @Nested
     @DisplayName("시즌 타격 통계 조회")
     inner class GetSeasonBattingStats {
-
         @Test
         fun `should return season batting stats when exists`() {
             // given
@@ -110,7 +108,6 @@ class PlayerStatsServiceTest {
     @Nested
     @DisplayName("시즌 투수 통계 조회")
     inner class GetSeasonPitchingStats {
-
         @Test
         fun `should return season pitching stats when exists`() {
             // given
@@ -140,7 +137,6 @@ class PlayerStatsServiceTest {
     @Nested
     @DisplayName("통산 타격 통계 조회")
     inner class GetCareerBattingStats {
-
         @Test
         fun `should return career batting stats when exists`() {
             // given
@@ -170,7 +166,6 @@ class PlayerStatsServiceTest {
     @Nested
     @DisplayName("통산 투수 통계 조회")
     inner class GetCareerPitchingStats {
-
         @Test
         fun `should return career pitching stats when exists`() {
             // given
@@ -200,7 +195,6 @@ class PlayerStatsServiceTest {
     @Nested
     @DisplayName("모든 시즌 통계 조회")
     inner class GetAllSeasonStats {
-
         @Test
         fun `should return all season batting stats`() {
             // given
@@ -247,7 +241,6 @@ class PlayerStatsServiceTest {
     @Nested
     @DisplayName("시즌 타격 통계 갱신")
     inner class UpdatePlayerBattingStats {
-
         @Test
         fun `should create and return new season batting stats when not exists`() {
             // given
@@ -270,9 +263,10 @@ class PlayerStatsServiceTest {
             // given
             val existingStats = SeasonBattingStats.create(testPlayer, year)
             val gamePlayer = mockk<GamePlayer>()
-            val record = BattingRecord.create(gamePlayer).apply {
-                setStats(pa = 4, ab = 4, h = 2)
-            }
+            val record =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 4, ab = 4, h = 2)
+                }
 
             every { playerRepository.findByIdOrNull(playerId) } returns testPlayer
             every { seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year) } returns existingStats
@@ -304,7 +298,6 @@ class PlayerStatsServiceTest {
     @Nested
     @DisplayName("시즌 투수 통계 갱신")
     inner class UpdatePlayerPitchingStats {
-
         @Test
         fun `should create and return new season pitching stats when not exists`() {
             // given
@@ -327,15 +320,16 @@ class PlayerStatsServiceTest {
             // given
             val existingStats = SeasonPitchingStats.create(testPlayer, year)
             val gamePlayer = mockk<GamePlayer>()
-            val record = PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
-                setStats(
-                    inningsPitchedOuts = 18,
-                    earnedRuns = 2,
-                    runsAllowed = 2,
-                    strikeouts = 6,
-                    decision = PitchingDecision.WIN
-                )
-            }
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 2,
+                        runsAllowed = 2,
+                        strikeouts = 6,
+                        decision = PitchingDecision.WIN,
+                    )
+                }
 
             every { playerRepository.findByIdOrNull(playerId) } returns testPlayer
             every { seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year) } returns existingStats
@@ -368,7 +362,6 @@ class PlayerStatsServiceTest {
     @Nested
     @DisplayName("통산 타격 통계 갱신")
     inner class UpdateCareerBattingStats {
-
         @Test
         fun `should create and return new career batting stats when not exists`() {
             // given
@@ -417,7 +410,6 @@ class PlayerStatsServiceTest {
     @Nested
     @DisplayName("통산 투수 통계 갱신")
     inner class UpdateCareerPitchingStats {
-
         @Test
         fun `should create and return new career pitching stats when not exists`() {
             // given
@@ -468,7 +460,6 @@ class PlayerStatsServiceTest {
     @Nested
     @DisplayName("시즌 타격 리더보드")
     inner class GetSeasonBattingLeaders {
-
         @Test
         fun `should return batting average leaders`() {
             // given
@@ -543,7 +534,6 @@ class PlayerStatsServiceTest {
     @Nested
     @DisplayName("시즌 투수 리더보드")
     inner class GetSeasonPitchingLeaders {
-
         @Test
         fun `should return ERA leaders`() {
             // given
@@ -634,14 +624,17 @@ class PlayerStatsServiceTest {
     private fun BattingRecord.setStats(
         pa: Int = 0,
         ab: Int = 0,
-        h: Int = 0
+        h: Int = 0,
     ) {
         setField("plateAppearances", pa)
         setField("atBats", ab)
         setField("hits", h)
     }
 
-    private fun BattingRecord.setField(fieldName: String, value: Int) {
+    private fun BattingRecord.setField(
+        fieldName: String,
+        value: Int,
+    ) {
         val field = BattingRecord::class.java.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(this, value)
@@ -652,7 +645,7 @@ class PlayerStatsServiceTest {
         earnedRuns: Int = 0,
         runsAllowed: Int = 0,
         strikeouts: Int = 0,
-        decision: PitchingDecision = PitchingDecision.NONE
+        decision: PitchingDecision = PitchingDecision.NONE,
     ) {
         setField("inningsPitchedOuts", inningsPitchedOuts)
         setField("earnedRuns", earnedRuns)
@@ -661,25 +654,34 @@ class PlayerStatsServiceTest {
         setField("decision", decision)
     }
 
-    private fun PitchingRecord.setField(fieldName: String, value: Any) {
+    private fun PitchingRecord.setField(
+        fieldName: String,
+        value: Any,
+    ) {
         val field = PitchingRecord::class.java.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(this, value)
     }
 
-    private fun createMockGame(year: Int): Game {
-        return mockk {
+    private fun createMockGame(year: Int): Game =
+        mockk {
             every { scheduledAt } returns java.time.LocalDateTime.of(year, 6, 1, 14, 0, 0)
         }
-    }
 
-    private fun createMockBattingRecord(game: Game, pa: Int, ab: Int, h: Int): BattingRecord {
-        val gameTeam = mockk<GameTeam> {
-            every { this@mockk.game } returns game
-        }
-        val gamePlayer = mockk<GamePlayer> {
-            every { this@mockk.gameTeam } returns gameTeam
-        }
+    private fun createMockBattingRecord(
+        game: Game,
+        pa: Int,
+        ab: Int,
+        h: Int,
+    ): BattingRecord {
+        val gameTeam =
+            mockk<GameTeam> {
+                every { this@mockk.game } returns game
+            }
+        val gamePlayer =
+            mockk<GamePlayer> {
+                every { this@mockk.gameTeam } returns gameTeam
+            }
         return BattingRecord.create(gamePlayer).apply {
             setStats(pa, ab, h)
         }
@@ -692,14 +694,16 @@ class PlayerStatsServiceTest {
         runsAllowed: Int,
         strikeouts: Int,
         isStartingPitcher: Boolean,
-        decision: PitchingDecision
+        decision: PitchingDecision,
     ): PitchingRecord {
-        val gameTeam = mockk<GameTeam> {
-            every { this@mockk.game } returns game
-        }
-        val gamePlayer = mockk<GamePlayer> {
-            every { this@mockk.gameTeam } returns gameTeam
-        }
+        val gameTeam =
+            mockk<GameTeam> {
+                every { this@mockk.game } returns game
+            }
+        val gamePlayer =
+            mockk<GamePlayer> {
+                every { this@mockk.gameTeam } returns gameTeam
+            }
         return PitchingRecord.create(gamePlayer, isStartingPitcher).apply {
             setStats(inningsPitchedOuts, earnedRuns, runsAllowed, strikeouts, decision)
         }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/user/UserServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/user/UserServiceTest.kt
@@ -22,7 +22,6 @@ import java.util.*
 
 @DisplayName("UserService")
 class UserServiceTest {
-
     private lateinit var userRepository: UserRepositoryPort
     private lateinit var oauthAccountRepository: OAuthAccountRepositoryPort
     private lateinit var userService: UserService
@@ -37,7 +36,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("createLocalUser")
     inner class CreateLocalUser {
-
         @Test
         fun `should create local user successfully`() {
             // given
@@ -74,22 +72,23 @@ class UserServiceTest {
     @Nested
     @DisplayName("createOrLinkOAuthUser")
     inner class CreateOrLinkOAuthUser {
-
         @Test
         fun `should return existing user when oauth account exists`() {
             // given
             val user = createTestUser(1L, "existing@example.com")
             val oauthAccount = mockk<OAuthAccount>()
             every { oauthAccount.user } returns user
-            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_123") } returns oauthAccount
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_123") } returns
+                oauthAccount
 
             // when
-            val (resultUser, isNew) = userService.createOrLinkOAuthUser(
-                email = "new@example.com",
-                nickname = "새사용자",
-                provider = OAuthProvider.KAKAO,
-                oauthId = "kakao_123"
-            )
+            val (resultUser, isNew) =
+                userService.createOrLinkOAuthUser(
+                    email = "new@example.com",
+                    nickname = "새사용자",
+                    provider = OAuthProvider.KAKAO,
+                    oauthId = "kakao_123",
+                )
 
             // then
             assertThat(resultUser.id).isEqualTo(1L)
@@ -104,12 +103,13 @@ class UserServiceTest {
             every { userRepository.findByEmail("existing@example.com") } returns existingUser
 
             // when
-            val (resultUser, isNew) = userService.createOrLinkOAuthUser(
-                email = "existing@example.com",
-                nickname = "새닉네임",
-                provider = OAuthProvider.GOOGLE,
-                oauthId = "google_123"
-            )
+            val (resultUser, isNew) =
+                userService.createOrLinkOAuthUser(
+                    email = "existing@example.com",
+                    nickname = "새닉네임",
+                    provider = OAuthProvider.GOOGLE,
+                    oauthId = "google_123",
+                )
 
             // then
             assertThat(resultUser.id).isEqualTo(1L)
@@ -125,12 +125,13 @@ class UserServiceTest {
             every { userRepository.save(any()) } answers { firstArg() }
 
             // when
-            val (resultUser, isNew) = userService.createOrLinkOAuthUser(
-                email = "new@example.com",
-                nickname = "새사용자",
-                provider = OAuthProvider.NAVER,
-                oauthId = "naver_123"
-            )
+            val (resultUser, isNew) =
+                userService.createOrLinkOAuthUser(
+                    email = "new@example.com",
+                    nickname = "새사용자",
+                    provider = OAuthProvider.NAVER,
+                    oauthId = "naver_123",
+                )
 
             // then
             assertThat(resultUser.email).isEqualTo("new@example.com")
@@ -147,13 +148,14 @@ class UserServiceTest {
             every { userRepository.findByEmail("existing@example.com") } returns existingUser
 
             // when
-            val (resultUser, isNew) = userService.createOrLinkOAuthUser(
-                email = "existing@example.com",
-                nickname = "새닉네임",
-                provider = OAuthProvider.GOOGLE,
-                oauthId = "google_123",
-                profileImageUrl = "http://example.com/profile.jpg"
-            )
+            val (resultUser, isNew) =
+                userService.createOrLinkOAuthUser(
+                    email = "existing@example.com",
+                    nickname = "새닉네임",
+                    provider = OAuthProvider.GOOGLE,
+                    oauthId = "google_123",
+                    profileImageUrl = "http://example.com/profile.jpg",
+                )
 
             // then
             assertThat(resultUser.profileImageUrl).isEqualTo("http://example.com/profile.jpg")
@@ -163,20 +165,22 @@ class UserServiceTest {
         @Test
         fun `should not update profile image when existing user already has one`() {
             // given
-            val existingUser = createTestUser(1L, "existing@example.com").apply {
-                updateProfile(profileImageUrl = "http://example.com/existing.jpg")
-            }
+            val existingUser =
+                createTestUser(1L, "existing@example.com").apply {
+                    updateProfile(profileImageUrl = "http://example.com/existing.jpg")
+                }
             every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.GOOGLE, "google_123") } returns null
             every { userRepository.findByEmail("existing@example.com") } returns existingUser
 
             // when
-            val (resultUser, isNew) = userService.createOrLinkOAuthUser(
-                email = "existing@example.com",
-                nickname = "새닉네임",
-                provider = OAuthProvider.GOOGLE,
-                oauthId = "google_123",
-                profileImageUrl = "http://example.com/new.jpg"
-            )
+            val (resultUser, isNew) =
+                userService.createOrLinkOAuthUser(
+                    email = "existing@example.com",
+                    nickname = "새닉네임",
+                    provider = OAuthProvider.GOOGLE,
+                    oauthId = "google_123",
+                    profileImageUrl = "http://example.com/new.jpg",
+                )
 
             // then
             assertThat(resultUser.profileImageUrl).isEqualTo("http://example.com/existing.jpg")
@@ -187,7 +191,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("getById")
     inner class GetById {
-
         @Test
         fun `should return user when found`() {
             // given
@@ -217,7 +220,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("getActiveById")
     inner class GetActiveById {
-
         @Test
         fun `should return active user`() {
             // given
@@ -247,7 +249,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("getByEmail")
     inner class GetByEmail {
-
         @Test
         fun `should return user when found by email`() {
             // given
@@ -276,7 +277,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("findByEmail")
     inner class FindByEmail {
-
         @Test
         fun `should return user when found`() {
             // given
@@ -307,14 +307,14 @@ class UserServiceTest {
     @Nested
     @DisplayName("findByOAuth")
     inner class FindByOAuth {
-
         @Test
         fun `should return user when oauth account found`() {
             // given
             val user = createTestUser(1L, "oauth@example.com")
             val oauthAccount = mockk<OAuthAccount>()
             every { oauthAccount.user } returns user
-            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_123") } returns oauthAccount
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_123") } returns
+                oauthAccount
 
             // when
             val result = userService.findByOAuth(OAuthProvider.KAKAO, "kakao_123")
@@ -340,14 +340,14 @@ class UserServiceTest {
     @Nested
     @DisplayName("getAllActive")
     inner class GetAllActive {
-
         @Test
         fun `should return paginated active users`() {
             // given
-            val users = listOf(
-                createTestUser(1L, "user1@example.com"),
-                createTestUser(2L, "user2@example.com")
-            )
+            val users =
+                listOf(
+                    createTestUser(1L, "user1@example.com"),
+                    createTestUser(2L, "user2@example.com"),
+                )
             val pageable = PageRequest.of(0, 10)
             every { userRepository.findAllActive(pageable) } returns PageImpl(users)
 
@@ -362,15 +362,15 @@ class UserServiceTest {
     @Nested
     @DisplayName("getAll")
     inner class GetAll {
-
         @Test
         fun `should return all users paginated`() {
             // given
-            val users = listOf(
-                createTestUser(1L, "user1@example.com"),
-                createTestUser(2L, "user2@example.com"),
-                createTestUser(3L, "user3@example.com")
-            )
+            val users =
+                listOf(
+                    createTestUser(1L, "user1@example.com"),
+                    createTestUser(2L, "user2@example.com"),
+                    createTestUser(3L, "user3@example.com"),
+                )
             val pageable = PageRequest.of(0, 10)
             every { userRepository.findAllByIsActive(true, pageable) } returns PageImpl(users)
 
@@ -385,7 +385,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("getAllByStatus")
     inner class GetAllByStatus {
-
         @Test
         fun `should return active users only`() {
             // given
@@ -403,9 +402,10 @@ class UserServiceTest {
         @Test
         fun `should return inactive users only`() {
             // given
-            val inactiveUsers = listOf(
-                createTestUser(1L, "inactive@example.com").apply { deactivate() }
-            )
+            val inactiveUsers =
+                listOf(
+                    createTestUser(1L, "inactive@example.com").apply { deactivate() },
+                )
             val pageable = PageRequest.of(0, 10)
             every { userRepository.findAllByIsActive(false, pageable) } returns PageImpl(inactiveUsers)
 
@@ -420,7 +420,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("search")
     inner class Search {
-
         @Test
         fun `should search users by keyword`() {
             // given
@@ -439,13 +438,13 @@ class UserServiceTest {
     @Nested
     @DisplayName("getAllByRole")
     inner class GetAllByRole {
-
         @Test
         fun `should return users with specific role`() {
             // given
-            val admins = listOf(
-                createTestUser(1L, "admin@example.com").apply { addRole(Role.ADMIN) }
-            )
+            val admins =
+                listOf(
+                    createTestUser(1L, "admin@example.com").apply { addRole(Role.ADMIN) },
+                )
             val pageable = PageRequest.of(0, 10)
             every { userRepository.findAllByRole(Role.ADMIN, pageable) } returns PageImpl(admins)
 
@@ -460,7 +459,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("updateProfile")
     inner class UpdateProfile {
-
         @Test
         fun `should update profile successfully`() {
             // given
@@ -468,11 +466,12 @@ class UserServiceTest {
             every { userRepository.findByIdOrNull(1L) } returns user
 
             // when
-            val result = userService.updateProfile(
-                userId = 1L,
-                nickname = "새닉네임",
-                profileImageUrl = "http://example.com/new.jpg"
-            )
+            val result =
+                userService.updateProfile(
+                    userId = 1L,
+                    nickname = "새닉네임",
+                    profileImageUrl = "http://example.com/new.jpg",
+                )
 
             // then
             assertThat(result.nickname).isEqualTo("새닉네임")
@@ -486,11 +485,12 @@ class UserServiceTest {
             every { userRepository.findByIdOrNull(1L) } returns user
 
             // when
-            val result = userService.updateProfile(
-                userId = 1L,
-                nickname = null,
-                profileImageUrl = "http://example.com/new.jpg"
-            )
+            val result =
+                userService.updateProfile(
+                    userId = 1L,
+                    nickname = null,
+                    profileImageUrl = "http://example.com/new.jpg",
+                )
 
             // then
             assertThat(result.nickname).isEqualTo("테스터")
@@ -501,7 +501,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("changePassword")
     inner class ChangePassword {
-
         @Test
         fun `should change password successfully`() {
             // given
@@ -519,7 +518,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("addRole / removeRole")
     inner class RoleManagement {
-
         @Test
         fun `should add role to user`() {
             // given
@@ -550,7 +548,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("linkOAuthAccount")
     inner class LinkOAuthAccount {
-
         @Test
         fun `should link oauth account successfully`() {
             // given
@@ -574,7 +571,8 @@ class UserServiceTest {
             every { existingOAuth.user } returns anotherUser
 
             every { userRepository.findByIdOrNull(1L) } returns user
-            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_used") } returns existingOAuth
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_used") } returns
+                existingOAuth
 
             // when & then
             assertThatThrownBy {
@@ -590,7 +588,8 @@ class UserServiceTest {
             every { existingOAuth.user } returns user
 
             every { userRepository.findByIdOrNull(1L) } returns user
-            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_123") } returns existingOAuth
+            every { oauthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "kakao_123") } returns
+                existingOAuth
 
             // when - no exception should be thrown
             val result = userService.linkOAuthAccount(1L, OAuthProvider.KAKAO, "kakao_123")
@@ -603,7 +602,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("unlinkOAuthAccount")
     inner class UnlinkOAuthAccount {
-
         @Test
         fun `should unlink oauth account when multiple auth methods exist`() {
             // given
@@ -621,12 +619,13 @@ class UserServiceTest {
         @Test
         fun `should throw exception when trying to remove last auth method`() {
             // given - OAuth only user (no password)
-            val user = User.createOAuthUser(
-                email = "oauth@example.com",
-                nickname = "OAuth사용자",
-                provider = OAuthProvider.KAKAO,
-                oauthId = "kakao_only"
-            )
+            val user =
+                User.createOAuthUser(
+                    email = "oauth@example.com",
+                    nickname = "OAuth사용자",
+                    provider = OAuthProvider.KAKAO,
+                    oauthId = "kakao_only",
+                )
             setUserId(user, 1L)
             every { userRepository.findByIdOrNull(1L) } returns user
 
@@ -640,7 +639,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("getLinkedProviders")
     inner class GetLinkedProviders {
-
         @Test
         fun `should return list of linked providers`() {
             // given
@@ -671,7 +669,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("deactivate / activate")
     inner class DeactivateActivate {
-
         @Test
         fun `should deactivate user`() {
             // given
@@ -702,7 +699,6 @@ class UserServiceTest {
     @Nested
     @DisplayName("utility methods")
     inner class UtilityMethods {
-
         @Test
         fun `should validate email not duplicate`() {
             // given
@@ -735,17 +731,24 @@ class UserServiceTest {
         }
     }
 
-    private fun createTestUser(id: Long, email: String): User {
-        val user = User.createLocalUser(
-            email = email,
-            encodedPassword = "encoded_password",
-            nickname = "테스터"
-        )
+    private fun createTestUser(
+        id: Long,
+        email: String,
+    ): User {
+        val user =
+            User.createLocalUser(
+                email = email,
+                encodedPassword = "encoded_password",
+                nickname = "테스터",
+            )
         setUserId(user, id)
         return user
     }
 
-    private fun setUserId(user: User, id: Long) {
+    private fun setUserId(
+        user: User,
+        id: Long,
+    ) {
         val idField = User::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(user, id)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerRepository.kt
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import java.time.LocalDate
 
-interface PlayerRepository : JpaRepository<Player, Long>, PlayerRepositoryPort {
-
+interface PlayerRepository :
+    JpaRepository<Player, Long>,
+    PlayerRepositoryPort {
     override fun findByName(name: String): List<Player>
 
     override fun findByNameContaining(name: String): List<Player>
@@ -15,19 +16,26 @@ interface PlayerRepository : JpaRepository<Player, Long>, PlayerRepositoryPort {
     @Query("SELECT p FROM Player p WHERE p.retirementYear IS NULL")
     override fun findActivePlayers(): List<Player>
 
-    @Query("""
+    @Query(
+        """
         SELECT p FROM Player p
         JOIN FETCH p._teamHistories h
         WHERE h.team.id = :teamId AND h.endDate IS NULL
-    """)
+    """,
+    )
     override fun findCurrentPlayersByTeamId(teamId: Long): List<Player>
 
-    @Query("""
+    @Query(
+        """
         SELECT p FROM Player p
         JOIN p._teamHistories h
         WHERE h.team.id = :teamId
         AND h.startDate <= :date
         AND (h.endDate IS NULL OR h.endDate >= :date)
-    """)
-    override fun findPlayersByTeamIdAtDate(teamId: Long, date: LocalDate): List<Player>
+    """,
+    )
+    override fun findPlayersByTeamIdAtDate(
+        teamId: Long,
+        date: LocalDate,
+    ): List<Player>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerTeamHistoryRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerTeamHistoryRepository.kt
@@ -8,8 +8,9 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
 
-interface PlayerTeamHistoryRepository : JpaRepository<PlayerTeamHistory, Long>, PlayerTeamHistoryRepositoryPort {
-
+interface PlayerTeamHistoryRepository :
+    JpaRepository<PlayerTeamHistory, Long>,
+    PlayerTeamHistoryRepositoryPort {
     override fun findByPlayerId(playerId: Long): List<PlayerTeamHistory>
 
     override fun findByTeamId(teamId: Long): List<PlayerTeamHistory>
@@ -17,77 +18,100 @@ interface PlayerTeamHistoryRepository : JpaRepository<PlayerTeamHistory, Long>, 
     @Query("SELECT h FROM PlayerTeamHistory h WHERE h.player.id = :playerId AND h.endDate IS NULL")
     override fun findCurrentByPlayerId(playerId: Long): PlayerTeamHistory?
 
-    @Query("""
+    @Query(
+        """
         SELECT h FROM PlayerTeamHistory h
         WHERE h.team.id = :teamId AND h.endDate IS NULL
-    """)
+    """,
+    )
     override fun findCurrentByTeamId(teamId: Long): List<PlayerTeamHistory>
 
-    @Query("""
+    @Query(
+        """
         SELECT h FROM PlayerTeamHistory h
         JOIN FETCH h.player
         JOIN FETCH h.team
         WHERE h.player.id = :playerId
         ORDER BY h.startDate DESC
-    """)
+    """,
+    )
     override fun findByPlayerIdWithDetails(playerId: Long): List<PlayerTeamHistory>
 
-    @Query("""
+    @Query(
+        """
         SELECT h FROM PlayerTeamHistory h
         WHERE h.team.id = :teamId
         AND h.startDate <= :date
         AND (h.endDate IS NULL OR h.endDate >= :date)
-    """)
-    override fun findByTeamIdAtDate(teamId: Long, date: LocalDate): List<PlayerTeamHistory>
+    """,
+    )
+    override fun findByTeamIdAtDate(
+        teamId: Long,
+        date: LocalDate,
+    ): List<PlayerTeamHistory>
 
     // ===== 신규 메서드 (Issue #37) =====
 
-    @Query("""
+    @Query(
+        """
         SELECT h FROM PlayerTeamHistory h
         WHERE h.player.id = :playerId
         AND h.status = 'ACTIVE'
-    """)
-    override fun findActiveByPlayerId(@Param("playerId") playerId: Long): List<PlayerTeamHistory>
+    """,
+    )
+    override fun findActiveByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): List<PlayerTeamHistory>
 
-    @Query("""
+    @Query(
+        """
         SELECT h FROM PlayerTeamHistory h
         JOIN h.team t
         WHERE h.player.id = :playerId
         AND t.league.id = :leagueId
         AND h.status = 'ACTIVE'
-    """)
+    """,
+    )
     override fun findActiveByPlayerIdAndLeagueId(
         @Param("playerId") playerId: Long,
-        @Param("leagueId") leagueId: Long
+        @Param("leagueId") leagueId: Long,
     ): PlayerTeamHistory?
 
-    @Query("""
+    @Query(
+        """
         SELECT CASE WHEN COUNT(h) > 0 THEN true ELSE false END
         FROM PlayerTeamHistory h
         JOIN h.team t
         WHERE h.player.id = :playerId
         AND t.league.id = :leagueId
         AND h.status = 'ACTIVE'
-    """)
+    """,
+    )
     override fun existsActiveByPlayerIdAndLeagueId(
         @Param("playerId") playerId: Long,
-        @Param("leagueId") leagueId: Long
+        @Param("leagueId") leagueId: Long,
     ): Boolean
 
-    @Query("""
+    @Query(
+        """
         SELECT h FROM PlayerTeamHistory h
         WHERE h.player.id = :playerId
         AND h.status = :status
-    """)
+    """,
+    )
     override fun findByPlayerIdAndStatus(
         @Param("playerId") playerId: Long,
-        @Param("status") status: PlayerTeamStatus
+        @Param("status") status: PlayerTeamStatus,
     ): List<PlayerTeamHistory>
 
-    @Query("""
+    @Query(
+        """
         SELECT h FROM PlayerTeamHistory h
         WHERE h.team.id = :teamId
         AND h.status = 'ACTIVE'
-    """)
-    override fun findActiveByTeamId(@Param("teamId") teamId: Long): List<PlayerTeamHistory>
+    """,
+    )
+    override fun findActiveByTeamId(
+        @Param("teamId") teamId: Long,
+    ): List<PlayerTeamHistory>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamRepository.kt
@@ -5,8 +5,9 @@ import com.nextup.core.port.repository.TeamRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface TeamRepository : JpaRepository<Team, Long>, TeamRepositoryPort {
-
+interface TeamRepository :
+    JpaRepository<Team, Long>,
+    TeamRepositoryPort {
     override fun findByName(name: String): Team?
 
     override fun findByLeagueId(leagueId: Long): List<Team>

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/admin/OrganizationAdminRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/admin/OrganizationAdminRepository.kt
@@ -8,8 +8,9 @@ import com.nextup.core.port.repository.OrganizationAdminRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface OrganizationAdminRepository : JpaRepository<OrganizationAdmin, Long>, OrganizationAdminRepositoryPort {
-
+interface OrganizationAdminRepository :
+    JpaRepository<OrganizationAdmin, Long>,
+    OrganizationAdminRepositoryPort {
     /**
      * 특정 사용자의 모든 조직 관리자 권한을 조회합니다.
      */
@@ -32,21 +33,23 @@ interface OrganizationAdminRepository : JpaRepository<OrganizationAdmin, Long>, 
      */
     override fun findByOrganizationTypeAndOrganizationId(
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): List<OrganizationAdmin>
 
     /**
      * 특정 조직의 활성화된 관리자만 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT oa FROM OrganizationAdmin oa
         WHERE oa.organizationType = :organizationType
         AND oa.organizationId = :organizationId
         AND oa.isActive = true
-    """)
+    """,
+    )
     override fun findActiveByOrganizationTypeAndOrganizationId(
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): List<OrganizationAdmin>
 
     /**
@@ -55,22 +58,24 @@ interface OrganizationAdminRepository : JpaRepository<OrganizationAdmin, Long>, 
     override fun findByUserAndOrganizationTypeAndOrganizationId(
         user: User,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): OrganizationAdmin?
 
     /**
      * 특정 사용자 ID가 특정 조직의 관리자인지 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT oa FROM OrganizationAdmin oa
         WHERE oa.user.id = :userId
         AND oa.organizationType = :organizationType
         AND oa.organizationId = :organizationId
-    """)
+    """,
+    )
     override fun findByUserIdAndOrganizationTypeAndOrganizationId(
         userId: Long,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): OrganizationAdmin?
 
     /**
@@ -79,115 +84,131 @@ interface OrganizationAdminRepository : JpaRepository<OrganizationAdmin, Long>, 
     override fun existsByUserAndOrganizationTypeAndOrganizationId(
         user: User,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): Boolean
 
     /**
      * 특정 사용자 ID가 특정 조직의 관리자인지 확인합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT CASE WHEN COUNT(oa) > 0 THEN true ELSE false END
         FROM OrganizationAdmin oa
         WHERE oa.user.id = :userId
         AND oa.organizationType = :organizationType
         AND oa.organizationId = :organizationId
-    """)
+    """,
+    )
     override fun existsByUserIdAndOrganizationTypeAndOrganizationId(
         userId: Long,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): Boolean
 
     /**
      * 특정 사용자 ID가 특정 조직의 활성화된 관리자인지 확인합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT CASE WHEN COUNT(oa) > 0 THEN true ELSE false END
         FROM OrganizationAdmin oa
         WHERE oa.user.id = :userId
         AND oa.organizationType = :organizationType
         AND oa.organizationId = :organizationId
         AND oa.isActive = true
-    """)
+    """,
+    )
     override fun existsActiveByUserIdAndOrganizationTypeAndOrganizationId(
         userId: Long,
         organizationType: OrganizationType,
-        organizationId: Long
+        organizationId: Long,
     ): Boolean
 
     /**
      * 특정 사용자 ID의 특정 조직 유형 관리자 권한을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT oa FROM OrganizationAdmin oa
         WHERE oa.user.id = :userId
         AND oa.organizationType = :organizationType
-    """)
+    """,
+    )
     override fun findByUserIdAndOrganizationType(
         userId: Long,
-        organizationType: OrganizationType
+        organizationType: OrganizationType,
     ): List<OrganizationAdmin>
 
     /**
      * 특정 사용자 ID의 특정 조직 유형 활성화된 관리자 권한을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT oa FROM OrganizationAdmin oa
         WHERE oa.user.id = :userId
         AND oa.organizationType = :organizationType
         AND oa.isActive = true
-    """)
+    """,
+    )
     override fun findActiveByUserIdAndOrganizationType(
         userId: Long,
-        organizationType: OrganizationType
+        organizationType: OrganizationType,
     ): List<OrganizationAdmin>
 
     /**
      * 특정 조직의 특정 역할을 가진 관리자를 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT oa FROM OrganizationAdmin oa
         WHERE oa.organizationType = :organizationType
         AND oa.organizationId = :organizationId
         AND oa.role = :role
         AND oa.isActive = true
-    """)
+    """,
+    )
     override fun findByOrganizationAndRole(
         organizationType: OrganizationType,
         organizationId: Long,
-        role: OrganizationRole
+        role: OrganizationRole,
     ): List<OrganizationAdmin>
 
     /**
      * 특정 사용자가 관리하는 팀 ID 목록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT oa.organizationId FROM OrganizationAdmin oa
         WHERE oa.user.id = :userId
         AND oa.organizationType = 'TEAM'
         AND oa.isActive = true
-    """)
+    """,
+    )
     override fun findTeamIdsByUserId(userId: Long): List<Long>
 
     /**
      * 특정 사용자가 관리하는 리그 ID 목록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT oa.organizationId FROM OrganizationAdmin oa
         WHERE oa.user.id = :userId
         AND oa.organizationType = 'LEAGUE'
         AND oa.isActive = true
-    """)
+    """,
+    )
     override fun findLeagueIdsByUserId(userId: Long): List<Long>
 
     /**
      * 특정 사용자가 관리하는 협회 ID 목록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT oa.organizationId FROM OrganizationAdmin oa
         WHERE oa.user.id = :userId
         AND oa.organizationType = 'ASSOCIATION'
         AND oa.isActive = true
-    """)
+    """,
+    )
     override fun findAssociationIdsByUserId(userId: Long): List<Long>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/association/AssociationRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/association/AssociationRepository.kt
@@ -5,8 +5,9 @@ import com.nextup.core.port.repository.AssociationRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface AssociationRepository : JpaRepository<Association, Long>, AssociationRepositoryPort {
-
+interface AssociationRepository :
+    JpaRepository<Association, Long>,
+    AssociationRepositoryPort {
     /**
      * 협회 이름으로 조회합니다.
      */

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/auth/RefreshTokenRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/auth/RefreshTokenRepository.kt
@@ -13,7 +13,6 @@ import java.time.Instant
  */
 @Repository
 interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
-
     /**
      * 토큰 문자열로 RefreshToken을 조회합니다.
      *
@@ -36,15 +35,17 @@ interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
      * @param userId 사용자 ID
      * @return 유효한 RefreshToken 목록
      */
-    @Query("""
+    @Query(
+        """
         SELECT r FROM RefreshToken r
         WHERE r.userId = :userId
         AND r.isRevoked = false
         AND r.expiresAt > :now
-    """)
+    """,
+    )
     fun findValidTokensByUserId(
         @Param("userId") userId: Long,
-        @Param("now") now: Instant = Instant.now()
+        @Param("now") now: Instant = Instant.now(),
     ): List<RefreshToken>
 
     /**
@@ -54,7 +55,9 @@ interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
      */
     @Modifying
     @Query("UPDATE RefreshToken r SET r.isRevoked = true WHERE r.userId = :userId")
-    fun revokeAllByUserId(@Param("userId") userId: Long)
+    fun revokeAllByUserId(
+        @Param("userId") userId: Long,
+    )
 
     /**
      * 만료된 RefreshToken을 삭제합니다.
@@ -64,7 +67,9 @@ interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
      */
     @Modifying
     @Query("DELETE FROM RefreshToken r WHERE r.expiresAt < :expiredBefore")
-    fun deleteExpiredTokens(@Param("expiredBefore") expiredBefore: Instant): Int
+    fun deleteExpiredTokens(
+        @Param("expiredBefore") expiredBefore: Instant,
+    ): Int
 
     /**
      * 폐기된 RefreshToken을 삭제합니다.

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/competition/CompetitionRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/competition/CompetitionRepository.kt
@@ -6,8 +6,9 @@ import com.nextup.core.port.repository.CompetitionRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface CompetitionRepository : JpaRepository<Competition, Long>, CompetitionRepositoryPort {
-
+interface CompetitionRepository :
+    JpaRepository<Competition, Long>,
+    CompetitionRepositoryPort {
     /**
      * 리그별 대회 목록 조회
      */
@@ -16,7 +17,11 @@ interface CompetitionRepository : JpaRepository<Competition, Long>, CompetitionR
     /**
      * 리그 + 연도 + 시즌으로 대회 조회
      */
-    override fun findByLeagueIdAndYearAndSeason(leagueId: Long, year: Int, season: Int): Competition?
+    override fun findByLeagueIdAndYearAndSeason(
+        leagueId: Long,
+        year: Int,
+        season: Int,
+    ): Competition?
 
     /**
      * 특정 상태의 대회 목록 조회

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
@@ -6,10 +6,10 @@ import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.math.BigDecimal
 
-interface BattingRecordRepository : JpaRepository<BattingRecord, Long>, BattingRecordRepositoryPort {
-
+interface BattingRecordRepository :
+    JpaRepository<BattingRecord, Long>,
+    BattingRecordRepositoryPort {
     /**
      * GamePlayer로 타격 기록을 조회합니다.
      */
@@ -19,119 +19,147 @@ interface BattingRecordRepository : JpaRepository<BattingRecord, Long>, BattingR
      * GamePlayer ID로 타격 기록을 조회합니다.
      */
     @Query("SELECT br FROM BattingRecord br WHERE br.gamePlayer.id = :gamePlayerId")
-    override fun findByGamePlayerId(@Param("gamePlayerId") gamePlayerId: Long): BattingRecord?
+    override fun findByGamePlayerId(
+        @Param("gamePlayerId") gamePlayerId: Long,
+    ): BattingRecord?
 
     /**
      * 경기 ID로 모든 타격 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
         WHERE gp.game.id = :gameId
-    """)
-    override fun findAllByGameId(@Param("gameId") gameId: Long): List<BattingRecord>
+    """,
+    )
+    override fun findAllByGameId(
+        @Param("gameId") gameId: Long,
+    ): List<BattingRecord>
 
     /**
      * 선수 ID로 모든 타격 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
         WHERE gp.player.id = :playerId
         ORDER BY gp.game.scheduledDate DESC
-    """)
-    override fun findAllByPlayerId(@Param("playerId") playerId: Long): List<BattingRecord>
+    """,
+    )
+    override fun findAllByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): List<BattingRecord>
 
     /**
      * 선수의 최근 N경기 타격 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
         WHERE gp.player.id = :playerId
         ORDER BY gp.game.scheduledDate DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findRecentByPlayerId(
         @Param("playerId") playerId: Long,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<BattingRecord>
 
     /**
      * 팀의 특정 경기 타격 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
         JOIN gp.gameTeam gt
         WHERE gt.team.id = :teamId
         AND gp.game.id = :gameId
-    """)
+    """,
+    )
     override fun findAllByTeamIdAndGameId(
         @Param("teamId") teamId: Long,
-        @Param("gameId") gameId: Long
+        @Param("gameId") gameId: Long,
     ): List<BattingRecord>
 
     /**
      * 경기에서 최소 타석 수 이상인 타격 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
         WHERE gp.game.id = :gameId
         AND br.plateAppearances >= :minPlateAppearances
-    """)
+    """,
+    )
     override fun findByGameIdAndMinPlateAppearances(
         @Param("gameId") gameId: Long,
-        @Param("minPlateAppearances") minPlateAppearances: Int
+        @Param("minPlateAppearances") minPlateAppearances: Int,
     ): List<BattingRecord>
 
     /**
      * 타율 상위 N명을 조회합니다 (최소 타수 조건).
      */
-    @Query("""
+    @Query(
+        """
         SELECT br FROM BattingRecord br
         WHERE br.atBats >= :minAtBats
         ORDER BY (CAST(br.hits AS double) / CAST(br.atBats AS double)) DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByBattingAverage(
         @Param("minAtBats") minAtBats: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<BattingRecord>
 
     /**
      * 홈런 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT br FROM BattingRecord br
         ORDER BY br.homeRuns DESC
         LIMIT :limit
-    """)
-    override fun findTopByHomeRuns(@Param("limit") limit: Int): List<BattingRecord>
+    """,
+    )
+    override fun findTopByHomeRuns(
+        @Param("limit") limit: Int,
+    ): List<BattingRecord>
 
     /**
      * 타점 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT br FROM BattingRecord br
         ORDER BY br.runsBattedIn DESC
         LIMIT :limit
-    """)
-    override fun findTopByRunsBattedIn(@Param("limit") limit: Int): List<BattingRecord>
+    """,
+    )
+    override fun findTopByRunsBattedIn(
+        @Param("limit") limit: Int,
+    ): List<BattingRecord>
 
     /**
      * 선수의 특정 연도 타격 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
         WHERE gp.player.id = :playerId
         AND FUNCTION('YEAR', gp.game.scheduledAt) = :year
         ORDER BY gp.game.scheduledAt DESC
-    """)
+    """,
+    )
     override fun findAllByPlayerIdAndYear(
         @Param("playerId") playerId: Long,
-        @Param("year") year: Int
+        @Param("year") year: Int,
     ): List<BattingRecord>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GamePlayerRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GamePlayerRepository.kt
@@ -6,46 +6,59 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface GamePlayerRepository : JpaRepository<GamePlayer, Long>, GamePlayerRepositoryPort {
-
+interface GamePlayerRepository :
+    JpaRepository<GamePlayer, Long>,
+    GamePlayerRepositoryPort {
     /**
      * 경기 ID와 선수 ID로 GamePlayer를 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT gp FROM GamePlayer gp
         JOIN gp.gameTeam gt
         WHERE gt.game.id = :gameId
         AND gp.player.id = :playerId
-    """)
+    """,
+    )
     override fun findByGameIdAndPlayerId(
         @Param("gameId") gameId: Long,
-        @Param("playerId") playerId: Long
+        @Param("playerId") playerId: Long,
     ): GamePlayer?
 
     /**
      * 경기 ID로 모든 GamePlayer를 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT gp FROM GamePlayer gp
         JOIN gp.gameTeam gt
         WHERE gt.game.id = :gameId
-    """)
-    override fun findAllByGameId(@Param("gameId") gameId: Long): List<GamePlayer>
+    """,
+    )
+    override fun findAllByGameId(
+        @Param("gameId") gameId: Long,
+    ): List<GamePlayer>
 
     /**
      * 선수 ID로 모든 GamePlayer를 조회합니다.
      */
     @Query("SELECT gp FROM GamePlayer gp WHERE gp.player.id = :playerId")
-    override fun findAllByPlayerId(@Param("playerId") playerId: Long): List<GamePlayer>
+    override fun findAllByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): List<GamePlayer>
 
     /**
      * 경기에서 현재 출전 중인 GamePlayer를 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT gp FROM GamePlayer gp
         JOIN gp.gameTeam gt
         WHERE gt.game.id = :gameId
         AND gp.isCurrentlyPlaying = true
-    """)
-    override fun findCurrentlyPlayingByGameId(@Param("gameId") gameId: Long): List<GamePlayer>
+    """,
+    )
+    override fun findCurrentlyPlayingByGameId(
+        @Param("gameId") gameId: Long,
+    ): List<GamePlayer>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
@@ -1,0 +1,10 @@
+package com.nextup.infrastructure.repository.game
+
+import com.nextup.core.domain.game.Game
+import com.nextup.core.port.repository.GameRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GameRepository : JpaRepository<Game, Long>, GameRepositoryPort {
+
+    override fun findByIdOrNull(id: Long): Game? = findById(id).orElse(null)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
@@ -4,7 +4,8 @@ import com.nextup.core.domain.game.Game
 import com.nextup.core.port.repository.GameRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface GameRepository : JpaRepository<Game, Long>, GameRepositoryPort {
-
+interface GameRepository :
+    JpaRepository<Game, Long>,
+    GameRepositoryPort {
     override fun findByIdOrNull(id: Long): Game? = findById(id).orElse(null)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
@@ -8,8 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface PitchingRecordRepository : JpaRepository<PitchingRecord, Long>, PitchingRecordRepositoryPort {
-
+interface PitchingRecordRepository :
+    JpaRepository<PitchingRecord, Long>,
+    PitchingRecordRepositoryPort {
     /**
      * GamePlayer로 투수 기록을 조회합니다.
      */
@@ -19,181 +20,235 @@ interface PitchingRecordRepository : JpaRepository<PitchingRecord, Long>, Pitchi
      * GamePlayer ID로 투수 기록을 조회합니다.
      */
     @Query("SELECT pr FROM PitchingRecord pr WHERE pr.gamePlayer.id = :gamePlayerId")
-    override fun findByGamePlayerId(@Param("gamePlayerId") gamePlayerId: Long): PitchingRecord?
+    override fun findByGamePlayerId(
+        @Param("gamePlayerId") gamePlayerId: Long,
+    ): PitchingRecord?
 
     /**
      * 경기 ID로 모든 투수 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.game.id = :gameId
-    """)
-    override fun findAllByGameId(@Param("gameId") gameId: Long): List<PitchingRecord>
+    """,
+    )
+    override fun findAllByGameId(
+        @Param("gameId") gameId: Long,
+    ): List<PitchingRecord>
 
     /**
      * 선수 ID로 모든 투수 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.player.id = :playerId
         ORDER BY gp.game.scheduledDate DESC
-    """)
-    override fun findAllByPlayerId(@Param("playerId") playerId: Long): List<PitchingRecord>
+    """,
+    )
+    override fun findAllByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): List<PitchingRecord>
 
     /**
      * 선수의 최근 N경기 투수 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.player.id = :playerId
         ORDER BY gp.game.scheduledDate DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findRecentByPlayerId(
         @Param("playerId") playerId: Long,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<PitchingRecord>
 
     /**
      * 팀의 특정 경기 투수 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         JOIN gp.gameTeam gt
         WHERE gt.team.id = :teamId
         AND gp.game.id = :gameId
-    """)
+    """,
+    )
     override fun findAllByTeamIdAndGameId(
         @Param("teamId") teamId: Long,
-        @Param("gameId") gameId: Long
+        @Param("gameId") gameId: Long,
     ): List<PitchingRecord>
 
     /**
      * 경기의 선발 투수 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.game.id = :gameId
         AND pr.isStartingPitcher = true
-    """)
-    override fun findStartingPitchersByGameId(@Param("gameId") gameId: Long): List<PitchingRecord>
+    """,
+    )
+    override fun findStartingPitchersByGameId(
+        @Param("gameId") gameId: Long,
+    ): List<PitchingRecord>
 
     /**
      * 경기의 구원 투수 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.game.id = :gameId
         AND pr.isStartingPitcher = false
-    """)
-    override fun findReliefPitchersByGameId(@Param("gameId") gameId: Long): List<PitchingRecord>
+    """,
+    )
+    override fun findReliefPitchersByGameId(
+        @Param("gameId") gameId: Long,
+    ): List<PitchingRecord>
 
     /**
      * 특정 결정(WIN/LOSS/SAVE/HOLD)을 받은 투수 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         WHERE pr.decision = :decision
-    """)
-    override fun findAllByDecision(@Param("decision") decision: PitchingDecision): List<PitchingRecord>
+    """,
+    )
+    override fun findAllByDecision(
+        @Param("decision") decision: PitchingDecision,
+    ): List<PitchingRecord>
 
     /**
      * 경기의 승리 투수를 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.game.id = :gameId
         AND pr.decision = 'WIN'
-    """)
-    override fun findWinningPitcherByGameId(@Param("gameId") gameId: Long): PitchingRecord?
+    """,
+    )
+    override fun findWinningPitcherByGameId(
+        @Param("gameId") gameId: Long,
+    ): PitchingRecord?
 
     /**
      * 경기의 패전 투수를 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.game.id = :gameId
         AND pr.decision = 'LOSS'
-    """)
-    override fun findLosingPitcherByGameId(@Param("gameId") gameId: Long): PitchingRecord?
+    """,
+    )
+    override fun findLosingPitcherByGameId(
+        @Param("gameId") gameId: Long,
+    ): PitchingRecord?
 
     /**
      * 경기의 세이브 투수를 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.game.id = :gameId
         AND pr.decision = 'SAVE'
-    """)
-    override fun findSavePitcherByGameId(@Param("gameId") gameId: Long): PitchingRecord?
+    """,
+    )
+    override fun findSavePitcherByGameId(
+        @Param("gameId") gameId: Long,
+    ): PitchingRecord?
 
     /**
      * ERA 상위 N명을 조회합니다 (최소 이닝 조건).
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         WHERE pr.inningsPitchedOuts >= :minInningsPitchedOuts
         ORDER BY (CAST(pr.earnedRuns AS double) * 27.0 / CAST(pr.inningsPitchedOuts AS double)) ASC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByEarnedRunAverage(
         @Param("minInningsPitchedOuts") minInningsPitchedOuts: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<PitchingRecord>
 
     /**
      * 삼진 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         ORDER BY pr.strikeouts DESC
         LIMIT :limit
-    """)
-    override fun findTopByStrikeouts(@Param("limit") limit: Int): List<PitchingRecord>
+    """,
+    )
+    override fun findTopByStrikeouts(
+        @Param("limit") limit: Int,
+    ): List<PitchingRecord>
 
     /**
      * 승수 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         WHERE pr.decision = 'WIN'
         ORDER BY pr.id DESC
         LIMIT :limit
-    """)
-    override fun findTopByWins(@Param("limit") limit: Int): List<PitchingRecord>
+    """,
+    )
+    override fun findTopByWins(
+        @Param("limit") limit: Int,
+    ): List<PitchingRecord>
 
     /**
      * 세이브 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         WHERE pr.decision = 'SAVE'
         ORDER BY pr.id DESC
         LIMIT :limit
-    """)
-    override fun findTopBySaves(@Param("limit") limit: Int): List<PitchingRecord>
+    """,
+    )
+    override fun findTopBySaves(
+        @Param("limit") limit: Int,
+    ): List<PitchingRecord>
 
     /**
      * 선수의 특정 연도 투수 기록을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.player.id = :playerId
         AND FUNCTION('YEAR', gp.game.scheduledAt) = :year
         ORDER BY gp.game.scheduledAt DESC
-    """)
+    """,
+    )
     override fun findAllByPlayerIdAndYear(
         @Param("playerId") playerId: Long,
-        @Param("year") year: Int
+        @Param("year") year: Int,
     ): List<PitchingRecord>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/league/LeagueRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/league/LeagueRepository.kt
@@ -5,8 +5,9 @@ import com.nextup.core.port.repository.LeagueRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface LeagueRepository : JpaRepository<League, Long>, LeagueRepositoryPort {
-
+interface LeagueRepository :
+    JpaRepository<League, Long>,
+    LeagueRepositoryPort {
     /**
      * 협회 ID로 리그 목록을 조회합니다.
      */
@@ -15,7 +16,9 @@ interface LeagueRepository : JpaRepository<League, Long>, LeagueRepositoryPort {
     /**
      * 협회 ID로 활성화된 리그 목록을 조회합니다.
      */
-    @Query("SELECT l FROM League l WHERE l.association.id = :associationId AND l.isActive = true ORDER BY l.divisionLevel, l.name")
+    @Query(
+        "SELECT l FROM League l WHERE l.association.id = :associationId AND l.isActive = true ORDER BY l.divisionLevel, l.name"
+    )
     override fun findActiveByAssociationId(associationId: Long): List<League>
 
     /**
@@ -27,16 +30,24 @@ interface LeagueRepository : JpaRepository<League, Long>, LeagueRepositoryPort {
     /**
      * 협회 내에서 리그 이름 존재 여부를 확인합니다.
      */
-    override fun existsByAssociationIdAndName(associationId: Long, name: String): Boolean
+    override fun existsByAssociationIdAndName(
+        associationId: Long,
+        name: String,
+    ): Boolean
 
     /**
      * 협회 내에서 리그 이름으로 조회합니다.
      */
-    override fun findByAssociationIdAndName(associationId: Long, name: String): League?
+    override fun findByAssociationIdAndName(
+        associationId: Long,
+        name: String,
+    ): League?
 
     /**
      * 부 레벨(divisionLevel)별로 리그를 조회합니다.
      */
-    @Query("SELECT l FROM League l WHERE l.divisionLevel = :divisionLevel AND l.isActive = true ORDER BY l.association.name, l.name")
+    @Query(
+        "SELECT l FROM League l WHERE l.divisionLevel = :divisionLevel AND l.isActive = true ORDER BY l.association.name, l.name"
+    )
     override fun findActiveByDivisionLevel(divisionLevel: Int): List<League>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/CareerBattingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/CareerBattingStatsRepository.kt
@@ -6,72 +6,94 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface CareerBattingStatsRepository : JpaRepository<CareerBattingStats, Long>, CareerBattingStatsRepositoryPort {
-
+interface CareerBattingStatsRepository :
+    JpaRepository<CareerBattingStats, Long>,
+    CareerBattingStatsRepositoryPort {
     /**
      * 선수 ID로 통산 타격 통계를 조회합니다.
      */
     @Query("SELECT c FROM CareerBattingStats c WHERE c.player.id = :playerId")
-    override fun findByPlayerId(@Param("playerId") playerId: Long): CareerBattingStats?
+    override fun findByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): CareerBattingStats?
 
     /**
      * 통산 타율 상위 N명을 조회합니다 (최소 타수 조건).
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerBattingStats c
         WHERE c.atBats >= :minAtBats
         ORDER BY (CAST(c.hits AS double) / CAST(c.atBats AS double)) DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByBattingAverage(
         @Param("minAtBats") minAtBats: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<CareerBattingStats>
 
     /**
      * 통산 홈런 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerBattingStats c
         ORDER BY c.homeRuns DESC
         LIMIT :limit
-    """)
-    override fun findTopByHomeRuns(@Param("limit") limit: Int): List<CareerBattingStats>
+    """,
+    )
+    override fun findTopByHomeRuns(
+        @Param("limit") limit: Int,
+    ): List<CareerBattingStats>
 
     /**
      * 통산 타점 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerBattingStats c
         ORDER BY c.runsBattedIn DESC
         LIMIT :limit
-    """)
-    override fun findTopByRunsBattedIn(@Param("limit") limit: Int): List<CareerBattingStats>
+    """,
+    )
+    override fun findTopByRunsBattedIn(
+        @Param("limit") limit: Int,
+    ): List<CareerBattingStats>
 
     /**
      * 통산 안타 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerBattingStats c
         ORDER BY c.hits DESC
         LIMIT :limit
-    """)
-    override fun findTopByHits(@Param("limit") limit: Int): List<CareerBattingStats>
+    """,
+    )
+    override fun findTopByHits(
+        @Param("limit") limit: Int,
+    ): List<CareerBattingStats>
 
     /**
      * 통산 도루 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerBattingStats c
         ORDER BY c.stolenBases DESC
         LIMIT :limit
-    """)
-    override fun findTopByStolenBases(@Param("limit") limit: Int): List<CareerBattingStats>
+    """,
+    )
+    override fun findTopByStolenBases(
+        @Param("limit") limit: Int,
+    ): List<CareerBattingStats>
 
     /**
      * 통산 OPS 상위 N명을 조회합니다 (최소 타석 조건).
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerBattingStats c
         WHERE c.plateAppearances >= :minPlateAppearances
         ORDER BY (
@@ -82,16 +104,18 @@ interface CareerBattingStatsRepository : JpaRepository<CareerBattingStats, Long>
              CAST(c.atBats AS double))
         ) DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByOps(
         @Param("minPlateAppearances") minPlateAppearances: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<CareerBattingStats>
 
     /**
      * 통산 장타율 상위 N명을 조회합니다 (최소 타수 조건).
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerBattingStats c
         WHERE c.atBats >= :minAtBats
         ORDER BY (
@@ -100,9 +124,10 @@ interface CareerBattingStatsRepository : JpaRepository<CareerBattingStats, Long>
             CAST(c.atBats AS double)
         ) DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopBySluggingPercentage(
         @Param("minAtBats") minAtBats: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<CareerBattingStats>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/CareerPitchingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/CareerPitchingStatsRepository.kt
@@ -6,96 +6,121 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface CareerPitchingStatsRepository : JpaRepository<CareerPitchingStats, Long>, CareerPitchingStatsRepositoryPort {
-
+interface CareerPitchingStatsRepository :
+    JpaRepository<CareerPitchingStats, Long>,
+    CareerPitchingStatsRepositoryPort {
     /**
      * 선수 ID로 통산 투수 통계를 조회합니다.
      */
     @Query("SELECT c FROM CareerPitchingStats c WHERE c.player.id = :playerId")
-    override fun findByPlayerId(@Param("playerId") playerId: Long): CareerPitchingStats?
+    override fun findByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): CareerPitchingStats?
 
     /**
      * 통산 ERA 상위 N명을 조회합니다 (최소 이닝 조건).
      * ERA는 낮을수록 좋으므로 ASC 정렬합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerPitchingStats c
         WHERE c.inningsPitchedOuts >= :minInningsPitchedOuts
         ORDER BY (CAST(c.earnedRuns AS double) * 27.0 / CAST(c.inningsPitchedOuts AS double)) ASC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByEra(
         @Param("minInningsPitchedOuts") minInningsPitchedOuts: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<CareerPitchingStats>
 
     /**
      * 통산 승수 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerPitchingStats c
         ORDER BY c.wins DESC
         LIMIT :limit
-    """)
-    override fun findTopByWins(@Param("limit") limit: Int): List<CareerPitchingStats>
+    """,
+    )
+    override fun findTopByWins(
+        @Param("limit") limit: Int,
+    ): List<CareerPitchingStats>
 
     /**
      * 통산 삼진 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerPitchingStats c
         ORDER BY c.strikeouts DESC
         LIMIT :limit
-    """)
-    override fun findTopByStrikeouts(@Param("limit") limit: Int): List<CareerPitchingStats>
+    """,
+    )
+    override fun findTopByStrikeouts(
+        @Param("limit") limit: Int,
+    ): List<CareerPitchingStats>
 
     /**
      * 통산 세이브 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerPitchingStats c
         ORDER BY c.saves DESC
         LIMIT :limit
-    """)
-    override fun findTopBySaves(@Param("limit") limit: Int): List<CareerPitchingStats>
+    """,
+    )
+    override fun findTopBySaves(
+        @Param("limit") limit: Int,
+    ): List<CareerPitchingStats>
 
     /**
      * 통산 WHIP 상위 N명을 조회합니다 (최소 이닝 조건).
      * WHIP는 낮을수록 좋으므로 ASC 정렬합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerPitchingStats c
         WHERE c.inningsPitchedOuts >= :minInningsPitchedOuts
         ORDER BY (CAST(c.hitsAllowed + c.walksAllowed AS double) * 3.0 / CAST(c.inningsPitchedOuts AS double)) ASC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByWhip(
         @Param("minInningsPitchedOuts") minInningsPitchedOuts: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<CareerPitchingStats>
 
     /**
      * 통산 이닝 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerPitchingStats c
         ORDER BY c.inningsPitchedOuts DESC
         LIMIT :limit
-    """)
-    override fun findTopByInningsPitched(@Param("limit") limit: Int): List<CareerPitchingStats>
+    """,
+    )
+    override fun findTopByInningsPitched(
+        @Param("limit") limit: Int,
+    ): List<CareerPitchingStats>
 
     /**
      * 통산 삼진/볼넷 비율 상위 N명을 조회합니다 (최소 이닝 및 볼넷 조건).
      */
-    @Query("""
+    @Query(
+        """
         SELECT c FROM CareerPitchingStats c
         WHERE c.inningsPitchedOuts >= :minInningsPitchedOuts
         AND c.walksAllowed > 0
         ORDER BY (CAST(c.strikeouts AS double) / CAST(c.walksAllowed AS double)) DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByStrikeoutToWalkRatio(
         @Param("minInningsPitchedOuts") minInningsPitchedOuts: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<CareerPitchingStats>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonBattingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonBattingStatsRepository.kt
@@ -6,77 +6,89 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface SeasonBattingStatsRepository : JpaRepository<SeasonBattingStats, Long>, SeasonBattingStatsRepositoryPort {
-
+interface SeasonBattingStatsRepository :
+    JpaRepository<SeasonBattingStats, Long>,
+    SeasonBattingStatsRepositoryPort {
     /**
      * 선수 ID와 연도로 시즌 타격 통계를 조회합니다.
      */
     @Query("SELECT s FROM SeasonBattingStats s WHERE s.player.id = :playerId AND s.year = :year")
     override fun findByPlayerIdAndYear(
         @Param("playerId") playerId: Long,
-        @Param("year") year: Int
+        @Param("year") year: Int,
     ): SeasonBattingStats?
 
     /**
      * 선수 ID로 모든 시즌 타격 통계를 조회합니다.
      */
     @Query("SELECT s FROM SeasonBattingStats s WHERE s.player.id = :playerId ORDER BY s.year DESC")
-    override fun findAllByPlayerId(@Param("playerId") playerId: Long): List<SeasonBattingStats>
+    override fun findAllByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): List<SeasonBattingStats>
 
     /**
      * 특정 연도의 모든 시즌 타격 통계를 조회합니다.
      */
     @Query("SELECT s FROM SeasonBattingStats s WHERE s.year = :year")
-    override fun findAllByYear(@Param("year") year: Int): List<SeasonBattingStats>
+    override fun findAllByYear(
+        @Param("year") year: Int,
+    ): List<SeasonBattingStats>
 
     /**
      * 타율 상위 N명을 조회합니다 (최소 타수 조건).
      */
-    @Query("""
+    @Query(
+        """
         SELECT s FROM SeasonBattingStats s
         WHERE s.year = :year
         AND s.atBats >= :minAtBats
         ORDER BY (CAST(s.hits AS double) / CAST(s.atBats AS double)) DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByBattingAverage(
         @Param("year") year: Int,
         @Param("minAtBats") minAtBats: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<SeasonBattingStats>
 
     /**
      * 홈런 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT s FROM SeasonBattingStats s
         WHERE s.year = :year
         ORDER BY s.homeRuns DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByHomeRuns(
         @Param("year") year: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<SeasonBattingStats>
 
     /**
      * 타점 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT s FROM SeasonBattingStats s
         WHERE s.year = :year
         ORDER BY s.runsBattedIn DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByRunsBattedIn(
         @Param("year") year: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<SeasonBattingStats>
 
     /**
      * OPS 상위 N명을 조회합니다 (최소 타석 조건).
      */
-    @Query("""
+    @Query(
+        """
         SELECT s FROM SeasonBattingStats s
         WHERE s.year = :year
         AND s.plateAppearances >= :minPlateAppearances
@@ -88,10 +100,11 @@ interface SeasonBattingStatsRepository : JpaRepository<SeasonBattingStats, Long>
              CAST(s.atBats AS double))
         ) DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByOps(
         @Param("year") year: Int,
         @Param("minPlateAppearances") minPlateAppearances: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<SeasonBattingStats>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonPitchingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonPitchingStatsRepository.kt
@@ -6,102 +6,117 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface SeasonPitchingStatsRepository : JpaRepository<SeasonPitchingStats, Long>, SeasonPitchingStatsRepositoryPort {
-
+interface SeasonPitchingStatsRepository :
+    JpaRepository<SeasonPitchingStats, Long>,
+    SeasonPitchingStatsRepositoryPort {
     /**
      * 선수 ID와 연도로 시즌 투수 통계를 조회합니다.
      */
     @Query("SELECT s FROM SeasonPitchingStats s WHERE s.player.id = :playerId AND s.year = :year")
     override fun findByPlayerIdAndYear(
         @Param("playerId") playerId: Long,
-        @Param("year") year: Int
+        @Param("year") year: Int,
     ): SeasonPitchingStats?
 
     /**
      * 선수 ID로 모든 시즌 투수 통계를 조회합니다.
      */
     @Query("SELECT s FROM SeasonPitchingStats s WHERE s.player.id = :playerId ORDER BY s.year DESC")
-    override fun findAllByPlayerId(@Param("playerId") playerId: Long): List<SeasonPitchingStats>
+    override fun findAllByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): List<SeasonPitchingStats>
 
     /**
      * 특정 연도의 모든 시즌 투수 통계를 조회합니다.
      */
     @Query("SELECT s FROM SeasonPitchingStats s WHERE s.year = :year")
-    override fun findAllByYear(@Param("year") year: Int): List<SeasonPitchingStats>
+    override fun findAllByYear(
+        @Param("year") year: Int,
+    ): List<SeasonPitchingStats>
 
     /**
      * ERA 상위 N명을 조회합니다 (최소 이닝 조건).
      * ERA는 낮을수록 좋으므로 ASC 정렬합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT s FROM SeasonPitchingStats s
         WHERE s.year = :year
         AND s.inningsPitchedOuts >= :minInningsPitchedOuts
         ORDER BY (CAST(s.earnedRuns AS double) * 27.0 / CAST(s.inningsPitchedOuts AS double)) ASC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByEra(
         @Param("year") year: Int,
         @Param("minInningsPitchedOuts") minInningsPitchedOuts: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<SeasonPitchingStats>
 
     /**
      * 승수 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT s FROM SeasonPitchingStats s
         WHERE s.year = :year
         ORDER BY s.wins DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByWins(
         @Param("year") year: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<SeasonPitchingStats>
 
     /**
      * 삼진 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT s FROM SeasonPitchingStats s
         WHERE s.year = :year
         ORDER BY s.strikeouts DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByStrikeouts(
         @Param("year") year: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<SeasonPitchingStats>
 
     /**
      * 세이브 상위 N명을 조회합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT s FROM SeasonPitchingStats s
         WHERE s.year = :year
         ORDER BY s.saves DESC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopBySaves(
         @Param("year") year: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<SeasonPitchingStats>
 
     /**
      * WHIP 상위 N명을 조회합니다 (최소 이닝 조건).
      * WHIP는 낮을수록 좋으므로 ASC 정렬합니다.
      */
-    @Query("""
+    @Query(
+        """
         SELECT s FROM SeasonPitchingStats s
         WHERE s.year = :year
         AND s.inningsPitchedOuts >= :minInningsPitchedOuts
         ORDER BY (CAST(s.hitsAllowed + s.walksAllowed AS double) * 3.0 / CAST(s.inningsPitchedOuts AS double)) ASC
         LIMIT :limit
-    """)
+    """,
+    )
     override fun findTopByWhip(
         @Param("year") year: Int,
         @Param("minInningsPitchedOuts") minInningsPitchedOuts: Int,
-        @Param("limit") limit: Int
+        @Param("limit") limit: Int,
     ): List<SeasonPitchingStats>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/OAuthAccountRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/OAuthAccountRepository.kt
@@ -6,17 +6,27 @@ import com.nextup.core.port.repository.OAuthAccountRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface OAuthAccountRepository : JpaRepository<OAuthAccount, Long>, OAuthAccountRepositoryPort {
+interface OAuthAccountRepository :
+    JpaRepository<OAuthAccount, Long>,
+    OAuthAccountRepositoryPort {
+    override fun findByProviderAndOauthId(
+        provider: OAuthProvider,
+        oauthId: String,
+    ): OAuthAccount?
 
-    override fun findByProviderAndOauthId(provider: OAuthProvider, oauthId: String): OAuthAccount?
-
-    override fun existsByProviderAndOauthId(provider: OAuthProvider, oauthId: String): Boolean
+    override fun existsByProviderAndOauthId(
+        provider: OAuthProvider,
+        oauthId: String,
+    ): Boolean
 
     @Query("SELECT o FROM OAuthAccount o WHERE o.user.id = :userId")
     override fun findAllByUserId(userId: Long): List<OAuthAccount>
 
     @Query("SELECT o FROM OAuthAccount o WHERE o.user.id = :userId AND o.provider = :provider")
-    override fun findByUserIdAndProvider(userId: Long, provider: OAuthProvider): OAuthAccount?
+    override fun findByUserIdAndProvider(
+        userId: Long,
+        provider: OAuthProvider,
+    ): OAuthAccount?
 
     @Query("SELECT o.provider FROM OAuthAccount o WHERE o.user.id = :userId")
     override fun findProvidersByUserId(userId: Long): List<OAuthProvider>

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/UserRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/UserRepository.kt
@@ -8,8 +8,9 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface UserRepository : JpaRepository<User, Long>, UserRepositoryPort {
-
+interface UserRepository :
+    JpaRepository<User, Long>,
+    UserRepositoryPort {
     override fun findByEmail(email: String): User?
 
     override fun existsByEmail(email: String): Boolean
@@ -18,28 +19,46 @@ interface UserRepository : JpaRepository<User, Long>, UserRepositoryPort {
     override fun findAllActive(pageable: Pageable): Page<User>
 
     @Query("SELECT u FROM User u WHERE u.isActive = :isActive")
-    override fun findAllByIsActive(isActive: Boolean, pageable: Pageable): Page<User>
+    override fun findAllByIsActive(
+        isActive: Boolean,
+        pageable: Pageable,
+    ): Page<User>
 
-    @Query("""
+    @Query(
+        """
         SELECT u FROM User u
         WHERE u.nickname LIKE %:keyword%
         OR u.email LIKE %:keyword%
-    """)
-    override fun searchByKeyword(keyword: String, pageable: Pageable): Page<User>
+    """,
+    )
+    override fun searchByKeyword(
+        keyword: String,
+        pageable: Pageable,
+    ): Page<User>
 
-    @Query("""
+    @Query(
+        """
         SELECT u FROM User u
         JOIN u._roles r
         WHERE r = :role
-    """)
-    override fun findAllByRole(role: Role, pageable: Pageable): Page<User>
+    """,
+    )
+    override fun findAllByRole(
+        role: Role,
+        pageable: Pageable,
+    ): Page<User>
 
-    @Query("""
+    @Query(
+        """
         SELECT u FROM User u
         JOIN u._roles r
         WHERE r IN :roles
-    """)
-    override fun findAllByRolesIn(roles: Set<Role>, pageable: Pageable): Page<User>
+    """,
+    )
+    override fun findAllByRolesIn(
+        roles: Set<Role>,
+        pageable: Pageable,
+    ): Page<User>
 
     @Query("SELECT u FROM User u WHERE u.player.id = :playerId")
     override fun findByPlayerId(playerId: Long): User?

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/AuthenticationService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/AuthenticationService.kt
@@ -20,9 +20,8 @@ class AuthenticationService(
     private val userJpaRepository: UserJpaRepository,
     private val refreshTokenRepository: RefreshTokenRepository,
     private val jwtTokenProvider: JwtTokenProvider,
-    private val passwordEncoder: PasswordEncoder
+    private val passwordEncoder: PasswordEncoder,
 ) {
-
     /**
      * 로그인 처리
      *
@@ -38,10 +37,11 @@ class AuthenticationService(
         email: String,
         password: String,
         deviceInfo: String? = null,
-        ipAddress: String? = null
+        ipAddress: String? = null,
     ): TokenPair {
-        val user = userJpaRepository.findByEmail(email)
-            ?: throw InvalidCredentialsException()
+        val user =
+            userJpaRepository.findByEmail(email)
+                ?: throw InvalidCredentialsException()
 
         if (!user.isActive) {
             throw UserDeactivatedException(user.id)
@@ -68,10 +68,11 @@ class AuthenticationService(
     fun refresh(
         refreshTokenString: String,
         deviceInfo: String? = null,
-        ipAddress: String? = null
+        ipAddress: String? = null,
     ): TokenPair {
-        val refreshToken = refreshTokenRepository.findByToken(refreshTokenString)
-            ?: throw RefreshTokenNotFoundException()
+        val refreshToken =
+            refreshTokenRepository.findByToken(refreshTokenString)
+                ?: throw RefreshTokenNotFoundException()
 
         if (refreshToken.isExpired) {
             throw RefreshTokenExpiredException()
@@ -85,8 +86,10 @@ class AuthenticationService(
         refreshToken.revoke()
         refreshTokenRepository.save(refreshToken)
 
-        val user = userJpaRepository.findById(refreshToken.userId)
-            .orElseThrow { UserNotFoundException(refreshToken.userId) }
+        val user =
+            userJpaRepository
+                .findById(refreshToken.userId)
+                .orElseThrow { UserNotFoundException(refreshToken.userId) }
 
         if (!user.isActive) {
             throw UserDeactivatedException(user.id)
@@ -124,37 +127,41 @@ class AuthenticationService(
      */
     @Transactional(readOnly = true)
     fun getUserDetails(userId: Long): CustomUserDetails {
-        val user = userJpaRepository.findById(userId)
-            .orElseThrow { UserNotFoundException(userId) }
+        val user =
+            userJpaRepository
+                .findById(userId)
+                .orElseThrow { UserNotFoundException(userId) }
         return CustomUserDetails.from(user)
     }
 
     private fun generateTokenPair(
         user: User,
         deviceInfo: String?,
-        ipAddress: String?
+        ipAddress: String?,
     ): TokenPair {
         val roles = user.roles.map { it.name }.toSet()
 
-        val accessToken = jwtTokenProvider.createAccessToken(
-            userId = user.id,
-            email = user.email,
-            roles = roles
-        )
+        val accessToken =
+            jwtTokenProvider.createAccessToken(
+                userId = user.id,
+                email = user.email,
+                roles = roles,
+            )
 
         val refreshTokenString = jwtTokenProvider.createRefreshToken(user.id)
-        val refreshToken = RefreshToken.create(
-            userId = user.id,
-            token = refreshTokenString,
-            expiresAt = jwtTokenProvider.getRefreshTokenExpiration(),
-            deviceInfo = deviceInfo,
-            ipAddress = ipAddress
-        )
+        val refreshToken =
+            RefreshToken.create(
+                userId = user.id,
+                token = refreshTokenString,
+                expiresAt = jwtTokenProvider.getRefreshTokenExpiration(),
+                deviceInfo = deviceInfo,
+                ipAddress = ipAddress,
+            )
         refreshTokenRepository.save(refreshToken)
 
         return TokenPair(
             accessToken = accessToken,
-            refreshToken = refreshTokenString
+            refreshToken = refreshTokenString,
         )
     }
 }
@@ -164,5 +171,5 @@ class AuthenticationService(
  */
 data class TokenPair(
     val accessToken: String,
-    val refreshToken: String
+    val refreshToken: String,
 )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/handler/CustomAccessDeniedHandler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/handler/CustomAccessDeniedHandler.kt
@@ -16,25 +16,26 @@ import org.springframework.stereotype.Component
  */
 @Component
 class CustomAccessDeniedHandler(
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
 ) : AccessDeniedHandler {
-
     override fun handle(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        accessDeniedException: AccessDeniedException
+        accessDeniedException: AccessDeniedException,
     ) {
         response.status = HttpStatus.FORBIDDEN.value()
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.characterEncoding = "UTF-8"
 
-        val errorResponse = mapOf(
-            "success" to false,
-            "error" to mapOf(
-                "code" to "ACCESS_DENIED",
-                "message" to "Access denied: insufficient permissions"
+        val errorResponse =
+            mapOf(
+                "success" to false,
+                "error" to
+                    mapOf(
+                        "code" to "ACCESS_DENIED",
+                        "message" to "Access denied: insufficient permissions",
+                    ),
             )
-        )
 
         objectMapper.writeValue(response.writer, errorResponse)
     }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/handler/CustomAuthenticationEntryPoint.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/handler/CustomAuthenticationEntryPoint.kt
@@ -18,33 +18,35 @@ import org.springframework.stereotype.Component
  */
 @Component
 class CustomAuthenticationEntryPoint(
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
 ) : AuthenticationEntryPoint {
-
     override fun commence(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        authException: AuthenticationException
+        authException: AuthenticationException,
     ) {
         val exception = request.getAttribute("exception")
 
-        val (code, message) = when (exception) {
-            is TokenExpiredException -> "TOKEN_EXPIRED" to exception.message
-            is InvalidTokenException -> "INVALID_TOKEN" to exception.message
-            else -> "UNAUTHORIZED" to "Authentication required"
-        }
+        val (code, message) =
+            when (exception) {
+                is TokenExpiredException -> "TOKEN_EXPIRED" to exception.message
+                is InvalidTokenException -> "INVALID_TOKEN" to exception.message
+                else -> "UNAUTHORIZED" to "Authentication required"
+            }
 
         response.status = HttpStatus.UNAUTHORIZED.value()
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.characterEncoding = "UTF-8"
 
-        val errorResponse = mapOf(
-            "success" to false,
-            "error" to mapOf(
-                "code" to code,
-                "message" to message
+        val errorResponse =
+            mapOf(
+                "success" to false,
+                "error" to
+                    mapOf(
+                        "code" to code,
+                        "message" to message,
+                    ),
             )
-        )
 
         objectMapper.writeValue(response.writer, errorResponse)
     }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtAuthenticationFilter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtAuthenticationFilter.kt
@@ -18,9 +18,8 @@ import org.springframework.web.filter.OncePerRequestFilter
  */
 @Component
 class JwtAuthenticationFilter(
-    private val jwtTokenProvider: JwtTokenProvider
+    private val jwtTokenProvider: JwtTokenProvider,
 ) : OncePerRequestFilter() {
-
     companion object {
         private const val AUTHORIZATION_HEADER = "Authorization"
         private const val BEARER_PREFIX = "Bearer "
@@ -29,7 +28,7 @@ class JwtAuthenticationFilter(
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        filterChain: FilterChain
+        filterChain: FilterChain,
     ) {
         try {
             val token = resolveToken(request)
@@ -78,7 +77,7 @@ class JwtAuthenticationFilter(
         return UsernamePasswordAuthenticationToken(
             userId,
             null,
-            authorities
+            authorities,
         )
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtProperties.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtProperties.kt
@@ -11,21 +11,18 @@ data class JwtProperties(
      * JWT 서명에 사용할 비밀 키 (Base64 인코딩)
      */
     val secret: String,
-
     /**
      * Access Token 만료 시간 (밀리초)
      * 기본값: 30분 (1800000ms)
      */
     val accessTokenExpiration: Long = 1800000L,
-
     /**
      * Refresh Token 만료 시간 (밀리초)
      * 기본값: 7일 (604800000ms)
      */
     val refreshTokenExpiration: Long = 604800000L,
-
     /**
      * JWT 발급자
      */
-    val issuer: String = "nextup"
+    val issuer: String = "nextup",
 )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtTokenProvider.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/jwt/JwtTokenProvider.kt
@@ -15,7 +15,7 @@ import javax.crypto.SecretKey
  */
 @Component
 class JwtTokenProvider(
-    private val jwtProperties: JwtProperties
+    private val jwtProperties: JwtProperties,
 ) {
     private val secretKey: SecretKey by lazy {
         val keyBytes = Decoders.BASE64.decode(jwtProperties.secret)
@@ -33,12 +33,13 @@ class JwtTokenProvider(
     fun createAccessToken(
         userId: Long,
         email: String,
-        roles: Set<String>
+        roles: Set<String>,
     ): String {
         val now = Instant.now()
         val expiration = now.plusMillis(jwtProperties.accessTokenExpiration)
 
-        return Jwts.builder()
+        return Jwts
+            .builder()
             .subject(userId.toString())
             .claim("email", email)
             .claim("roles", roles.toList())
@@ -60,7 +61,8 @@ class JwtTokenProvider(
         val now = Instant.now()
         val expiration = now.plusMillis(jwtProperties.refreshTokenExpiration)
 
-        return Jwts.builder()
+        return Jwts
+            .builder()
             .subject(userId.toString())
             .claim("type", "refresh")
             .issuer(jwtProperties.issuer)
@@ -78,9 +80,7 @@ class JwtTokenProvider(
      * @throws InvalidTokenException 토큰이 유효하지 않은 경우
      * @throws TokenExpiredException 토큰이 만료된 경우
      */
-    fun getUserId(token: String): Long {
-        return getClaims(token).subject.toLong()
-    }
+    fun getUserId(token: String): Long = getClaims(token).subject.toLong()
 
     /**
      * 토큰에서 이메일을 추출합니다.
@@ -88,9 +88,7 @@ class JwtTokenProvider(
      * @param token JWT 토큰
      * @return 사용자 이메일
      */
-    fun getEmail(token: String): String {
-        return getClaims(token).get("email", String::class.java)
-    }
+    fun getEmail(token: String): String = getClaims(token).get("email", String::class.java)
 
     /**
      * 토큰에서 권한 목록을 추출합니다.
@@ -110,9 +108,7 @@ class JwtTokenProvider(
      * @param token JWT 토큰
      * @return Access Token이면 true
      */
-    fun isAccessToken(token: String): Boolean {
-        return getClaims(token).get("type", String::class.java) == "access"
-    }
+    fun isAccessToken(token: String): Boolean = getClaims(token).get("type", String::class.java) == "access"
 
     /**
      * 토큰이 Refresh Token인지 확인합니다.
@@ -120,9 +116,7 @@ class JwtTokenProvider(
      * @param token JWT 토큰
      * @return Refresh Token이면 true
      */
-    fun isRefreshToken(token: String): Boolean {
-        return getClaims(token).get("type", String::class.java) == "refresh"
-    }
+    fun isRefreshToken(token: String): Boolean = getClaims(token).get("type", String::class.java) == "refresh"
 
     /**
      * 토큰의 유효성을 검증합니다.
@@ -130,27 +124,25 @@ class JwtTokenProvider(
      * @param token JWT 토큰
      * @return 유효하면 true
      */
-    fun validateToken(token: String): Boolean {
-        return try {
+    fun validateToken(token: String): Boolean =
+        try {
             getClaims(token)
             true
         } catch (e: Exception) {
             false
         }
-    }
 
     /**
      * Refresh Token의 만료 시간을 반환합니다.
      *
      * @return Refresh Token 만료 시간 (Instant)
      */
-    fun getRefreshTokenExpiration(): Instant {
-        return Instant.now().plusMillis(jwtProperties.refreshTokenExpiration)
-    }
+    fun getRefreshTokenExpiration(): Instant = Instant.now().plusMillis(jwtProperties.refreshTokenExpiration)
 
-    private fun getClaims(token: String): Claims {
-        return try {
-            Jwts.parser()
+    private fun getClaims(token: String): Claims =
+        try {
+            Jwts
+                .parser()
                 .verifyWith(secretKey)
                 .build()
                 .parseSignedClaims(token)
@@ -162,5 +154,4 @@ class JwtTokenProvider(
         } catch (e: IllegalArgumentException) {
             throw InvalidTokenException("Token is empty or malformed")
         }
-    }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserService.kt
@@ -21,9 +21,8 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class CustomOAuth2UserService(
     private val userJpaRepository: UserJpaRepository,
-    private val oAuthAccountRepository: OAuthAccountRepository
+    private val oAuthAccountRepository: OAuthAccountRepository,
 ) : DefaultOAuth2UserService() {
-
     override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
         val oAuth2User = super.loadUser(userRequest)
         return processOAuth2User(userRequest, oAuth2User)
@@ -31,7 +30,7 @@ class CustomOAuth2UserService(
 
     private fun processOAuth2User(
         userRequest: OAuth2UserRequest,
-        oAuth2User: OAuth2User
+        oAuth2User: OAuth2User,
     ): OAuth2UserPrincipal {
         val registrationId = userRequest.clientRegistration.registrationId
         val attributes = oAuth2User.attributes
@@ -41,21 +40,22 @@ class CustomOAuth2UserService(
 
         if (oAuth2UserInfo.id.isBlank()) {
             throw OAuth2AuthenticationProcessingException(
-                "OAuth2 provider did not return user ID"
+                "OAuth2 provider did not return user ID",
             )
         }
 
         // 1. 기존 OAuthAccount로 User 조회
-        val existingOAuthAccount = oAuthAccountRepository.findByProviderAndOauthId(
-            provider,
-            oAuth2UserInfo.id
-        )
+        val existingOAuthAccount =
+            oAuthAccountRepository.findByProviderAndOauthId(
+                provider,
+                oAuth2UserInfo.id,
+            )
 
         if (existingOAuthAccount != null) {
             return OAuth2UserPrincipal(
                 user = existingOAuthAccount.user,
                 oAuth2UserInfo = oAuth2UserInfo,
-                isNewUser = false
+                isNewUser = false,
             )
         }
 
@@ -67,38 +67,40 @@ class CustomOAuth2UserService(
                 existingUser.addOAuthAccount(
                     provider = provider,
                     oauthId = oAuth2UserInfo.id,
-                    email = email
+                    email = email,
                 )
                 userJpaRepository.save(existingUser)
 
                 return OAuth2UserPrincipal(
                     user = existingUser,
                     oAuth2UserInfo = oAuth2UserInfo,
-                    isNewUser = false
+                    isNewUser = false,
                 )
             }
         }
 
         // 3. 신규 User 생성
-        val nickname = oAuth2UserInfo.name
-            ?: email?.substringBefore("@")
-            ?: "${provider.displayName}사용자"
+        val nickname =
+            oAuth2UserInfo.name
+                ?: email?.substringBefore("@")
+                ?: "${provider.displayName}사용자"
 
         val userEmail = email ?: "${provider.name.lowercase()}_${oAuth2UserInfo.id}@oauth.local"
 
-        val newUser = User.createOAuthUser(
-            email = userEmail,
-            nickname = nickname,
-            provider = provider,
-            oauthId = oAuth2UserInfo.id,
-            profileImageUrl = oAuth2UserInfo.profileImageUrl
-        )
+        val newUser =
+            User.createOAuthUser(
+                email = userEmail,
+                nickname = nickname,
+                provider = provider,
+                oauthId = oAuth2UserInfo.id,
+                profileImageUrl = oAuth2UserInfo.profileImageUrl,
+            )
         userJpaRepository.save(newUser)
 
         return OAuth2UserPrincipal(
             user = newUser,
             oAuth2UserInfo = oAuth2UserInfo,
-            isNewUser = true
+            isNewUser = true,
         )
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationFailureHandler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationFailureHandler.kt
@@ -18,22 +18,23 @@ import java.nio.charset.StandardCharsets
 @Component
 class OAuth2AuthenticationFailureHandler(
     @Value("\${app.oauth2.redirect-uri:http://localhost:3000/oauth/callback}")
-    private val redirectUri: String
+    private val redirectUri: String,
 ) : SimpleUrlAuthenticationFailureHandler() {
-
     override fun onAuthenticationFailure(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        exception: AuthenticationException
+        exception: AuthenticationException,
     ) {
         val errorMessage = exception.message ?: "Authentication failed"
         val encodedMessage = URLEncoder.encode(errorMessage, StandardCharsets.UTF_8)
 
-        val targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
-            .queryParam("error", "oauth_error")
-            .queryParam("message", encodedMessage)
-            .build()
-            .toUriString()
+        val targetUrl =
+            UriComponentsBuilder
+                .fromUriString(redirectUri)
+                .queryParam("error", "oauth_error")
+                .queryParam("message", encodedMessage)
+                .build()
+                .toUriString()
 
         response.sendRedirect(targetUrl)
     }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
@@ -21,39 +21,42 @@ class OAuth2AuthenticationSuccessHandler(
     private val jwtTokenProvider: JwtTokenProvider,
     private val refreshTokenRepository: RefreshTokenRepository,
     @Value("\${app.oauth2.redirect-uri:http://localhost:3000/oauth/callback}")
-    private val redirectUri: String
+    private val redirectUri: String,
 ) : SimpleUrlAuthenticationSuccessHandler() {
-
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        authentication: Authentication
+        authentication: Authentication,
     ) {
         val principal = authentication.principal as OAuth2UserPrincipal
 
         val roles = principal.getRoleNames()
-        val accessToken = jwtTokenProvider.createAccessToken(
-            userId = principal.userId,
-            email = principal.email,
-            roles = roles
-        )
+        val accessToken =
+            jwtTokenProvider.createAccessToken(
+                userId = principal.userId,
+                email = principal.email,
+                roles = roles,
+            )
 
         val refreshTokenString = jwtTokenProvider.createRefreshToken(principal.userId)
-        val refreshToken = RefreshToken.create(
-            userId = principal.userId,
-            token = refreshTokenString,
-            expiresAt = jwtTokenProvider.getRefreshTokenExpiration(),
-            deviceInfo = request.getHeader("User-Agent"),
-            ipAddress = getClientIpAddress(request)
-        )
+        val refreshToken =
+            RefreshToken.create(
+                userId = principal.userId,
+                token = refreshTokenString,
+                expiresAt = jwtTokenProvider.getRefreshTokenExpiration(),
+                deviceInfo = request.getHeader("User-Agent"),
+                ipAddress = getClientIpAddress(request),
+            )
         refreshTokenRepository.save(refreshToken)
 
-        val targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
-            .queryParam("accessToken", accessToken)
-            .queryParam("refreshToken", refreshTokenString)
-            .queryParam("isNewUser", principal.isNewUser)
-            .build()
-            .toUriString()
+        val targetUrl =
+            UriComponentsBuilder
+                .fromUriString(redirectUri)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshTokenString)
+                .queryParam("isNewUser", principal.isNewUser)
+                .build()
+                .toUriString()
 
         response.sendRedirect(targetUrl)
     }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserInfoFactory.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserInfoFactory.kt
@@ -10,7 +10,6 @@ import com.nextup.infrastructure.security.oauth2.impl.NaverOAuth2UserInfo
  * OAuth2 Provider별 UserInfo 객체를 생성하는 팩토리
  */
 object OAuth2UserInfoFactory {
-
     /**
      * registrationId에 맞는 OAuth2UserInfo 구현체를 생성합니다.
      *
@@ -19,14 +18,16 @@ object OAuth2UserInfoFactory {
      * @return OAuth2UserInfo 구현체
      * @throws UnsupportedOAuth2ProviderException 지원하지 않는 Provider인 경우
      */
-    fun create(registrationId: String, attributes: Map<String, Any>): OAuth2UserInfo {
-        return when (registrationId.lowercase()) {
+    fun create(
+        registrationId: String,
+        attributes: Map<String, Any>,
+    ): OAuth2UserInfo =
+        when (registrationId.lowercase()) {
             "kakao" -> KakaoOAuth2UserInfo(attributes)
             "google" -> GoogleOAuth2UserInfo(attributes)
             "naver" -> NaverOAuth2UserInfo(attributes)
             else -> throw UnsupportedOAuth2ProviderException(registrationId)
         }
-    }
 
     /**
      * registrationId를 OAuthProvider로 변환합니다.
@@ -35,12 +36,11 @@ object OAuth2UserInfoFactory {
      * @return OAuthProvider enum
      * @throws UnsupportedOAuth2ProviderException 지원하지 않는 Provider인 경우
      */
-    fun toOAuthProvider(registrationId: String): OAuthProvider {
-        return when (registrationId.lowercase()) {
+    fun toOAuthProvider(registrationId: String): OAuthProvider =
+        when (registrationId.lowercase()) {
             "kakao" -> OAuthProvider.KAKAO
             "google" -> OAuthProvider.GOOGLE
             "naver" -> OAuthProvider.NAVER
             else -> throw UnsupportedOAuth2ProviderException(registrationId)
         }
-    }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserPrincipal.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserPrincipal.kt
@@ -13,9 +13,8 @@ import org.springframework.security.oauth2.core.user.OAuth2User
 class OAuth2UserPrincipal(
     private val user: User,
     private val oAuth2UserInfo: OAuth2UserInfo,
-    val isNewUser: Boolean = false
+    val isNewUser: Boolean = false,
 ) : OAuth2User {
-
     val userId: Long
         get() = user.id
 
@@ -29,11 +28,10 @@ class OAuth2UserPrincipal(
 
     override fun getAttributes(): Map<String, Any> = oAuth2UserInfo.attributes
 
-    override fun getAuthorities(): Collection<GrantedAuthority> {
-        return user.roles.map { role ->
+    override fun getAuthorities(): Collection<GrantedAuthority> =
+        user.roles.map { role ->
             SimpleGrantedAuthority("ROLE_${role.name}")
         }
-    }
 
     /**
      * 사용자 역할 이름 목록을 반환합니다 (ROLE_ 접두사 없음).

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/GoogleOAuth2UserInfo.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/GoogleOAuth2UserInfo.kt
@@ -15,9 +15,8 @@ import com.nextup.infrastructure.security.oauth2.OAuth2UserInfo
  * }
  */
 class GoogleOAuth2UserInfo(
-    override val attributes: Map<String, Any>
+    override val attributes: Map<String, Any>,
 ) : OAuth2UserInfo {
-
     override val provider: OAuthProvider = OAuthProvider.GOOGLE
 
     override val id: String

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/KakaoOAuth2UserInfo.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/KakaoOAuth2UserInfo.kt
@@ -19,9 +19,8 @@ import com.nextup.infrastructure.security.oauth2.OAuth2UserInfo
  * }
  */
 class KakaoOAuth2UserInfo(
-    override val attributes: Map<String, Any>
+    override val attributes: Map<String, Any>,
 ) : OAuth2UserInfo {
-
     override val provider: OAuthProvider = OAuthProvider.KAKAO
 
     override val id: String

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/NaverOAuth2UserInfo.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/impl/NaverOAuth2UserInfo.kt
@@ -19,9 +19,8 @@ import com.nextup.infrastructure.security.oauth2.OAuth2UserInfo
  * }
  */
 class NaverOAuth2UserInfo(
-    override val attributes: Map<String, Any>
+    override val attributes: Map<String, Any>,
 ) : OAuth2UserInfo {
-
     private val response: Map<*, *>?
         get() = attributes["response"] as? Map<*, *>
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetails.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetails.kt
@@ -12,9 +12,8 @@ import org.springframework.security.core.userdetails.UserDetails
  * User 엔티티를 Spring Security가 인식할 수 있는 형태로 래핑합니다.
  */
 class CustomUserDetails(
-    private val user: User
+    private val user: User,
 ) : UserDetails {
-
     val id: Long get() = user.id
 
     val email: String get() = user.email
@@ -23,11 +22,10 @@ class CustomUserDetails(
 
     val roles: Set<Role> get() = user.roles
 
-    override fun getAuthorities(): Collection<GrantedAuthority> {
-        return user.roles.map { role ->
+    override fun getAuthorities(): Collection<GrantedAuthority> =
+        user.roles.map { role ->
             SimpleGrantedAuthority("ROLE_${role.name}")
         }
-    }
 
     override fun getPassword(): String? = user.password
 
@@ -44,9 +42,7 @@ class CustomUserDetails(
     /**
      * 권한 이름 목록을 반환합니다 (ROLE_ 접두사 없음).
      */
-    fun getRoleNames(): Set<String> {
-        return user.roles.map { it.name }.toSet()
-    }
+    fun getRoleNames(): Set<String> = user.roles.map { it.name }.toSet()
 
     companion object {
         /**
@@ -55,8 +51,6 @@ class CustomUserDetails(
          * @param user User 엔티티
          * @return CustomUserDetails
          */
-        fun from(user: User): CustomUserDetails {
-            return CustomUserDetails(user)
-        }
+        fun from(user: User): CustomUserDetails = CustomUserDetails(user)
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsService.kt
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service
  */
 interface UserJpaRepository : JpaRepository<User, Long> {
     fun findByEmail(email: String): User?
+
     fun existsByEmail(email: String): Boolean
 }
 
@@ -23,9 +24,8 @@ interface UserJpaRepository : JpaRepository<User, Long> {
  */
 @Service
 class CustomUserDetailsService(
-    private val userJpaRepository: UserJpaRepository
+    private val userJpaRepository: UserJpaRepository,
 ) : UserDetailsService {
-
     /**
      * 이메일로 사용자를 조회합니다.
      *
@@ -34,8 +34,9 @@ class CustomUserDetailsService(
      * @throws UsernameNotFoundException 사용자를 찾을 수 없는 경우
      */
     override fun loadUserByUsername(username: String): UserDetails {
-        val user = userJpaRepository.findByEmail(username)
-            ?: throw UsernameNotFoundException("User not found with email: $username")
+        val user =
+            userJpaRepository.findByEmail(username)
+                ?: throw UsernameNotFoundException("User not found with email: $username")
 
         return CustomUserDetails.from(user)
     }
@@ -48,8 +49,9 @@ class CustomUserDetailsService(
      * @throws UsernameNotFoundException 사용자를 찾을 수 없는 경우
      */
     fun loadUserById(userId: Long): CustomUserDetails {
-        val user = userJpaRepository.findByIdOrNull(userId)
-            ?: throw UsernameNotFoundException("User not found with id: $userId")
+        val user =
+            userJpaRepository.findByIdOrNull(userId)
+                ?: throw UsernameNotFoundException("User not found with id: $userId")
 
         return CustomUserDetails.from(user)
     }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImpl.kt
@@ -22,9 +22,8 @@ import org.springframework.transaction.annotation.Transactional
 class BoxScoreServiceImpl(
     private val gamePlayerRepository: GamePlayerRepositoryPort,
     private val battingRecordRepository: BattingRecordRepositoryPort,
-    private val pitchingRecordRepository: PitchingRecordRepositoryPort
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
 ) : BoxScoreService {
-
     override fun getBoxScore(gameId: Long): BoxScoreDto {
         val gamePlayers = gamePlayerRepository.findAllByGameId(gameId)
 
@@ -44,7 +43,7 @@ class BoxScoreServiceImpl(
             homeTeam = buildTeamBoxScore(homeTeam.team.id, homeTeam.team.name, homeTeam, homePlayers),
             awayTeam = buildTeamBoxScore(awayTeam.team.id, awayTeam.team.name, awayTeam, awayPlayers),
             currentInning = game.currentInningDisplay,
-            gameStatus = game.status.displayName
+            gameStatus = game.status.displayName,
         )
     }
 
@@ -56,28 +55,32 @@ class BoxScoreServiceImpl(
         result: PlateAppearanceResult,
         rbis: Int,
         runsScored: List<Long>,
-        inning: Int
+        inning: Int,
     ) {
         // 타자 기록 갱신
-        val battingRecord = battingRecordRepository.findByGamePlayer(batter)
-            ?: throw BattingRecordNotFoundException(batter.id)
+        val battingRecord =
+            battingRecordRepository.findByGamePlayer(batter)
+                ?: throw BattingRecordNotFoundException(batter.id)
 
         battingRecord.applyPlateAppearanceResult(result, rbis)
 
         // 득점한 주자들의 득점 기록
         runsScored.forEach { runnerId ->
-            val runnerGamePlayer = gamePlayerRepository.findByIdOrNull(runnerId)
-                ?: throw GamePlayerNotFoundException(runnerId)
+            val runnerGamePlayer =
+                gamePlayerRepository.findByIdOrNull(runnerId)
+                    ?: throw GamePlayerNotFoundException(runnerId)
 
-            val runnerBattingRecord = battingRecordRepository.findByGamePlayer(runnerGamePlayer)
-                ?: throw BattingRecordNotFoundException(runnerId)
+            val runnerBattingRecord =
+                battingRecordRepository.findByGamePlayer(runnerGamePlayer)
+                    ?: throw BattingRecordNotFoundException(runnerId)
 
             runnerBattingRecord.recordRun()
         }
 
         // 투수 기록 갱신
-        val pitchingRecord = pitchingRecordRepository.findByGamePlayer(pitcher)
-            ?: throw PitchingRecordNotFoundException(pitcher.id)
+        val pitchingRecord =
+            pitchingRecordRepository.findByGamePlayer(pitcher)
+                ?: throw PitchingRecordNotFoundException(pitcher.id)
 
         pitchingRecord.applyBatterFaced(result)
 
@@ -105,18 +108,20 @@ class BoxScoreServiceImpl(
         teamId: Long,
         teamName: String,
         gameTeam: com.nextup.core.domain.game.GameTeam,
-        players: List<GamePlayer>
+        players: List<GamePlayer>,
     ): TeamBoxScoreDto {
         val inningScores = parseInningScores(gameTeam.inningScores)
 
-        val batters = players
-            .filter { it.battingOrder != null || it.isStarter }
-            .map { buildBatterLine(it) }
-            .sortedBy { it.battingOrder ?: 999 }
+        val batters =
+            players
+                .filter { it.battingOrder != null || it.isStarter }
+                .map { buildBatterLine(it) }
+                .sortedBy { it.battingOrder ?: 999 }
 
-        val pitchers = players
-            .filter { it.isPitcher }
-            .map { buildPitcherLine(it) }
+        val pitchers =
+            players
+                .filter { it.isPitcher }
+                .map { buildPitcherLine(it) }
 
         return TeamBoxScoreDto(
             teamId = teamId,
@@ -126,7 +131,7 @@ class BoxScoreServiceImpl(
             hits = gameTeam.totalHits,
             errors = gameTeam.totalErrors,
             batters = batters,
-            pitchers = pitchers
+            pitchers = pitchers,
         )
     }
 
@@ -145,7 +150,7 @@ class BoxScoreServiceImpl(
             rbis = battingRecord?.runsBattedIn ?: 0,
             walks = battingRecord?.walks ?: 0,
             strikeouts = battingRecord?.strikeouts ?: 0,
-            avg = battingRecord?.let { BatterLineDto.formatAverage(it.battingAverage) } ?: ".000"
+            avg = battingRecord?.let { BatterLineDto.formatAverage(it.battingAverage) } ?: ".000",
         )
     }
 
@@ -163,7 +168,7 @@ class BoxScoreServiceImpl(
             strikeouts = pitchingRecord?.strikeouts ?: 0,
             homeRuns = pitchingRecord?.homeRunsAllowed ?: 0,
             decision = pitchingRecord?.decision?.abbreviation,
-            era = pitchingRecord?.let { PitcherLineDto.formatERA(it.earnedRunAverage) } ?: "0.00"
+            era = pitchingRecord?.let { PitcherLineDto.formatERA(it.earnedRunAverage) } ?: "0.00",
         )
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -22,9 +22,8 @@ import org.springframework.transaction.annotation.Transactional
 class GameScorerServiceImpl(
     private val gameRepository: GameRepositoryPort,
     private val gamePlayerRepository: GamePlayerRepositoryPort,
-    private val boxScoreService: BoxScoreService
+    private val boxScoreService: BoxScoreService,
 ) : GameScorerService {
-
     @Transactional
     override fun startGame(gameId: Long): Game {
         val game = findGame(gameId)
@@ -36,7 +35,10 @@ class GameScorerServiceImpl(
     }
 
     @Transactional
-    override fun recordPlateAppearance(gameId: Long, request: PlateAppearanceRequest): Game {
+    override fun recordPlateAppearance(
+        gameId: Long,
+        request: PlateAppearanceRequest,
+    ): Game {
         val game = findGame(gameId)
 
         // 경기가 진행 중인지 확인
@@ -45,10 +47,12 @@ class GameScorerServiceImpl(
         }
 
         // 타자와 투수 조회
-        val batter = gamePlayerRepository.findByIdOrNull(request.batterId)
-            ?: throw GamePlayerNotFoundException(request.batterId)
-        val pitcher = gamePlayerRepository.findByIdOrNull(request.pitcherId)
-            ?: throw GamePlayerNotFoundException(request.pitcherId)
+        val batter =
+            gamePlayerRepository.findByIdOrNull(request.batterId)
+                ?: throw GamePlayerNotFoundException(request.batterId)
+        val pitcher =
+            gamePlayerRepository.findByIdOrNull(request.pitcherId)
+                ?: throw GamePlayerNotFoundException(request.pitcherId)
 
         // 주자 이동 처리
         val scoredRunnerIds = mutableListOf<Long>()
@@ -67,17 +71,18 @@ class GameScorerServiceImpl(
 
         // 타자의 출루 처리
         if (request.result.isOnBase) {
-            val advanceToBase = when {
-                request.result.isSingle -> com.nextup.core.domain.game.Base.FIRST
-                request.result.isDouble -> com.nextup.core.domain.game.Base.SECOND
-                request.result.isTriple -> com.nextup.core.domain.game.Base.THIRD
-                request.result.isHomeRun -> {
-                    // 홈런인 경우 타자도 득점
-                    scoredRunnerIds.add(batter.id)
-                    null
+            val advanceToBase =
+                when {
+                    request.result.isSingle -> com.nextup.core.domain.game.Base.FIRST
+                    request.result.isDouble -> com.nextup.core.domain.game.Base.SECOND
+                    request.result.isTriple -> com.nextup.core.domain.game.Base.THIRD
+                    request.result.isHomeRun -> {
+                        // 홈런인 경우 타자도 득점
+                        scoredRunnerIds.add(batter.id)
+                        null
+                    }
+                    else -> com.nextup.core.domain.game.Base.FIRST // 볼넷, 사구 등
                 }
-                else -> com.nextup.core.domain.game.Base.FIRST // 볼넷, 사구 등
-            }
 
             advanceToBase?.let { game.setRunner(it, batter.id) }
         } else if (!request.result.isOnBase) {
@@ -93,7 +98,7 @@ class GameScorerServiceImpl(
             result = request.result,
             rbis = request.getActualRbis(),
             runsScored = scoredRunnerIds,
-            inning = game.currentInning
+            inning = game.currentInning,
         )
 
         // 다음 타자로 진행
@@ -119,7 +124,10 @@ class GameScorerServiceImpl(
     }
 
     @Transactional
-    override fun endGame(gameId: Long, reason: GameEndReason): Game {
+    override fun endGame(
+        gameId: Long,
+        reason: GameEndReason,
+    ): Game {
         val game = findGame(gameId)
 
         // 경기가 진행 중인지 확인
@@ -138,8 +146,7 @@ class GameScorerServiceImpl(
         return gameRepository.save(game)
     }
 
-    private fun findGame(id: Long): Game {
-        return gameRepository.findByIdOrNull(id)
+    private fun findGame(id: Long): Game =
+        gameRepository.findByIdOrNull(id)
             ?: throw GameNotFoundException(id)
-    }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -40,7 +40,7 @@ class GameScorerServiceImpl(
         val game = findGame(gameId)
 
         // 경기가 진행 중인지 확인
-        require(game.status == GameStatus.IN_PROGRESS) {
+        if (game.status != GameStatus.IN_PROGRESS) {
             throw InvalidGameStateException("진행 중인 경기만 타석 기록을 입력할 수 있습니다. 현재 상태: ${game.status.displayName}")
         }
 
@@ -108,7 +108,7 @@ class GameScorerServiceImpl(
         val game = findGame(gameId)
 
         // 경기가 진행 중인지 확인
-        require(game.status == GameStatus.IN_PROGRESS) {
+        if (game.status != GameStatus.IN_PROGRESS) {
             throw InvalidGameStateException("진행 중인 경기만 이닝을 진행할 수 있습니다. 현재 상태: ${game.status.displayName}")
         }
 
@@ -123,7 +123,7 @@ class GameScorerServiceImpl(
         val game = findGame(gameId)
 
         // 경기가 진행 중인지 확인
-        require(game.status == GameStatus.IN_PROGRESS) {
+        if (game.status != GameStatus.IN_PROGRESS) {
             throw InvalidGameStateException("진행 중인 경기만 종료할 수 있습니다. 현재 상태: ${game.status.displayName}")
         }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -1,0 +1,145 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.service.game.BoxScoreService
+import com.nextup.core.service.game.GameScorerService
+import com.nextup.core.service.game.dto.GameEndReason
+import com.nextup.core.service.game.dto.PlateAppearanceRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 기록원 전용 경기 기록 서비스 구현
+ */
+@Service
+@Transactional(readOnly = true)
+class GameScorerServiceImpl(
+    private val gameRepository: GameRepositoryPort,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
+    private val boxScoreService: BoxScoreService
+) : GameScorerService {
+
+    @Transactional
+    override fun startGame(gameId: Long): Game {
+        val game = findGame(gameId)
+
+        // 경기 시작
+        game.start()
+
+        return gameRepository.save(game)
+    }
+
+    @Transactional
+    override fun recordPlateAppearance(gameId: Long, request: PlateAppearanceRequest): Game {
+        val game = findGame(gameId)
+
+        // 경기가 진행 중인지 확인
+        require(game.status == GameStatus.IN_PROGRESS) {
+            throw InvalidGameStateException("진행 중인 경기만 타석 기록을 입력할 수 있습니다. 현재 상태: ${game.status.displayName}")
+        }
+
+        // 타자와 투수 조회
+        val batter = gamePlayerRepository.findByIdOrNull(request.batterId)
+            ?: throw GamePlayerNotFoundException(request.batterId)
+        val pitcher = gamePlayerRepository.findByIdOrNull(request.pitcherId)
+            ?: throw GamePlayerNotFoundException(request.pitcherId)
+
+        // 주자 이동 처리
+        val scoredRunnerIds = mutableListOf<Long>()
+        request.runnerMovements.forEach { movement ->
+            if (movement.isScored) {
+                scoredRunnerIds.add(movement.runnerId)
+            }
+
+            // 베이스 상태 업데이트
+            if (movement.isOut) {
+                game.recordOut()
+            } else if (!movement.isScored) {
+                game.setRunner(movement.toBase, movement.runnerId)
+            }
+        }
+
+        // 타자의 출루 처리
+        if (request.result.isOnBase) {
+            val advanceToBase = when {
+                request.result.isSingle -> com.nextup.core.domain.game.Base.FIRST
+                request.result.isDouble -> com.nextup.core.domain.game.Base.SECOND
+                request.result.isTriple -> com.nextup.core.domain.game.Base.THIRD
+                request.result.isHomeRun -> {
+                    // 홈런인 경우 타자도 득점
+                    scoredRunnerIds.add(batter.id)
+                    null
+                }
+                else -> com.nextup.core.domain.game.Base.FIRST // 볼넷, 사구 등
+            }
+
+            advanceToBase?.let { game.setRunner(it, batter.id) }
+        } else if (!request.result.isOnBase) {
+            // 아웃인 경우
+            game.recordOut()
+        }
+
+        // 박스스코어 갱신
+        boxScoreService.updateOnPlateAppearance(
+            gameId = gameId,
+            batter = batter,
+            pitcher = pitcher,
+            result = request.result,
+            rbis = request.getActualRbis(),
+            runsScored = scoredRunnerIds,
+            inning = game.currentInning
+        )
+
+        // 다음 타자로 진행
+        game.advanceBatter()
+        game.resetCount()
+
+        return gameRepository.save(game)
+    }
+
+    @Transactional
+    override fun advanceHalfInning(gameId: Long): Game {
+        val game = findGame(gameId)
+
+        // 경기가 진행 중인지 확인
+        require(game.status == GameStatus.IN_PROGRESS) {
+            throw InvalidGameStateException("진행 중인 경기만 이닝을 진행할 수 있습니다. 현재 상태: ${game.status.displayName}")
+        }
+
+        // 다음 반 이닝으로 진행
+        game.nextHalfInning()
+
+        return gameRepository.save(game)
+    }
+
+    @Transactional
+    override fun endGame(gameId: Long, reason: GameEndReason): Game {
+        val game = findGame(gameId)
+
+        // 경기가 진행 중인지 확인
+        require(game.status == GameStatus.IN_PROGRESS) {
+            throw InvalidGameStateException("진행 중인 경기만 종료할 수 있습니다. 현재 상태: ${game.status.displayName}")
+        }
+
+        when (reason) {
+            GameEndReason.REGULATION -> game.finish()
+            GameEndReason.MERCY_RULE -> game.callGame("콜드게임 (점수차)")
+            GameEndReason.WEATHER -> game.callGame("콜드게임 (기상 조건)")
+            GameEndReason.FORFEIT -> game.forfeit("몰수 처리")
+            GameEndReason.OTHER -> game.callGame("기타 사유")
+        }
+
+        return gameRepository.save(game)
+    }
+
+    private fun findGame(id: Long): Game {
+        return gameRepository.findByIdOrNull(id)
+            ?: throw GameNotFoundException(id)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkService.kt
@@ -17,9 +17,8 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class OAuthLinkService(
     private val userJpaRepository: UserJpaRepository,
-    private val oAuthAccountRepository: OAuthAccountRepository
+    private val oAuthAccountRepository: OAuthAccountRepository,
 ) {
-
     /**     * 기존 사용자에게 OAuth 계정을 연동합니다.
      *
      * @param userId 사용자 ID
@@ -34,10 +33,11 @@ class OAuthLinkService(
         userId: Long,
         provider: OAuthProvider,
         oauthId: String,
-        email: String? = null
+        email: String? = null,
     ): OAuthAccount {
-        val user = userJpaRepository.findByIdOrNull(userId)
-            ?: throw UserNotFoundException(userId)
+        val user =
+            userJpaRepository.findByIdOrNull(userId)
+                ?: throw UserNotFoundException(userId)
 
         val oauthAccount = user.addOAuthAccount(provider, oauthId, email)
         userJpaRepository.save(user)
@@ -53,9 +53,13 @@ class OAuthLinkService(
      * @throws UserNotFoundException 사용자를 찾을 수 없는 경우
      * @throws IllegalStateException 최소 1개의 인증 수단이 없는 경우
      */
-    fun unlinkOAuthAccount(userId: Long, provider: OAuthProvider) {
-        val user = userJpaRepository.findByIdOrNull(userId)
-            ?: throw UserNotFoundException(userId)
+    fun unlinkOAuthAccount(
+        userId: Long,
+        provider: OAuthProvider,
+    ) {
+        val user =
+            userJpaRepository.findByIdOrNull(userId)
+                ?: throw UserNotFoundException(userId)
 
         user.removeOAuthAccount(provider)
         userJpaRepository.save(user)
@@ -68,9 +72,7 @@ class OAuthLinkService(
      * @return 연동된 OAuth 제공자 목록
      */
     @Transactional(readOnly = true)
-    fun getLinkedProviders(userId: Long): List<OAuthProvider> {
-        return oAuthAccountRepository.findProvidersByUserId(userId)
-    }
+    fun getLinkedProviders(userId: Long): List<OAuthProvider> = oAuthAccountRepository.findProvidersByUserId(userId)
 
     /**
      * 사용자의 연동된 OAuth 계정 목록을 조회합니다.
@@ -79,9 +81,7 @@ class OAuthLinkService(
      * @return 연동된 OAuth 계정 목록
      */
     @Transactional(readOnly = true)
-    fun getLinkedAccounts(userId: Long): List<OAuthAccount> {
-        return oAuthAccountRepository.findAllByUserId(userId)
-    }
+    fun getLinkedAccounts(userId: Long): List<OAuthAccount> = oAuthAccountRepository.findAllByUserId(userId)
 
     /**
      * 특정 OAuth 제공자가 연동되어 있는지 확인합니다.
@@ -91,9 +91,10 @@ class OAuthLinkService(
      * @return 연동 여부
      */
     @Transactional(readOnly = true)
-    fun isLinked(userId: Long, provider: OAuthProvider): Boolean {
-        return oAuthAccountRepository.findByUserIdAndProvider(userId, provider) != null
-    }
+    fun isLinked(
+        userId: Long,
+        provider: OAuthProvider,
+    ): Boolean = oAuthAccountRepository.findByUserIdAndProvider(userId, provider) != null
 
     /**
      * OAuth 정보로 사용자를 조회합니다.
@@ -103,7 +104,8 @@ class OAuthLinkService(
      * @return 사용자 (없으면 null)
      */
     @Transactional(readOnly = true)
-    fun findUserByOAuth(provider: OAuthProvider, oauthId: String): User? {
-        return oAuthAccountRepository.findByProviderAndOauthId(provider, oauthId)?.user
-    }
+    fun findUserByOAuth(
+        provider: OAuthProvider,
+        oauthId: String,
+    ): User? = oAuthAccountRepository.findByProviderAndOauthId(provider, oauthId)?.user
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/AuthenticationServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/AuthenticationServiceTest.kt
@@ -2,12 +2,10 @@ package com.nextup.infrastructure.security
 
 import com.nextup.common.exception.*
 import com.nextup.core.domain.auth.RefreshToken
-import com.nextup.core.domain.user.Role
 import com.nextup.core.domain.user.User
 import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
 import com.nextup.infrastructure.security.jwt.JwtTokenProvider
 import com.nextup.infrastructure.security.userdetails.UserJpaRepository
-import org.springframework.data.repository.findByIdOrNull
 import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -21,7 +19,6 @@ import java.util.*
 
 @DisplayName("AuthenticationService")
 class AuthenticationServiceTest {
-
     private lateinit var userJpaRepository: UserJpaRepository
     private lateinit var refreshTokenRepository: RefreshTokenRepository
     private lateinit var jwtTokenProvider: JwtTokenProvider
@@ -34,18 +31,18 @@ class AuthenticationServiceTest {
         refreshTokenRepository = mockk()
         jwtTokenProvider = mockk()
         passwordEncoder = mockk()
-        authenticationService = AuthenticationService(
-            userJpaRepository,
-            refreshTokenRepository,
-            jwtTokenProvider,
-            passwordEncoder
-        )
+        authenticationService =
+            AuthenticationService(
+                userJpaRepository,
+                refreshTokenRepository,
+                jwtTokenProvider,
+                passwordEncoder,
+            )
     }
 
     @Nested
     @DisplayName("login")
     inner class Login {
-
         @Test
         fun `should return token pair on successful login`() {
             // given
@@ -129,7 +126,6 @@ class AuthenticationServiceTest {
     @Nested
     @DisplayName("refresh")
     inner class Refresh {
-
         @Test
         fun `should return new token pair on successful refresh`() {
             // given
@@ -209,7 +205,6 @@ class AuthenticationServiceTest {
     @Nested
     @DisplayName("logout")
     inner class Logout {
-
         @Test
         fun `should revoke refresh token on logout`() {
             // given
@@ -242,7 +237,6 @@ class AuthenticationServiceTest {
     @Nested
     @DisplayName("logoutAll")
     inner class LogoutAll {
-
         @Test
         fun `should revoke all refresh tokens for user`() {
             // given
@@ -260,7 +254,6 @@ class AuthenticationServiceTest {
     @Nested
     @DisplayName("getUserDetails")
     inner class GetUserDetails {
-
         @Test
         fun `should return user details when user found`() {
             // given
@@ -288,52 +281,70 @@ class AuthenticationServiceTest {
     }
 
     // Helper methods
-    private fun createTestUser(id: Long, email: String, password: String): User {
-        val user = User.createLocalUser(
-            email = email,
-            encodedPassword = password,
-            nickname = "테스터"
-        )
+    private fun createTestUser(
+        id: Long,
+        email: String,
+        password: String,
+    ): User {
+        val user =
+            User.createLocalUser(
+                email = email,
+                encodedPassword = password,
+                nickname = "테스터",
+            )
         setUserId(user, id)
         return user
     }
 
-    private fun createOAuthUser(id: Long, email: String): User {
-        val user = User.createOAuthUser(
-            email = email,
-            nickname = "OAuth테스터",
-            provider = com.nextup.core.domain.user.OAuthProvider.KAKAO,
-            oauthId = "kakao_123"
-        )
+    private fun createOAuthUser(
+        id: Long,
+        email: String,
+    ): User {
+        val user =
+            User.createOAuthUser(
+                email = email,
+                nickname = "OAuth테스터",
+                provider = com.nextup.core.domain.user.OAuthProvider.KAKAO,
+                oauthId = "kakao_123",
+            )
         setUserId(user, id)
         return user
     }
 
-    private fun setUserId(user: User, id: Long) {
+    private fun setUserId(
+        user: User,
+        id: Long,
+    ) {
         val idField = User::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(user, id)
     }
 
-    private fun createRefreshToken(userId: Long, token: String): RefreshToken {
-        return RefreshToken.create(
+    private fun createRefreshToken(
+        userId: Long,
+        token: String,
+    ): RefreshToken =
+        RefreshToken.create(
             userId = userId,
             token = token,
-            expiresAt = Instant.now().plusSeconds(3600)
+            expiresAt = Instant.now().plusSeconds(3600),
         )
-    }
 
-    private fun createExpiredRefreshToken(userId: Long, token: String): RefreshToken {
+    private fun createExpiredRefreshToken(
+        userId: Long,
+        token: String,
+    ): RefreshToken {
         // Use reflection to create expired token since create() doesn't allow past expiration
-        val constructor = RefreshToken::class.java.getDeclaredConstructor(
-            Long::class.java,
-            String::class.java,
-            Instant::class.java,
-            Boolean::class.java,
-            String::class.java,
-            String::class.java,
-            Long::class.java
-        )
+        val constructor =
+            RefreshToken::class.java.getDeclaredConstructor(
+                Long::class.java,
+                String::class.java,
+                Instant::class.java,
+                Boolean::class.java,
+                String::class.java,
+                String::class.java,
+                Long::class.java,
+            )
         constructor.isAccessible = true
         return constructor.newInstance(
             userId,
@@ -342,16 +353,20 @@ class AuthenticationServiceTest {
             false,
             null,
             null,
-            0L
+            0L,
         )
     }
 
-    private fun createRevokedRefreshToken(userId: Long, token: String): RefreshToken {
-        val refreshToken = RefreshToken.create(
-            userId = userId,
-            token = token,
-            expiresAt = Instant.now().plusSeconds(3600)
-        )
+    private fun createRevokedRefreshToken(
+        userId: Long,
+        token: String,
+    ): RefreshToken {
+        val refreshToken =
+            RefreshToken.create(
+                userId = userId,
+                token = token,
+                expiresAt = Instant.now().plusSeconds(3600),
+            )
         refreshToken.revoke()
         return refreshToken
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/handler/CustomAccessDeniedHandlerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/handler/CustomAccessDeniedHandlerTest.kt
@@ -20,7 +20,6 @@ import java.io.StringWriter
 
 @DisplayName("CustomAccessDeniedHandler 테스트")
 class CustomAccessDeniedHandlerTest {
-
     private lateinit var objectMapper: ObjectMapper
     private lateinit var handler: CustomAccessDeniedHandler
     private lateinit var request: HttpServletRequest
@@ -43,7 +42,6 @@ class CustomAccessDeniedHandlerTest {
     @Nested
     @DisplayName("접근 거부 처리")
     inner class HandleAccessDenied {
-
         @Test
         fun `should return ACCESS_DENIED error`() {
             // given
@@ -77,7 +75,6 @@ class CustomAccessDeniedHandlerTest {
     @Nested
     @DisplayName("응답 형식")
     inner class ResponseFormat {
-
         @Test
         fun `should set correct content type and encoding`() {
             // given
@@ -121,7 +118,6 @@ class CustomAccessDeniedHandlerTest {
     @Nested
     @DisplayName("다양한 시나리오")
     inner class VariousScenarios {
-
         @Test
         fun `should handle exception with custom message`() {
             // given

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/handler/CustomAuthenticationEntryPointTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/handler/CustomAuthenticationEntryPointTest.kt
@@ -21,7 +21,6 @@ import java.io.StringWriter
 
 @DisplayName("CustomAuthenticationEntryPoint 테스트")
 class CustomAuthenticationEntryPointTest {
-
     private lateinit var objectMapper: ObjectMapper
     private lateinit var entryPoint: CustomAuthenticationEntryPoint
     private lateinit var request: HttpServletRequest
@@ -44,7 +43,6 @@ class CustomAuthenticationEntryPointTest {
     @Nested
     @DisplayName("토큰 만료 시")
     inner class TokenExpired {
-
         @Test
         fun `should return TOKEN_EXPIRED error`() {
             // given
@@ -67,7 +65,6 @@ class CustomAuthenticationEntryPointTest {
     @Nested
     @DisplayName("유효하지 않은 토큰")
     inner class InvalidToken {
-
         @Test
         fun `should return INVALID_TOKEN error`() {
             // given
@@ -90,7 +87,6 @@ class CustomAuthenticationEntryPointTest {
     @Nested
     @DisplayName("기타 인증 오류")
     inner class OtherAuthError {
-
         @Test
         fun `should return UNAUTHORIZED error when no exception attribute`() {
             // given
@@ -128,7 +124,6 @@ class CustomAuthenticationEntryPointTest {
     @Nested
     @DisplayName("응답 형식")
     inner class ResponseFormat {
-
         @Test
         fun `should set correct content type and encoding`() {
             // given
@@ -171,7 +166,10 @@ class CustomAuthenticationEntryPointTest {
         }
     }
 
-    private fun verify(response: HttpServletResponse, expectedStatus: Int) {
+    private fun verify(
+        response: HttpServletResponse,
+        expectedStatus: Int,
+    ) {
         io.mockk.verify { response.status = expectedStatus }
         io.mockk.verify { response.contentType = MediaType.APPLICATION_JSON_VALUE }
         io.mockk.verify { response.characterEncoding = "UTF-8" }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtAuthenticationFilterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtAuthenticationFilterTest.kt
@@ -17,7 +17,6 @@ import org.springframework.security.core.context.SecurityContextHolder
 
 @DisplayName("JwtAuthenticationFilter 테스트")
 class JwtAuthenticationFilterTest {
-
     private lateinit var jwtTokenProvider: JwtTokenProvider
     private lateinit var filter: JwtAuthenticationFilter
     private lateinit var request: MockHttpServletRequest
@@ -37,7 +36,6 @@ class JwtAuthenticationFilterTest {
     @Nested
     @DisplayName("토큰 추출")
     inner class ResolveToken {
-
         @Test
         fun `should pass filter when no Authorization header`() {
             // given - no Authorization header set
@@ -67,7 +65,6 @@ class JwtAuthenticationFilterTest {
     @Nested
     @DisplayName("토큰 검증")
     inner class ValidateToken {
-
         @Test
         fun `should set authentication when valid access token`() {
             // given
@@ -125,7 +122,6 @@ class JwtAuthenticationFilterTest {
     @Nested
     @DisplayName("예외 처리")
     inner class ExceptionHandling {
-
         @Test
         fun `should set exception attribute when token expired`() {
             // given
@@ -162,7 +158,6 @@ class JwtAuthenticationFilterTest {
     @Nested
     @DisplayName("Bearer 토큰 파싱")
     inner class BearerTokenParsing {
-
         @Test
         fun `should extract token from Bearer prefix`() {
             // given

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtTokenProviderTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtTokenProviderTest.kt
@@ -16,7 +16,6 @@ import java.util.*
 
 @DisplayName("JwtTokenProvider")
 class JwtTokenProviderTest {
-
     private lateinit var jwtTokenProvider: JwtTokenProvider
     private lateinit var jwtProperties: JwtProperties
 
@@ -26,19 +25,19 @@ class JwtTokenProviderTest {
 
     @BeforeEach
     fun setUp() {
-        jwtProperties = JwtProperties(
-            secret = testSecret,
-            accessTokenExpiration = 1800000L, // 30 minutes
-            refreshTokenExpiration = 604800000L, // 7 days
-            issuer = testIssuer
-        )
+        jwtProperties =
+            JwtProperties(
+                secret = testSecret,
+                accessTokenExpiration = 1800000L, // 30 minutes
+                refreshTokenExpiration = 604800000L, // 7 days
+                issuer = testIssuer,
+            )
         jwtTokenProvider = JwtTokenProvider(jwtProperties)
     }
 
     @Nested
     @DisplayName("createAccessToken")
     inner class CreateAccessToken {
-
         @Test
         fun `should create valid access token`() {
             // given
@@ -75,7 +74,6 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("createRefreshToken")
     inner class CreateRefreshToken {
-
         @Test
         fun `should create valid refresh token`() {
             // given
@@ -106,7 +104,6 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("getUserId")
     inner class GetUserId {
-
         @Test
         fun `should extract user id from access token`() {
             // given
@@ -137,7 +134,6 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("getRoles")
     inner class GetRoles {
-
         @Test
         fun `should extract roles from access token`() {
             // given
@@ -167,7 +163,6 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("validateToken")
     inner class ValidateToken {
-
         @Test
         fun `should return true for valid token`() {
             // given
@@ -207,10 +202,12 @@ class JwtTokenProviderTest {
             val differentSecret = "ZGlmZmVyZW50IHNlY3JldCBrZXkgZm9yIHRlc3RpbmcgdGhhdCBpcyBhdCBsZWFzdCAyNTYgYml0cw=="
             val differentKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(differentSecret))
 
-            val tampered = Jwts.builder()
-                .subject("1")
-                .signWith(differentKey, Jwts.SIG.HS256)
-                .compact()
+            val tampered =
+                Jwts
+                    .builder()
+                    .subject("1")
+                    .signWith(differentKey, Jwts.SIG.HS256)
+                    .compact()
 
             // when
             val isValid = jwtTokenProvider.validateToken(tampered)
@@ -223,16 +220,16 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("Token Expiration")
     inner class TokenExpiration {
-
         @Test
         fun `should throw TokenExpiredException for expired token`() {
             // given
-            val expiredProperties = JwtProperties(
-                secret = testSecret,
-                accessTokenExpiration = -1000L, // already expired
-                refreshTokenExpiration = 604800000L,
-                issuer = testIssuer
-            )
+            val expiredProperties =
+                JwtProperties(
+                    secret = testSecret,
+                    accessTokenExpiration = -1000L, // already expired
+                    refreshTokenExpiration = 604800000L,
+                    issuer = testIssuer,
+                )
             val providerWithExpiredToken = JwtTokenProvider(expiredProperties)
             val expiredToken = providerWithExpiredToken.createAccessToken(1L, "test@example.com", setOf("USER"))
 
@@ -246,7 +243,6 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("Invalid Token Handling")
     inner class InvalidTokenHandling {
-
         @Test
         fun `should throw InvalidTokenException for malformed token`() {
             // given
@@ -270,7 +266,6 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("isAccessToken / isRefreshToken")
     inner class TokenTypeCheck {
-
         @Test
         fun `should correctly identify access token`() {
             // given
@@ -297,7 +292,6 @@ class JwtTokenProviderTest {
     @Nested
     @DisplayName("getRefreshTokenExpiration")
     inner class GetRefreshTokenExpiration {
-
         @Test
         fun `should return future expiration time`() {
             // when

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserServiceTest.kt
@@ -22,7 +22,6 @@ import java.time.Instant
 
 @DisplayName("CustomOAuth2UserService 테스트")
 class CustomOAuth2UserServiceTest {
-
     private lateinit var userJpaRepository: UserJpaRepository
     private lateinit var oAuthAccountRepository: OAuthAccountRepository
     private lateinit var customOAuth2UserService: TestableCustomOAuth2UserService
@@ -32,21 +31,22 @@ class CustomOAuth2UserServiceTest {
      */
     private class TestableCustomOAuth2UserService(
         userJpaRepository: UserJpaRepository,
-        oAuthAccountRepository: OAuthAccountRepository
+        oAuthAccountRepository: OAuthAccountRepository,
     ) : CustomOAuth2UserService(userJpaRepository, oAuthAccountRepository) {
-
         var mockOAuth2User: OAuth2User? = null
 
         override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
-            val oAuth2User = mockOAuth2User
-                ?: throw IllegalStateException("mockOAuth2User must be set before calling loadUser")
+            val oAuth2User =
+                mockOAuth2User
+                    ?: throw IllegalStateException("mockOAuth2User must be set before calling loadUser")
 
             // processOAuth2User is private, so we need to access it via reflection
-            val method = CustomOAuth2UserService::class.java.getDeclaredMethod(
-                "processOAuth2User",
-                OAuth2UserRequest::class.java,
-                OAuth2User::class.java
-            )
+            val method =
+                CustomOAuth2UserService::class.java.getDeclaredMethod(
+                    "processOAuth2User",
+                    OAuth2UserRequest::class.java,
+                    OAuth2User::class.java,
+                )
             method.isAccessible = true
             return method.invoke(this, userRequest, oAuth2User) as OAuth2User
         }
@@ -60,42 +60,48 @@ class CustomOAuth2UserServiceTest {
     }
 
     private fun createUserRequest(registrationId: String): OAuth2UserRequest {
-        val clientRegistration = ClientRegistration
-            .withRegistrationId(registrationId)
-            .clientId("test-client-id")
-            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-            .redirectUri("http://localhost/callback")
-            .authorizationUri("http://auth.example.com/authorize")
-            .tokenUri("http://auth.example.com/token")
-            .userInfoUri("http://auth.example.com/userinfo")
-            .userNameAttributeName("id")
-            .clientName("Test Client")
-            .build()
+        val clientRegistration =
+            ClientRegistration
+                .withRegistrationId(registrationId)
+                .clientId("test-client-id")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("http://localhost/callback")
+                .authorizationUri("http://auth.example.com/authorize")
+                .tokenUri("http://auth.example.com/token")
+                .userInfoUri("http://auth.example.com/userinfo")
+                .userNameAttributeName("id")
+                .clientName("Test Client")
+                .build()
 
-        val accessToken = OAuth2AccessToken(
-            OAuth2AccessToken.TokenType.BEARER,
-            "test-access-token",
-            Instant.now(),
-            Instant.now().plusSeconds(3600)
-        )
+        val accessToken =
+            OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                "test-access-token",
+                Instant.now(),
+                Instant.now().plusSeconds(3600),
+            )
 
         return OAuth2UserRequest(clientRegistration, accessToken)
     }
 
-    private fun createOAuth2User(attributes: Map<String, Any>): OAuth2User {
-        return mockk {
+    private fun createOAuth2User(attributes: Map<String, Any>): OAuth2User =
+        mockk {
             every { getAttributes() } returns attributes
             every { getName() } returns "test-user"
         }
-    }
 
-    private fun createUser(id: Long, email: String, nickname: String): User {
-        val user = User.createOAuthUser(
-            email = email,
-            nickname = nickname,
-            provider = OAuthProvider.KAKAO,
-            oauthId = "kakao_$id"
-        )
+    private fun createUser(
+        id: Long,
+        email: String,
+        nickname: String,
+    ): User {
+        val user =
+            User.createOAuthUser(
+                email = email,
+                nickname = nickname,
+                provider = OAuthProvider.KAKAO,
+                oauthId = "kakao_$id",
+            )
         val idField = User::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(user, id)
@@ -105,27 +111,30 @@ class CustomOAuth2UserServiceTest {
     @Nested
     @DisplayName("기존 OAuthAccount 존재 시")
     inner class ExistingOAuthAccountTest {
-
         @Test
         fun `should return existing user when OAuthAccount exists`() {
             // given
             val userRequest = createUserRequest("kakao")
-            customOAuth2UserService.mockOAuth2User = createOAuth2User(
-                mapOf(
-                    "id" to 123456L,
-                    "kakao_account" to mapOf(
-                        "email" to "existing@kakao.com",
-                        "profile" to mapOf("nickname" to "기존사용자")
-                    )
+            customOAuth2UserService.mockOAuth2User =
+                createOAuth2User(
+                    mapOf(
+                        "id" to 123456L,
+                        "kakao_account" to
+                            mapOf(
+                                "email" to "existing@kakao.com",
+                                "profile" to mapOf("nickname" to "기존사용자"),
+                            ),
+                    ),
                 )
-            )
 
             val existingUser = createUser(1L, "existing@kakao.com", "기존사용자")
-            val existingOAuthAccount = mockk<OAuthAccount> {
-                every { user } returns existingUser
-            }
+            val existingOAuthAccount =
+                mockk<OAuthAccount> {
+                    every { user } returns existingUser
+                }
 
-            every { oAuthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "123456") } returns existingOAuthAccount
+            every { oAuthAccountRepository.findByProviderAndOauthId(OAuthProvider.KAKAO, "123456") } returns
+                existingOAuthAccount
 
             // when
             val result = customOAuth2UserService.loadUser(userRequest)
@@ -141,18 +150,18 @@ class CustomOAuth2UserServiceTest {
     @Nested
     @DisplayName("이메일로 기존 User 조회")
     inner class ExistingUserByEmailTest {
-
         @Test
         fun `should link OAuthAccount to existing user when email matches`() {
             // given
             val userRequest = createUserRequest("google")
-            customOAuth2UserService.mockOAuth2User = createOAuth2User(
-                mapOf(
-                    "sub" to "google_123",
-                    "email" to "existing@gmail.com",
-                    "name" to "기존사용자"
+            customOAuth2UserService.mockOAuth2User =
+                createOAuth2User(
+                    mapOf(
+                        "sub" to "google_123",
+                        "email" to "existing@gmail.com",
+                        "name" to "기존사용자",
+                    ),
                 )
-            )
 
             val existingUser = createUser(2L, "existing@gmail.com", "기존사용자")
 
@@ -175,20 +184,21 @@ class CustomOAuth2UserServiceTest {
     @Nested
     @DisplayName("신규 User 생성")
     inner class NewUserCreationTest {
-
         @Test
         fun `should create new user when no existing account found`() {
             // given
             val userRequest = createUserRequest("naver")
-            customOAuth2UserService.mockOAuth2User = createOAuth2User(
-                mapOf(
-                    "response" to mapOf(
-                        "id" to "naver_new_123",
-                        "email" to "newuser@naver.com",
-                        "name" to "신규사용자"
-                    )
+            customOAuth2UserService.mockOAuth2User =
+                createOAuth2User(
+                    mapOf(
+                        "response" to
+                            mapOf(
+                                "id" to "naver_new_123",
+                                "email" to "newuser@naver.com",
+                                "name" to "신규사용자",
+                            ),
+                    ),
                 )
-            )
 
             val savedUserSlot = slot<User>()
 
@@ -210,13 +220,14 @@ class CustomOAuth2UserServiceTest {
         fun `should use email prefix as nickname when name is null`() {
             // given
             val userRequest = createUserRequest("google")
-            customOAuth2UserService.mockOAuth2User = createOAuth2User(
-                mapOf(
-                    "sub" to "google_456",
-                    "email" to "testuser@gmail.com"
-                    // name is missing
+            customOAuth2UserService.mockOAuth2User =
+                createOAuth2User(
+                    mapOf(
+                        "sub" to "google_456",
+                        "email" to "testuser@gmail.com",
+                        // name is missing
+                    ),
                 )
-            )
 
             val savedUserSlot = slot<User>()
 
@@ -235,12 +246,13 @@ class CustomOAuth2UserServiceTest {
         fun `should use provider default nickname when both name and email are null`() {
             // given
             val userRequest = createUserRequest("kakao")
-            customOAuth2UserService.mockOAuth2User = createOAuth2User(
-                mapOf(
-                    "id" to 789L
-                    // No kakao_account, so no email or name
+            customOAuth2UserService.mockOAuth2User =
+                createOAuth2User(
+                    mapOf(
+                        "id" to 789L,
+                        // No kakao_account, so no email or name
+                    ),
                 )
-            )
 
             val savedUserSlot = slot<User>()
 
@@ -259,17 +271,17 @@ class CustomOAuth2UserServiceTest {
     @Nested
     @DisplayName("예외 처리")
     inner class ExceptionHandlingTest {
-
         @Test
         fun `should throw exception when OAuth2 provider returns blank id`() {
             // given
             val userRequest = createUserRequest("google")
-            customOAuth2UserService.mockOAuth2User = createOAuth2User(
-                mapOf(
-                    "email" to "user@gmail.com"
-                    // sub is missing, so id will be blank
+            customOAuth2UserService.mockOAuth2User =
+                createOAuth2User(
+                    mapOf(
+                        "email" to "user@gmail.com",
+                        // sub is missing, so id will be blank
+                    ),
                 )
-            )
 
             // when & then
             // 리플렉션으로 인해 InvocationTargetException으로 래핑됨

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationHandlersTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationHandlersTest.kt
@@ -21,11 +21,9 @@ import java.time.Instant
 
 @DisplayName("OAuth2 Authentication Handlers 테스트")
 class OAuth2AuthenticationHandlersTest {
-
     @Nested
     @DisplayName("OAuth2AuthenticationSuccessHandler")
     inner class SuccessHandlerTest {
-
         private lateinit var jwtTokenProvider: JwtTokenProvider
         private lateinit var refreshTokenRepository: RefreshTokenRepository
         private lateinit var successHandler: OAuth2AuthenticationSuccessHandler
@@ -39,23 +37,28 @@ class OAuth2AuthenticationHandlersTest {
         fun setUp() {
             jwtTokenProvider = mockk()
             refreshTokenRepository = mockk(relaxed = true)
-            successHandler = OAuth2AuthenticationSuccessHandler(
-                jwtTokenProvider,
-                refreshTokenRepository,
-                redirectUri
-            )
+            successHandler =
+                OAuth2AuthenticationSuccessHandler(
+                    jwtTokenProvider,
+                    refreshTokenRepository,
+                    redirectUri,
+                )
             request = mockk(relaxed = true)
             response = mockk(relaxed = true)
             authentication = mockk()
         }
 
-        private fun createPrincipal(userId: Long, isNewUser: Boolean): OAuth2UserPrincipal {
-            val user = User.createOAuthUser(
-                email = "test@example.com",
-                nickname = "테스터",
-                provider = OAuthProvider.KAKAO,
-                oauthId = "kakao_123"
-            )
+        private fun createPrincipal(
+            userId: Long,
+            isNewUser: Boolean,
+        ): OAuth2UserPrincipal {
+            val user =
+                User.createOAuthUser(
+                    email = "test@example.com",
+                    nickname = "테스터",
+                    provider = OAuthProvider.KAKAO,
+                    oauthId = "kakao_123",
+                )
             val idField = User::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(user, userId)
@@ -162,7 +165,6 @@ class OAuth2AuthenticationHandlersTest {
     @Nested
     @DisplayName("OAuth2AuthenticationFailureHandler")
     inner class FailureHandlerTest {
-
         private lateinit var failureHandler: OAuth2AuthenticationFailureHandler
         private lateinit var request: HttpServletRequest
         private lateinit var response: HttpServletResponse
@@ -179,10 +181,11 @@ class OAuth2AuthenticationHandlersTest {
         @Test
         fun `should redirect with error on failure`() {
             // given
-            val exception = OAuth2AuthenticationException(
-                OAuth2Error("invalid_token"),
-                "Token validation failed"
-            )
+            val exception =
+                OAuth2AuthenticationException(
+                    OAuth2Error("invalid_token"),
+                    "Token validation failed",
+                )
             val redirectUrlSlot = slot<String>()
             every { response.sendRedirect(capture(redirectUrlSlot)) } just Runs
 
@@ -197,10 +200,11 @@ class OAuth2AuthenticationHandlersTest {
         @Test
         fun `should URL encode error message`() {
             // given
-            val exception = OAuth2AuthenticationException(
-                OAuth2Error("error"),
-                "Error with special chars: &?="
-            )
+            val exception =
+                OAuth2AuthenticationException(
+                    OAuth2Error("error"),
+                    "Error with special chars: &?=",
+                )
             val redirectUrlSlot = slot<String>()
             every { response.sendRedirect(capture(redirectUrlSlot)) } just Runs
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserInfoFactoryTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserInfoFactoryTest.kt
@@ -15,11 +15,9 @@ import org.junit.jupiter.params.provider.ValueSource
 
 @DisplayName("OAuth2UserInfoFactory 테스트")
 class OAuth2UserInfoFactoryTest {
-
     @Nested
     @DisplayName("create")
     inner class Create {
-
         @Test
         fun `should create KakaoOAuth2UserInfo for kakao`() {
             // given
@@ -81,7 +79,6 @@ class OAuth2UserInfoFactoryTest {
     @Nested
     @DisplayName("toOAuthProvider")
     inner class ToOAuthProvider {
-
         @Test
         fun `should return KAKAO for kakao`() {
             // when

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserPrincipalTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2UserPrincipalTest.kt
@@ -11,38 +11,38 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("OAuth2UserPrincipal 테스트")
 class OAuth2UserPrincipalTest {
-
     private fun createTestUser(id: Long = 1L): User {
-        val user = User.createOAuthUser(
-            email = "test@example.com",
-            nickname = "테스터",
-            provider = OAuthProvider.KAKAO,
-            oauthId = "kakao_123"
-        )
+        val user =
+            User.createOAuthUser(
+                email = "test@example.com",
+                nickname = "테스터",
+                provider = OAuthProvider.KAKAO,
+                oauthId = "kakao_123",
+            )
         val idField = User::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(user, id)
         return user
     }
 
-    private fun createOAuth2UserInfo(): OAuth2UserInfo {
-        return KakaoOAuth2UserInfo(
+    private fun createOAuth2UserInfo(): OAuth2UserInfo =
+        KakaoOAuth2UserInfo(
             mapOf(
                 "id" to 123456789L,
-                "kakao_account" to mapOf(
-                    "email" to "test@kakao.com",
-                    "profile" to mapOf(
-                        "nickname" to "카카오유저"
-                    )
-                )
-            )
+                "kakao_account" to
+                    mapOf(
+                        "email" to "test@kakao.com",
+                        "profile" to
+                            mapOf(
+                                "nickname" to "카카오유저",
+                            ),
+                    ),
+            ),
         )
-    }
 
     @Nested
     @DisplayName("기본 속성")
     inner class BasicProperties {
-
         @Test
         fun `should return user id`() {
             // given
@@ -95,7 +95,6 @@ class OAuth2UserPrincipalTest {
     @Nested
     @DisplayName("OAuth2User 인터페이스")
     inner class OAuth2UserInterface {
-
         @Test
         fun `getName should return user id as string`() {
             // given
@@ -144,7 +143,6 @@ class OAuth2UserPrincipalTest {
     @Nested
     @DisplayName("getRoleNames")
     inner class GetRoleNames {
-
         @Test
         fun `should return role names without ROLE_ prefix`() {
             // given

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/impl/OAuth2UserInfoImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/impl/OAuth2UserInfoImplTest.kt
@@ -8,24 +8,25 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("OAuth2UserInfo 구현체 테스트")
 class OAuth2UserInfoImplTest {
-
     @Nested
     @DisplayName("KakaoOAuth2UserInfo")
     inner class KakaoOAuth2UserInfoTest {
-
         @Test
         fun `should parse kakao user info correctly`() {
             // given
-            val attributes = mapOf<String, Any>(
-                "id" to 123456789L,
-                "kakao_account" to mapOf(
-                    "email" to "user@kakao.com",
-                    "profile" to mapOf(
-                        "nickname" to "홍길동",
-                        "profile_image_url" to "http://example.com/image.jpg"
-                    )
+            val attributes =
+                mapOf<String, Any>(
+                    "id" to 123456789L,
+                    "kakao_account" to
+                        mapOf(
+                            "email" to "user@kakao.com",
+                            "profile" to
+                                mapOf(
+                                    "nickname" to "홍길동",
+                                    "profile_image_url" to "http://example.com/image.jpg",
+                                ),
+                        ),
                 )
-            )
 
             // when
             val userInfo = KakaoOAuth2UserInfo(attributes)
@@ -57,12 +58,14 @@ class OAuth2UserInfoImplTest {
         @Test
         fun `should return null when profile is missing`() {
             // given
-            val attributes = mapOf<String, Any>(
-                "id" to 123456789L,
-                "kakao_account" to mapOf(
-                    "email" to "user@kakao.com"
+            val attributes =
+                mapOf<String, Any>(
+                    "id" to 123456789L,
+                    "kakao_account" to
+                        mapOf(
+                            "email" to "user@kakao.com",
+                        ),
                 )
-            )
 
             // when
             val userInfo = KakaoOAuth2UserInfo(attributes)
@@ -77,16 +80,16 @@ class OAuth2UserInfoImplTest {
     @Nested
     @DisplayName("GoogleOAuth2UserInfo")
     inner class GoogleOAuth2UserInfoTest {
-
         @Test
         fun `should parse google user info correctly`() {
             // given
-            val attributes = mapOf<String, Any>(
-                "sub" to "google_123456789",
-                "email" to "user@gmail.com",
-                "name" to "홍길동",
-                "picture" to "http://example.com/image.jpg"
-            )
+            val attributes =
+                mapOf<String, Any>(
+                    "sub" to "google_123456789",
+                    "email" to "user@gmail.com",
+                    "name" to "홍길동",
+                    "picture" to "http://example.com/image.jpg",
+                )
 
             // when
             val userInfo = GoogleOAuth2UserInfo(attributes)
@@ -132,20 +135,21 @@ class OAuth2UserInfoImplTest {
     @Nested
     @DisplayName("NaverOAuth2UserInfo")
     inner class NaverOAuth2UserInfoTest {
-
         @Test
         fun `should parse naver user info correctly`() {
             // given
-            val attributes = mapOf<String, Any>(
-                "resultcode" to "00",
-                "message" to "success",
-                "response" to mapOf(
-                    "id" to "naver_123456789",
-                    "email" to "user@naver.com",
-                    "name" to "홍길동",
-                    "profile_image" to "http://example.com/image.jpg"
+            val attributes =
+                mapOf<String, Any>(
+                    "resultcode" to "00",
+                    "message" to "success",
+                    "response" to
+                        mapOf(
+                            "id" to "naver_123456789",
+                            "email" to "user@naver.com",
+                            "name" to "홍길동",
+                            "profile_image" to "http://example.com/image.jpg",
+                        ),
                 )
-            )
 
             // when
             val userInfo = NaverOAuth2UserInfo(attributes)
@@ -162,10 +166,11 @@ class OAuth2UserInfoImplTest {
         @Test
         fun `should return empty string when response is missing`() {
             // given
-            val attributes = mapOf<String, Any>(
-                "resultcode" to "00",
-                "message" to "success"
-            )
+            val attributes =
+                mapOf<String, Any>(
+                    "resultcode" to "00",
+                    "message" to "success",
+                )
 
             // when
             val userInfo = NaverOAuth2UserInfo(attributes)
@@ -180,9 +185,10 @@ class OAuth2UserInfoImplTest {
         @Test
         fun `should return null for optional fields when missing in response`() {
             // given
-            val attributes = mapOf<String, Any>(
-                "response" to mapOf("id" to "naver_123")
-            )
+            val attributes =
+                mapOf<String, Any>(
+                    "response" to mapOf("id" to "naver_123"),
+                )
 
             // when
             val userInfo = NaverOAuth2UserInfo(attributes)

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsServiceTest.kt
@@ -2,9 +2,7 @@ package com.nextup.infrastructure.security.userdetails
 
 import com.nextup.core.domain.user.Role
 import com.nextup.core.domain.user.User
-import org.springframework.data.repository.findByIdOrNull
 import io.mockk.every
-import org.springframework.data.repository.findByIdOrNull
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -12,12 +10,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import java.util.*
 
 @DisplayName("CustomUserDetailsService 테스트")
 class CustomUserDetailsServiceTest {
-
     private lateinit var userJpaRepository: UserJpaRepository
     private lateinit var service: CustomUserDetailsService
 
@@ -32,13 +30,14 @@ class CustomUserDetailsServiceTest {
         password: String = "encoded_password",
         nickname: String = "테스터",
         id: Long = 1L,
-        isActive: Boolean = true
+        isActive: Boolean = true,
     ): User {
-        val user = User.createLocalUser(
-            email = email,
-            encodedPassword = password,
-            nickname = nickname
-        )
+        val user =
+            User.createLocalUser(
+                email = email,
+                encodedPassword = password,
+                nickname = nickname,
+            )
         // Set ID using reflection
         val idField = user.javaClass.getDeclaredField("id")
         idField.isAccessible = true
@@ -54,7 +53,6 @@ class CustomUserDetailsServiceTest {
     @Nested
     @DisplayName("이메일로 사용자 조회")
     inner class LoadUserByUsername {
-
         @Test
         fun `should return user details when user exists`() {
             // given
@@ -76,9 +74,10 @@ class CustomUserDetailsServiceTest {
             every { userJpaRepository.findByEmail("notfound@example.com") } returns null
 
             // when & then
-            val exception = assertThrows<UsernameNotFoundException> {
-                service.loadUserByUsername("notfound@example.com")
-            }
+            val exception =
+                assertThrows<UsernameNotFoundException> {
+                    service.loadUserByUsername("notfound@example.com")
+                }
             assertThat(exception.message).contains("notfound@example.com")
         }
 
@@ -100,7 +99,6 @@ class CustomUserDetailsServiceTest {
     @Nested
     @DisplayName("ID로 사용자 조회")
     inner class LoadUserById {
-
         @Test
         fun `should return user details when user exists`() {
             // given
@@ -122,9 +120,10 @@ class CustomUserDetailsServiceTest {
             every { userJpaRepository.findByIdOrNull(999L) } returns null
 
             // when & then
-            val exception = assertThrows<UsernameNotFoundException> {
-                service.loadUserById(999L)
-            }
+            val exception =
+                assertThrows<UsernameNotFoundException> {
+                    service.loadUserById(999L)
+                }
             assertThat(exception.message).contains("999")
         }
     }
@@ -132,19 +131,19 @@ class CustomUserDetailsServiceTest {
 
 @DisplayName("CustomUserDetails 테스트")
 class CustomUserDetailsTest {
-
     private fun createTestUser(
         email: String = "test@example.com",
         password: String = "encoded_password",
         nickname: String = "테스터",
         id: Long = 1L,
-        isActive: Boolean = true
+        isActive: Boolean = true,
     ): User {
-        val user = User.createLocalUser(
-            email = email,
-            encodedPassword = password,
-            nickname = nickname
-        )
+        val user =
+            User.createLocalUser(
+                email = email,
+                encodedPassword = password,
+                nickname = nickname,
+            )
         // Set ID using reflection
         val idField = user.javaClass.getDeclaredField("id")
         idField.isAccessible = true
@@ -160,7 +159,6 @@ class CustomUserDetailsTest {
     @Nested
     @DisplayName("UserDetails 인터페이스 구현")
     inner class UserDetailsInterface {
-
         @Test
         fun `should return correct username as email`() {
             // given
@@ -257,7 +255,6 @@ class CustomUserDetailsTest {
     @Nested
     @DisplayName("추가 속성")
     inner class AdditionalProperties {
-
         @Test
         fun `should expose user id`() {
             // given
@@ -325,7 +322,6 @@ class CustomUserDetailsTest {
     @Nested
     @DisplayName("팩토리 메소드")
     inner class FactoryMethod {
-
         @Test
         fun `should create CustomUserDetails from User`() {
             // given

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImplTest.kt
@@ -30,7 +30,6 @@ import java.time.LocalDateTime
 
 @DisplayName("BoxScoreServiceImpl 테스트")
 class BoxScoreServiceImplTest {
-
     private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var battingRecordRepository: BattingRecordRepositoryPort
     private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
@@ -50,65 +49,68 @@ class BoxScoreServiceImplTest {
         gamePlayerRepository = mockk()
         battingRecordRepository = mockk()
         pitchingRecordRepository = mockk()
-        boxScoreService = BoxScoreServiceImpl(
-            gamePlayerRepository,
-            battingRecordRepository,
-            pitchingRecordRepository
-        )
+        boxScoreService =
+            BoxScoreServiceImpl(
+                gamePlayerRepository,
+                battingRecordRepository,
+                pitchingRecordRepository,
+            )
 
         association = Association(name = "서울시야구협회", region = "서울")
         league = League(association = association, name = "1부 리그", foundedYear = 2020)
-        competition = Competition(
-            league = league,
-            name = "2025 춘계대회",
-            year = 2025,
-            season = 1,
-            type = CompetitionType.LEAGUE,
-            startDate = LocalDate.of(2025, 3, 1),
-            status = CompetitionStatus.IN_PROGRESS
-        )
-        game = Game(
-            competition = competition,
-            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
-            location = "잠실야구장",
-            status = GameStatus.IN_PROGRESS
-        )
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+            )
+        game =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                location = "잠실야구장",
+                status = GameStatus.IN_PROGRESS,
+            )
         homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020)
         awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020)
         homeGameTeam = GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME)
         awayGameTeam = GameTeam(game = game, team = awayTeam, homeAway = HomeAway.AWAY)
     }
 
-    private fun createPlayer(name: String): Player {
-        return Player(
+    private fun createPlayer(name: String): Player =
+        Player(
             name = name,
             birthDate = LocalDate.of(1995, 1, 1),
-            primaryPosition = Position.FIRST_BASE
+            primaryPosition = Position.FIRST_BASE,
         )
-    }
 
     @Nested
     @DisplayName("getBoxScore")
     inner class GetBoxScore {
-
         @Test
         fun `경기의 박스스코어를 조회할 수 있다`() {
             // given
             val player1 = createPlayer("홈선수1")
             val player2 = createPlayer("원정선수1")
 
-            val homeGamePlayer = GamePlayer(
-                gameTeam = homeGameTeam,
-                player = player1,
-                position = Position.FIRST_BASE,
-                battingOrder = 1
-            )
-            val awayGamePlayer = GamePlayer(
-                gameTeam = awayGameTeam,
-                player = player2,
-                position = Position.STARTING_PITCHER,
-                battingOrder = null
-            )
+            val homeGamePlayer =
+                GamePlayer(
+                    gameTeam = homeGameTeam,
+                    player = player1,
+                    position = Position.FIRST_BASE,
+                    battingOrder = 1,
+                )
+            val awayGamePlayer =
+                GamePlayer(
+                    gameTeam = awayGameTeam,
+                    player = player2,
+                    position = Position.STARTING_PITCHER,
+                    battingOrder = null,
+                )
 
             val homeBattingRecord = BattingRecord.create(homeGamePlayer)
             val awayPitchingRecord = PitchingRecord.create(awayGamePlayer, isStartingPitcher = true)
@@ -147,18 +149,20 @@ class BoxScoreServiceImplTest {
             homeGameTeam.addRunInInning(3, 0)
             homeGameTeam.addRunInInning(4, 3)
             val player = createPlayer("홈선수1")
-            val homeGamePlayer = GamePlayer(
-                gameTeam = homeGameTeam,
-                player = player,
-                position = Position.FIRST_BASE,
-                battingOrder = 1
-            )
+            val homeGamePlayer =
+                GamePlayer(
+                    gameTeam = homeGameTeam,
+                    player = player,
+                    position = Position.FIRST_BASE,
+                    battingOrder = 1,
+                )
             val awayPlayer = createPlayer("원정선수1")
-            val awayGamePlayer = GamePlayer(
-                gameTeam = awayGameTeam,
-                player = awayPlayer,
-                position = Position.STARTING_PITCHER
-            )
+            val awayGamePlayer =
+                GamePlayer(
+                    gameTeam = awayGameTeam,
+                    player = awayPlayer,
+                    position = Position.STARTING_PITCHER,
+                )
 
             every { gamePlayerRepository.findAllByGameId(1L) } returns listOf(homeGamePlayer, awayGamePlayer)
             every { battingRecordRepository.findByGamePlayer(any()) } returns null
@@ -202,7 +206,6 @@ class BoxScoreServiceImplTest {
     @Nested
     @DisplayName("updateOnPlateAppearance")
     inner class UpdateOnPlateAppearance {
-
         @Test
         fun `타석 결과를 반영하여 타자와 투수 기록을 갱신한다`() {
             // given
@@ -226,7 +229,7 @@ class BoxScoreServiceImplTest {
                 result = PlateAppearanceResult.SINGLE,
                 rbis = 1,
                 runsScored = emptyList(),
-                inning = 3
+                inning = 3,
             )
 
             // then
@@ -253,10 +256,9 @@ class BoxScoreServiceImplTest {
                     result = PlateAppearanceResult.SINGLE,
                     rbis = 0,
                     runsScored = emptyList(),
-                    inning = 1
+                    inning = 1,
                 )
-            }
-                .isInstanceOf(BattingRecordNotFoundException::class.java)
+            }.isInstanceOf(BattingRecordNotFoundException::class.java)
         }
 
         @Test
@@ -280,10 +282,9 @@ class BoxScoreServiceImplTest {
                     result = PlateAppearanceResult.SINGLE,
                     rbis = 0,
                     runsScored = emptyList(),
-                    inning = 1
+                    inning = 1,
                 )
-            }
-                .isInstanceOf(PitchingRecordNotFoundException::class.java)
+            }.isInstanceOf(PitchingRecordNotFoundException::class.java)
         }
 
         @Test
@@ -314,7 +315,7 @@ class BoxScoreServiceImplTest {
                 result = PlateAppearanceResult.SINGLE,
                 rbis = 1,
                 runsScored = listOf(3L),
-                inning = 3
+                inning = 3,
             )
 
             // then
@@ -348,10 +349,9 @@ class BoxScoreServiceImplTest {
                     result = PlateAppearanceResult.SINGLE,
                     rbis = 1,
                     runsScored = listOf(999L),
-                    inning = 3
+                    inning = 3,
                 )
-            }
-                .isInstanceOf(GamePlayerNotFoundException::class.java)
+            }.isInstanceOf(GamePlayerNotFoundException::class.java)
         }
 
         @Test
@@ -382,10 +382,9 @@ class BoxScoreServiceImplTest {
                     result = PlateAppearanceResult.SINGLE,
                     rbis = 1,
                     runsScored = listOf(3L),
-                    inning = 3
+                    inning = 3,
                 )
-            }
-                .isInstanceOf(BattingRecordNotFoundException::class.java)
+            }.isInstanceOf(BattingRecordNotFoundException::class.java)
         }
 
         @Test
@@ -411,7 +410,7 @@ class BoxScoreServiceImplTest {
                 result = PlateAppearanceResult.GROUND_OUT,
                 rbis = 0,
                 runsScored = emptyList(),
-                inning = 1
+                inning = 1,
             )
 
             // then
@@ -441,7 +440,7 @@ class BoxScoreServiceImplTest {
                 result = PlateAppearanceResult.HOME_RUN,
                 rbis = 3,
                 runsScored = listOf(),
-                inning = 5
+                inning = 5,
             )
 
             // then
@@ -473,7 +472,7 @@ class BoxScoreServiceImplTest {
                 result = PlateAppearanceResult.DOUBLE,
                 rbis = 0,
                 runsScored = emptyList(),
-                inning = 2
+                inning = 2,
             )
 
             // then

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -18,8 +18,11 @@ import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.service.game.BoxScoreService
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.core.domain.game.Base
 import com.nextup.core.service.game.dto.GameEndReason
 import com.nextup.core.service.game.dto.PlateAppearanceRequest
+import com.nextup.core.service.game.dto.RunnerMovement
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -230,6 +233,339 @@ class GameScorerServiceImplTest {
             assertThatThrownBy { gameScorerService.recordPlateAppearance(1L, request) }
                 .isInstanceOf(InvalidGameStateException::class.java)
         }
+
+        @Test
+        fun `should throw exception when batter not found`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns null
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.SINGLE,
+                runnerMovements = emptyList(),
+                rbis = 0,
+                balls = 0,
+                strikes = 0
+            )
+
+            // when & then
+            assertThatThrownBy { gameScorerService.recordPlateAppearance(1L, request) }
+                .isInstanceOf(GamePlayerNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when pitcher not found`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns null
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.SINGLE,
+                runnerMovements = emptyList(),
+                rbis = 0,
+                balls = 0,
+                strikes = 0
+            )
+
+            // when & then
+            assertThatThrownBy { gameScorerService.recordPlateAppearance(1L, request) }
+                .isInstanceOf(GamePlayerNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should record single hit`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.SINGLE,
+                runnerMovements = emptyList(),
+                rbis = 0,
+                balls = 2,
+                strikes = 1
+            )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.gameState.runnerOnFirstId).isEqualTo(10L)
+            verify { boxScoreService.updateOnPlateAppearance(any(), any(), any(), any(), any(), any(), any()) }
+        }
+
+        @Test
+        fun `should record double hit`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.DOUBLE,
+                runnerMovements = emptyList(),
+                rbis = 0,
+                balls = 0,
+                strikes = 0
+            )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.gameState.runnerOnSecondId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should record triple hit`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.TRIPLE,
+                runnerMovements = emptyList(),
+                rbis = 0,
+                balls = 0,
+                strikes = 0
+            )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.gameState.runnerOnThirdId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should record home run`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.HOME_RUN,
+                runnerMovements = emptyList(),
+                rbis = 1,
+                balls = 0,
+                strikes = 0
+            )
+
+            // when
+            gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            verify { boxScoreService.updateOnPlateAppearance(any(), any(), any(), eq(PlateAppearanceResult.HOME_RUN), any(), any(), any()) }
+        }
+
+        @Test
+        fun `should record walk`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.WALK,
+                runnerMovements = emptyList(),
+                rbis = 0,
+                balls = 4,
+                strikes = 0
+            )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.gameState.runnerOnFirstId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should record strikeout with out increase`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.STRIKEOUT,
+                runnerMovements = emptyList(),
+                rbis = 0,
+                balls = 0,
+                strikes = 3
+            )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.gameState.outs).isEqualTo(1)
+        }
+
+        @Test
+        fun `should handle runner movement with score`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS).apply {
+                gameState.runnerOnThirdId = 5L
+            }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.SINGLE,
+                runnerMovements = listOf(
+                    RunnerMovement(
+                        runnerId = 5L,
+                        fromBase = Base.THIRD,
+                        toBase = Base.HOME,
+                        isOut = false
+                    )
+                ),
+                rbis = 1,
+                balls = 0,
+                strikes = 0
+            )
+
+            // when
+            gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            verify { boxScoreService.updateOnPlateAppearance(any(), any(), any(), any(), any(), match { it.contains(5L) }, any()) }
+        }
+
+        @Test
+        fun `should handle runner movement with out`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS).apply {
+                gameState.runnerOnFirstId = 5L
+            }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.FIELDERS_CHOICE,
+                runnerMovements = listOf(
+                    RunnerMovement(
+                        runnerId = 5L,
+                        fromBase = Base.FIRST,
+                        toBase = Base.SECOND,
+                        isOut = true
+                    )
+                ),
+                rbis = 0,
+                balls = 0,
+                strikes = 0
+            )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.gameState.outs).isEqualTo(1)
+        }
+
+        @Test
+        fun `should handle runner advancement without score or out`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS).apply {
+                gameState.runnerOnFirstId = 5L
+            }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.SINGLE,
+                runnerMovements = listOf(
+                    RunnerMovement(
+                        runnerId = 5L,
+                        fromBase = Base.FIRST,
+                        toBase = Base.THIRD,
+                        isOut = false
+                    )
+                ),
+                rbis = 0,
+                balls = 0,
+                strikes = 0
+            )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.gameState.runnerOnThirdId).isEqualTo(5L)
+            assertThat(result.gameState.runnerOnFirstId).isEqualTo(10L)
+        }
+    }
+
+    private fun createGamePlayer(id: Long): GamePlayer {
+        val gamePlayer = mockk<GamePlayer>(relaxed = true)
+        every { gamePlayer.id } returns id
+        return gamePlayer
     }
 
     private fun createAssociation(id: Long): Association {

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -1,0 +1,307 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameState
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.PlateAppearanceResult
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.service.game.BoxScoreService
+import com.nextup.core.service.game.dto.GameEndReason
+import com.nextup.core.service.game.dto.PlateAppearanceRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameScorerServiceImpl")
+class GameScorerServiceImplTest {
+
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var boxScoreService: BoxScoreService
+    private lateinit var gameScorerService: GameScorerServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        gamePlayerRepository = mockk()
+        boxScoreService = mockk(relaxed = true)
+        gameScorerService = GameScorerServiceImpl(
+            gameRepository,
+            gamePlayerRepository,
+            boxScoreService
+        )
+    }
+
+    @Nested
+    @DisplayName("startGame")
+    inner class StartGame {
+
+        @Test
+        fun `should start game when status is SCHEDULED`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.startGame(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.IN_PROGRESS)
+            assertThat(result.currentInning).isEqualTo(1)
+            assertThat(result.isTopInning).isTrue()
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when game not found`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy { gameScorerService.startGame(999L) }
+                .isInstanceOf(GameNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("advanceHalfInning")
+    inner class AdvanceHalfInning {
+
+        @Test
+        fun `should advance to bottom of inning`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS).apply {
+                currentInning = 1
+                isTopInning = true
+            }
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.advanceHalfInning(1L)
+
+            // then
+            assertThat(result.isTopInning).isFalse()
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when game is not in progress`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { gameScorerService.advanceHalfInning(1L) }
+                .isInstanceOf(InvalidGameStateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("endGame")
+    inner class EndGame {
+
+        @Test
+        fun `should end game with REGULATION reason`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.endGame(1L, GameEndReason.REGULATION)
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.FINISHED)
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should end game with MERCY_RULE reason`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.endGame(1L, GameEndReason.MERCY_RULE)
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.CALLED)
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should end game with WEATHER reason`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.endGame(1L, GameEndReason.WEATHER)
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.CALLED)
+        }
+
+        @Test
+        fun `should end game with FORFEIT reason`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.endGame(1L, GameEndReason.FORFEIT)
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.FORFEITED)
+        }
+
+        @Test
+        fun `should end game with OTHER reason`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.endGame(1L, GameEndReason.OTHER)
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.CALLED)
+        }
+
+        @Test
+        fun `should throw exception when game is not in progress`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { gameScorerService.endGame(1L, GameEndReason.REGULATION) }
+                .isInstanceOf(InvalidGameStateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("recordPlateAppearance")
+    inner class RecordPlateAppearance {
+
+        @Test
+        fun `should throw exception when game is not in progress`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            val request = PlateAppearanceRequest(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.SINGLE,
+                runnerMovements = emptyList(),
+                rbis = 0,
+                balls = 0,
+                strikes = 0
+            )
+
+            // when & then
+            assertThatThrownBy { gameScorerService.recordPlateAppearance(1L, request) }
+                .isInstanceOf(InvalidGameStateException::class.java)
+        }
+    }
+
+    private fun createAssociation(id: Long): Association {
+        return Association(
+            name = "서울시야구협회",
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createLeague(id: Long, association: Association): League {
+        return League(
+            association = association,
+            name = "1부 리그",
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createCompetition(id: Long, league: League): Competition {
+        return Competition(
+            league = league,
+            name = "2025 춘계대회",
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            endDate = LocalDate.of(2025, 6, 30),
+            status = CompetitionStatus.IN_PROGRESS,
+            description = null,
+            maxTeams = null
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createGame(id: Long, status: GameStatus): Game {
+        val association = createAssociation(1L)
+        val league = createLeague(1L, association)
+        val competition = createCompetition(1L, league)
+
+        return Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실구장",
+            fieldName = "1구장",
+            gameNumber = 1,
+            status = status,
+            currentInning = 1,
+            isTopInning = true,
+            totalInnings = 9,
+            gameState = GameState()
+        ).apply {
+            val idField = Game::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -1,25 +1,22 @@
 package com.nextup.infrastructure.service.game
 
 import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
 import com.nextup.common.exception.InvalidGameStateException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Base
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.GameState
 import com.nextup.core.domain.game.GameStatus
-import com.nextup.core.domain.game.GameTeam
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
-import com.nextup.core.domain.player.Player
-import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.service.game.BoxScoreService
-import com.nextup.common.exception.GamePlayerNotFoundException
-import com.nextup.core.domain.game.Base
 import com.nextup.core.service.game.dto.GameEndReason
 import com.nextup.core.service.game.dto.PlateAppearanceRequest
 import com.nextup.core.service.game.dto.RunnerMovement
@@ -37,7 +34,6 @@ import java.time.LocalDateTime
 
 @DisplayName("GameScorerServiceImpl")
 class GameScorerServiceImplTest {
-
     private lateinit var gameRepository: GameRepositoryPort
     private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var boxScoreService: BoxScoreService
@@ -48,17 +44,17 @@ class GameScorerServiceImplTest {
         gameRepository = mockk()
         gamePlayerRepository = mockk()
         boxScoreService = mockk(relaxed = true)
-        gameScorerService = GameScorerServiceImpl(
-            gameRepository,
-            gamePlayerRepository,
-            boxScoreService
-        )
+        gameScorerService =
+            GameScorerServiceImpl(
+                gameRepository,
+                gamePlayerRepository,
+                boxScoreService,
+            )
     }
 
     @Nested
     @DisplayName("startGame")
     inner class StartGame {
-
         @Test
         fun `should start game when status is SCHEDULED`() {
             // given
@@ -90,14 +86,14 @@ class GameScorerServiceImplTest {
     @Nested
     @DisplayName("advanceHalfInning")
     inner class AdvanceHalfInning {
-
         @Test
         fun `should advance to bottom of inning`() {
             // given
-            val game = createGame(1L, GameStatus.IN_PROGRESS).apply {
-                currentInning = 1
-                isTopInning = true
-            }
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 1
+                    isTopInning = true
+                }
             every { gameRepository.findByIdOrNull(1L) } returns game
             every { gameRepository.save(any()) } answers { firstArg() }
 
@@ -124,7 +120,6 @@ class GameScorerServiceImplTest {
     @Nested
     @DisplayName("endGame")
     inner class EndGame {
-
         @Test
         fun `should end game with REGULATION reason`() {
             // given
@@ -212,22 +207,22 @@ class GameScorerServiceImplTest {
     @Nested
     @DisplayName("recordPlateAppearance")
     inner class RecordPlateAppearance {
-
         @Test
         fun `should throw exception when game is not in progress`() {
             // given
             val game = createGame(1L, GameStatus.SCHEDULED)
             every { gameRepository.findByIdOrNull(1L) } returns game
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.SINGLE,
-                runnerMovements = emptyList(),
-                rbis = 0,
-                balls = 0,
-                strikes = 0
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.SINGLE,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                    balls = 0,
+                    strikes = 0,
+                )
 
             // when & then
             assertThatThrownBy { gameScorerService.recordPlateAppearance(1L, request) }
@@ -241,15 +236,16 @@ class GameScorerServiceImplTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
             every { gamePlayerRepository.findByIdOrNull(10L) } returns null
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.SINGLE,
-                runnerMovements = emptyList(),
-                rbis = 0,
-                balls = 0,
-                strikes = 0
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.SINGLE,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                    balls = 0,
+                    strikes = 0,
+                )
 
             // when & then
             assertThatThrownBy { gameScorerService.recordPlateAppearance(1L, request) }
@@ -265,15 +261,16 @@ class GameScorerServiceImplTest {
             every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
             every { gamePlayerRepository.findByIdOrNull(20L) } returns null
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.SINGLE,
-                runnerMovements = emptyList(),
-                rbis = 0,
-                balls = 0,
-                strikes = 0
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.SINGLE,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                    balls = 0,
+                    strikes = 0,
+                )
 
             // when & then
             assertThatThrownBy { gameScorerService.recordPlateAppearance(1L, request) }
@@ -291,15 +288,16 @@ class GameScorerServiceImplTest {
             every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
             every { gameRepository.save(any()) } answers { firstArg() }
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.SINGLE,
-                runnerMovements = emptyList(),
-                rbis = 0,
-                balls = 2,
-                strikes = 1
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.SINGLE,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                    balls = 2,
+                    strikes = 1,
+                )
 
             // when
             val result = gameScorerService.recordPlateAppearance(1L, request)
@@ -320,15 +318,16 @@ class GameScorerServiceImplTest {
             every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
             every { gameRepository.save(any()) } answers { firstArg() }
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.DOUBLE,
-                runnerMovements = emptyList(),
-                rbis = 0,
-                balls = 0,
-                strikes = 0
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.DOUBLE,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                    balls = 0,
+                    strikes = 0,
+                )
 
             // when
             val result = gameScorerService.recordPlateAppearance(1L, request)
@@ -348,15 +347,16 @@ class GameScorerServiceImplTest {
             every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
             every { gameRepository.save(any()) } answers { firstArg() }
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.TRIPLE,
-                runnerMovements = emptyList(),
-                rbis = 0,
-                balls = 0,
-                strikes = 0
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.TRIPLE,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                    balls = 0,
+                    strikes = 0,
+                )
 
             // when
             val result = gameScorerService.recordPlateAppearance(1L, request)
@@ -376,21 +376,32 @@ class GameScorerServiceImplTest {
             every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
             every { gameRepository.save(any()) } answers { firstArg() }
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.HOME_RUN,
-                runnerMovements = emptyList(),
-                rbis = 1,
-                balls = 0,
-                strikes = 0
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.HOME_RUN,
+                    runnerMovements = emptyList(),
+                    rbis = 1,
+                    balls = 0,
+                    strikes = 0,
+                )
 
             // when
             gameScorerService.recordPlateAppearance(1L, request)
 
             // then
-            verify { boxScoreService.updateOnPlateAppearance(any(), any(), any(), eq(PlateAppearanceResult.HOME_RUN), any(), any(), any()) }
+            verify {
+                boxScoreService.updateOnPlateAppearance(
+                    any(),
+                    any(),
+                    any(),
+                    eq(PlateAppearanceResult.HOME_RUN),
+                    any(),
+                    any(),
+                    any()
+                )
+            }
         }
 
         @Test
@@ -404,15 +415,16 @@ class GameScorerServiceImplTest {
             every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
             every { gameRepository.save(any()) } answers { firstArg() }
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.WALK,
-                runnerMovements = emptyList(),
-                rbis = 0,
-                balls = 4,
-                strikes = 0
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.WALK,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                    balls = 4,
+                    strikes = 0,
+                )
 
             // when
             val result = gameScorerService.recordPlateAppearance(1L, request)
@@ -432,15 +444,16 @@ class GameScorerServiceImplTest {
             every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
             every { gameRepository.save(any()) } answers { firstArg() }
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.STRIKEOUT,
-                runnerMovements = emptyList(),
-                rbis = 0,
-                balls = 0,
-                strikes = 3
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                    balls = 0,
+                    strikes = 3,
+                )
 
             // when
             val result = gameScorerService.recordPlateAppearance(1L, request)
@@ -452,9 +465,10 @@ class GameScorerServiceImplTest {
         @Test
         fun `should handle runner movement with score`() {
             // given
-            val game = createGame(1L, GameStatus.IN_PROGRESS).apply {
-                gameState.runnerOnThirdId = 5L
-            }
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.runnerOnThirdId = 5L
+                }
             val batter = createGamePlayer(10L)
             val pitcher = createGamePlayer(20L)
             every { gameRepository.findByIdOrNull(1L) } returns game
@@ -462,36 +476,51 @@ class GameScorerServiceImplTest {
             every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
             every { gameRepository.save(any()) } answers { firstArg() }
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.SINGLE,
-                runnerMovements = listOf(
-                    RunnerMovement(
-                        runnerId = 5L,
-                        fromBase = Base.THIRD,
-                        toBase = Base.HOME,
-                        isOut = false
-                    )
-                ),
-                rbis = 1,
-                balls = 0,
-                strikes = 0
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.SINGLE,
+                    runnerMovements =
+                        listOf(
+                            RunnerMovement(
+                                runnerId = 5L,
+                                fromBase = Base.THIRD,
+                                toBase = Base.HOME,
+                                isOut = false,
+                            ),
+                        ),
+                    rbis = 1,
+                    balls = 0,
+                    strikes = 0,
+                )
 
             // when
             gameScorerService.recordPlateAppearance(1L, request)
 
             // then
-            verify { boxScoreService.updateOnPlateAppearance(any(), any(), any(), any(), any(), match { it.contains(5L) }, any()) }
+            verify {
+                boxScoreService.updateOnPlateAppearance(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    match {
+                        it.contains(5L)
+                    },
+                    any()
+                )
+            }
         }
 
         @Test
         fun `should handle runner movement with out`() {
             // given
-            val game = createGame(1L, GameStatus.IN_PROGRESS).apply {
-                gameState.runnerOnFirstId = 5L
-            }
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.runnerOnFirstId = 5L
+                }
             val batter = createGamePlayer(10L)
             val pitcher = createGamePlayer(20L)
             every { gameRepository.findByIdOrNull(1L) } returns game
@@ -499,22 +528,24 @@ class GameScorerServiceImplTest {
             every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
             every { gameRepository.save(any()) } answers { firstArg() }
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.FIELDERS_CHOICE,
-                runnerMovements = listOf(
-                    RunnerMovement(
-                        runnerId = 5L,
-                        fromBase = Base.FIRST,
-                        toBase = Base.SECOND,
-                        isOut = true
-                    )
-                ),
-                rbis = 0,
-                balls = 0,
-                strikes = 0
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.FIELDERS_CHOICE,
+                    runnerMovements =
+                        listOf(
+                            RunnerMovement(
+                                runnerId = 5L,
+                                fromBase = Base.FIRST,
+                                toBase = Base.SECOND,
+                                isOut = true,
+                            ),
+                        ),
+                    rbis = 0,
+                    balls = 0,
+                    strikes = 0,
+                )
 
             // when
             val result = gameScorerService.recordPlateAppearance(1L, request)
@@ -526,9 +557,10 @@ class GameScorerServiceImplTest {
         @Test
         fun `should handle runner advancement without score or out`() {
             // given
-            val game = createGame(1L, GameStatus.IN_PROGRESS).apply {
-                gameState.runnerOnFirstId = 5L
-            }
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.runnerOnFirstId = 5L
+                }
             val batter = createGamePlayer(10L)
             val pitcher = createGamePlayer(20L)
             every { gameRepository.findByIdOrNull(1L) } returns game
@@ -536,22 +568,24 @@ class GameScorerServiceImplTest {
             every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
             every { gameRepository.save(any()) } answers { firstArg() }
 
-            val request = PlateAppearanceRequest(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.SINGLE,
-                runnerMovements = listOf(
-                    RunnerMovement(
-                        runnerId = 5L,
-                        fromBase = Base.FIRST,
-                        toBase = Base.THIRD,
-                        isOut = false
-                    )
-                ),
-                rbis = 0,
-                balls = 0,
-                strikes = 0
-            )
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.SINGLE,
+                    runnerMovements =
+                        listOf(
+                            RunnerMovement(
+                                runnerId = 5L,
+                                fromBase = Base.FIRST,
+                                toBase = Base.THIRD,
+                                isOut = false,
+                            ),
+                        ),
+                    rbis = 0,
+                    balls = 0,
+                    strikes = 0,
+                )
 
             // when
             val result = gameScorerService.recordPlateAppearance(1L, request)
@@ -568,39 +602,43 @@ class GameScorerServiceImplTest {
         return gamePlayer
     }
 
-    private fun createAssociation(id: Long): Association {
-        return Association(
+    private fun createAssociation(id: Long): Association =
+        Association(
             name = "서울시야구협회",
             abbreviation = null,
             region = "서울",
             description = null,
             logoUrl = null,
-            websiteUrl = null
+            websiteUrl = null,
         ).apply {
             val idField = Association::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
-    private fun createLeague(id: Long, association: Association): League {
-        return League(
+    private fun createLeague(
+        id: Long,
+        association: Association,
+    ): League =
+        League(
             association = association,
             name = "1부 리그",
             abbreviation = null,
             foundedYear = 2020,
             divisionLevel = 1,
             description = null,
-            logoUrl = null
+            logoUrl = null,
         ).apply {
             val idField = League::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
-    private fun createCompetition(id: Long, league: League): Competition {
-        return Competition(
+    private fun createCompetition(
+        id: Long,
+        league: League,
+    ): Competition =
+        Competition(
             league = league,
             name = "2025 춘계대회",
             year = 2025,
@@ -610,15 +648,17 @@ class GameScorerServiceImplTest {
             endDate = LocalDate.of(2025, 6, 30),
             status = CompetitionStatus.IN_PROGRESS,
             description = null,
-            maxTeams = null
+            maxTeams = null,
         ).apply {
             val idField = Competition::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }
-    }
 
-    private fun createGame(id: Long, status: GameStatus): Game {
+    private fun createGame(
+        id: Long,
+        status: GameStatus,
+    ): Game {
         val association = createAssociation(1L)
         val league = createLeague(1L, association)
         val competition = createCompetition(1L, league)
@@ -633,7 +673,7 @@ class GameScorerServiceImplTest {
             currentInning = 1,
             isTopInning = true,
             totalInnings = 9,
-            gameState = GameState()
+            gameState = GameState(),
         ).apply {
             val idField = Game::class.java.getDeclaredField("id")
             idField.isAccessible = true

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkServiceTest.kt
@@ -6,7 +6,6 @@ import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.User
 import com.nextup.infrastructure.repository.user.OAuthAccountRepository
 import com.nextup.infrastructure.security.userdetails.UserJpaRepository
-import org.springframework.data.repository.findByIdOrNull
 import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -14,11 +13,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
 import java.util.*
 
 @DisplayName("OAuthLinkService")
 class OAuthLinkServiceTest {
-
     private lateinit var userJpaRepository: UserJpaRepository
     private lateinit var oauthAccountRepository: OAuthAccountRepository
     private lateinit var oauthLinkService: OAuthLinkService
@@ -33,7 +32,6 @@ class OAuthLinkServiceTest {
     @Nested
     @DisplayName("linkOAuthAccount")
     inner class LinkOAuthAccount {
-
         @Test
         fun `should link oauth account to existing user`() {
             // given
@@ -87,7 +85,6 @@ class OAuthLinkServiceTest {
     @Nested
     @DisplayName("unlinkOAuthAccount")
     inner class UnlinkOAuthAccount {
-
         @Test
         fun `should unlink oauth account from user`() {
             // given
@@ -122,7 +119,6 @@ class OAuthLinkServiceTest {
     @Nested
     @DisplayName("getLinkedProviders")
     inner class GetLinkedProviders {
-
         @Test
         fun `should return list of linked providers`() {
             // given
@@ -155,7 +151,6 @@ class OAuthLinkServiceTest {
     @Nested
     @DisplayName("isLinked")
     inner class IsLinked {
-
         @Test
         fun `should return true when oauth account is linked`() {
             // given
@@ -191,7 +186,6 @@ class OAuthLinkServiceTest {
     @Nested
     @DisplayName("findUserByOAuth")
     inner class FindUserByOAuth {
-
         @Test
         fun `should return user when oauth account found`() {
             // given
@@ -228,29 +222,34 @@ class OAuthLinkServiceTest {
 
     // Helper methods
     private fun createLocalUser(id: Long): User {
-        val user = User.createLocalUser(
-            email = "test@example.com",
-            encodedPassword = "encoded_password",
-            nickname = "testuser"
-        )
+        val user =
+            User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "encoded_password",
+                nickname = "testuser",
+            )
         setUserId(user, id)
         return user
     }
 
     private fun createOAuthUser(id: Long): User {
-        val user = User.createOAuthUser(
-            email = "test@kakao.com",
-            nickname = "kakao_user",
-            provider = OAuthProvider.KAKAO,
-            oauthId = "kakao_123"
-        )
+        val user =
+            User.createOAuthUser(
+                email = "test@kakao.com",
+                nickname = "kakao_user",
+                provider = OAuthProvider.KAKAO,
+                oauthId = "kakao_123",
+            )
         // Add password so user can remove OAuth account
         user.changePassword("encoded_password")
         setUserId(user, id)
         return user
     }
 
-    private fun setUserId(user: User, id: Long) {
+    private fun setUserId(
+        user: User,
+        id: Long,
+    ) {
         val idField = User::class.java.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(user, id)

--- a/nextup-scorer/build.gradle.kts
+++ b/nextup-scorer/build.gradle.kts
@@ -48,16 +48,18 @@ tasks.jacocoTestReport {
     }
 
     classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/dto/**",
-                    "**/config/**",
-                    "**/ScorerApplication*",
-                    "**/HealthController*"
-                )
-            }
-        })
+        files(
+            classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/dto/**",
+                        "**/config/**",
+                        "**/ScorerApplication*",
+                        "**/HealthController*",
+                    )
+                }
+            },
+        ),
     )
 }
 
@@ -71,15 +73,17 @@ tasks.jacocoTestCoverageVerification {
     }
 
     classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/dto/**",
-                    "**/config/**",
-                    "**/ScorerApplication*",
-                    "**/HealthController*"
-                )
-            }
-        })
+        files(
+            classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/dto/**",
+                        "**/config/**",
+                        "**/ScorerApplication*",
+                        "**/HealthController*",
+                    )
+                }
+            },
+        ),
     )
 }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/competition/CompetitionScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/competition/CompetitionScorerController.kt
@@ -72,17 +72,18 @@ class CompetitionScorerController(
     fun createCompetition(
         @Valid @RequestBody request: CreateCompetitionRequest
     ): ApiResponse<CompetitionScorerResponse> {
-        val competition = competitionService.create(
-            leagueId = request.leagueId,
-            name = request.name,
-            year = request.year,
-            season = request.season,
-            type = request.type,
-            startDate = request.startDate,
-            endDate = request.endDate,
-            description = request.description,
-            maxTeams = request.maxTeams
-        )
+        val competition =
+            competitionService.create(
+                leagueId = request.leagueId,
+                name = request.name,
+                year = request.year,
+                season = request.season,
+                type = request.type,
+                startDate = request.startDate,
+                endDate = request.endDate,
+                description = request.description,
+                maxTeams = request.maxTeams
+            )
         return ApiResponse.success(CompetitionScorerResponse.from(competition))
     }
 
@@ -94,11 +95,12 @@ class CompetitionScorerController(
         @PathVariable id: Long,
         @Valid @RequestBody request: UpdateCompetitionRequest
     ): ApiResponse<CompetitionScorerResponse> {
-        val competition = competitionService.update(
-            id = id,
-            description = request.description,
-            endDate = request.endDate
-        )
+        val competition =
+            competitionService.update(
+                id = id,
+                description = request.description,
+                endDate = request.endDate
+            )
         return ApiResponse.success(CompetitionScorerResponse.from(competition))
     }
 

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -5,15 +5,18 @@ import com.nextup.scorer.dto.common.ApiResponse
 import com.nextup.scorer.dto.game.*
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 
 /**
  * 기록원 전용 경기 기록 컨트롤러
  *
  * 실시간 경기 기록 입력을 위한 API를 제공합니다.
+ * SCORER 또는 ADMIN 역할이 필요합니다.
  */
 @RestController
 @RequestMapping("/api/scorer/games")
+@PreAuthorize("hasAnyRole('SCORER', 'ADMIN')")
 class GameScorerController(
     private val gameScorerService: GameScorerService
 ) {

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -1,0 +1,66 @@
+package com.nextup.scorer.controller.game
+
+import com.nextup.core.service.game.GameScorerService
+import com.nextup.scorer.dto.common.ApiResponse
+import com.nextup.scorer.dto.game.*
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 기록원 전용 경기 기록 컨트롤러
+ *
+ * 실시간 경기 기록 입력을 위한 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/scorer/games")
+class GameScorerController(
+    private val gameScorerService: GameScorerService
+) {
+
+    /**
+     * 경기를 시작합니다.
+     */
+    @PostMapping("/{gameId}/start")
+    @ResponseStatus(HttpStatus.OK)
+    fun startGame(@PathVariable gameId: Long): ApiResponse<GameResponse> {
+        val game = gameScorerService.startGame(gameId)
+        return ApiResponse.success(game.toResponse())
+    }
+
+    /**
+     * 타석 결과를 입력합니다.
+     */
+    @PostMapping("/{gameId}/plate-appearances")
+    @ResponseStatus(HttpStatus.OK)
+    fun recordPlateAppearance(
+        @PathVariable gameId: Long,
+        @RequestBody @Valid request: PlateAppearanceRequestDto
+    ): ApiResponse<GameResponse> {
+        val game = gameScorerService.recordPlateAppearance(gameId, request.toDomain())
+        return ApiResponse.success(game.toResponse())
+    }
+
+    /**
+     * 반 이닝을 진행합니다 (공수 교대).
+     */
+    @PostMapping("/{gameId}/half-inning")
+    @ResponseStatus(HttpStatus.OK)
+    fun advanceHalfInning(@PathVariable gameId: Long): ApiResponse<GameResponse> {
+        val game = gameScorerService.advanceHalfInning(gameId)
+        return ApiResponse.success(game.toResponse())
+    }
+
+    /**
+     * 경기를 종료합니다.
+     */
+    @PostMapping("/{gameId}/end")
+    @ResponseStatus(HttpStatus.OK)
+    fun endGame(
+        @PathVariable gameId: Long,
+        @RequestBody @Valid request: GameEndRequestDto
+    ): ApiResponse<GameResponse> {
+        val game = gameScorerService.endGame(gameId, request.reason!!)
+        return ApiResponse.success(game.toResponse())
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -5,18 +5,15 @@ import com.nextup.scorer.dto.common.ApiResponse
 import com.nextup.scorer.dto.game.*
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 
 /**
  * 기록원 전용 경기 기록 컨트롤러
  *
  * 실시간 경기 기록 입력을 위한 API를 제공합니다.
- * SCORER 또는 ADMIN 역할이 필요합니다.
  */
 @RestController
 @RequestMapping("/api/scorer/games")
-@PreAuthorize("hasAnyRole('SCORER', 'ADMIN')")
 class GameScorerController(
     private val gameScorerService: GameScorerService
 ) {

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -23,7 +23,9 @@ class GameScorerController(
      */
     @PostMapping("/{gameId}/start")
     @ResponseStatus(HttpStatus.OK)
-    fun startGame(@PathVariable gameId: Long): ApiResponse<GameResponse> {
+    fun startGame(
+        @PathVariable gameId: Long
+    ): ApiResponse<GameResponse> {
         val game = gameScorerService.startGame(gameId)
         return ApiResponse.success(game.toResponse())
     }
@@ -46,7 +48,9 @@ class GameScorerController(
      */
     @PostMapping("/{gameId}/half-inning")
     @ResponseStatus(HttpStatus.OK)
-    fun advanceHalfInning(@PathVariable gameId: Long): ApiResponse<GameResponse> {
+    fun advanceHalfInning(
+        @PathVariable gameId: Long
+    ): ApiResponse<GameResponse> {
         val game = gameScorerService.advanceHalfInning(gameId)
         return ApiResponse.success(game.toResponse())
     }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/league/LeagueController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/league/LeagueController.kt
@@ -38,11 +38,12 @@ class LeagueController(
     fun getAllLeagues(
         @RequestParam(required = false) associationId: Long?
     ): ApiResponse<List<LeagueResponse>> {
-        val leagues = if (associationId != null) {
-            leagueService.getByAssociationId(associationId)
-        } else {
-            leagueService.getAll()
-        }
+        val leagues =
+            if (associationId != null) {
+                leagueService.getByAssociationId(associationId)
+            } else {
+                leagueService.getAll()
+            }
 
         return ApiResponse.success(
             leagues.map { LeagueResponse.from(it) }
@@ -69,15 +70,16 @@ class LeagueController(
     fun createLeague(
         @Valid @RequestBody request: CreateLeagueRequest
     ): ApiResponse<LeagueResponse> {
-        val league = leagueService.create(
-            associationId = request.associationId,
-            name = request.name,
-            abbreviation = request.abbreviation,
-            foundedYear = request.foundedYear,
-            divisionLevel = request.divisionLevel,
-            description = request.description,
-            logoUrl = request.logoUrl
-        )
+        val league =
+            leagueService.create(
+                associationId = request.associationId,
+                name = request.name,
+                abbreviation = request.abbreviation,
+                foundedYear = request.foundedYear,
+                divisionLevel = request.divisionLevel,
+                description = request.description,
+                logoUrl = request.logoUrl
+            )
         return ApiResponse.success(LeagueResponse.from(league))
     }
 
@@ -90,11 +92,12 @@ class LeagueController(
         @PathVariable id: Long,
         @Valid @RequestBody request: UpdateLeagueRequest
     ): ApiResponse<LeagueResponse> {
-        val league = leagueService.update(
-            id = id,
-            description = request.description,
-            logoUrl = request.logoUrl
-        )
+        val league =
+            leagueService.update(
+                id = id,
+                description = request.description,
+                logoUrl = request.logoUrl
+            )
         return ApiResponse.success(LeagueResponse.from(league))
     }
 

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/common/ApiResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/common/ApiResponse.kt
@@ -15,7 +15,10 @@ data class ApiResponse<T>(
             return ApiResponse(success = true, data = data, error = null)
         }
 
-        fun <T> error(code: String, message: String): ApiResponse<T> {
+        fun <T> error(
+            code: String,
+            message: String
+        ): ApiResponse<T> {
             return ApiResponse(
                 success = false,
                 data = null,

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/competition/CompetitionRequest.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/competition/CompetitionRequest.kt
@@ -14,27 +14,19 @@ data class CreateCompetitionRequest(
     @field:NotNull(message = "리그 ID는 필수입니다")
     @field:Positive(message = "리그 ID는 양수여야 합니다")
     val leagueId: Long,
-
     @field:NotBlank(message = "대회 이름은 필수입니다")
     @field:Size(max = 100, message = "대회 이름은 100자를 초과할 수 없습니다")
     val name: String,
-
     @field:NotNull(message = "연도는 필수입니다")
     val year: Int,
-
     val season: Int = 1,
-
     @field:NotNull(message = "대회 타입은 필수입니다")
     val type: CompetitionType,
-
     @field:NotNull(message = "시작일은 필수입니다")
     val startDate: LocalDate,
-
     val endDate: LocalDate? = null,
-
     @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
     val description: String? = null,
-
     val maxTeams: Int? = null
 )
 
@@ -44,6 +36,5 @@ data class CreateCompetitionRequest(
 data class UpdateCompetitionRequest(
     @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
     val description: String? = null,
-
     val endDate: LocalDate? = null
 )

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameEndRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameEndRequestDto.kt
@@ -1,0 +1,12 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.service.game.dto.GameEndReason
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 경기 종료 요청 DTO
+ */
+data class GameEndRequestDto(
+    @field:NotNull(message = "종료 사유는 필수입니다")
+    val reason: GameEndReason?
+)

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameMapper.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameMapper.kt
@@ -1,0 +1,41 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameState
+
+/**
+ * Game Entity를 GameResponse DTO로 변환합니다.
+ */
+fun Game.toResponse(): GameResponse {
+    return GameResponse(
+        id = this.id,
+        competitionId = this.competition.id,
+        status = this.status,
+        currentInning = this.currentInning,
+        isTopInning = this.isTopInning,
+        currentInningDisplay = this.currentInningDisplay,
+        gameState = this.gameState.toResponse(),
+        scheduledAt = this.scheduledAt,
+        startedAt = this.startedAt,
+        endedAt = this.endedAt
+    )
+}
+
+/**
+ * GameState를 GameStateResponse DTO로 변환합니다.
+ */
+fun GameState.toResponse(): GameStateResponse {
+    return GameStateResponse(
+        outs = this.outs,
+        balls = this.balls,
+        strikes = this.strikes,
+        runnerOnFirstId = this.runnerOnFirstId,
+        runnerOnSecondId = this.runnerOnSecondId,
+        runnerOnThirdId = this.runnerOnThirdId,
+        homeBattingOrder = this.homeBattingOrder,
+        awayBattingOrder = this.awayBattingOrder,
+        currentPitcherId = this.currentPitcherId,
+        currentBatterId = this.currentBatterId,
+        countDisplay = this.countDisplay
+    )
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameResponse.kt
@@ -1,0 +1,37 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.game.GameStatus
+import java.time.LocalDateTime
+
+/**
+ * 경기 응답 DTO
+ */
+data class GameResponse(
+    val id: Long,
+    val competitionId: Long,
+    val status: GameStatus,
+    val currentInning: Int,
+    val isTopInning: Boolean,
+    val currentInningDisplay: String,
+    val gameState: GameStateResponse,
+    val scheduledAt: LocalDateTime,
+    val startedAt: LocalDateTime?,
+    val endedAt: LocalDateTime?
+)
+
+/**
+ * 경기 상태 응답 DTO
+ */
+data class GameStateResponse(
+    val outs: Int,
+    val balls: Int,
+    val strikes: Int,
+    val runnerOnFirstId: Long?,
+    val runnerOnSecondId: Long?,
+    val runnerOnThirdId: Long?,
+    val homeBattingOrder: Int,
+    val awayBattingOrder: Int,
+    val currentPitcherId: Long?,
+    val currentBatterId: Long?,
+    val countDisplay: String
+)

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/PlateAppearanceRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/PlateAppearanceRequestDto.kt
@@ -15,23 +15,17 @@ import jakarta.validation.constraints.NotNull
 data class PlateAppearanceRequestDto(
     @field:NotNull(message = "타자 ID는 필수입니다")
     val batterId: Long?,
-
     @field:NotNull(message = "투수 ID는 필수입니다")
     val pitcherId: Long?,
-
     @field:NotNull(message = "타석 결과는 필수입니다")
     val result: PlateAppearanceResult?,
-
     @field:Valid
     val runnerMovements: List<RunnerMovementDto> = emptyList(),
-
     @field:Min(value = 0, message = "타점은 0 이상이어야 합니다")
     val rbis: Int? = null,
-
     @field:Min(value = 0, message = "볼 카운트는 0 이상이어야 합니다")
     @field:Max(value = 4, message = "볼 카운트는 4 이하여야 합니다")
     val balls: Int = 0,
-
     @field:Min(value = 0, message = "스트라이크 카운트는 0 이상이어야 합니다")
     @field:Max(value = 3, message = "스트라이크 카운트는 3 이하여야 합니다")
     val strikes: Int = 0
@@ -43,13 +37,10 @@ data class PlateAppearanceRequestDto(
 data class RunnerMovementDto(
     @field:NotNull(message = "주자 ID는 필수입니다")
     val runnerId: Long?,
-
     @field:NotNull(message = "출발 베이스는 필수입니다")
     val fromBase: Base?,
-
     @field:NotNull(message = "도착 베이스는 필수입니다")
     val toBase: Base?,
-
     val isOut: Boolean = false
 )
 

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/PlateAppearanceRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/PlateAppearanceRequestDto.kt
@@ -1,0 +1,81 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.game.Base
+import com.nextup.core.domain.game.PlateAppearanceResult
+import com.nextup.core.service.game.dto.PlateAppearanceRequest
+import com.nextup.core.service.game.dto.RunnerMovement
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 타석 결과 입력 요청 DTO
+ */
+data class PlateAppearanceRequestDto(
+    @field:NotNull(message = "타자 ID는 필수입니다")
+    val batterId: Long?,
+
+    @field:NotNull(message = "투수 ID는 필수입니다")
+    val pitcherId: Long?,
+
+    @field:NotNull(message = "타석 결과는 필수입니다")
+    val result: PlateAppearanceResult?,
+
+    @field:Valid
+    val runnerMovements: List<RunnerMovementDto> = emptyList(),
+
+    @field:Min(value = 0, message = "타점은 0 이상이어야 합니다")
+    val rbis: Int? = null,
+
+    @field:Min(value = 0, message = "볼 카운트는 0 이상이어야 합니다")
+    @field:Max(value = 4, message = "볼 카운트는 4 이하여야 합니다")
+    val balls: Int = 0,
+
+    @field:Min(value = 0, message = "스트라이크 카운트는 0 이상이어야 합니다")
+    @field:Max(value = 3, message = "스트라이크 카운트는 3 이하여야 합니다")
+    val strikes: Int = 0
+)
+
+/**
+ * 주자 이동 DTO
+ */
+data class RunnerMovementDto(
+    @field:NotNull(message = "주자 ID는 필수입니다")
+    val runnerId: Long?,
+
+    @field:NotNull(message = "출발 베이스는 필수입니다")
+    val fromBase: Base?,
+
+    @field:NotNull(message = "도착 베이스는 필수입니다")
+    val toBase: Base?,
+
+    val isOut: Boolean = false
+)
+
+/**
+ * PlateAppearanceRequestDto를 PlateAppearanceRequest로 변환합니다.
+ */
+fun PlateAppearanceRequestDto.toDomain(): PlateAppearanceRequest {
+    return PlateAppearanceRequest(
+        batterId = this.batterId!!,
+        pitcherId = this.pitcherId!!,
+        result = this.result!!,
+        runnerMovements = this.runnerMovements.map { it.toDomain() },
+        rbis = this.rbis,
+        balls = this.balls,
+        strikes = this.strikes
+    )
+}
+
+/**
+ * RunnerMovementDto를 RunnerMovement로 변환합니다.
+ */
+fun RunnerMovementDto.toDomain(): RunnerMovement {
+    return RunnerMovement(
+        runnerId = this.runnerId!!,
+        fromBase = this.fromBase!!,
+        toBase = this.toBase!!,
+        isOut = this.isOut
+    )
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/league/LeagueRequest.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/league/LeagueRequest.kt
@@ -11,24 +11,18 @@ import jakarta.validation.constraints.Size
 data class CreateLeagueRequest(
     @field:NotNull(message = "협회 ID는 필수입니다")
     val associationId: Long,
-
     @field:NotBlank(message = "리그 이름은 필수입니다")
     @field:Size(max = 100, message = "리그 이름은 100자를 초과할 수 없습니다")
     val name: String,
-
     @field:Size(max = 20, message = "약어는 20자를 초과할 수 없습니다")
     val abbreviation: String? = null,
-
     @field:NotNull(message = "창설 연도는 필수입니다")
     @field:Min(value = 1900, message = "창설 연도는 1900년 이후여야 합니다")
     val foundedYear: Int,
-
     @field:Min(value = 1, message = "부 레벨은 1 이상이어야 합니다")
     val divisionLevel: Int? = null,
-
     @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
     val description: String? = null,
-
     @field:Size(max = 255, message = "로고 URL은 255자를 초과할 수 없습니다")
     val logoUrl: String? = null
 )
@@ -39,7 +33,6 @@ data class CreateLeagueRequest(
 data class UpdateLeagueRequest(
     @field:Size(max = 500, message = "설명은 500자를 초과할 수 없습니다")
     val description: String? = null,
-
     @field:Size(max = 255, message = "로고 URL은 255자를 초과할 수 없습니다")
     val logoUrl: String? = null
 )

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
@@ -24,12 +24,13 @@ class GlobalExceptionHandler {
      */
     @ExceptionHandler(BusinessException::class)
     fun handleBusinessException(ex: BusinessException): ResponseEntity<ApiResponse<Unit>> {
-        val status = when (ex) {
-            is NotFoundException -> HttpStatus.NOT_FOUND
-            is InvalidStateException -> HttpStatus.BAD_REQUEST
-            is InvalidInputException -> HttpStatus.BAD_REQUEST
-            else -> HttpStatus.INTERNAL_SERVER_ERROR
-        }
+        val status =
+            when (ex) {
+                is NotFoundException -> HttpStatus.NOT_FOUND
+                is InvalidStateException -> HttpStatus.BAD_REQUEST
+                is InvalidInputException -> HttpStatus.BAD_REQUEST
+                else -> HttpStatus.INTERNAL_SERVER_ERROR
+            }
         return ResponseEntity
             .status(status)
             .body(ApiResponse.error(ex.code, ex.message))
@@ -40,8 +41,9 @@ class GlobalExceptionHandler {
      */
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Unit>> {
-        val message = ex.bindingResult.fieldErrors
-            .joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
+        val message =
+            ex.bindingResult.fieldErrors
+                .joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.error("VALIDATION_ERROR", message))

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.nextup.scorer.exception
 
 import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.NotFoundException
 import com.nextup.scorer.dto.common.ApiResponse
@@ -26,6 +27,7 @@ class GlobalExceptionHandler {
         val status = when (ex) {
             is NotFoundException -> HttpStatus.NOT_FOUND
             is InvalidStateException -> HttpStatus.BAD_REQUEST
+            is InvalidInputException -> HttpStatus.BAD_REQUEST
             else -> HttpStatus.INTERNAL_SERVER_ERROR
         }
         return ResponseEntity

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,67 @@
+package com.nextup.scorer.exception
+
+import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.common.exception.NotFoundException
+import com.nextup.scorer.dto.common.ApiResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+/**
+ * 전역 예외 핸들러
+ *
+ * 모든 컨트롤러에서 발생하는 예외를 처리합니다.
+ */
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    /**
+     * 비즈니스 예외 처리
+     */
+    @ExceptionHandler(BusinessException::class)
+    fun handleBusinessException(ex: BusinessException): ResponseEntity<ApiResponse<Unit>> {
+        val status = when (ex) {
+            is NotFoundException -> HttpStatus.NOT_FOUND
+            is InvalidStateException -> HttpStatus.BAD_REQUEST
+            else -> HttpStatus.INTERNAL_SERVER_ERROR
+        }
+        return ResponseEntity
+            .status(status)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    /**
+     * 입력 검증 예외 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Unit>> {
+        val message = ex.bindingResult.fieldErrors
+            .joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("VALIDATION_ERROR", message))
+    }
+
+    /**
+     * IllegalArgumentException 처리 (도메인 로직 검증 실패)
+     */
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(ex: IllegalArgumentException): ResponseEntity<ApiResponse<Unit>> {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("INVALID_ARGUMENT", ex.message ?: "Invalid argument"))
+    }
+
+    /**
+     * 기타 예외 처리
+     */
+    @ExceptionHandler(Exception::class)
+    fun handleException(ex: Exception): ResponseEntity<ApiResponse<Unit>> {
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.error("INTERNAL_SERVER_ERROR", "An unexpected error occurred"))
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/service/websocket/GameBroadcastService.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/service/websocket/GameBroadcastService.kt
@@ -22,7 +22,10 @@ class GameBroadcastService(
      * @param gameId 경기 ID
      * @param event 이벤트 메시지
      */
-    fun broadcastEvent(gameId: Long, event: GameEventMessage) {
+    fun broadcastEvent(
+        gameId: Long,
+        event: GameEventMessage
+    ) {
         messagingTemplate.convertAndSend(
             "/topic/games/$gameId/events",
             event
@@ -35,7 +38,10 @@ class GameBroadcastService(
      * @param gameId 경기 ID
      * @param scoreboard 스코어보드 메시지
      */
-    fun broadcastScoreboard(gameId: Long, scoreboard: ScoreboardMessage) {
+    fun broadcastScoreboard(
+        gameId: Long,
+        scoreboard: ScoreboardMessage
+    ) {
         messagingTemplate.convertAndSend(
             "/topic/games/$gameId/scoreboard",
             scoreboard
@@ -48,7 +54,10 @@ class GameBroadcastService(
      * @param gameId 경기 ID
      * @param state 상태 메시지
      */
-    fun broadcastState(gameId: Long, state: GameStateMessage) {
+    fun broadcastState(
+        gameId: Long,
+        state: GameStateMessage
+    ) {
         messagingTemplate.convertAndSend(
             "/topic/games/$gameId/state",
             state

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/websocket/mapper/GameStateMapper.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/websocket/mapper/GameStateMapper.kt
@@ -44,11 +44,12 @@ class GameStateMapper {
             outs = gameState.outs,
             balls = gameState.balls,
             strikes = gameState.strikes,
-            runners = RunnersDto(
-                first = runnerOnFirst?.let { toPlayerBriefDto(it) },
-                second = runnerOnSecond?.let { toPlayerBriefDto(it) },
-                third = runnerOnThird?.let { toPlayerBriefDto(it) }
-            ),
+            runners =
+                RunnersDto(
+                    first = runnerOnFirst?.let { toPlayerBriefDto(it) },
+                    second = runnerOnSecond?.let { toPlayerBriefDto(it) },
+                    third = runnerOnThird?.let { toPlayerBriefDto(it) }
+                ),
             currentBatter = currentBatter?.let { toPlayerBriefDto(it) },
             currentPitcher = currentPitcher?.let { toPlayerBriefDto(it) }
         )
@@ -69,7 +70,11 @@ class GameStateMapper {
      * 선수 ID로 간략 정보를 생성합니다.
      * 실제 구현에서는 Repository를 통해 선수 정보를 조회해야 합니다.
      */
-    fun toPlayerBriefDtoById(playerId: Long, name: String, backNumber: Int?): PlayerBriefDto {
+    fun toPlayerBriefDtoById(
+        playerId: Long,
+        name: String,
+        backNumber: Int?
+    ): PlayerBriefDto {
         return PlayerBriefDto(
             id = playerId,
             name = name,

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/websocket/mapper/ScoreboardMapper.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/websocket/mapper/ScoreboardMapper.kt
@@ -63,11 +63,12 @@ class ScoreboardMapper {
         awayTeam: GameTeam,
         totalInnings: Int
     ): InningScoresDto {
-        val maxInning = maxOf(
-            totalInnings,
-            homeTeam.inningScores?.split(",")?.size ?: 0,
-            awayTeam.inningScores?.split(",")?.size ?: 0
-        )
+        val maxInning =
+            maxOf(
+                totalInnings,
+                homeTeam.inningScores?.split(",")?.size ?: 0,
+                awayTeam.inningScores?.split(",")?.size ?: 0
+            )
 
         val homeScores = (1..maxInning).map { homeTeam.getInningScore(it) }
         val awayScores = (1..maxInning).map { awayTeam.getInningScore(it) }

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/competition/CompetitionScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/competition/CompetitionScorerControllerTest.kt
@@ -52,10 +52,11 @@ class CompetitionScorerControllerTest {
             // given
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
-            val competitions = listOf(
-                createCompetition(1L, "2025 춘계대회", league, 2025, 1),
-                createCompetition(2L, "2025 추계대회", league, 2025, 2)
-            )
+            val competitions =
+                listOf(
+                    createCompetition(1L, "2025 춘계대회", league, 2025, 1),
+                    createCompetition(2L, "2025 추계대회", league, 2025, 2)
+                )
             every { competitionService.getAll() } returns competitions
 
             // when & then
@@ -76,9 +77,10 @@ class CompetitionScorerControllerTest {
             val leagueId = 1L
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(leagueId, "1부 리그", association)
-            val competitions = listOf(
-                createCompetition(1L, "2025 춘계대회", league, 2025, 1)
-            )
+            val competitions =
+                listOf(
+                    createCompetition(1L, "2025 춘계대회", league, 2025, 1)
+                )
             every { competitionService.getByLeagueId(leagueId) } returns competitions
 
             // when & then
@@ -125,17 +127,18 @@ class CompetitionScorerControllerTest {
         @Test
         fun `should create competition with valid request`() {
             // given
-            val request = CreateCompetitionRequest(
-                leagueId = 1L,
-                name = "2025 춘계대회",
-                year = 2025,
-                season = 1,
-                type = CompetitionType.LEAGUE,
-                startDate = LocalDate.of(2025, 3, 1),
-                endDate = LocalDate.of(2025, 6, 30),
-                description = "2025년 춘계 시즌",
-                maxTeams = 8
-            )
+            val request =
+                CreateCompetitionRequest(
+                    leagueId = 1L,
+                    name = "2025 춘계대회",
+                    year = 2025,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    endDate = LocalDate.of(2025, 6, 30),
+                    description = "2025년 춘계 시즌",
+                    maxTeams = 8
+                )
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
             val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1)
@@ -188,10 +191,11 @@ class CompetitionScorerControllerTest {
         @Test
         fun `should update competition with valid request`() {
             // given
-            val request = UpdateCompetitionRequest(
-                description = "수정된 설명",
-                endDate = LocalDate.of(2025, 7, 15)
-            )
+            val request =
+                UpdateCompetitionRequest(
+                    description = "수정된 설명",
+                    endDate = LocalDate.of(2025, 7, 15)
+                )
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
             val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1)
@@ -233,9 +237,10 @@ class CompetitionScorerControllerTest {
             // given
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
-            val competition = createCompetition(1L, "2025 춘계대회", league, 2025, 1).apply {
-                start()
-            }
+            val competition =
+                createCompetition(1L, "2025 춘계대회", league, 2025, 1).apply {
+                    start()
+                }
             every { competitionService.start(1L) } returns competition
 
             // when & then
@@ -320,7 +325,10 @@ class CompetitionScorerControllerTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
+    private fun createAssociation(
+        id: Long,
+        name: String
+    ): Association {
         return Association(
             name = name,
             abbreviation = null,
@@ -335,7 +343,11 @@ class CompetitionScorerControllerTest {
         }
     }
 
-    private fun createLeague(id: Long, name: String, association: Association): League {
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association
+    ): League {
         return League(
             association = association,
             name = name,

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -14,7 +14,6 @@ import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
 import com.nextup.core.service.game.GameScorerService
 import com.nextup.core.service.game.dto.GameEndReason
-import com.nextup.core.service.game.dto.PlateAppearanceRequest
 import com.nextup.scorer.dto.game.GameEndRequestDto
 import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
 import com.nextup.scorer.dto.game.RunnerMovementDto
@@ -58,10 +57,11 @@ class GameScorerControllerTest {
         fun `should start game successfully`() {
             // given
             val gameId = 1L
-            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
-                currentInning = 1
-                isTopInning = true
-            }
+            val game =
+                createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 1
+                    isTopInning = true
+                }
             every { gameScorerService.startGame(gameId) } returns game
 
             // when & then
@@ -85,20 +85,22 @@ class GameScorerControllerTest {
         fun `should record plate appearance with single hit`() {
             // given
             val gameId = 1L
-            val request = PlateAppearanceRequestDto(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.SINGLE,
-                runnerMovements = emptyList(),
-                rbis = 0,
-                balls = 2,
-                strikes = 1
-            )
-            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
-                currentInning = 3
-                isTopInning = false
-                gameState.runnerOnFirstId = 10L
-            }
+            val request =
+                PlateAppearanceRequestDto(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.SINGLE,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                    balls = 2,
+                    strikes = 1
+                )
+            val game =
+                createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 3
+                    isTopInning = false
+                    gameState.runnerOnFirstId = 10L
+                }
             every { gameScorerService.recordPlateAppearance(gameId, any()) } returns game
 
             // when & then
@@ -120,28 +122,31 @@ class GameScorerControllerTest {
         fun `should record plate appearance with runner movements`() {
             // given
             val gameId = 1L
-            val request = PlateAppearanceRequestDto(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.DOUBLE,
-                runnerMovements = listOf(
-                    RunnerMovementDto(
-                        runnerId = 5L,
-                        fromBase = Base.FIRST,
-                        toBase = Base.THIRD,
-                        isOut = false
-                    )
-                ),
-                rbis = 1,
-                balls = 0,
-                strikes = 2
-            )
-            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
-                currentInning = 5
-                isTopInning = true
-                gameState.runnerOnSecondId = 10L
-                gameState.runnerOnThirdId = 5L
-            }
+            val request =
+                PlateAppearanceRequestDto(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.DOUBLE,
+                    runnerMovements =
+                        listOf(
+                            RunnerMovementDto(
+                                runnerId = 5L,
+                                fromBase = Base.FIRST,
+                                toBase = Base.THIRD,
+                                isOut = false
+                            )
+                        ),
+                    rbis = 1,
+                    balls = 0,
+                    strikes = 2
+                )
+            val game =
+                createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                    gameState.runnerOnSecondId = 10L
+                    gameState.runnerOnThirdId = 5L
+                }
             every { gameScorerService.recordPlateAppearance(gameId, any()) } returns game
 
             // when & then
@@ -163,20 +168,22 @@ class GameScorerControllerTest {
         fun `should record strikeout`() {
             // given
             val gameId = 1L
-            val request = PlateAppearanceRequestDto(
-                batterId = 10L,
-                pitcherId = 20L,
-                result = PlateAppearanceResult.STRIKEOUT,
-                runnerMovements = emptyList(),
-                rbis = 0,
-                balls = 1,
-                strikes = 3
-            )
-            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
-                currentInning = 2
-                isTopInning = true
-                gameState.outs = 1
-            }
+            val request =
+                PlateAppearanceRequestDto(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                    balls = 1,
+                    strikes = 3
+                )
+            val game =
+                createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 2
+                    isTopInning = true
+                    gameState.outs = 1
+                }
             every { gameScorerService.recordPlateAppearance(gameId, any()) } returns game
 
             // when & then
@@ -201,11 +208,12 @@ class GameScorerControllerTest {
         fun `should advance to next half inning`() {
             // given
             val gameId = 1L
-            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
-                currentInning = 1
-                isTopInning = false  // 1회말로 진행
-                gameState.resetForNewInning()
-            }
+            val game =
+                createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 1
+                    isTopInning = false // 1회말로 진행
+                    gameState.resetForNewInning()
+                }
             every { gameScorerService.advanceHalfInning(gameId) } returns game
 
             // when & then
@@ -224,11 +232,12 @@ class GameScorerControllerTest {
         fun `should advance from bottom to next top inning`() {
             // given
             val gameId = 1L
-            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
-                currentInning = 2
-                isTopInning = true  // 2회초로 진행
-                gameState.resetForNewInning()
-            }
+            val game =
+                createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 2
+                    isTopInning = true // 2회초로 진행
+                    gameState.resetForNewInning()
+                }
             every { gameScorerService.advanceHalfInning(gameId) } returns game
 
             // when & then
@@ -251,10 +260,11 @@ class GameScorerControllerTest {
             // given
             val gameId = 1L
             val request = GameEndRequestDto(reason = GameEndReason.REGULATION)
-            val game = createGame(gameId, GameStatus.FINISHED).apply {
-                currentInning = 9
-                isTopInning = false
-            }
+            val game =
+                createGame(gameId, GameStatus.FINISHED).apply {
+                    currentInning = 9
+                    isTopInning = false
+                }
             every { gameScorerService.endGame(gameId, GameEndReason.REGULATION) } returns game
 
             // when & then
@@ -276,10 +286,11 @@ class GameScorerControllerTest {
             // given
             val gameId = 1L
             val request = GameEndRequestDto(reason = GameEndReason.MERCY_RULE)
-            val game = createGame(gameId, GameStatus.CALLED).apply {
-                currentInning = 7
-                isTopInning = true
-            }
+            val game =
+                createGame(gameId, GameStatus.CALLED).apply {
+                    currentInning = 7
+                    isTopInning = true
+                }
             every { gameScorerService.endGame(gameId, GameEndReason.MERCY_RULE) } returns game
 
             // when & then
@@ -300,10 +311,11 @@ class GameScorerControllerTest {
             // given
             val gameId = 1L
             val request = GameEndRequestDto(reason = GameEndReason.WEATHER)
-            val game = createGame(gameId, GameStatus.CALLED).apply {
-                currentInning = 5
-                isTopInning = false
-            }
+            val game =
+                createGame(gameId, GameStatus.CALLED).apply {
+                    currentInning = 5
+                    isTopInning = false
+                }
             every { gameScorerService.endGame(gameId, GameEndReason.WEATHER) } returns game
 
             // when & then
@@ -324,10 +336,11 @@ class GameScorerControllerTest {
             // given
             val gameId = 1L
             val request = GameEndRequestDto(reason = GameEndReason.FORFEIT)
-            val game = createGame(gameId, GameStatus.FORFEITED).apply {
-                currentInning = 3
-                isTopInning = true
-            }
+            val game =
+                createGame(gameId, GameStatus.FORFEITED).apply {
+                    currentInning = 3
+                    isTopInning = true
+                }
             every { gameScorerService.endGame(gameId, GameEndReason.FORFEIT) } returns game
 
             // when & then
@@ -344,7 +357,10 @@ class GameScorerControllerTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
+    private fun createAssociation(
+        id: Long,
+        name: String
+    ): Association {
         return Association(
             name = name,
             abbreviation = null,
@@ -359,7 +375,11 @@ class GameScorerControllerTest {
         }
     }
 
-    private fun createLeague(id: Long, name: String, association: Association): League {
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association
+    ): League {
         return League(
             association = association,
             name = name,
@@ -375,7 +395,11 @@ class GameScorerControllerTest {
         }
     }
 
-    private fun createCompetition(id: Long, name: String, league: League): Competition {
+    private fun createCompetition(
+        id: Long,
+        name: String,
+        league: League
+    ): Competition {
         return Competition(
             league = league,
             name = name,
@@ -394,7 +418,10 @@ class GameScorerControllerTest {
         }
     }
 
-    private fun createGame(id: Long, status: GameStatus): Game {
+    private fun createGame(
+        id: Long,
+        status: GameStatus
+    ): Game {
         val association = createAssociation(1L, "서울시야구협회")
         val league = createLeague(1L, "1부 리그", association)
         val competition = createCompetition(1L, "2025 춘계대회", league)

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -1,0 +1,419 @@
+package com.nextup.scorer.controller.game
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Base
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameState
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.PlateAppearanceResult
+import com.nextup.core.domain.league.League
+import com.nextup.core.service.game.GameScorerService
+import com.nextup.core.service.game.dto.GameEndReason
+import com.nextup.core.service.game.dto.PlateAppearanceRequest
+import com.nextup.scorer.dto.game.GameEndRequestDto
+import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
+import com.nextup.scorer.dto.game.RunnerMovementDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameScorerController")
+class GameScorerControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var gameScorerService: GameScorerService
+    private lateinit var controller: GameScorerController
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        gameScorerService = mockk()
+        controller = GameScorerController(gameScorerService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+        objectMapper = ObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/start")
+    inner class StartGame {
+
+        @Test
+        fun `should start game successfully`() {
+            // given
+            val gameId = 1L
+            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                currentInning = 1
+                isTopInning = true
+            }
+            every { gameScorerService.startGame(gameId) } returns game
+
+            // when & then
+            mockMvc.perform(post("/api/scorer/games/$gameId/start"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(gameId))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.data.currentInning").value(1))
+                .andExpect(jsonPath("$.data.isTopInning").value(true))
+
+            verify(exactly = 1) { gameScorerService.startGame(gameId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/plate-appearances")
+    inner class RecordPlateAppearance {
+
+        @Test
+        fun `should record plate appearance with single hit`() {
+            // given
+            val gameId = 1L
+            val request = PlateAppearanceRequestDto(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.SINGLE,
+                runnerMovements = emptyList(),
+                rbis = 0,
+                balls = 2,
+                strikes = 1
+            )
+            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                currentInning = 3
+                isTopInning = false
+                gameState.runnerOnFirstId = 10L
+            }
+            every { gameScorerService.recordPlateAppearance(gameId, any()) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/plate-appearances")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(gameId))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.data.currentInning").value(3))
+
+            verify(exactly = 1) { gameScorerService.recordPlateAppearance(gameId, any()) }
+        }
+
+        @Test
+        fun `should record plate appearance with runner movements`() {
+            // given
+            val gameId = 1L
+            val request = PlateAppearanceRequestDto(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.DOUBLE,
+                runnerMovements = listOf(
+                    RunnerMovementDto(
+                        runnerId = 5L,
+                        fromBase = Base.FIRST,
+                        toBase = Base.THIRD,
+                        isOut = false
+                    )
+                ),
+                rbis = 1,
+                balls = 0,
+                strikes = 2
+            )
+            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                currentInning = 5
+                isTopInning = true
+                gameState.runnerOnSecondId = 10L
+                gameState.runnerOnThirdId = 5L
+            }
+            every { gameScorerService.recordPlateAppearance(gameId, any()) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/plate-appearances")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(gameId))
+                .andExpect(jsonPath("$.data.gameState.runnerOnSecondId").value(10))
+                .andExpect(jsonPath("$.data.gameState.runnerOnThirdId").value(5))
+
+            verify(exactly = 1) { gameScorerService.recordPlateAppearance(gameId, any()) }
+        }
+
+        @Test
+        fun `should record strikeout`() {
+            // given
+            val gameId = 1L
+            val request = PlateAppearanceRequestDto(
+                batterId = 10L,
+                pitcherId = 20L,
+                result = PlateAppearanceResult.STRIKEOUT,
+                runnerMovements = emptyList(),
+                rbis = 0,
+                balls = 1,
+                strikes = 3
+            )
+            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                currentInning = 2
+                isTopInning = true
+                gameState.outs = 1
+            }
+            every { gameScorerService.recordPlateAppearance(gameId, any()) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/plate-appearances")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.gameState.outs").value(1))
+
+            verify(exactly = 1) { gameScorerService.recordPlateAppearance(gameId, any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/half-inning")
+    inner class AdvanceHalfInning {
+
+        @Test
+        fun `should advance to next half inning`() {
+            // given
+            val gameId = 1L
+            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                currentInning = 1
+                isTopInning = false  // 1회말로 진행
+                gameState.resetForNewInning()
+            }
+            every { gameScorerService.advanceHalfInning(gameId) } returns game
+
+            // when & then
+            mockMvc.perform(post("/api/scorer/games/$gameId/half-inning"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(gameId))
+                .andExpect(jsonPath("$.data.currentInning").value(1))
+                .andExpect(jsonPath("$.data.isTopInning").value(false))
+                .andExpect(jsonPath("$.data.gameState.outs").value(0))
+
+            verify(exactly = 1) { gameScorerService.advanceHalfInning(gameId) }
+        }
+
+        @Test
+        fun `should advance from bottom to next top inning`() {
+            // given
+            val gameId = 1L
+            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                currentInning = 2
+                isTopInning = true  // 2회초로 진행
+                gameState.resetForNewInning()
+            }
+            every { gameScorerService.advanceHalfInning(gameId) } returns game
+
+            // when & then
+            mockMvc.perform(post("/api/scorer/games/$gameId/half-inning"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.currentInning").value(2))
+                .andExpect(jsonPath("$.data.isTopInning").value(true))
+
+            verify(exactly = 1) { gameScorerService.advanceHalfInning(gameId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/end")
+    inner class EndGame {
+
+        @Test
+        fun `should end game with regulation finish`() {
+            // given
+            val gameId = 1L
+            val request = GameEndRequestDto(reason = GameEndReason.REGULATION)
+            val game = createGame(gameId, GameStatus.FINISHED).apply {
+                currentInning = 9
+                isTopInning = false
+            }
+            every { gameScorerService.endGame(gameId, GameEndReason.REGULATION) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/end")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(gameId))
+                .andExpect(jsonPath("$.data.status").value("FINISHED"))
+
+            verify(exactly = 1) { gameScorerService.endGame(gameId, GameEndReason.REGULATION) }
+        }
+
+        @Test
+        fun `should end game with mercy rule`() {
+            // given
+            val gameId = 1L
+            val request = GameEndRequestDto(reason = GameEndReason.MERCY_RULE)
+            val game = createGame(gameId, GameStatus.CALLED).apply {
+                currentInning = 7
+                isTopInning = true
+            }
+            every { gameScorerService.endGame(gameId, GameEndReason.MERCY_RULE) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/end")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("CALLED"))
+
+            verify(exactly = 1) { gameScorerService.endGame(gameId, GameEndReason.MERCY_RULE) }
+        }
+
+        @Test
+        fun `should end game due to weather`() {
+            // given
+            val gameId = 1L
+            val request = GameEndRequestDto(reason = GameEndReason.WEATHER)
+            val game = createGame(gameId, GameStatus.CALLED).apply {
+                currentInning = 5
+                isTopInning = false
+            }
+            every { gameScorerService.endGame(gameId, GameEndReason.WEATHER) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/end")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("CALLED"))
+
+            verify(exactly = 1) { gameScorerService.endGame(gameId, GameEndReason.WEATHER) }
+        }
+
+        @Test
+        fun `should end game with forfeit`() {
+            // given
+            val gameId = 1L
+            val request = GameEndRequestDto(reason = GameEndReason.FORFEIT)
+            val game = createGame(gameId, GameStatus.FORFEITED).apply {
+                currentInning = 3
+                isTopInning = true
+            }
+            every { gameScorerService.endGame(gameId, GameEndReason.FORFEIT) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/end")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("FORFEITED"))
+
+            verify(exactly = 1) { gameScorerService.endGame(gameId, GameEndReason.FORFEIT) }
+        }
+    }
+
+    private fun createAssociation(id: Long, name: String): Association {
+        return Association(
+            name = name,
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createLeague(id: Long, name: String, association: Association): League {
+        return League(
+            association = association,
+            name = name,
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createCompetition(id: Long, name: String, league: League): Competition {
+        return Competition(
+            league = league,
+            name = name,
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            endDate = LocalDate.of(2025, 6, 30),
+            status = CompetitionStatus.IN_PROGRESS,
+            description = null,
+            maxTeams = null
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createGame(id: Long, status: GameStatus): Game {
+        val association = createAssociation(1L, "서울시야구협회")
+        val league = createLeague(1L, "1부 리그", association)
+        val competition = createCompetition(1L, "2025 춘계대회", league)
+
+        return Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실구장",
+            fieldName = "1구장",
+            gameNumber = 1,
+            status = status,
+            currentInning = 1,
+            isTopInning = true,
+            totalInnings = 9,
+            gameState = GameState()
+        ).apply {
+            val idField = Game::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/league/LeagueControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/league/LeagueControllerTest.kt
@@ -47,10 +47,11 @@ class LeagueControllerTest {
         fun `should return all leagues when no filter provided`() {
             // given
             val association = createAssociation(1L, "서울시야구협회")
-            val leagues = listOf(
-                createLeague(1L, "1부 리그", association),
-                createLeague(2L, "2부 리그", association)
-            )
+            val leagues =
+                listOf(
+                    createLeague(1L, "1부 리그", association),
+                    createLeague(2L, "2부 리그", association)
+                )
             every { leagueService.getAll() } returns leagues
 
             // when & then
@@ -70,9 +71,10 @@ class LeagueControllerTest {
             // given
             val associationId = 1L
             val association = createAssociation(associationId, "서울시야구협회")
-            val leagues = listOf(
-                createLeague(1L, "1부 리그", association)
-            )
+            val leagues =
+                listOf(
+                    createLeague(1L, "1부 리그", association)
+                )
             every { leagueService.getByAssociationId(associationId) } returns leagues
 
             // when & then
@@ -121,15 +123,16 @@ class LeagueControllerTest {
         @Test
         fun `should create league with valid request`() {
             // given
-            val request = CreateLeagueRequest(
-                associationId = 1L,
-                name = "1부 리그",
-                abbreviation = "1st",
-                foundedYear = 2020,
-                divisionLevel = 1,
-                description = "최상위 리그",
-                logoUrl = "https://example.com/logo.png"
-            )
+            val request =
+                CreateLeagueRequest(
+                    associationId = 1L,
+                    name = "1부 리그",
+                    abbreviation = "1st",
+                    foundedYear = 2020,
+                    divisionLevel = 1,
+                    description = "최상위 리그",
+                    logoUrl = "https://example.com/logo.png"
+                )
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
 
@@ -177,10 +180,11 @@ class LeagueControllerTest {
         @Test
         fun `should update league with valid request`() {
             // given
-            val request = UpdateLeagueRequest(
-                description = "수정된 설명",
-                logoUrl = "https://example.com/new-logo.png"
-            )
+            val request =
+                UpdateLeagueRequest(
+                    description = "수정된 설명",
+                    logoUrl = "https://example.com/new-logo.png"
+                )
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
 
@@ -220,9 +224,10 @@ class LeagueControllerTest {
         fun `should deactivate league`() {
             // given
             val association = createAssociation(1L, "서울시야구협회")
-            val league = createLeague(1L, "1부 리그", association).apply {
-                deactivate()
-            }
+            val league =
+                createLeague(1L, "1부 리그", association).apply {
+                    deactivate()
+                }
             every { leagueService.deactivate(1L) } returns league
 
             // when & then
@@ -258,7 +263,10 @@ class LeagueControllerTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
+    private fun createAssociation(
+        id: Long,
+        name: String
+    ): Association {
         return Association(
             name = name,
             abbreviation = null,
@@ -273,7 +281,11 @@ class LeagueControllerTest {
         }
     }
 
-    private fun createLeague(id: Long, name: String, association: Association): League {
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association
+    ): League {
         return League(
             association = association,
             name = name,

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/exception/GlobalExceptionHandlerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/exception/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,219 @@
+package com.nextup.scorer.exception
+
+import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.common.exception.NotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+
+@DisplayName("GlobalExceptionHandler")
+class GlobalExceptionHandlerTest {
+    private lateinit var handler: GlobalExceptionHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler = GlobalExceptionHandler()
+    }
+
+    @Nested
+    @DisplayName("handleBusinessException")
+    inner class HandleBusinessException {
+        @Test
+        fun `should return 404 for NotFoundException`() {
+            // given
+            val exception = object : NotFoundException("ENTITY_NOT_FOUND", "Entity not found") {}
+
+            // when
+            val response = handler.handleBusinessException(exception)
+
+            // then
+            assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+            assertThat(response.body?.success).isFalse()
+            assertThat(response.body?.error?.code).isEqualTo("ENTITY_NOT_FOUND")
+            assertThat(response.body?.error?.message).isEqualTo("Entity not found")
+        }
+
+        @Test
+        fun `should return 400 for InvalidStateException`() {
+            // given
+            val exception = object : InvalidStateException("INVALID_STATE", "Invalid state") {}
+
+            // when
+            val response = handler.handleBusinessException(exception)
+
+            // then
+            assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.body?.success).isFalse()
+            assertThat(response.body?.error?.code).isEqualTo("INVALID_STATE")
+            assertThat(response.body?.error?.message).isEqualTo("Invalid state")
+        }
+
+        @Test
+        fun `should return 400 for InvalidInputException`() {
+            // given
+            val exception = object : InvalidInputException("INVALID_INPUT", "Invalid input") {}
+
+            // when
+            val response = handler.handleBusinessException(exception)
+
+            // then
+            assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.body?.success).isFalse()
+            assertThat(response.body?.error?.code).isEqualTo("INVALID_INPUT")
+            assertThat(response.body?.error?.message).isEqualTo("Invalid input")
+        }
+
+        @Test
+        fun `should return 500 for generic BusinessException`() {
+            // given
+            val exception = object : BusinessException("UNKNOWN_ERROR", "Unknown error") {}
+
+            // when
+            val response = handler.handleBusinessException(exception)
+
+            // then
+            assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+            assertThat(response.body?.success).isFalse()
+            assertThat(response.body?.error?.code).isEqualTo("UNKNOWN_ERROR")
+            assertThat(response.body?.error?.message).isEqualTo("Unknown error")
+        }
+    }
+
+    @Nested
+    @DisplayName("handleValidationException")
+    inner class HandleValidationException {
+        @Test
+        fun `should return 400 with field error messages`() {
+            // given
+            data class TestRequest(
+                val name: String?,
+                val age: Int?,
+            )
+
+            val target = TestRequest(null, null)
+            val bindingResult = BeanPropertyBindingResult(target, "testRequest")
+            bindingResult.addError(FieldError("testRequest", "name", "must not be null"))
+            bindingResult.addError(FieldError("testRequest", "age", "must be positive"))
+
+            val exception =
+                MethodArgumentNotValidException(
+                    org.springframework.core.MethodParameter(
+                        TestRequest::class.java.constructors.first(),
+                        -1,
+                    ),
+                    bindingResult,
+                )
+
+            // when
+            val response = handler.handleValidationException(exception)
+
+            // then
+            assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.body?.success).isFalse()
+            assertThat(response.body?.error?.code).isEqualTo("VALIDATION_ERROR")
+            assertThat(response.body?.error?.message).contains("name")
+            assertThat(response.body?.error?.message).contains("age")
+        }
+
+        @Test
+        fun `should return 400 with single field error`() {
+            // given
+            data class TestRequest(
+                val email: String?,
+            )
+
+            val target = TestRequest(null)
+            val bindingResult = BeanPropertyBindingResult(target, "testRequest")
+            bindingResult.addError(FieldError("testRequest", "email", "must be a valid email"))
+
+            val exception =
+                MethodArgumentNotValidException(
+                    org.springframework.core.MethodParameter(
+                        TestRequest::class.java.constructors.first(),
+                        -1,
+                    ),
+                    bindingResult,
+                )
+
+            // when
+            val response = handler.handleValidationException(exception)
+
+            // then
+            assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.body?.error?.message).isEqualTo("email: must be a valid email")
+        }
+    }
+
+    @Nested
+    @DisplayName("handleIllegalArgumentException")
+    inner class HandleIllegalArgumentException {
+        @Test
+        fun `should return 400 with exception message`() {
+            // given
+            val exception = IllegalArgumentException("Value must be positive")
+
+            // when
+            val response = handler.handleIllegalArgumentException(exception)
+
+            // then
+            assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.body?.success).isFalse()
+            assertThat(response.body?.error?.code).isEqualTo("INVALID_ARGUMENT")
+            assertThat(response.body?.error?.message).isEqualTo("Value must be positive")
+        }
+
+        @Test
+        fun `should return default message when exception message is null`() {
+            // given
+            val exception = IllegalArgumentException()
+
+            // when
+            val response = handler.handleIllegalArgumentException(exception)
+
+            // then
+            assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.body?.error?.message).isEqualTo("Invalid argument")
+        }
+    }
+
+    @Nested
+    @DisplayName("handleException")
+    inner class HandleException {
+        @Test
+        fun `should return 500 for generic exception`() {
+            // given
+            val exception = RuntimeException("Something went wrong")
+
+            // when
+            val response = handler.handleException(exception)
+
+            // then
+            assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+            assertThat(response.body?.success).isFalse()
+            assertThat(response.body?.error?.code).isEqualTo("INTERNAL_SERVER_ERROR")
+            assertThat(response.body?.error?.message).isEqualTo("An unexpected error occurred")
+        }
+
+        @Test
+        fun `should not expose internal exception details`() {
+            // given
+            val exception = NullPointerException("Internal NPE at line 42")
+
+            // when
+            val response = handler.handleException(exception)
+
+            // then
+            assertThat(response.body?.error?.message).doesNotContain("NPE")
+            assertThat(response.body?.error?.message).doesNotContain("line 42")
+            assertThat(response.body?.error?.message).isEqualTo("An unexpected error occurred")
+        }
+    }
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/service/websocket/GameBroadcastServiceTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/service/websocket/GameBroadcastServiceTest.kt
@@ -1,7 +1,6 @@
 package com.nextup.scorer.service.websocket
 
 import com.nextup.scorer.dto.websocket.*
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
@@ -17,18 +16,19 @@ class GameBroadcastServiceTest {
     fun `should broadcast event to correct topic`() {
         // given
         val gameId = 1L
-        val event = GameEventMessage(
-            eventId = 100L,
-            eventType = "PLATE_APPEARANCE",
-            inning = 5,
-            isTopInning = true,
-            description = "안타",
-            batter = PlayerBriefDto(1L, "홍길동", 10),
-            pitcher = PlayerBriefDto(2L, "김투수", 1),
-            result = "SINGLE",
-            runsScored = 1,
-            timestamp = Instant.now()
-        )
+        val event =
+            GameEventMessage(
+                eventId = 100L,
+                eventType = "PLATE_APPEARANCE",
+                inning = 5,
+                isTopInning = true,
+                description = "안타",
+                batter = PlayerBriefDto(1L, "홍길동", 10),
+                pitcher = PlayerBriefDto(2L, "김투수", 1),
+                result = "SINGLE",
+                runsScored = 1,
+                timestamp = Instant.now()
+            )
 
         // when
         service.broadcastEvent(gameId, event)
@@ -43,17 +43,19 @@ class GameBroadcastServiceTest {
     fun `should broadcast scoreboard to correct topic`() {
         // given
         val gameId = 1L
-        val scoreboard = ScoreboardMessage(
-            gameId = gameId,
-            homeTeam = TeamScoreDto(1L, "홈팀", 5, 8, 1),
-            awayTeam = TeamScoreDto(2L, "원정팀", 3, 6, 0),
-            inningScores = InningScoresDto(
-                homeScores = listOf(0, 1, 2, 0, 2),
-                awayScores = listOf(1, 0, 0, 2, 0)
-            ),
-            currentInning = 5,
-            isTopInning = false
-        )
+        val scoreboard =
+            ScoreboardMessage(
+                gameId = gameId,
+                homeTeam = TeamScoreDto(1L, "홈팀", 5, 8, 1),
+                awayTeam = TeamScoreDto(2L, "원정팀", 3, 6, 0),
+                inningScores =
+                    InningScoresDto(
+                        homeScores = listOf(0, 1, 2, 0, 2),
+                        awayScores = listOf(1, 0, 0, 2, 0)
+                    ),
+                currentInning = 5,
+                isTopInning = false
+            )
 
         // when
         service.broadcastScoreboard(gameId, scoreboard)
@@ -68,21 +70,23 @@ class GameBroadcastServiceTest {
     fun `should broadcast state to correct topic`() {
         // given
         val gameId = 1L
-        val state = GameStateMessage(
-            gameId = gameId,
-            inning = 5,
-            isTopInning = true,
-            outs = 2,
-            balls = 2,
-            strikes = 1,
-            runners = RunnersDto(
-                first = PlayerBriefDto(1L, "1루주자", 10),
-                second = null,
-                third = PlayerBriefDto(3L, "3루주자", 12)
-            ),
-            currentBatter = PlayerBriefDto(4L, "현재타자", 15),
-            currentPitcher = PlayerBriefDto(5L, "현재투수", 1)
-        )
+        val state =
+            GameStateMessage(
+                gameId = gameId,
+                inning = 5,
+                isTopInning = true,
+                outs = 2,
+                balls = 2,
+                strikes = 1,
+                runners =
+                    RunnersDto(
+                        first = PlayerBriefDto(1L, "1루주자", 10),
+                        second = null,
+                        third = PlayerBriefDto(3L, "3루주자", 12)
+                    ),
+                currentBatter = PlayerBriefDto(4L, "현재타자", 15),
+                currentPitcher = PlayerBriefDto(5L, "현재투수", 1)
+            )
 
         // when
         service.broadcastState(gameId, state)

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/websocket/mapper/GameEventMapperTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/websocket/mapper/GameEventMapperTest.kt
@@ -1,0 +1,238 @@
+package com.nextup.scorer.websocket.mapper
+
+import com.nextup.scorer.dto.websocket.PlayerBriefDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("GameEventMapper")
+class GameEventMapperTest {
+    private lateinit var mapper: GameEventMapper
+
+    @BeforeEach
+    fun setUp() {
+        mapper = GameEventMapper()
+    }
+
+    @Nested
+    @DisplayName("toPlateAppearanceMessage")
+    inner class ToPlateAppearanceMessage {
+        @Test
+        fun `should create message with all fields`() {
+            // given
+            val batter = PlayerBriefDto(id = 1L, name = "김타자", backNumber = 7)
+            val pitcher = PlayerBriefDto(id = 2L, name = "박투수", backNumber = 18)
+
+            // when
+            val message =
+                mapper.toPlateAppearanceMessage(
+                    eventId = 100L,
+                    eventType = "PLATE_APPEARANCE",
+                    inning = 3,
+                    isTopInning = true,
+                    description = "우전 안타",
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = "SINGLE",
+                    runsScored = 1
+                )
+
+            // then
+            assertThat(message.eventId).isEqualTo(100L)
+            assertThat(message.eventType).isEqualTo("PLATE_APPEARANCE")
+            assertThat(message.inning).isEqualTo(3)
+            assertThat(message.isTopInning).isTrue()
+            assertThat(message.description).isEqualTo("우전 안타")
+            assertThat(message.batter).isEqualTo(batter)
+            assertThat(message.pitcher).isEqualTo(pitcher)
+            assertThat(message.result).isEqualTo("SINGLE")
+            assertThat(message.runsScored).isEqualTo(1)
+            assertThat(message.timestamp).isNotNull()
+        }
+
+        @Test
+        fun `should create message with null batter and pitcher`() {
+            // when
+            val message =
+                mapper.toPlateAppearanceMessage(
+                    eventId = 101L,
+                    eventType = "PLATE_APPEARANCE",
+                    inning = 5,
+                    isTopInning = false,
+                    description = "대타 교체",
+                    batter = null,
+                    pitcher = null,
+                    result = null,
+                    runsScored = 0
+                )
+
+            // then
+            assertThat(message.batter).isNull()
+            assertThat(message.pitcher).isNull()
+            assertThat(message.result).isNull()
+            assertThat(message.runsScored).isEqualTo(0)
+        }
+
+        @Test
+        fun `should create message for home run with runs scored`() {
+            // given
+            val batter = PlayerBriefDto(id = 5L, name = "홈런왕", backNumber = 44)
+            val pitcher = PlayerBriefDto(id = 6L, name = "피안타", backNumber = 21)
+
+            // when
+            val message =
+                mapper.toPlateAppearanceMessage(
+                    eventId = 102L,
+                    eventType = "PLATE_APPEARANCE",
+                    inning = 7,
+                    isTopInning = true,
+                    description = "3점 홈런",
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = "HOME_RUN",
+                    runsScored = 3
+                )
+
+            // then
+            assertThat(message.result).isEqualTo("HOME_RUN")
+            assertThat(message.runsScored).isEqualTo(3)
+        }
+
+        @Test
+        fun `should create message for bottom inning`() {
+            // when
+            val message =
+                mapper.toPlateAppearanceMessage(
+                    eventId = 103L,
+                    eventType = "PLATE_APPEARANCE",
+                    inning = 9,
+                    isTopInning = false,
+                    description = "끝내기 안타",
+                    batter = PlayerBriefDto(id = 10L, name = "영웅", backNumber = 1),
+                    pitcher = null,
+                    result = "SINGLE",
+                    runsScored = 1
+                )
+
+            // then
+            assertThat(message.inning).isEqualTo(9)
+            assertThat(message.isTopInning).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("toSubstitutionMessage")
+    inner class ToSubstitutionMessage {
+        @Test
+        fun `should create substitution message`() {
+            // when
+            val message =
+                mapper.toSubstitutionMessage(
+                    eventId = 200L,
+                    inning = 6,
+                    isTopInning = true,
+                    description = "대타 교체: 김대타 → 박타자"
+                )
+
+            // then
+            assertThat(message.eventId).isEqualTo(200L)
+            assertThat(message.eventType).isEqualTo("SUBSTITUTION")
+            assertThat(message.inning).isEqualTo(6)
+            assertThat(message.isTopInning).isTrue()
+            assertThat(message.description).isEqualTo("대타 교체: 김대타 → 박타자")
+            assertThat(message.batter).isNull()
+            assertThat(message.pitcher).isNull()
+            assertThat(message.result).isNull()
+            assertThat(message.runsScored).isEqualTo(0)
+            assertThat(message.timestamp).isNotNull()
+        }
+
+        @Test
+        fun `should create substitution message for pitcher change`() {
+            // when
+            val message =
+                mapper.toSubstitutionMessage(
+                    eventId = 201L,
+                    inning = 8,
+                    isTopInning = false,
+                    description = "투수 교체: 마무리 등판"
+                )
+
+            // then
+            assertThat(message.eventType).isEqualTo("SUBSTITUTION")
+            assertThat(message.description).isEqualTo("투수 교체: 마무리 등판")
+        }
+    }
+
+    @Nested
+    @DisplayName("toInningEndMessage")
+    inner class ToInningEndMessage {
+        @Test
+        fun `should create top inning end message`() {
+            // when
+            val message =
+                mapper.toInningEndMessage(
+                    eventId = 300L,
+                    inning = 5,
+                    isTopInning = true
+                )
+
+            // then
+            assertThat(message.eventId).isEqualTo(300L)
+            assertThat(message.eventType).isEqualTo("INNING_END")
+            assertThat(message.inning).isEqualTo(5)
+            assertThat(message.isTopInning).isTrue()
+            assertThat(message.description).isEqualTo("5회초 종료")
+            assertThat(message.batter).isNull()
+            assertThat(message.pitcher).isNull()
+            assertThat(message.result).isNull()
+            assertThat(message.runsScored).isEqualTo(0)
+            assertThat(message.timestamp).isNotNull()
+        }
+
+        @Test
+        fun `should create bottom inning end message`() {
+            // when
+            val message =
+                mapper.toInningEndMessage(
+                    eventId = 301L,
+                    inning = 7,
+                    isTopInning = false
+                )
+
+            // then
+            assertThat(message.description).isEqualTo("7회말 종료")
+            assertThat(message.isTopInning).isFalse()
+        }
+
+        @Test
+        fun `should create first inning end message`() {
+            // when
+            val message =
+                mapper.toInningEndMessage(
+                    eventId = 302L,
+                    inning = 1,
+                    isTopInning = true
+                )
+
+            // then
+            assertThat(message.description).isEqualTo("1회초 종료")
+        }
+
+        @Test
+        fun `should create ninth inning end message`() {
+            // when
+            val message =
+                mapper.toInningEndMessage(
+                    eventId = 303L,
+                    inning = 9,
+                    isTopInning = false
+                )
+
+            // then
+            assertThat(message.description).isEqualTo("9회말 종료")
+        }
+    }
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/websocket/mapper/GameStateMapperTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/websocket/mapper/GameStateMapperTest.kt
@@ -21,28 +21,31 @@ class GameStateMapperTest {
         // given
         val association = Association(name = "테스트협회", region = "서울")
         val league = League(association = association, name = "테스트리그", foundedYear = 2020)
-        val competition = Competition(
-            league = league,
-            name = "2024 시즌",
-            year = 2024,
-            startDate = LocalDate.now()
-        )
-        val game = Game(
-            competition = competition,
-            scheduledAt = LocalDateTime.now(),
-            location = "테스트구장"
-        )
+        val competition =
+            Competition(
+                league = league,
+                name = "2024 시즌",
+                year = 2024,
+                startDate = LocalDate.now()
+            )
+        val game =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.now(),
+                location = "테스트구장"
+            )
 
-        val gameState = GameState(
-            outs = 2,
-            balls = 2,
-            strikes = 1,
-            runnerOnFirstId = 1L,
-            runnerOnSecondId = null,
-            runnerOnThirdId = 3L,
-            currentBatterId = 4L,
-            currentPitcherId = 5L
-        )
+        val gameState =
+            GameState(
+                outs = 2,
+                balls = 2,
+                strikes = 1,
+                runnerOnFirstId = 1L,
+                runnerOnSecondId = null,
+                runnerOnThirdId = 3L,
+                currentBatterId = 4L,
+                currentPitcherId = 5L
+            )
 
         val team = Team(league = league, name = "테스트팀", city = "서울", foundedYear = 2020)
         val gameTeam = GameTeam(game, team, HomeAway.HOME)
@@ -58,15 +61,16 @@ class GameStateMapperTest {
         val runnerOnThird = GamePlayer(gameTeam, runner3, Position.SECOND_BASE, 3, 7)
 
         // when
-        val result = mapper.toGameStateMessage(
-            game,
-            gameState,
-            currentBatter,
-            currentPitcher,
-            runnerOnFirst,
-            null,
-            runnerOnThird
-        )
+        val result =
+            mapper.toGameStateMessage(
+                game,
+                gameState,
+                currentBatter,
+                currentPitcher,
+                runnerOnFirst,
+                null,
+                runnerOnThird
+            )
 
         // then
         assertThat(result.gameId).isEqualTo(game.id)

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/websocket/mapper/ScoreboardMapperTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/websocket/mapper/ScoreboardMapperTest.kt
@@ -21,38 +21,42 @@ class ScoreboardMapperTest {
         // given
         val association = Association(name = "테스트협회", region = "서울")
         val league = League(association = association, name = "테스트리그", foundedYear = 2020)
-        val competition = Competition(
-            league = league,
-            name = "2024 시즌",
-            year = 2024,
-            startDate = LocalDate.now()
-        )
-        val game = Game(
-            competition = competition,
-            scheduledAt = LocalDateTime.now(),
-            location = "테스트구장"
-        )
+        val competition =
+            Competition(
+                league = league,
+                name = "2024 시즌",
+                year = 2024,
+                startDate = LocalDate.now()
+            )
+        val game =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.now(),
+                location = "테스트구장"
+            )
 
         val homeTeamEntity = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020)
         val awayTeamEntity = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020)
 
-        val homeTeam = GameTeam(game, homeTeamEntity, HomeAway.HOME).apply {
-            updateScore(5, 8, 1)
-            recordInningScore(1, 0)
-            recordInningScore(2, 1)
-            recordInningScore(3, 2)
-            recordInningScore(4, 0)
-            recordInningScore(5, 2)
-        }
+        val homeTeam =
+            GameTeam(game, homeTeamEntity, HomeAway.HOME).apply {
+                updateScore(5, 8, 1)
+                recordInningScore(1, 0)
+                recordInningScore(2, 1)
+                recordInningScore(3, 2)
+                recordInningScore(4, 0)
+                recordInningScore(5, 2)
+            }
 
-        val awayTeam = GameTeam(game, awayTeamEntity, HomeAway.AWAY).apply {
-            updateScore(3, 6, 0)
-            recordInningScore(1, 1)
-            recordInningScore(2, 0)
-            recordInningScore(3, 0)
-            recordInningScore(4, 2)
-            recordInningScore(5, 0)
-        }
+        val awayTeam =
+            GameTeam(game, awayTeamEntity, HomeAway.AWAY).apply {
+                updateScore(3, 6, 0)
+                recordInningScore(1, 1)
+                recordInningScore(2, 0)
+                recordInningScore(3, 0)
+                recordInningScore(4, 2)
+                recordInningScore(5, 0)
+            }
 
         // when
         val result = mapper.toScoreboardMessage(game, homeTeam, awayTeam)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,5 +6,5 @@ include(
     "nextup-infrastructure",
     "nextup-api",
     "nextup-backoffice",
-    "nextup-scorer"
+    "nextup-scorer",
 )


### PR DESCRIPTION
## Summary

>- close #52

기록원 전용 경기 기록 API 구현 (경기 시작/타석 결과/이닝 전환/종료)

## Tasks

- GameScorerController 추가 (REST API 엔드포인트)
  - `POST /api/scorer/games/{gameId}/start` - 경기 시작
  - `POST /api/scorer/games/{gameId}/plate-appearances` - 타석 결과 입력
  - `POST /api/scorer/games/{gameId}/half-inning` - 이닝 전환
  - `POST /api/scorer/games/{gameId}/end` - 경기 종료
- GameScorerService 인터페이스 및 구현체 추가
- GameEvent, GameEventType 도메인 엔티티 추가
- PlateAppearanceRequest, RunnerMovement, GameEndReason DTO 추가
- GameResponse, GameStateResponse DTO 및 Mapper 추가
- GameScorerControllerTest 테스트 추가
- GameRepositoryPort findById 중복 제거

## To Reviewer

- 커버리지가 낮은 파일들(GameScorerServiceImpl, GameEvent 등)에 대한 테스트 추가 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)