### PR TITLE
feat(#49): GameEvent Entity 및 이벤트 타입 설계

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BaseRunningEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BaseRunningEvent.kt
@@ -1,0 +1,76 @@
+package com.nextup.core.domain.game
+
+/**
+ * 주루 이벤트
+ *
+ * 타석 결과와 별개로 발생하는 주루 관련 이벤트를 정의합니다.
+ */
+enum class BaseRunningEvent(
+    val displayName: String,
+    val description: String
+) {
+    // 도루 관련
+    STOLEN_BASE("도루", "도루 성공"),
+    CAUGHT_STEALING("도루 실패", "도루 시도 중 아웃"),
+    DOUBLE_STEAL("더블 스틸", "2명 동시 도루"),
+    TRIPLE_STEAL("트리플 스틸", "3명 동시 도루"),
+
+    // 투수 관련 진루
+    WILD_PITCH("폭투", "투수 폭투로 주자 진루"),
+    PASSED_BALL("포일", "포수 포일로 주자 진루"),
+    BALK("보크", "보크로 주자 진루"),
+
+    // 견제/픽오프
+    PICKOFF("견제사", "견제로 아웃"),
+    PICKOFF_ERROR("견제 실책", "견제 실책으로 주자 진루"),
+
+    // 기타 진루
+    ADVANCE_ON_THROW("송구 사이 진루", "송구 사이 추가 진루"),
+    ADVANCE_ON_ERROR("실책 진루", "수비 실책으로 추가 진루"),
+    ADVANCE_ON_FLYOUT("태그업", "플라이 아웃 후 태그업 진루"),
+    ADVANCE_ON_GROUND_OUT("땅볼 사이 진루", "땅볼 아웃 사이 진루"),
+
+    // 주루 아웃
+    OUT_ON_BASES("주루사", "주루 중 아웃"),
+    OUT_ON_APPEAL("어필 아웃", "어필 플레이로 아웃"),
+    OUT_PASSING_RUNNER("추월 아웃", "앞 주자 추월로 아웃"),
+    OUT_INTERFERENCE("주루 방해", "주루 중 수비 방해로 아웃");
+
+    /**
+     * 도루 관련 이벤트인지 확인합니다.
+     */
+    val isStealAttempt: Boolean
+        get() = this in listOf(STOLEN_BASE, CAUGHT_STEALING, DOUBLE_STEAL, TRIPLE_STEAL)
+
+    /**
+     * 도루 성공인지 확인합니다.
+     */
+    val isSuccessfulSteal: Boolean
+        get() = this in listOf(STOLEN_BASE, DOUBLE_STEAL, TRIPLE_STEAL)
+
+    /**
+     * 투수/포수 책임 진루인지 확인합니다.
+     */
+    val isBatteryError: Boolean
+        get() = this in listOf(WILD_PITCH, PASSED_BALL, BALK)
+
+    /**
+     * 아웃 이벤트인지 확인합니다.
+     */
+    val isOut: Boolean
+        get() = this in listOf(
+            CAUGHT_STEALING, PICKOFF,
+            OUT_ON_BASES, OUT_ON_APPEAL, OUT_PASSING_RUNNER, OUT_INTERFERENCE
+        )
+
+    /**
+     * 진루 이벤트인지 확인합니다.
+     */
+    val isAdvance: Boolean
+        get() = this in listOf(
+            STOLEN_BASE, DOUBLE_STEAL, TRIPLE_STEAL,
+            WILD_PITCH, PASSED_BALL, BALK,
+            PICKOFF_ERROR, ADVANCE_ON_THROW, ADVANCE_ON_ERROR,
+            ADVANCE_ON_FLYOUT, ADVANCE_ON_GROUND_OUT
+        )
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -1,0 +1,316 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * 경기 이벤트 엔티티
+ *
+ * 경기 중 발생하는 모든 이벤트를 기록합니다.
+ * 타석 결과, 주루 이벤트, 선수 교체, 이닝 전환 등을 포함합니다.
+ */
+@Entity
+@Table(
+    name = "game_events",
+    indexes = [
+        Index(name = "idx_game_events_game", columnList = "game_id"),
+        Index(name = "idx_game_events_game_order", columnList = "game_id, event_order"),
+        Index(name = "idx_game_events_game_inning", columnList = "game_id, inning, is_top_inning"),
+        Index(name = "idx_game_events_type", columnList = "event_type"),
+        Index(name = "idx_game_events_batter", columnList = "batter_id"),
+        Index(name = "idx_game_events_pitcher", columnList = "pitcher_id")
+    ]
+)
+class GameEvent(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    val game: Game,
+
+    @Column(nullable = false)
+    val inning: Int,
+
+    @Column(name = "is_top_inning", nullable = false)
+    val isTopInning: Boolean,
+
+    @Column(name = "out_count_before", nullable = false)
+    val outCountBefore: Int,
+
+    @Column(name = "out_count_after", nullable = false)
+    val outCountAfter: Int,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 30)
+    val eventType: GameEventType,
+
+    @Column(nullable = false, length = 500)
+    val description: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batter_id")
+    val batter: GamePlayer? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pitcher_id")
+    val pitcher: GamePlayer? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "involved_runner_id")
+    val involvedRunner: GamePlayer? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "substituted_in_id")
+    val substitutedIn: GamePlayer? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "substituted_out_id")
+    val substitutedOut: GamePlayer? = null,
+
+    @Column(name = "runners_before", columnDefinition = "TEXT")
+    val runnersBefore: String? = null,
+
+    @Column(name = "runners_after", columnDefinition = "TEXT")
+    val runnersAfter: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "plate_appearance_result", length = 30)
+    val plateAppearanceResult: PlateAppearanceResult? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "base_running_event", length = 30)
+    val baseRunningEvent: BaseRunningEvent? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "substitution_type", length = 30)
+    val substitutionType: SubstitutionType? = null,
+
+    @Column(name = "runs_scored", nullable = false)
+    val runsScored: Int = 0,
+
+    @Column(nullable = false)
+    val rbis: Int = 0,
+
+    @Column(name = "is_earned_run", nullable = false)
+    val isEarnedRun: Boolean = true,
+
+    @Column(name = "event_order", nullable = false)
+    val eventOrder: Int,
+
+    @Column(name = "event_timestamp", nullable = false)
+    val eventTimestamp: Instant = Instant.now(),
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+) : BaseTimeEntity() {
+
+    init {
+        require(inning >= 1) { "이닝은 1 이상이어야 합니다." }
+        require(outCountBefore in 0..3) { "아웃 카운트(before)는 0~3 사이여야 합니다." }
+        require(outCountAfter in 0..3) { "아웃 카운트(after)는 0~3 사이여야 합니다." }
+        require(runsScored >= 0) { "득점은 0 이상이어야 합니다." }
+        require(rbis >= 0) { "타점은 0 이상이어야 합니다." }
+        require(eventOrder >= 1) { "이벤트 순서는 1 이상이어야 합니다." }
+
+        if (eventType == GameEventType.PLATE_APPEARANCE) {
+            requireNotNull(batter) { "타석 결과에는 타자가 필수입니다." }
+            requireNotNull(pitcher) { "타석 결과에는 투수가 필수입니다." }
+            requireNotNull(plateAppearanceResult) { "타석 결과에는 결과 유형이 필수입니다." }
+        }
+
+        if (eventType == GameEventType.BASE_RUNNING) {
+            requireNotNull(baseRunningEvent) { "주루 이벤트에는 이벤트 유형이 필수입니다." }
+        }
+
+        if (eventType == GameEventType.SUBSTITUTION) {
+            requireNotNull(substitutionType) { "선수 교체에는 교체 유형이 필수입니다." }
+            requireNotNull(substitutedIn) { "선수 교체에는 교체 투입 선수가 필수입니다." }
+        }
+    }
+
+    /**
+     * 이닝 표시 (예: "5회초", "7회말")
+     */
+    val inningDisplay: String
+        get() = "${inning}회${if (isTopInning) "초" else "말"}"
+
+    /**
+     * 아웃 추가 수
+     */
+    val outsAdded: Int
+        get() = outCountAfter - outCountBefore
+
+    /**
+     * 이닝 종료 이벤트인지 확인
+     */
+    val isInningEndingEvent: Boolean
+        get() = outCountAfter >= 3
+
+    /**
+     * 득점이 발생한 이벤트인지 확인
+     */
+    val isScoringEvent: Boolean
+        get() = runsScored > 0
+
+    companion object {
+        /**
+         * 타석 결과 이벤트를 생성합니다.
+         */
+        fun createPlateAppearance(
+            game: Game,
+            inning: Int,
+            isTopInning: Boolean,
+            outCountBefore: Int,
+            outCountAfter: Int,
+            batter: GamePlayer,
+            pitcher: GamePlayer,
+            result: PlateAppearanceResult,
+            description: String,
+            runsScored: Int = 0,
+            rbis: Int = 0,
+            isEarnedRun: Boolean = true,
+            runnersBefore: String? = null,
+            runnersAfter: String? = null,
+            eventOrder: Int
+        ): GameEvent = GameEvent(
+            game = game,
+            inning = inning,
+            isTopInning = isTopInning,
+            outCountBefore = outCountBefore,
+            outCountAfter = outCountAfter,
+            eventType = GameEventType.PLATE_APPEARANCE,
+            description = description,
+            batter = batter,
+            pitcher = pitcher,
+            plateAppearanceResult = result,
+            runsScored = runsScored,
+            rbis = rbis,
+            isEarnedRun = isEarnedRun,
+            runnersBefore = runnersBefore,
+            runnersAfter = runnersAfter,
+            eventOrder = eventOrder
+        )
+
+        /**
+         * 주루 이벤트를 생성합니다.
+         */
+        fun createBaseRunning(
+            game: Game,
+            inning: Int,
+            isTopInning: Boolean,
+            outCountBefore: Int,
+            outCountAfter: Int,
+            runner: GamePlayer,
+            pitcher: GamePlayer,
+            event: BaseRunningEvent,
+            description: String,
+            runsScored: Int = 0,
+            isEarnedRun: Boolean = true,
+            runnersBefore: String? = null,
+            runnersAfter: String? = null,
+            eventOrder: Int
+        ): GameEvent = GameEvent(
+            game = game,
+            inning = inning,
+            isTopInning = isTopInning,
+            outCountBefore = outCountBefore,
+            outCountAfter = outCountAfter,
+            eventType = GameEventType.BASE_RUNNING,
+            description = description,
+            pitcher = pitcher,
+            involvedRunner = runner,
+            baseRunningEvent = event,
+            runsScored = runsScored,
+            isEarnedRun = isEarnedRun,
+            runnersBefore = runnersBefore,
+            runnersAfter = runnersAfter,
+            eventOrder = eventOrder
+        )
+
+        /**
+         * 선수 교체 이벤트를 생성합니다.
+         */
+        fun createSubstitution(
+            game: Game,
+            inning: Int,
+            isTopInning: Boolean,
+            outCount: Int,
+            substitutionType: SubstitutionType,
+            playerIn: GamePlayer,
+            playerOut: GamePlayer?,
+            description: String,
+            eventOrder: Int
+        ): GameEvent = GameEvent(
+            game = game,
+            inning = inning,
+            isTopInning = isTopInning,
+            outCountBefore = outCount,
+            outCountAfter = outCount,
+            eventType = GameEventType.SUBSTITUTION,
+            description = description,
+            substitutedIn = playerIn,
+            substitutedOut = playerOut,
+            substitutionType = substitutionType,
+            eventOrder = eventOrder
+        )
+
+        /**
+         * 이닝 전환 이벤트를 생성합니다.
+         */
+        fun createHalfInningChange(
+            game: Game,
+            inning: Int,
+            isTopInning: Boolean,
+            description: String,
+            eventOrder: Int
+        ): GameEvent = GameEvent(
+            game = game,
+            inning = inning,
+            isTopInning = isTopInning,
+            outCountBefore = 3,
+            outCountAfter = 0,
+            eventType = GameEventType.HALF_INNING_CHANGE,
+            description = description,
+            eventOrder = eventOrder
+        )
+
+        /**
+         * 경기 시작 이벤트를 생성합니다.
+         */
+        fun createGameStart(
+            game: Game,
+            description: String = "경기 시작",
+            eventOrder: Int = 1
+        ): GameEvent = GameEvent(
+            game = game,
+            inning = 1,
+            isTopInning = true,
+            outCountBefore = 0,
+            outCountAfter = 0,
+            eventType = GameEventType.GAME_START,
+            description = description,
+            eventOrder = eventOrder
+        )
+
+        /**
+         * 경기 종료 이벤트를 생성합니다.
+         */
+        fun createGameEnd(
+            game: Game,
+            inning: Int,
+            isTopInning: Boolean,
+            outCount: Int,
+            description: String = "경기 종료",
+            eventOrder: Int
+        ): GameEvent = GameEvent(
+            game = game,
+            inning = inning,
+            isTopInning = isTopInning,
+            outCountBefore = outCount,
+            outCountAfter = outCount,
+            eventType = GameEventType.GAME_END,
+            description = description,
+            eventOrder = eventOrder
+        )
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
@@ -1,0 +1,64 @@
+package com.nextup.core.domain.game
+
+/**
+ * 경기 이벤트 유형
+ *
+ * 경기 중 발생할 수 있는 이벤트의 대분류를 정의합니다.
+ */
+enum class GameEventType(
+    val displayName: String,
+    val description: String
+) {
+    // 타석 관련
+    PLATE_APPEARANCE("타석 결과", "타자의 타석 결과 (안타, 아웃, 볼넷 등)"),
+
+    // 주루 관련
+    BASE_RUNNING("주루 이벤트", "도루, 보크, 폭투 등 주루 관련 이벤트"),
+
+    // 선수 교체
+    SUBSTITUTION("선수 교체", "타자, 투수, 수비 교체"),
+
+    // 이닝/경기 진행
+    INNING_START("이닝 시작", "새 이닝 시작"),
+    INNING_END("이닝 종료", "이닝 종료 (3아웃)"),
+    HALF_INNING_CHANGE("공수 교대", "초/말 전환"),
+    GAME_START("경기 시작", "경기 시작"),
+    GAME_END("경기 종료", "경기 정상 종료"),
+    GAME_CALLED("콜드게임", "우천, 일몰 등으로 경기 중단"),
+
+    // 기타
+    TIMEOUT("타임아웃", "타임아웃 요청"),
+    MOUND_VISIT("마운드 방문", "감독/코치 마운드 방문"),
+    REVIEW("비디오 판독", "비디오 판독 요청"),
+    INJURY("부상", "선수 부상 발생"),
+    EJECTION("퇴장", "퇴장 처분"),
+    DELAY("지연", "경기 지연"),
+    OTHER("기타", "기타 이벤트");
+
+    /**
+     * 타석 결과 이벤트인지 확인합니다.
+     */
+    val isPlateAppearance: Boolean
+        get() = this == PLATE_APPEARANCE
+
+    /**
+     * 주루 이벤트인지 확인합니다.
+     */
+    val isBaseRunning: Boolean
+        get() = this == BASE_RUNNING
+
+    /**
+     * 선수 교체 이벤트인지 확인합니다.
+     */
+    val isSubstitution: Boolean
+        get() = this == SUBSTITUTION
+
+    /**
+     * 경기 진행 관련 이벤트인지 확인합니다.
+     */
+    val isGameProgress: Boolean
+        get() = this in listOf(
+            INNING_START, INNING_END, HALF_INNING_CHANGE,
+            GAME_START, GAME_END, GAME_CALLED
+        )
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/SubstitutionType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/SubstitutionType.kt
@@ -1,0 +1,54 @@
+package com.nextup.core.domain.game
+
+/**
+ * 선수 교체 유형
+ *
+ * 경기 중 발생하는 선수 교체의 유형을 정의합니다.
+ */
+enum class SubstitutionType(
+    val displayName: String,
+    val description: String
+) {
+    // 타자 교체
+    PINCH_HITTER("대타", "타순 대신 타격"),
+    PINCH_RUNNER("대주자", "주자 대신 주루"),
+
+    // 투수 교체
+    PITCHING_CHANGE("투수 교체", "투수 교체"),
+
+    // 수비 교체
+    DEFENSIVE_REPLACEMENT("수비 교체", "수비 위치 교체"),
+    POSITION_SWITCH("포지션 변경", "출전 중 선수들의 포지션 교환"),
+
+    // DH 관련
+    DH_INTO_FIELD("DH 수비 투입", "DH가 수비 위치로 이동 (DH 규칙 해제)"),
+    PITCHER_TO_BATTING_ORDER("투수 타순 진입", "투수가 타순에 진입 (DH 규칙 해제)"),
+
+    // 특수 상황
+    DOUBLE_SWITCH("더블 스위치", "투수 교체와 타순 변경 동시 진행"),
+    LINEUP_CORRECTION("라인업 정정", "라인업 오류 정정");
+
+    /**
+     * 타자 관련 교체인지 확인합니다.
+     */
+    val isBatterSubstitution: Boolean
+        get() = this in listOf(PINCH_HITTER, PINCH_RUNNER)
+
+    /**
+     * 투수 교체인지 확인합니다.
+     */
+    val isPitchingChange: Boolean
+        get() = this == PITCHING_CHANGE || this == DOUBLE_SWITCH
+
+    /**
+     * 수비 교체인지 확인합니다.
+     */
+    val isDefensiveChange: Boolean
+        get() = this in listOf(DEFENSIVE_REPLACEMENT, POSITION_SWITCH, DH_INTO_FIELD)
+
+    /**
+     * DH 규칙 관련 교체인지 확인합니다.
+     */
+    val isDHRelated: Boolean
+        get() = this in listOf(DH_INTO_FIELD, PITCHER_TO_BATTING_ORDER)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
@@ -1,0 +1,39 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
+
+/**
+ * GameEvent Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface GameEventRepositoryPort {
+
+    fun save(gameEvent: GameEvent): GameEvent
+
+    fun saveAll(gameEvents: List<GameEvent>): List<GameEvent>
+
+    fun findByIdOrNull(id: Long): GameEvent?
+
+    fun findAllByGameId(gameId: Long): List<GameEvent>
+
+    fun findAllByGameIdOrderByEventOrder(gameId: Long): List<GameEvent>
+
+    fun findAllByGameIdAndInning(gameId: Long, inning: Int): List<GameEvent>
+
+    fun findAllByGameIdAndInningAndIsTopInning(
+        gameId: Long,
+        inning: Int,
+        isTopInning: Boolean
+    ): List<GameEvent>
+
+    fun findAllByGameIdAndEventType(gameId: Long, eventType: GameEventType): List<GameEvent>
+
+    fun findLastEventByGameId(gameId: Long): GameEvent?
+
+    fun countByGameId(gameId: Long): Long
+
+    fun deleteById(id: Long)
+
+    fun deleteAllByGameId(gameId: Long)
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BaseRunningEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BaseRunningEventTest.kt
@@ -1,0 +1,104 @@
+package com.nextup.core.domain.game
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("BaseRunningEvent enum 테스트")
+class BaseRunningEventTest {
+
+    @Nested
+    @DisplayName("도루 관련 이벤트")
+    inner class StealEvents {
+
+        @Test
+        fun `도루 시도 이벤트를 구분할 수 있다`() {
+            assertThat(BaseRunningEvent.STOLEN_BASE.isStealAttempt).isTrue()
+            assertThat(BaseRunningEvent.CAUGHT_STEALING.isStealAttempt).isTrue()
+            assertThat(BaseRunningEvent.DOUBLE_STEAL.isStealAttempt).isTrue()
+            assertThat(BaseRunningEvent.TRIPLE_STEAL.isStealAttempt).isTrue()
+        }
+
+        @Test
+        fun `도루 성공 이벤트를 구분할 수 있다`() {
+            assertThat(BaseRunningEvent.STOLEN_BASE.isSuccessfulSteal).isTrue()
+            assertThat(BaseRunningEvent.DOUBLE_STEAL.isSuccessfulSteal).isTrue()
+            assertThat(BaseRunningEvent.TRIPLE_STEAL.isSuccessfulSteal).isTrue()
+            assertThat(BaseRunningEvent.CAUGHT_STEALING.isSuccessfulSteal).isFalse()
+        }
+
+        @Test
+        fun `폭투는 도루 시도가 아니다`() {
+            assertThat(BaseRunningEvent.WILD_PITCH.isStealAttempt).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("투수/포수 책임 이벤트")
+    inner class BatteryErrorEvents {
+
+        @Test
+        fun `폭투, 포일, 보크는 배터리 책임 이벤트이다`() {
+            assertThat(BaseRunningEvent.WILD_PITCH.isBatteryError).isTrue()
+            assertThat(BaseRunningEvent.PASSED_BALL.isBatteryError).isTrue()
+            assertThat(BaseRunningEvent.BALK.isBatteryError).isTrue()
+        }
+
+        @Test
+        fun `도루는 배터리 책임 이벤트가 아니다`() {
+            assertThat(BaseRunningEvent.STOLEN_BASE.isBatteryError).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("아웃/진루 구분")
+    inner class OutOrAdvance {
+
+        @Test
+        fun `아웃 이벤트를 구분할 수 있다`() {
+            assertThat(BaseRunningEvent.CAUGHT_STEALING.isOut).isTrue()
+            assertThat(BaseRunningEvent.PICKOFF.isOut).isTrue()
+            assertThat(BaseRunningEvent.OUT_ON_BASES.isOut).isTrue()
+            assertThat(BaseRunningEvent.OUT_ON_APPEAL.isOut).isTrue()
+            assertThat(BaseRunningEvent.OUT_PASSING_RUNNER.isOut).isTrue()
+            assertThat(BaseRunningEvent.OUT_INTERFERENCE.isOut).isTrue()
+        }
+
+        @Test
+        fun `진루 이벤트를 구분할 수 있다`() {
+            assertThat(BaseRunningEvent.STOLEN_BASE.isAdvance).isTrue()
+            assertThat(BaseRunningEvent.WILD_PITCH.isAdvance).isTrue()
+            assertThat(BaseRunningEvent.PASSED_BALL.isAdvance).isTrue()
+            assertThat(BaseRunningEvent.BALK.isAdvance).isTrue()
+            assertThat(BaseRunningEvent.ADVANCE_ON_THROW.isAdvance).isTrue()
+            assertThat(BaseRunningEvent.ADVANCE_ON_ERROR.isAdvance).isTrue()
+            assertThat(BaseRunningEvent.ADVANCE_ON_FLYOUT.isAdvance).isTrue()
+        }
+
+        @Test
+        fun `아웃 이벤트는 진루 이벤트가 아니다`() {
+            assertThat(BaseRunningEvent.CAUGHT_STEALING.isAdvance).isFalse()
+            assertThat(BaseRunningEvent.PICKOFF.isAdvance).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("이벤트 속성")
+    inner class EventProperties {
+
+        @Test
+        fun `모든 이벤트는 표시 이름을 가진다`() {
+            BaseRunningEvent.entries.forEach { event ->
+                assertThat(event.displayName).isNotBlank()
+            }
+        }
+
+        @Test
+        fun `모든 이벤트는 설명을 가진다`() {
+            BaseRunningEvent.entries.forEach { event ->
+                assertThat(event.description).isNotBlank()
+            }
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
@@ -1,0 +1,566 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameEvent 엔티티 테스트")
+class GameEventTest {
+
+    private lateinit var game: Game
+    private lateinit var homeTeam: GameTeam
+    private lateinit var awayTeam: GameTeam
+    private lateinit var batter: GamePlayer
+    private lateinit var pitcher: GamePlayer
+    private lateinit var runner: GamePlayer
+
+    @BeforeEach
+    fun setUp() {
+        val association = Association(name = "서울시야구협회", region = "서울")
+        val league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        val competition = Competition(
+            league = league,
+            name = "2025 춘계대회",
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            status = CompetitionStatus.IN_PROGRESS
+        )
+
+        game = Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실야구장",
+            status = GameStatus.IN_PROGRESS
+        )
+
+        val team1 = Team(league = league, name = "레드삭스", city = "서울", foundedYear = 2020)
+        val team2 = Team(league = league, name = "양키스", city = "부산", foundedYear = 2020)
+
+        homeTeam = GameTeam(game = game, team = team1, homeAway = HomeAway.HOME)
+        awayTeam = GameTeam(game = game, team = team2, homeAway = HomeAway.AWAY)
+
+        val batterPlayer = Player(
+            name = "김타자",
+            birthDate = LocalDate.of(1995, 5, 15),
+            primaryPosition = Position.SHORTSTOP,
+            battingHand = BattingHand.RIGHT,
+            throwingHand = ThrowingHand.RIGHT
+        )
+
+        val pitcherPlayer = Player(
+            name = "이투수",
+            birthDate = LocalDate.of(1993, 3, 10),
+            primaryPosition = Position.STARTING_PITCHER,
+            battingHand = BattingHand.RIGHT,
+            throwingHand = ThrowingHand.LEFT
+        )
+
+        val runnerPlayer = Player(
+            name = "박주자",
+            birthDate = LocalDate.of(1997, 7, 20),
+            primaryPosition = Position.CENTER_FIELD,
+            battingHand = BattingHand.LEFT,
+            throwingHand = ThrowingHand.LEFT
+        )
+
+        batter = GamePlayer.createStarter(
+            gameTeam = awayTeam,
+            player = batterPlayer,
+            position = Position.SHORTSTOP,
+            battingOrder = 3,
+            backNumber = 6
+        )
+
+        pitcher = GamePlayer.createStarter(
+            gameTeam = homeTeam,
+            player = pitcherPlayer,
+            position = Position.STARTING_PITCHER,
+            battingOrder = null,
+            backNumber = 21
+        )
+
+        runner = GamePlayer.createStarter(
+            gameTeam = awayTeam,
+            player = runnerPlayer,
+            position = Position.CENTER_FIELD,
+            battingOrder = 1,
+            backNumber = 51
+        )
+    }
+
+    @Nested
+    @DisplayName("타석 결과 이벤트 생성")
+    inner class CreatePlateAppearance {
+
+        @Test
+        fun `안타 이벤트를 생성할 수 있다`() {
+            // when
+            val event = GameEvent.createPlateAppearance(
+                game = game,
+                inning = 1,
+                isTopInning = true,
+                outCountBefore = 0,
+                outCountAfter = 0,
+                batter = batter,
+                pitcher = pitcher,
+                result = PlateAppearanceResult.SINGLE,
+                description = "좌전 안타",
+                eventOrder = 1
+            )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.PLATE_APPEARANCE)
+            assertThat(event.plateAppearanceResult).isEqualTo(PlateAppearanceResult.SINGLE)
+            assertThat(event.inningDisplay).isEqualTo("1회초")
+            assertThat(event.outsAdded).isEqualTo(0)
+        }
+
+        @Test
+        fun `홈런 득점 이벤트를 생성할 수 있다`() {
+            // when
+            val event = GameEvent.createPlateAppearance(
+                game = game,
+                inning = 5,
+                isTopInning = false,
+                outCountBefore = 1,
+                outCountAfter = 1,
+                batter = batter,
+                pitcher = pitcher,
+                result = PlateAppearanceResult.HOME_RUN,
+                description = "2점 홈런",
+                runsScored = 2,
+                rbis = 2,
+                eventOrder = 25
+            )
+
+            // then
+            assertThat(event.runsScored).isEqualTo(2)
+            assertThat(event.rbis).isEqualTo(2)
+            assertThat(event.isScoringEvent).isTrue()
+            assertThat(event.inningDisplay).isEqualTo("5회말")
+        }
+
+        @Test
+        fun `삼진 아웃 이벤트를 생성할 수 있다`() {
+            // when
+            val event = GameEvent.createPlateAppearance(
+                game = game,
+                inning = 3,
+                isTopInning = true,
+                outCountBefore = 2,
+                outCountAfter = 3,
+                batter = batter,
+                pitcher = pitcher,
+                result = PlateAppearanceResult.STRIKEOUT,
+                description = "헛스윙 삼진",
+                eventOrder = 15
+            )
+
+            // then
+            assertThat(event.outsAdded).isEqualTo(1)
+            assertThat(event.isInningEndingEvent).isTrue()
+        }
+
+        @Test
+        fun `타자 없이 타석 결과 이벤트를 생성하면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                GameEvent(
+                    game = game,
+                    inning = 1,
+                    isTopInning = true,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventType = GameEventType.PLATE_APPEARANCE,
+                    description = "안타",
+                    batter = null,
+                    pitcher = pitcher,
+                    plateAppearanceResult = PlateAppearanceResult.SINGLE,
+                    eventOrder = 1
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("타자")
+        }
+
+        @Test
+        fun `투수 없이 타석 결과 이벤트를 생성하면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                GameEvent(
+                    game = game,
+                    inning = 1,
+                    isTopInning = true,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventType = GameEventType.PLATE_APPEARANCE,
+                    description = "안타",
+                    batter = batter,
+                    pitcher = null,
+                    plateAppearanceResult = PlateAppearanceResult.SINGLE,
+                    eventOrder = 1
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("투수")
+        }
+
+        @Test
+        fun `결과 유형 없이 타석 결과 이벤트를 생성하면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                GameEvent(
+                    game = game,
+                    inning = 1,
+                    isTopInning = true,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventType = GameEventType.PLATE_APPEARANCE,
+                    description = "안타",
+                    batter = batter,
+                    pitcher = pitcher,
+                    plateAppearanceResult = null,
+                    eventOrder = 1
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("결과 유형")
+        }
+    }
+
+    @Nested
+    @DisplayName("주루 이벤트 생성")
+    inner class CreateBaseRunning {
+
+        @Test
+        fun `도루 성공 이벤트를 생성할 수 있다`() {
+            // when
+            val event = GameEvent.createBaseRunning(
+                game = game,
+                inning = 2,
+                isTopInning = true,
+                outCountBefore = 1,
+                outCountAfter = 1,
+                runner = runner,
+                pitcher = pitcher,
+                event = BaseRunningEvent.STOLEN_BASE,
+                description = "2루 도루 성공",
+                eventOrder = 10
+            )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.BASE_RUNNING)
+            assertThat(event.baseRunningEvent).isEqualTo(BaseRunningEvent.STOLEN_BASE)
+            assertThat(event.involvedRunner).isEqualTo(runner)
+            assertThat(event.outsAdded).isEqualTo(0)
+        }
+
+        @Test
+        fun `도루 실패 이벤트를 생성할 수 있다`() {
+            // when
+            val event = GameEvent.createBaseRunning(
+                game = game,
+                inning = 4,
+                isTopInning = false,
+                outCountBefore = 0,
+                outCountAfter = 1,
+                runner = runner,
+                pitcher = pitcher,
+                event = BaseRunningEvent.CAUGHT_STEALING,
+                description = "2루 도루 실패",
+                eventOrder = 20
+            )
+
+            // then
+            assertThat(event.baseRunningEvent).isEqualTo(BaseRunningEvent.CAUGHT_STEALING)
+            assertThat(event.outsAdded).isEqualTo(1)
+        }
+
+        @Test
+        fun `폭투로 득점하는 이벤트를 생성할 수 있다`() {
+            // when
+            val event = GameEvent.createBaseRunning(
+                game = game,
+                inning = 7,
+                isTopInning = true,
+                outCountBefore = 2,
+                outCountAfter = 2,
+                runner = runner,
+                pitcher = pitcher,
+                event = BaseRunningEvent.WILD_PITCH,
+                description = "폭투, 3루 주자 홈인",
+                runsScored = 1,
+                eventOrder = 35
+            )
+
+            // then
+            assertThat(event.baseRunningEvent).isEqualTo(BaseRunningEvent.WILD_PITCH)
+            assertThat(event.runsScored).isEqualTo(1)
+            assertThat(event.isScoringEvent).isTrue()
+        }
+
+        @Test
+        fun `이벤트 유형 없이 주루 이벤트를 생성하면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                GameEvent(
+                    game = game,
+                    inning = 1,
+                    isTopInning = true,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventType = GameEventType.BASE_RUNNING,
+                    description = "도루",
+                    involvedRunner = runner,
+                    pitcher = pitcher,
+                    baseRunningEvent = null,
+                    eventOrder = 1
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이벤트 유형")
+        }
+    }
+
+    @Nested
+    @DisplayName("선수 교체 이벤트 생성")
+    inner class CreateSubstitution {
+
+        @Test
+        fun `대타 교체 이벤트를 생성할 수 있다`() {
+            // given
+            val pinchHitterPlayer = Player(
+                name = "최대타",
+                birthDate = LocalDate.of(1994, 2, 28),
+                primaryPosition = Position.DESIGNATED_HITTER,
+                battingHand = BattingHand.LEFT,
+                throwingHand = ThrowingHand.RIGHT
+            )
+            val pinchHitter = GamePlayer.createBench(
+                gameTeam = awayTeam,
+                player = pinchHitterPlayer,
+                position = Position.DESIGNATED_HITTER,
+                backNumber = 25
+            )
+
+            // when
+            val event = GameEvent.createSubstitution(
+                game = game,
+                inning = 8,
+                isTopInning = true,
+                outCount = 2,
+                substitutionType = SubstitutionType.PINCH_HITTER,
+                playerIn = pinchHitter,
+                playerOut = batter,
+                description = "대타 최대타, 김타자 대신 출전",
+                eventOrder = 40
+            )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.SUBSTITUTION)
+            assertThat(event.substitutionType).isEqualTo(SubstitutionType.PINCH_HITTER)
+            assertThat(event.substitutedIn).isEqualTo(pinchHitter)
+            assertThat(event.substitutedOut).isEqualTo(batter)
+            assertThat(event.outsAdded).isEqualTo(0)
+        }
+
+        @Test
+        fun `투수 교체 이벤트를 생성할 수 있다`() {
+            // given
+            val relieverPlayer = Player(
+                name = "정마무리",
+                birthDate = LocalDate.of(1996, 8, 12),
+                primaryPosition = Position.RELIEF_PITCHER,
+                battingHand = BattingHand.RIGHT,
+                throwingHand = ThrowingHand.RIGHT
+            )
+            val reliever = GamePlayer.createBench(
+                gameTeam = homeTeam,
+                player = relieverPlayer,
+                position = Position.RELIEF_PITCHER,
+                backNumber = 47
+            )
+
+            // when
+            val event = GameEvent.createSubstitution(
+                game = game,
+                inning = 9,
+                isTopInning = true,
+                outCount = 0,
+                substitutionType = SubstitutionType.PITCHING_CHANGE,
+                playerIn = reliever,
+                playerOut = pitcher,
+                description = "투수 교체: 정마무리 등판",
+                eventOrder = 45
+            )
+
+            // then
+            assertThat(event.substitutionType).isEqualTo(SubstitutionType.PITCHING_CHANGE)
+        }
+
+        @Test
+        fun `교체 투입 선수 없이 교체 이벤트를 생성하면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                GameEvent(
+                    game = game,
+                    inning = 1,
+                    isTopInning = true,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventType = GameEventType.SUBSTITUTION,
+                    description = "대타",
+                    substitutionType = SubstitutionType.PINCH_HITTER,
+                    substitutedIn = null,
+                    eventOrder = 1
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("교체 투입 선수")
+        }
+    }
+
+    @Nested
+    @DisplayName("경기 진행 이벤트 생성")
+    inner class CreateGameProgressEvents {
+
+        @Test
+        fun `경기 시작 이벤트를 생성할 수 있다`() {
+            // when
+            val event = GameEvent.createGameStart(game = game)
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.GAME_START)
+            assertThat(event.inning).isEqualTo(1)
+            assertThat(event.isTopInning).isTrue()
+            assertThat(event.eventOrder).isEqualTo(1)
+        }
+
+        @Test
+        fun `이닝 전환 이벤트를 생성할 수 있다`() {
+            // when
+            val event = GameEvent.createHalfInningChange(
+                game = game,
+                inning = 1,
+                isTopInning = true,
+                description = "1회초 종료, 공수 교대",
+                eventOrder = 12
+            )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.HALF_INNING_CHANGE)
+            assertThat(event.outCountBefore).isEqualTo(3)
+            assertThat(event.outCountAfter).isEqualTo(0)
+        }
+
+        @Test
+        fun `경기 종료 이벤트를 생성할 수 있다`() {
+            // when
+            val event = GameEvent.createGameEnd(
+                game = game,
+                inning = 9,
+                isTopInning = false,
+                outCount = 3,
+                description = "경기 종료, 최종 스코어 5:3",
+                eventOrder = 100
+            )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.GAME_END)
+            assertThat(event.inning).isEqualTo(9)
+        }
+    }
+
+    @Nested
+    @DisplayName("유효성 검증")
+    inner class Validation {
+
+        @Test
+        fun `이닝은 1 이상이어야 한다`() {
+            // when & then
+            assertThatThrownBy {
+                GameEvent(
+                    game = game,
+                    inning = 0,
+                    isTopInning = true,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventType = GameEventType.GAME_START,
+                    description = "경기 시작",
+                    eventOrder = 1
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이닝")
+        }
+
+        @Test
+        fun `아웃 카운트는 0-3 사이여야 한다`() {
+            // when & then
+            assertThatThrownBy {
+                GameEvent(
+                    game = game,
+                    inning = 1,
+                    isTopInning = true,
+                    outCountBefore = 4,
+                    outCountAfter = 0,
+                    eventType = GameEventType.HALF_INNING_CHANGE,
+                    description = "이닝 전환",
+                    eventOrder = 1
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("아웃 카운트")
+        }
+
+        @Test
+        fun `득점은 0 이상이어야 한다`() {
+            // when & then
+            assertThatThrownBy {
+                GameEvent(
+                    game = game,
+                    inning = 1,
+                    isTopInning = true,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventType = GameEventType.PLATE_APPEARANCE,
+                    description = "안타",
+                    batter = batter,
+                    pitcher = pitcher,
+                    plateAppearanceResult = PlateAppearanceResult.SINGLE,
+                    runsScored = -1,
+                    eventOrder = 1
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("득점")
+        }
+
+        @Test
+        fun `이벤트 순서는 1 이상이어야 한다`() {
+            // when & then
+            assertThatThrownBy {
+                GameEvent(
+                    game = game,
+                    inning = 1,
+                    isTopInning = true,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventType = GameEventType.GAME_START,
+                    description = "경기 시작",
+                    eventOrder = 0
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이벤트 순서")
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTypeTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTypeTest.kt
@@ -1,0 +1,71 @@
+package com.nextup.core.domain.game
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("GameEventType enum 테스트")
+class GameEventTypeTest {
+
+    @Nested
+    @DisplayName("이벤트 타입 분류")
+    inner class EventTypeClassification {
+
+        @Test
+        fun `PLATE_APPEARANCE는 타석 결과 이벤트이다`() {
+            assertThat(GameEventType.PLATE_APPEARANCE.isPlateAppearance).isTrue()
+            assertThat(GameEventType.PLATE_APPEARANCE.isBaseRunning).isFalse()
+            assertThat(GameEventType.PLATE_APPEARANCE.isSubstitution).isFalse()
+        }
+
+        @Test
+        fun `BASE_RUNNING은 주루 이벤트이다`() {
+            assertThat(GameEventType.BASE_RUNNING.isBaseRunning).isTrue()
+            assertThat(GameEventType.BASE_RUNNING.isPlateAppearance).isFalse()
+        }
+
+        @Test
+        fun `SUBSTITUTION은 선수 교체 이벤트이다`() {
+            assertThat(GameEventType.SUBSTITUTION.isSubstitution).isTrue()
+            assertThat(GameEventType.SUBSTITUTION.isGameProgress).isFalse()
+        }
+
+        @Test
+        fun `경기 진행 관련 이벤트들을 구분할 수 있다`() {
+            assertThat(GameEventType.GAME_START.isGameProgress).isTrue()
+            assertThat(GameEventType.GAME_END.isGameProgress).isTrue()
+            assertThat(GameEventType.INNING_START.isGameProgress).isTrue()
+            assertThat(GameEventType.INNING_END.isGameProgress).isTrue()
+            assertThat(GameEventType.HALF_INNING_CHANGE.isGameProgress).isTrue()
+            assertThat(GameEventType.GAME_CALLED.isGameProgress).isTrue()
+        }
+
+        @Test
+        fun `기타 이벤트들은 경기 진행 이벤트가 아니다`() {
+            assertThat(GameEventType.TIMEOUT.isGameProgress).isFalse()
+            assertThat(GameEventType.MOUND_VISIT.isGameProgress).isFalse()
+            assertThat(GameEventType.REVIEW.isGameProgress).isFalse()
+            assertThat(GameEventType.INJURY.isGameProgress).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("이벤트 타입 속성")
+    inner class EventTypeProperties {
+
+        @Test
+        fun `모든 이벤트 타입은 표시 이름을 가진다`() {
+            GameEventType.entries.forEach { type ->
+                assertThat(type.displayName).isNotBlank()
+            }
+        }
+
+        @Test
+        fun `모든 이벤트 타입은 설명을 가진다`() {
+            GameEventType.entries.forEach { type ->
+                assertThat(type.description).isNotBlank()
+            }
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/GameEventRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/GameEventRepository.kt
@@ -1,0 +1,59 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+
+interface GameEventRepository : JpaRepository<GameEvent, Long>, GameEventRepositoryPort {
+
+    override fun findByIdOrNull(id: Long): GameEvent? = findById(id).orElse(null)
+
+    @Query("SELECT e FROM GameEvent e WHERE e.game.id = :gameId")
+    override fun findAllByGameId(gameId: Long): List<GameEvent>
+
+    @Query("SELECT e FROM GameEvent e WHERE e.game.id = :gameId ORDER BY e.eventOrder ASC")
+    override fun findAllByGameIdOrderByEventOrder(gameId: Long): List<GameEvent>
+
+    @Query("""
+        SELECT e FROM GameEvent e
+        WHERE e.game.id = :gameId AND e.inning = :inning
+        ORDER BY e.eventOrder ASC
+    """)
+    override fun findAllByGameIdAndInning(gameId: Long, inning: Int): List<GameEvent>
+
+    @Query("""
+        SELECT e FROM GameEvent e
+        WHERE e.game.id = :gameId AND e.inning = :inning AND e.isTopInning = :isTopInning
+        ORDER BY e.eventOrder ASC
+    """)
+    override fun findAllByGameIdAndInningAndIsTopInning(
+        gameId: Long,
+        inning: Int,
+        isTopInning: Boolean
+    ): List<GameEvent>
+
+    @Query("""
+        SELECT e FROM GameEvent e
+        WHERE e.game.id = :gameId AND e.eventType = :eventType
+        ORDER BY e.eventOrder ASC
+    """)
+    override fun findAllByGameIdAndEventType(gameId: Long, eventType: GameEventType): List<GameEvent>
+
+    @Query("""
+        SELECT e FROM GameEvent e
+        WHERE e.game.id = :gameId
+        ORDER BY e.eventOrder DESC
+        LIMIT 1
+    """)
+    override fun findLastEventByGameId(gameId: Long): GameEvent?
+
+    @Query("SELECT COUNT(e) FROM GameEvent e WHERE e.game.id = :gameId")
+    override fun countByGameId(gameId: Long): Long
+
+    @Modifying
+    @Query("DELETE FROM GameEvent e WHERE e.game.id = :gameId")
+    override fun deleteAllByGameId(gameId: Long)
+}


### PR DESCRIPTION
## Summary
- 경기 중 발생하는 모든 이벤트를 저장하는 GameEvent Entity 구현
- 타석 결과, 주루 이벤트, 이벤트 타입 enum 설계

## Changes
### Core 모듈
- `GameEvent` 엔티티: 경기 이벤트 기록용 도메인 모델
- `GameEventType` enum: PLATE_APPEARANCE, BASE_RUNNING, SUBSTITUTION 등
- `PlateAppearanceResult` enum: 안타, 아웃, 출루 등 타석 결과
- `GameEventRepositoryPort` 인터페이스

## Test plan
- [x] `./gradlew build` 성공

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)