### PR TITLE
feat(#55): Phase 2 조회/통계 API 고도화

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -48,23 +48,27 @@ mcp__github__create_pull_request:
 ```markdown
 ## Summary
 
->- Close #[이슈번호]
+>- close #52
 
-[변경 사항 요약]
+Phase 2: 조회/통계 API 고도화 구현
 
 ## Tasks
 
-- [완료한 작업 1]
-- [완료한 작업 2]
+- [x] 경기 타임라인 API 구현
+- [x] 팀 통계 API 구현
+- [x] 선수 기록실 API 구현
 
 ## To Reviewer
 
-[리뷰어에게 전달할 사항]
+- 커버리지: 79% (목표 80%에 1% 부족)
+- 빌드/테스트: ✅ 통과
 
 ## Screenshot
 
-(해당 시 스크린샷 첨부)
+N/A (API 전용)
 ```
+
+> ⚠️ **주의**: Summary의 `>- close #이슈번호` 형식을 정확히 지켜야 이슈가 자동으로 닫힙니다.
 
 ## 사용 예시
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -48,6 +48,29 @@ mcp__github__create_pull_request:
 ```markdown
 ## Summary
 
+>- close #[이슈번호]
+
+[변경 사항 요약]
+
+## Tasks
+
+- [완료한 작업 1]
+- [완료한 작업 2]
+
+## To Reviewer
+
+[리뷰어에게 전달할 사항]
+
+## Screenshot
+
+(해당 시 스크린샷 첨부)
+```
+
+### Example
+
+```markdown
+## Summary
+
 >- close #52
 
 Phase 2: 조회/통계 API 고도화 구현
@@ -56,11 +79,10 @@ Phase 2: 조회/통계 API 고도화 구현
 
 - [x] 경기 타임라인 API 구현
 - [x] 팀 통계 API 구현
-- [x] 선수 기록실 API 구현
 
 ## To Reviewer
 
-- 커버리지: 79% (목표 80%에 1% 부족)
+- 커버리지: 79%
 - 빌드/테스트: ✅ 통과
 
 ## Screenshot

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -27,7 +27,7 @@ git push -u origin [branch-name]
 mcp__github__create_pull_request:
   owner: nextup-dugout
   repo: next-up-server
-  title: [브랜치명 그대로]
+  title: [타입(#이슈번호): 간단한 설명]
   body: [PR 템플릿]
   head: [feature-branch]
   base: develop
@@ -35,12 +35,13 @@ mcp__github__create_pull_request:
 
 ## PR Title Rule
 
-**PR 제목 = 브랜치명 그대로**
+**PR 제목 = `타입(#이슈번호): 간단한 설명`**
 
 | 브랜치 | PR 제목 |
 |--------|---------|
-| `feat/#1-user-auth` | `feat/#1-user-auth` |
-| `fix/#2-login-error` | `fix/#2-login-error` |
+| `feat/#1-user-auth` | `feat(#1): 사용자 인증 기능 구현` |
+| `fix/#2-login-error` | `fix(#2): 로그인 오류 수정` |
+| `feat/#54-box-score` | `feat(#54): 박스스코어 자동 계산 및 Exception 개선` |
 
 ## PR Template
 
@@ -87,7 +88,7 @@ PR 생성을 시작합니다...
 
 ## PR Created Successfully
 
-- **Title**: feat/#5-agent-skill-refactoring
+- **Title**: feat(#5): Agent/Skill 구조 리팩토링
 - **URL**: https://github.com/nextup-dugout/next-up-server/pull/6
 - **Base**: develop
 - **Head**: feat/#5-agent-skill-refactoring

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ out/
 .mcp.json
 /.omc
 .omc/
+/docs

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/GameTimelineController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/GameTimelineController.kt
@@ -1,0 +1,40 @@
+package com.nextup.api.controller.game
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.game.GameTimelineResponse
+import com.nextup.api.mapper.game.toResponse
+import com.nextup.core.service.game.GameTimelineService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 경기 타임라인 API 컨트롤러
+ *
+ * 경기의 이벤트 타임라인(문자 중계 다시보기)을 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/games/{gameId}/timeline")
+class GameTimelineController(
+    private val gameTimelineService: GameTimelineService,
+) {
+    /**
+     * 경기의 타임라인을 조회합니다.
+     *
+     * @param gameId 경기 ID
+     * @param fromInning 시작 이닝 (선택)
+     * @param toInning 종료 이닝 (선택)
+     * @return 경기 타임라인 응답
+     */
+    @GetMapping
+    fun getTimeline(
+        @PathVariable gameId: Long,
+        @RequestParam(required = false) fromInning: Int?,
+        @RequestParam(required = false) toInning: Int?,
+    ): ApiResponse<GameTimelineResponse> {
+        val timeline = gameTimelineService.getTimeline(gameId, fromInning, toInning)
+        return ApiResponse.success(timeline.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/GameTimelineController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/GameTimelineController.kt
@@ -4,6 +4,9 @@ import com.nextup.api.dto.common.ApiResponse
 import com.nextup.api.dto.game.GameTimelineResponse
 import com.nextup.api.mapper.game.toResponse
 import com.nextup.core.service.game.GameTimelineService
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController
  *
  * 경기의 이벤트 타임라인(문자 중계 다시보기)을 제공합니다.
  */
+@Validated
 @RestController
 @RequestMapping("/api/v1/games/{gameId}/timeline")
 class GameTimelineController(
@@ -24,15 +28,15 @@ class GameTimelineController(
      * 경기의 타임라인을 조회합니다.
      *
      * @param gameId 경기 ID
-     * @param fromInning 시작 이닝 (선택)
-     * @param toInning 종료 이닝 (선택)
+     * @param fromInning 시작 이닝 (선택, 1-99)
+     * @param toInning 종료 이닝 (선택, 1-99)
      * @return 경기 타임라인 응답
      */
     @GetMapping
     fun getTimeline(
         @PathVariable gameId: Long,
-        @RequestParam(required = false) fromInning: Int?,
-        @RequestParam(required = false) toInning: Int?,
+        @RequestParam(required = false) @Min(1) @Max(99) fromInning: Int?,
+        @RequestParam(required = false) @Min(1) @Max(99) toInning: Int?,
     ): ApiResponse<GameTimelineResponse> {
         val timeline = gameTimelineService.getTimeline(gameId, fromInning, toInning)
         return ApiResponse.success(timeline.toResponse())

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/MatchupController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/MatchupController.kt
@@ -4,6 +4,9 @@ import com.nextup.api.dto.common.ApiResponse
 import com.nextup.api.dto.stats.MatchupResponse
 import com.nextup.api.mapper.stats.toResponse
 import com.nextup.core.service.stats.MatchupService
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
  * 투수와 타자의 대결 기록을 조회합니다.
  * 모든 응답은 ApiResponse로 래핑됩니다.
  */
+@Validated
 @RestController
 @RequestMapping("/api/v1/matchups")
 class MatchupController(
@@ -36,7 +40,7 @@ class MatchupController(
     fun getMatchup(
         @PathVariable pitcherId: Long,
         @PathVariable batterId: Long,
-        @RequestParam(required = false) year: Int?,
+        @RequestParam(required = false) @Min(1900) @Max(2100) year: Int?,
         @RequestParam(required = false) competitionId: Long?,
     ): ApiResponse<MatchupResponse> {
         val matchup = matchupService.getMatchup(pitcherId, batterId, year, competitionId)

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/MatchupController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/MatchupController.kt
@@ -1,0 +1,45 @@
+package com.nextup.api.controller.stats
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.stats.MatchupResponse
+import com.nextup.api.mapper.stats.toResponse
+import com.nextup.core.service.stats.MatchupService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 투수 vs 타자 매치업 통계 API
+ *
+ * 투수와 타자의 대결 기록을 조회합니다.
+ * 모든 응답은 ApiResponse로 래핑됩니다.
+ */
+@RestController
+@RequestMapping("/api/v1/matchups")
+class MatchupController(
+    private val matchupService: MatchupService,
+) {
+    /**
+     * 투수 vs 타자 매치업 기록 조회
+     *
+     * GET /api/v1/matchups/pitcher/{pitcherId}/batter/{batterId}
+     *
+     * @param pitcherId 투수 ID
+     * @param batterId 타자 ID
+     * @param year 시즌 연도 (선택)
+     * @param competitionId 대회 ID (선택, 추후 구현)
+     * @return 매치업 통계 및 히스토리
+     */
+    @GetMapping("/pitcher/{pitcherId}/batter/{batterId}")
+    fun getMatchup(
+        @PathVariable pitcherId: Long,
+        @PathVariable batterId: Long,
+        @RequestParam(required = false) year: Int?,
+        @RequestParam(required = false) competitionId: Long?,
+    ): ApiResponse<MatchupResponse> {
+        val matchup = matchupService.getMatchup(pitcherId, batterId, year, competitionId)
+        return ApiResponse.success(matchup.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/PlayerRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/PlayerRecordController.kt
@@ -2,10 +2,16 @@ package com.nextup.api.controller.stats
 
 import com.nextup.api.dto.common.ApiResponse
 import com.nextup.api.dto.stats.PlayerRecordResponse
+import com.nextup.api.dto.stats.RecentFormResponse
 import com.nextup.api.mapper.stats.toResponse
 import com.nextup.core.service.stats.PlayerRecordService
+import com.nextup.core.service.stats.RecentFormService
+import com.nextup.core.service.stats.dto.FormType
 import com.nextup.core.service.stats.dto.RecordScope
 import com.nextup.core.service.stats.dto.RecordType
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,10 +23,12 @@ import org.springframework.web.bind.annotation.RestController
  *
  * 선수의 타격/투수 기록을 조회하는 API를 제공합니다.
  */
+@Validated
 @RestController
 @RequestMapping("/api/v1/players/{playerId}/records")
 class PlayerRecordController(
     private val playerRecordService: PlayerRecordService,
+    private val recentFormService: RecentFormService,
 ) {
     /**
      * 선수 기록을 조회합니다.
@@ -42,5 +50,23 @@ class PlayerRecordController(
     ): ApiResponse<PlayerRecordResponse> {
         val record = playerRecordService.getPlayerRecord(playerId, scope, type, year, competitionId)
         return ApiResponse.success(record.toResponse())
+    }
+
+    /**
+     * 선수의 최근 N경기 폼을 조회합니다.
+     *
+     * @param playerId 선수 ID
+     * @param games 조회할 경기 수 (기본값: 5, 최대: 20)
+     * @param type 조회 타입 (BATTING, PITCHING)
+     * @return 최근 폼 분석 응답
+     */
+    @GetMapping("/form")
+    fun getRecentForm(
+        @PathVariable playerId: Long,
+        @RequestParam(defaultValue = "5") @Min(1) @Max(20) games: Int,
+        @RequestParam(defaultValue = "BATTING") type: FormType,
+    ): ApiResponse<RecentFormResponse> {
+        val form = recentFormService.getRecentForm(playerId, games, type)
+        return ApiResponse.success(form.toResponse())
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/PlayerRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/PlayerRecordController.kt
@@ -1,0 +1,46 @@
+package com.nextup.api.controller.stats
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.stats.PlayerRecordResponse
+import com.nextup.api.mapper.stats.toResponse
+import com.nextup.core.service.stats.PlayerRecordService
+import com.nextup.core.service.stats.dto.RecordScope
+import com.nextup.core.service.stats.dto.RecordType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 선수 기록 컨트롤러
+ *
+ * 선수의 타격/투수 기록을 조회하는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/players/{playerId}/records")
+class PlayerRecordController(
+    private val playerRecordService: PlayerRecordService,
+) {
+    /**
+     * 선수 기록을 조회합니다.
+     *
+     * @param playerId 선수 ID
+     * @param scope 조회 범위 (SEASON, CAREER, COMPETITION)
+     * @param type 조회 타입 (BATTING, PITCHING, ALL)
+     * @param year 시즌 연도 (scope=SEASON일 때 사용, 미지정 시 현재 연도)
+     * @param competitionId 대회 ID (scope=COMPETITION일 때 필수)
+     * @return 선수 기록 응답
+     */
+    @GetMapping
+    fun getPlayerRecord(
+        @PathVariable playerId: Long,
+        @RequestParam(defaultValue = "CAREER") scope: RecordScope,
+        @RequestParam(defaultValue = "ALL") type: RecordType,
+        @RequestParam(required = false) year: Int?,
+        @RequestParam(required = false) competitionId: Long?,
+    ): ApiResponse<PlayerRecordResponse> {
+        val record = playerRecordService.getPlayerRecord(playerId, scope, type, year, competitionId)
+        return ApiResponse.success(record.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/TeamStatsController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/TeamStatsController.kt
@@ -4,21 +4,38 @@ import com.nextup.api.dto.common.ApiResponse
 import com.nextup.api.dto.stats.TeamStatsResponse
 import com.nextup.api.mapper.stats.toResponse
 import com.nextup.core.service.stats.TeamStatsService
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 팀 통계 API 컨트롤러
+ *
+ * 팀의 경기 성적, 타격/투수 통계를 제공합니다.
+ */
+@Validated
 @RestController
 @RequestMapping("/api/v1/teams/{teamId}/stats")
 class TeamStatsController(
     private val teamStatsService: TeamStatsService,
 ) {
+    /**
+     * 팀 통계를 조회합니다.
+     *
+     * @param teamId 팀 ID
+     * @param year 시즌 연도 (선택, 1900-2100)
+     * @param competitionId 대회 ID (선택)
+     * @return 팀 통계 응답
+     */
     @GetMapping
     fun getTeamStats(
         @PathVariable teamId: Long,
-        @RequestParam(required = false) year: Int?,
+        @RequestParam(required = false) @Min(1900) @Max(2100) year: Int?,
         @RequestParam(required = false) competitionId: Long?,
     ): ApiResponse<TeamStatsResponse> {
         val stats = teamStatsService.getTeamStats(teamId, year, competitionId)

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/TeamStatsController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/TeamStatsController.kt
@@ -1,0 +1,27 @@
+package com.nextup.api.controller.stats
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.stats.TeamStatsResponse
+import com.nextup.api.mapper.stats.toResponse
+import com.nextup.core.service.stats.TeamStatsService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/teams/{teamId}/stats")
+class TeamStatsController(
+    private val teamStatsService: TeamStatsService,
+) {
+    @GetMapping
+    fun getTeamStats(
+        @PathVariable teamId: Long,
+        @RequestParam(required = false) year: Int?,
+        @RequestParam(required = false) competitionId: Long?,
+    ): ApiResponse<TeamStatsResponse> {
+        val stats = teamStatsService.getTeamStats(teamId, year, competitionId)
+        return ApiResponse.success(stats.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/GameTimelineResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/GameTimelineResponse.kt
@@ -1,0 +1,33 @@
+package com.nextup.api.dto.game
+
+import java.time.Instant
+
+/**
+ * 경기 타임라인 응답 DTO
+ */
+data class GameTimelineResponse(
+    val gameId: Long,
+    val events: List<TimelineEventResponse>,
+    val totalEvents: Int,
+)
+
+/**
+ * 타임라인 이벤트 응답 DTO
+ */
+data class TimelineEventResponse(
+    val eventId: Long,
+    val inning: Int,
+    val isTopInning: Boolean,
+    val inningDisplay: String,
+    val eventType: String,
+    val description: String,
+    val batterId: Long?,
+    val batterName: String?,
+    val pitcherId: Long?,
+    val pitcherName: String?,
+    val plateAppearanceResult: String?,
+    val runsScored: Int,
+    val outCountBefore: Int,
+    val outCountAfter: Int,
+    val eventTimestamp: Instant,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/MatchupResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/MatchupResponse.kt
@@ -1,0 +1,37 @@
+package com.nextup.api.dto.stats
+
+import java.math.BigDecimal
+
+data class MatchupResponse(
+    val pitcherId: Long,
+    val pitcherName: String,
+    val batterId: Long,
+    val batterName: String,
+    val year: Int?,
+    val stats: MatchupStatsResponse,
+    val history: List<MatchupHistoryResponse>,
+)
+
+data class MatchupStatsResponse(
+    val plateAppearances: Int,
+    val atBats: Int,
+    val hits: Int,
+    val doubles: Int,
+    val triples: Int,
+    val homeRuns: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val hitByPitch: Int,
+    val sacrificeFlies: Int,
+    val runsBattedIn: Int,
+    val battingAverage: BigDecimal,
+    val onBasePercentage: BigDecimal,
+    val sluggingPercentage: BigDecimal,
+)
+
+data class MatchupHistoryResponse(
+    val gameId: Long,
+    val gameDate: String,
+    val result: String,
+    val description: String,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/PlayerRecordResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/PlayerRecordResponse.kt
@@ -1,0 +1,62 @@
+package com.nextup.api.dto.stats
+
+import com.nextup.core.service.stats.dto.RecordScope
+import com.nextup.core.service.stats.dto.RecordType
+import java.math.BigDecimal
+
+/**
+ * 선수 기록 응답 DTO
+ */
+data class PlayerRecordResponse(
+    val playerId: Long,
+    val playerName: String,
+    val scope: RecordScope,
+    val type: RecordType,
+    val year: Int?,
+    val competitionId: Long?,
+    val competitionName: String?,
+    val battingStats: BattingStatsResponse?,
+    val pitchingStats: PitchingStatsResponse?,
+)
+
+/**
+ * 타격 통계 응답 DTO
+ */
+data class BattingStatsResponse(
+    val gamesPlayed: Int,
+    val plateAppearances: Int,
+    val atBats: Int,
+    val hits: Int,
+    val doubles: Int,
+    val triples: Int,
+    val homeRuns: Int,
+    val runs: Int,
+    val runsBattedIn: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val stolenBases: Int,
+    val battingAverage: BigDecimal,
+    val onBasePercentage: BigDecimal,
+    val sluggingPercentage: BigDecimal,
+    val ops: BigDecimal,
+)
+
+/**
+ * 투수 통계 응답 DTO
+ */
+data class PitchingStatsResponse(
+    val gamesPlayed: Int,
+    val gamesStarted: Int,
+    val inningsPitched: String,
+    val wins: Int,
+    val losses: Int,
+    val saves: Int,
+    val holds: Int,
+    val earnedRuns: Int,
+    val hitsAllowed: Int,
+    val walksAllowed: Int,
+    val strikeouts: Int,
+    val homeRunsAllowed: Int,
+    val era: BigDecimal,
+    val whip: BigDecimal,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/RecentFormResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/RecentFormResponse.kt
@@ -1,0 +1,93 @@
+package com.nextup.api.dto.stats
+
+import java.math.BigDecimal
+
+/**
+ * 최근 N경기 폼 분석 응답
+ */
+data class RecentFormResponse(
+    val playerId: Long,
+    val playerName: String,
+    val type: FormTypeResponse,
+    val gamesRequested: Int,
+    val gamesFound: Int,
+    val trend: FormTrendResponse,
+    val trendDescription: String,
+    val batting: RecentBattingFormResponse?,
+    val pitching: RecentPitchingFormResponse?,
+)
+
+/**
+ * 폼 분석 타입 응답
+ */
+enum class FormTypeResponse {
+    BATTING,
+    PITCHING,
+}
+
+/**
+ * 폼 트렌드 응답
+ */
+enum class FormTrendResponse {
+    UP,
+    DOWN,
+    STABLE,
+}
+
+/**
+ * 최근 타격 폼 응답
+ */
+data class RecentBattingFormResponse(
+    val games: List<GameBattingResponse>,
+    val totalAtBats: Int,
+    val totalHits: Int,
+    val totalHomeRuns: Int,
+    val totalRbis: Int,
+    val totalRuns: Int,
+    val recentAverage: BigDecimal,
+    val overallAverage: BigDecimal?,
+)
+
+/**
+ * 경기별 타격 기록 응답
+ */
+data class GameBattingResponse(
+    val gameId: Long,
+    val gameDate: String,
+    val opponentName: String,
+    val atBats: Int,
+    val hits: Int,
+    val homeRuns: Int,
+    val rbis: Int,
+    val runs: Int,
+    val walks: Int,
+    val strikeouts: Int,
+)
+
+/**
+ * 최근 투수 폼 응답
+ */
+data class RecentPitchingFormResponse(
+    val games: List<GamePitchingResponse>,
+    val totalInningsPitchedOuts: Int,
+    val inningsPitchedDisplay: String,
+    val totalEarnedRuns: Int,
+    val totalStrikeouts: Int,
+    val recentEra: BigDecimal,
+    val overallEra: BigDecimal?,
+)
+
+/**
+ * 경기별 투수 기록 응답
+ */
+data class GamePitchingResponse(
+    val gameId: Long,
+    val gameDate: String,
+    val opponentName: String,
+    val inningsPitched: String,
+    val earnedRuns: Int,
+    val strikeouts: Int,
+    val walksAllowed: Int,
+    val hitsAllowed: Int,
+    val decision: String?,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/TeamStatsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/TeamStatsResponse.kt
@@ -1,0 +1,43 @@
+package com.nextup.api.dto.stats
+
+import java.math.BigDecimal
+
+data class TeamStatsResponse(
+    val teamId: Long,
+    val teamName: String,
+    val year: Int?,
+    val competitionId: Long?,
+    val competitionName: String?,
+    val record: TeamRecordResponse,
+    val batting: TeamBattingStatsResponse,
+    val pitching: TeamPitchingStatsResponse,
+)
+
+data class TeamRecordResponse(
+    val gamesPlayed: Int,
+    val wins: Int,
+    val losses: Int,
+    val draws: Int,
+    val winningPercentage: BigDecimal, // 승률 (승 / (승 + 패))
+)
+
+data class TeamBattingStatsResponse(
+    val totalAtBats: Int,
+    val totalHits: Int,
+    val totalHomeRuns: Int,
+    val totalRunsBattedIn: Int,
+    val totalRuns: Int,
+    val teamBattingAverage: BigDecimal, // 팀 타율
+    val teamOnBasePercentage: BigDecimal, // 팀 출루율
+    val teamSluggingPercentage: BigDecimal, // 팀 장타율
+)
+
+data class TeamPitchingStatsResponse(
+    val totalInningsPitchedOuts: Int,
+    val inningsPitchedDisplay: String, // "150.2" 형식
+    val totalEarnedRuns: Int,
+    val totalStrikeouts: Int,
+    val totalWalksAllowed: Int,
+    val teamEra: BigDecimal, // 팀 방어율
+    val teamWhip: BigDecimal, // 팀 WHIP
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/GameTimelineMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/GameTimelineMapper.kt
@@ -1,0 +1,38 @@
+package com.nextup.api.mapper.game
+
+import com.nextup.api.dto.game.GameTimelineResponse
+import com.nextup.api.dto.game.TimelineEventResponse
+import com.nextup.core.service.game.dto.GameTimelineDto
+import com.nextup.core.service.game.dto.TimelineEventDto
+
+/**
+ * GameTimelineDto를 GameTimelineResponse로 변환합니다.
+ */
+fun GameTimelineDto.toResponse(): GameTimelineResponse =
+    GameTimelineResponse(
+        gameId = gameId,
+        events = events.map { it.toResponse() },
+        totalEvents = totalEvents,
+    )
+
+/**
+ * TimelineEventDto를 TimelineEventResponse로 변환합니다.
+ */
+fun TimelineEventDto.toResponse(): TimelineEventResponse =
+    TimelineEventResponse(
+        eventId = eventId,
+        inning = inning,
+        isTopInning = isTopInning,
+        inningDisplay = inningDisplay,
+        eventType = eventType,
+        description = description,
+        batterId = batterId,
+        batterName = batterName,
+        pitcherId = pitcherId,
+        pitcherName = pitcherName,
+        plateAppearanceResult = plateAppearanceResult,
+        runsScored = runsScored,
+        outCountBefore = outCountBefore,
+        outCountAfter = outCountAfter,
+        eventTimestamp = eventTimestamp,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/MatchupMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/MatchupMapper.kt
@@ -1,0 +1,45 @@
+package com.nextup.api.mapper.stats
+
+import com.nextup.api.dto.stats.MatchupHistoryResponse
+import com.nextup.api.dto.stats.MatchupResponse
+import com.nextup.api.dto.stats.MatchupStatsResponse
+import com.nextup.core.service.stats.dto.MatchupDto
+import com.nextup.core.service.stats.dto.MatchupHistoryDto
+import com.nextup.core.service.stats.dto.MatchupStatsDto
+
+fun MatchupDto.toResponse(): MatchupResponse =
+    MatchupResponse(
+        pitcherId = pitcherId,
+        pitcherName = pitcherName,
+        batterId = batterId,
+        batterName = batterName,
+        year = year,
+        stats = stats.toResponse(),
+        history = history.map { it.toResponse() },
+    )
+
+fun MatchupStatsDto.toResponse(): MatchupStatsResponse =
+    MatchupStatsResponse(
+        plateAppearances = plateAppearances,
+        atBats = atBats,
+        hits = hits,
+        doubles = doubles,
+        triples = triples,
+        homeRuns = homeRuns,
+        walks = walks,
+        strikeouts = strikeouts,
+        hitByPitch = hitByPitch,
+        sacrificeFlies = sacrificeFlies,
+        runsBattedIn = runsBattedIn,
+        battingAverage = battingAverage,
+        onBasePercentage = onBasePercentage,
+        sluggingPercentage = sluggingPercentage,
+    )
+
+fun MatchupHistoryDto.toResponse(): MatchupHistoryResponse =
+    MatchupHistoryResponse(
+        gameId = gameId,
+        gameDate = gameDate,
+        result = result,
+        description = description,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/PlayerRecordMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/PlayerRecordMapper.kt
@@ -1,0 +1,68 @@
+package com.nextup.api.mapper.stats
+
+import com.nextup.api.dto.stats.BattingStatsResponse
+import com.nextup.api.dto.stats.PitchingStatsResponse
+import com.nextup.api.dto.stats.PlayerRecordResponse
+import com.nextup.core.service.stats.dto.BattingStatsDto
+import com.nextup.core.service.stats.dto.PitchingStatsDto
+import com.nextup.core.service.stats.dto.PlayerRecordDto
+
+/**
+ * PlayerRecordDto를 PlayerRecordResponse로 변환합니다.
+ */
+fun PlayerRecordDto.toResponse(): PlayerRecordResponse =
+    PlayerRecordResponse(
+        playerId = this.playerId,
+        playerName = this.playerName,
+        scope = this.scope,
+        type = this.type,
+        year = this.year,
+        competitionId = this.competitionId,
+        competitionName = this.competitionName,
+        battingStats = this.battingStats?.toResponse(),
+        pitchingStats = this.pitchingStats?.toResponse(),
+    )
+
+/**
+ * BattingStatsDto를 BattingStatsResponse로 변환합니다.
+ */
+fun BattingStatsDto.toResponse(): BattingStatsResponse =
+    BattingStatsResponse(
+        gamesPlayed = this.gamesPlayed,
+        plateAppearances = this.plateAppearances,
+        atBats = this.atBats,
+        hits = this.hits,
+        doubles = this.doubles,
+        triples = this.triples,
+        homeRuns = this.homeRuns,
+        runs = this.runs,
+        runsBattedIn = this.runsBattedIn,
+        walks = this.walks,
+        strikeouts = this.strikeouts,
+        stolenBases = this.stolenBases,
+        battingAverage = this.battingAverage,
+        onBasePercentage = this.onBasePercentage,
+        sluggingPercentage = this.sluggingPercentage,
+        ops = this.ops,
+    )
+
+/**
+ * PitchingStatsDto를 PitchingStatsResponse로 변환합니다.
+ */
+fun PitchingStatsDto.toResponse(): PitchingStatsResponse =
+    PitchingStatsResponse(
+        gamesPlayed = this.gamesPlayed,
+        gamesStarted = this.gamesStarted,
+        inningsPitched = this.inningsPitched,
+        wins = this.wins,
+        losses = this.losses,
+        saves = this.saves,
+        holds = this.holds,
+        earnedRuns = this.earnedRuns,
+        hitsAllowed = this.hitsAllowed,
+        walksAllowed = this.walksAllowed,
+        strikeouts = this.strikeouts,
+        homeRunsAllowed = this.homeRunsAllowed,
+        era = this.era,
+        whip = this.whip,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/PlayerRecordMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/PlayerRecordMapper.kt
@@ -12,15 +12,15 @@ import com.nextup.core.service.stats.dto.PlayerRecordDto
  */
 fun PlayerRecordDto.toResponse(): PlayerRecordResponse =
     PlayerRecordResponse(
-        playerId = this.playerId,
-        playerName = this.playerName,
-        scope = this.scope,
-        type = this.type,
-        year = this.year,
-        competitionId = this.competitionId,
-        competitionName = this.competitionName,
-        battingStats = this.battingStats?.toResponse(),
-        pitchingStats = this.pitchingStats?.toResponse(),
+        playerId = playerId,
+        playerName = playerName,
+        scope = scope,
+        type = type,
+        year = year,
+        competitionId = competitionId,
+        competitionName = competitionName,
+        battingStats = battingStats?.toResponse(),
+        pitchingStats = pitchingStats?.toResponse(),
     )
 
 /**
@@ -28,22 +28,22 @@ fun PlayerRecordDto.toResponse(): PlayerRecordResponse =
  */
 fun BattingStatsDto.toResponse(): BattingStatsResponse =
     BattingStatsResponse(
-        gamesPlayed = this.gamesPlayed,
-        plateAppearances = this.plateAppearances,
-        atBats = this.atBats,
-        hits = this.hits,
-        doubles = this.doubles,
-        triples = this.triples,
-        homeRuns = this.homeRuns,
-        runs = this.runs,
-        runsBattedIn = this.runsBattedIn,
-        walks = this.walks,
-        strikeouts = this.strikeouts,
-        stolenBases = this.stolenBases,
-        battingAverage = this.battingAverage,
-        onBasePercentage = this.onBasePercentage,
-        sluggingPercentage = this.sluggingPercentage,
-        ops = this.ops,
+        gamesPlayed = gamesPlayed,
+        plateAppearances = plateAppearances,
+        atBats = atBats,
+        hits = hits,
+        doubles = doubles,
+        triples = triples,
+        homeRuns = homeRuns,
+        runs = runs,
+        runsBattedIn = runsBattedIn,
+        walks = walks,
+        strikeouts = strikeouts,
+        stolenBases = stolenBases,
+        battingAverage = battingAverage,
+        onBasePercentage = onBasePercentage,
+        sluggingPercentage = sluggingPercentage,
+        ops = ops,
     )
 
 /**
@@ -51,18 +51,18 @@ fun BattingStatsDto.toResponse(): BattingStatsResponse =
  */
 fun PitchingStatsDto.toResponse(): PitchingStatsResponse =
     PitchingStatsResponse(
-        gamesPlayed = this.gamesPlayed,
-        gamesStarted = this.gamesStarted,
-        inningsPitched = this.inningsPitched,
-        wins = this.wins,
-        losses = this.losses,
-        saves = this.saves,
-        holds = this.holds,
-        earnedRuns = this.earnedRuns,
-        hitsAllowed = this.hitsAllowed,
-        walksAllowed = this.walksAllowed,
-        strikeouts = this.strikeouts,
-        homeRunsAllowed = this.homeRunsAllowed,
-        era = this.era,
-        whip = this.whip,
+        gamesPlayed = gamesPlayed,
+        gamesStarted = gamesStarted,
+        inningsPitched = inningsPitched,
+        wins = wins,
+        losses = losses,
+        saves = saves,
+        holds = holds,
+        earnedRuns = earnedRuns,
+        hitsAllowed = hitsAllowed,
+        walksAllowed = walksAllowed,
+        strikeouts = strikeouts,
+        homeRunsAllowed = homeRunsAllowed,
+        era = era,
+        whip = whip,
     )

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/RecentFormMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/RecentFormMapper.kt
@@ -1,0 +1,101 @@
+package com.nextup.api.mapper.stats
+
+import com.nextup.api.dto.stats.*
+import com.nextup.core.service.stats.dto.*
+
+/**
+ * RecentFormDto → RecentFormResponse 변환
+ */
+fun RecentFormDto.toResponse(): RecentFormResponse =
+    RecentFormResponse(
+        playerId = playerId,
+        playerName = playerName,
+        type = type.toResponse(),
+        gamesRequested = gamesRequested,
+        gamesFound = gamesFound,
+        trend = trend.toResponse(),
+        trendDescription = trendDescription,
+        batting = batting?.toResponse(),
+        pitching = pitching?.toResponse(),
+    )
+
+/**
+ * FormType → FormTypeResponse 변환
+ */
+fun FormType.toResponse(): FormTypeResponse =
+    when (this) {
+        FormType.BATTING -> FormTypeResponse.BATTING
+        FormType.PITCHING -> FormTypeResponse.PITCHING
+    }
+
+/**
+ * FormTrend → FormTrendResponse 변환
+ */
+fun FormTrend.toResponse(): FormTrendResponse =
+    when (this) {
+        FormTrend.UP -> FormTrendResponse.UP
+        FormTrend.DOWN -> FormTrendResponse.DOWN
+        FormTrend.STABLE -> FormTrendResponse.STABLE
+    }
+
+/**
+ * RecentBattingFormDto → RecentBattingFormResponse 변환
+ */
+fun RecentBattingFormDto.toResponse(): RecentBattingFormResponse =
+    RecentBattingFormResponse(
+        games = games.map { it.toResponse() },
+        totalAtBats = totalAtBats,
+        totalHits = totalHits,
+        totalHomeRuns = totalHomeRuns,
+        totalRbis = totalRbis,
+        totalRuns = totalRuns,
+        recentAverage = recentAverage,
+        overallAverage = overallAverage,
+    )
+
+/**
+ * GameBattingDto → GameBattingResponse 변환
+ */
+fun GameBattingDto.toResponse(): GameBattingResponse =
+    GameBattingResponse(
+        gameId = gameId,
+        gameDate = gameDate,
+        opponentName = opponentName,
+        atBats = atBats,
+        hits = hits,
+        homeRuns = homeRuns,
+        rbis = rbis,
+        runs = runs,
+        walks = walks,
+        strikeouts = strikeouts,
+    )
+
+/**
+ * RecentPitchingFormDto → RecentPitchingFormResponse 변환
+ */
+fun RecentPitchingFormDto.toResponse(): RecentPitchingFormResponse =
+    RecentPitchingFormResponse(
+        games = games.map { it.toResponse() },
+        totalInningsPitchedOuts = totalInningsPitchedOuts,
+        inningsPitchedDisplay = inningsPitchedDisplay,
+        totalEarnedRuns = totalEarnedRuns,
+        totalStrikeouts = totalStrikeouts,
+        recentEra = recentEra,
+        overallEra = overallEra,
+    )
+
+/**
+ * GamePitchingDto → GamePitchingResponse 변환
+ */
+fun GamePitchingDto.toResponse(): GamePitchingResponse =
+    GamePitchingResponse(
+        gameId = gameId,
+        gameDate = gameDate,
+        opponentName = opponentName,
+        inningsPitched = inningsPitched,
+        earnedRuns = earnedRuns,
+        strikeouts = strikeouts,
+        walksAllowed = walksAllowed,
+        hitsAllowed = hitsAllowed,
+        decision = decision,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/TeamStatsMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/TeamStatsMapper.kt
@@ -1,0 +1,54 @@
+package com.nextup.api.mapper.stats
+
+import com.nextup.api.dto.stats.TeamBattingStatsResponse
+import com.nextup.api.dto.stats.TeamPitchingStatsResponse
+import com.nextup.api.dto.stats.TeamRecordResponse
+import com.nextup.api.dto.stats.TeamStatsResponse
+import com.nextup.core.service.stats.dto.TeamBattingStatsDto
+import com.nextup.core.service.stats.dto.TeamPitchingStatsDto
+import com.nextup.core.service.stats.dto.TeamRecordDto
+import com.nextup.core.service.stats.dto.TeamStatsDto
+
+fun TeamStatsDto.toResponse(): TeamStatsResponse =
+    TeamStatsResponse(
+        teamId = teamId,
+        teamName = teamName,
+        year = year,
+        competitionId = competitionId,
+        competitionName = competitionName,
+        record = record.toResponse(),
+        batting = batting.toResponse(),
+        pitching = pitching.toResponse(),
+    )
+
+fun TeamRecordDto.toResponse(): TeamRecordResponse =
+    TeamRecordResponse(
+        gamesPlayed = gamesPlayed,
+        wins = wins,
+        losses = losses,
+        draws = draws,
+        winningPercentage = winningPercentage,
+    )
+
+fun TeamBattingStatsDto.toResponse(): TeamBattingStatsResponse =
+    TeamBattingStatsResponse(
+        totalAtBats = totalAtBats,
+        totalHits = totalHits,
+        totalHomeRuns = totalHomeRuns,
+        totalRunsBattedIn = totalRunsBattedIn,
+        totalRuns = totalRuns,
+        teamBattingAverage = teamBattingAverage,
+        teamOnBasePercentage = teamOnBasePercentage,
+        teamSluggingPercentage = teamSluggingPercentage,
+    )
+
+fun TeamPitchingStatsDto.toResponse(): TeamPitchingStatsResponse =
+    TeamPitchingStatsResponse(
+        totalInningsPitchedOuts = totalInningsPitchedOuts,
+        inningsPitchedDisplay = inningsPitchedDisplay,
+        totalEarnedRuns = totalEarnedRuns,
+        totalStrikeouts = totalStrikeouts,
+        totalWalksAllowed = totalWalksAllowed,
+        teamEra = teamEra,
+        teamWhip = teamWhip,
+    )

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/GameTimelineControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/GameTimelineControllerTest.kt
@@ -1,0 +1,187 @@
+package com.nextup.api.controller.game
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.core.service.game.GameTimelineService
+import com.nextup.core.service.game.dto.GameTimelineDto
+import com.nextup.core.service.game.dto.TimelineEventDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+
+@DisplayName("GameTimelineController 테스트")
+class GameTimelineControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var gameTimelineService: GameTimelineService
+
+    @BeforeEach
+    fun setUp() {
+        gameTimelineService = mockk()
+
+        val controller = GameTimelineController(gameTimelineService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/games/{gameId}/timeline")
+    inner class GetTimeline {
+        @Test
+        fun `경기 타임라인을 정상적으로 조회한다`() {
+            // given
+            val gameId = 1L
+            val timelineDto =
+                GameTimelineDto(
+                    gameId = gameId,
+                    events =
+                        listOf(
+                            TimelineEventDto(
+                                eventId = 1L,
+                                inning = 1,
+                                isTopInning = true,
+                                inningDisplay = "1회초",
+                                eventType = "PLATE_APPEARANCE",
+                                description = "홍길동 안타",
+                                batterId = 100L,
+                                batterName = "홍길동",
+                                pitcherId = 200L,
+                                pitcherName = "김철수",
+                                plateAppearanceResult = "SINGLE",
+                                runsScored = 0,
+                                outCountBefore = 0,
+                                outCountAfter = 0,
+                                eventTimestamp = Instant.parse("2026-01-01T10:00:00Z"),
+                            ),
+                        ),
+                    totalEvents = 1,
+                )
+
+            every { gameTimelineService.getTimeline(gameId, null, null) } returns timelineDto
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/games/$gameId/timeline"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.gameId").value(gameId))
+                .andExpect(jsonPath("$.data.totalEvents").value(1))
+                .andExpect(jsonPath("$.data.events[0].eventId").value(1))
+                .andExpect(jsonPath("$.data.events[0].inningDisplay").value("1회초"))
+                .andExpect(jsonPath("$.data.events[0].description").value("홍길동 안타"))
+        }
+
+        @Test
+        fun `이닝 필터로 타임라인을 조회한다`() {
+            // given
+            val gameId = 1L
+            val fromInning = 3
+            val toInning = 5
+            val timelineDto =
+                GameTimelineDto(
+                    gameId = gameId,
+                    events =
+                        listOf(
+                            TimelineEventDto(
+                                eventId = 10L,
+                                inning = 3,
+                                isTopInning = true,
+                                inningDisplay = "3회초",
+                                eventType = "PLATE_APPEARANCE",
+                                description = "3회초 첫 타석",
+                                batterId = 100L,
+                                batterName = "타자A",
+                                pitcherId = 200L,
+                                pitcherName = "투수B",
+                                plateAppearanceResult = "OUT",
+                                runsScored = 0,
+                                outCountBefore = 0,
+                                outCountAfter = 1,
+                                eventTimestamp = Instant.parse("2026-01-01T10:30:00Z"),
+                            ),
+                        ),
+                    totalEvents = 1,
+                )
+
+            every { gameTimelineService.getTimeline(gameId, fromInning, toInning) } returns timelineDto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/games/$gameId/timeline")
+                        .param("fromInning", fromInning.toString())
+                        .param("toInning", toInning.toString()),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.events[0].inning").value(3))
+        }
+
+        @Test
+        fun `타자 및 투수 정보를 정확하게 반환한다`() {
+            // given
+            val gameId = 1L
+            val timelineDto =
+                GameTimelineDto(
+                    gameId = gameId,
+                    events =
+                        listOf(
+                            TimelineEventDto(
+                                eventId = 5L,
+                                inning = 2,
+                                isTopInning = false,
+                                inningDisplay = "2회말",
+                                eventType = "PLATE_APPEARANCE",
+                                description = "홈런",
+                                batterId = 300L,
+                                batterName = "박지성",
+                                pitcherId = 400L,
+                                pitcherName = "이영표",
+                                plateAppearanceResult = "HOME_RUN",
+                                runsScored = 2,
+                                outCountBefore = 1,
+                                outCountAfter = 1,
+                                eventTimestamp = Instant.parse("2026-01-01T11:00:00Z"),
+                            ),
+                        ),
+                    totalEvents = 1,
+                )
+
+            every { gameTimelineService.getTimeline(gameId, null, null) } returns timelineDto
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/games/$gameId/timeline"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.data.events[0].batterId").value(300))
+                .andExpect(jsonPath("$.data.events[0].batterName").value("박지성"))
+                .andExpect(jsonPath("$.data.events[0].pitcherId").value(400))
+                .andExpect(jsonPath("$.data.events[0].pitcherName").value("이영표"))
+                .andExpect(jsonPath("$.data.events[0].runsScored").value(2))
+        }
+
+        @Test
+        fun `예외 발생 시 에러 응답을 반환한다`() {
+            // given
+            val gameId = 999L
+            every { gameTimelineService.getTimeline(gameId, null, null) } throws
+                IllegalArgumentException("경기를 찾을 수 없습니다")
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/games/$gameId/timeline"))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/MatchupControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/MatchupControllerTest.kt
@@ -1,0 +1,214 @@
+package com.nextup.api.controller.stats
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.core.service.stats.MatchupService
+import com.nextup.core.service.stats.dto.MatchupDto
+import com.nextup.core.service.stats.dto.MatchupHistoryDto
+import com.nextup.core.service.stats.dto.MatchupStatsDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+
+@DisplayName("MatchupController 테스트")
+class MatchupControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var matchupService: MatchupService
+
+    @BeforeEach
+    fun setUp() {
+        matchupService = mockk()
+
+        val controller = MatchupController(matchupService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/matchups/pitcher/{pitcherId}/batter/{batterId}")
+    inner class GetMatchup {
+        @Test
+        fun `투수 vs 타자 매치업을 정상적으로 조회한다`() {
+            // given
+            val pitcherId = 100L
+            val batterId = 200L
+            val matchupDto =
+                MatchupDto(
+                    pitcherId = pitcherId,
+                    pitcherName = "김투수",
+                    batterId = batterId,
+                    batterName = "이타자",
+                    year = null,
+                    stats =
+                        MatchupStatsDto(
+                            plateAppearances = 15,
+                            atBats = 12,
+                            hits = 4,
+                            doubles = 1,
+                            triples = 0,
+                            homeRuns = 1,
+                            walks = 2,
+                            strikeouts = 3,
+                            hitByPitch = 1,
+                            sacrificeFlies = 0,
+                            runsBattedIn = 3,
+                            battingAverage = BigDecimal("0.333"),
+                            onBasePercentage = BigDecimal("0.467"),
+                            sluggingPercentage = BigDecimal("0.583"),
+                        ),
+                    history =
+                        listOf(
+                            MatchupHistoryDto(
+                                gameId = 1L,
+                                gameDate = "2026-01-15",
+                                result = "안타",
+                                description = "2타수 1안타 (1루타)",
+                            ),
+                            MatchupHistoryDto(
+                                gameId = 2L,
+                                gameDate = "2026-01-22",
+                                result = "홈런",
+                                description = "3타수 1안타 (솔로 홈런)",
+                            ),
+                        ),
+                )
+
+            every { matchupService.getMatchup(pitcherId, batterId, null, null) } returns matchupDto
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/matchups/pitcher/$pitcherId/batter/$batterId"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.pitcherId").value(pitcherId))
+                .andExpect(jsonPath("$.data.pitcherName").value("김투수"))
+                .andExpect(jsonPath("$.data.batterId").value(batterId))
+                .andExpect(jsonPath("$.data.batterName").value("이타자"))
+                .andExpect(jsonPath("$.data.stats.plateAppearances").value(15))
+                .andExpect(jsonPath("$.data.stats.hits").value(4))
+                .andExpect(jsonPath("$.data.history").isArray)
+                .andExpect(jsonPath("$.data.history[0].gameDate").value("2026-01-15"))
+        }
+
+        @Test
+        fun `연도 필터로 매치업을 조회한다`() {
+            // given
+            val pitcherId = 100L
+            val batterId = 200L
+            val year = 2025
+            val matchupDto =
+                MatchupDto(
+                    pitcherId = pitcherId,
+                    pitcherName = "김투수",
+                    batterId = batterId,
+                    batterName = "이타자",
+                    year = year,
+                    stats =
+                        MatchupStatsDto(
+                            plateAppearances = 8,
+                            atBats = 7,
+                            hits = 2,
+                            doubles = 0,
+                            triples = 0,
+                            homeRuns = 0,
+                            walks = 1,
+                            strikeouts = 2,
+                            hitByPitch = 0,
+                            sacrificeFlies = 0,
+                            runsBattedIn = 1,
+                            battingAverage = BigDecimal("0.286"),
+                            onBasePercentage = BigDecimal("0.375"),
+                            sluggingPercentage = BigDecimal("0.286"),
+                        ),
+                    history = emptyList(),
+                )
+
+            every { matchupService.getMatchup(pitcherId, batterId, year, null) } returns matchupDto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/matchups/pitcher/$pitcherId/batter/$batterId")
+                        .param("year", year.toString()),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.year").value(year))
+        }
+
+        @Test
+        fun `매치업 통계를 정확하게 반환한다`() {
+            // given
+            val pitcherId = 100L
+            val batterId = 200L
+            val matchupDto =
+                MatchupDto(
+                    pitcherId = pitcherId,
+                    pitcherName = "에이스",
+                    batterId = batterId,
+                    batterName = "클린업",
+                    year = null,
+                    stats =
+                        MatchupStatsDto(
+                            plateAppearances = 20,
+                            atBats = 16,
+                            hits = 5,
+                            doubles = 2,
+                            triples = 1,
+                            homeRuns = 2,
+                            walks = 3,
+                            strikeouts = 5,
+                            hitByPitch = 1,
+                            sacrificeFlies = 0,
+                            runsBattedIn = 6,
+                            battingAverage = BigDecimal("0.313"),
+                            onBasePercentage = BigDecimal("0.450"),
+                            sluggingPercentage = BigDecimal("0.750"),
+                        ),
+                    history = emptyList(),
+                )
+
+            every { matchupService.getMatchup(pitcherId, batterId, null, null) } returns matchupDto
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/matchups/pitcher/$pitcherId/batter/$batterId"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.data.stats.plateAppearances").value(20))
+                .andExpect(jsonPath("$.data.stats.atBats").value(16))
+                .andExpect(jsonPath("$.data.stats.hits").value(5))
+                .andExpect(jsonPath("$.data.stats.doubles").value(2))
+                .andExpect(jsonPath("$.data.stats.triples").value(1))
+                .andExpect(jsonPath("$.data.stats.homeRuns").value(2))
+                .andExpect(jsonPath("$.data.stats.walks").value(3))
+                .andExpect(jsonPath("$.data.stats.strikeouts").value(5))
+                .andExpect(jsonPath("$.data.stats.runsBattedIn").value(6))
+        }
+
+        @Test
+        fun `예외 발생 시 에러 응답을 반환한다`() {
+            // given
+            val pitcherId = 999L
+            val batterId = 888L
+            every { matchupService.getMatchup(pitcherId, batterId, null, null) } throws
+                IllegalArgumentException("선수를 찾을 수 없습니다")
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/matchups/pitcher/$pitcherId/batter/$batterId"))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/PlayerRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/PlayerRecordControllerTest.kt
@@ -1,0 +1,379 @@
+package com.nextup.api.controller.stats
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.core.service.stats.PlayerRecordService
+import com.nextup.core.service.stats.RecentFormService
+import com.nextup.core.service.stats.dto.*
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+
+@DisplayName("PlayerRecordController 테스트")
+class PlayerRecordControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var playerRecordService: PlayerRecordService
+    private lateinit var recentFormService: RecentFormService
+
+    @BeforeEach
+    fun setUp() {
+        playerRecordService = mockk()
+        recentFormService = mockk()
+
+        val controller = PlayerRecordController(playerRecordService, recentFormService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/players/{playerId}/records")
+    inner class GetPlayerRecord {
+        @Test
+        fun `선수 기록을 정상적으로 조회한다`() {
+            // given
+            val playerId = 1L
+            val recordDto =
+                PlayerRecordDto(
+                    playerId = playerId,
+                    playerName = "홍길동",
+                    scope = RecordScope.CAREER,
+                    type = RecordType.ALL,
+                    year = null,
+                    competitionId = null,
+                    competitionName = null,
+                    battingStats =
+                        BattingStatsDto(
+                            gamesPlayed = 100,
+                            plateAppearances = 450,
+                            atBats = 400,
+                            hits = 120,
+                            doubles = 25,
+                            triples = 3,
+                            homeRuns = 15,
+                            runs = 60,
+                            runsBattedIn = 55,
+                            walks = 40,
+                            strikeouts = 80,
+                            stolenBases = 10,
+                            battingAverage = BigDecimal("0.300"),
+                            onBasePercentage = BigDecimal("0.378"),
+                            sluggingPercentage = BigDecimal("0.485"),
+                            ops = BigDecimal("0.863"),
+                        ),
+                    pitchingStats = null,
+                )
+
+            every { playerRecordService.getPlayerRecord(playerId, RecordScope.CAREER, RecordType.ALL, null, null) } returns recordDto
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/records"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.playerId").value(playerId))
+                .andExpect(jsonPath("$.data.playerName").value("홍길동"))
+                .andExpect(jsonPath("$.data.battingStats.gamesPlayed").value(100))
+                .andExpect(jsonPath("$.data.battingStats.hits").value(120))
+        }
+
+        @Test
+        fun `시즌 범위로 선수 기록을 조회한다`() {
+            // given
+            val playerId = 1L
+            val year = 2026
+            val recordDto =
+                PlayerRecordDto(
+                    playerId = playerId,
+                    playerName = "홍길동",
+                    scope = RecordScope.SEASON,
+                    type = RecordType.BATTING,
+                    year = year,
+                    competitionId = null,
+                    competitionName = null,
+                    battingStats =
+                        BattingStatsDto(
+                            gamesPlayed = 30,
+                            plateAppearances = 130,
+                            atBats = 115,
+                            hits = 35,
+                            doubles = 8,
+                            triples = 1,
+                            homeRuns = 5,
+                            runs = 20,
+                            runsBattedIn = 18,
+                            walks = 12,
+                            strikeouts = 25,
+                            stolenBases = 3,
+                            battingAverage = BigDecimal("0.304"),
+                            onBasePercentage = BigDecimal("0.369"),
+                            sluggingPercentage = BigDecimal("0.496"),
+                            ops = BigDecimal("0.865"),
+                        ),
+                    pitchingStats = null,
+                )
+
+            every {
+                playerRecordService.getPlayerRecord(playerId, RecordScope.SEASON, RecordType.BATTING, year, null)
+            } returns recordDto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/players/$playerId/records")
+                        .param("scope", "SEASON")
+                        .param("type", "BATTING")
+                        .param("year", year.toString()),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.scope").value("SEASON"))
+                .andExpect(jsonPath("$.data.year").value(year))
+        }
+
+        @Test
+        fun `투수 기록을 조회한다`() {
+            // given
+            val playerId = 2L
+            val recordDto =
+                PlayerRecordDto(
+                    playerId = playerId,
+                    playerName = "김투수",
+                    scope = RecordScope.CAREER,
+                    type = RecordType.PITCHING,
+                    year = null,
+                    competitionId = null,
+                    competitionName = null,
+                    battingStats = null,
+                    pitchingStats =
+                        PitchingStatsDto(
+                            gamesPlayed = 50,
+                            gamesStarted = 40,
+                            inningsPitched = "250.1",
+                            wins = 15,
+                            losses = 8,
+                            saves = 0,
+                            holds = 0,
+                            earnedRuns = 70,
+                            hitsAllowed = 220,
+                            walksAllowed = 60,
+                            strikeouts = 200,
+                            homeRunsAllowed = 20,
+                            era = BigDecimal("2.52"),
+                            whip = BigDecimal("1.12"),
+                        ),
+                )
+
+            every {
+                playerRecordService.getPlayerRecord(playerId, RecordScope.CAREER, RecordType.PITCHING, null, null)
+            } returns recordDto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/players/$playerId/records")
+                        .param("type", "PITCHING"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.pitchingStats.wins").value(15))
+                .andExpect(jsonPath("$.data.pitchingStats.strikeouts").value(200))
+                .andExpect(jsonPath("$.data.pitchingStats.inningsPitched").value("250.1"))
+        }
+
+        @Test
+        fun `예외 발생 시 에러 응답을 반환한다`() {
+            // given
+            val playerId = 999L
+            every {
+                playerRecordService.getPlayerRecord(playerId, RecordScope.CAREER, RecordType.ALL, null, null)
+            } throws IllegalArgumentException("선수를 찾을 수 없습니다")
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/records"))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/players/{playerId}/records/form")
+    inner class GetRecentForm {
+        @Test
+        fun `최근 타격 폼을 정상적으로 조회한다`() {
+            // given
+            val playerId = 1L
+            val games = 5
+            val formDto =
+                RecentFormDto(
+                    playerId = playerId,
+                    playerName = "홍길동",
+                    type = FormType.BATTING,
+                    gamesRequested = games,
+                    gamesFound = games,
+                    trend = FormTrend.UP,
+                    trendDescription = "최근 5경기 타율 상승세",
+                    batting =
+                        RecentBattingFormDto(
+                            games =
+                                listOf(
+                                    GameBattingDto(
+                                        gameId = 1L,
+                                        gameDate = "2026-01-20",
+                                        opponentName = "상대팀A",
+                                        atBats = 4,
+                                        hits = 2,
+                                        homeRuns = 1,
+                                        rbis = 2,
+                                        runs = 1,
+                                        walks = 0,
+                                        strikeouts = 1,
+                                    ),
+                                ),
+                            totalAtBats = 20,
+                            totalHits = 8,
+                            totalHomeRuns = 2,
+                            totalRbis = 5,
+                            totalRuns = 4,
+                            recentAverage = BigDecimal("0.400"),
+                            overallAverage = BigDecimal("0.300"),
+                        ),
+                    pitching = null,
+                )
+
+            every { recentFormService.getRecentForm(playerId, games, FormType.BATTING) } returns formDto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/players/$playerId/records/form")
+                        .param("games", games.toString())
+                        .param("type", "BATTING"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.playerId").value(playerId))
+                .andExpect(jsonPath("$.data.trend").value("UP"))
+                .andExpect(jsonPath("$.data.batting.totalHits").value(8))
+        }
+
+        @Test
+        fun `최근 투수 폼을 조회한다`() {
+            // given
+            val playerId = 2L
+            val games = 3
+            val formDto =
+                RecentFormDto(
+                    playerId = playerId,
+                    playerName = "김투수",
+                    type = FormType.PITCHING,
+                    gamesRequested = games,
+                    gamesFound = games,
+                    trend = FormTrend.STABLE,
+                    trendDescription = "최근 3경기 안정적인 투구",
+                    batting = null,
+                    pitching =
+                        RecentPitchingFormDto(
+                            games =
+                                listOf(
+                                    GamePitchingDto(
+                                        gameId = 10L,
+                                        gameDate = "2026-01-25",
+                                        opponentName = "상대팀B",
+                                        inningsPitched = "7.0",
+                                        earnedRuns = 2,
+                                        strikeouts = 8,
+                                        walksAllowed = 2,
+                                        hitsAllowed = 5,
+                                        decision = "W",
+                                    ),
+                                ),
+                            totalInningsPitchedOuts = 63,
+                            inningsPitchedDisplay = "21.0",
+                            totalEarnedRuns = 5,
+                            totalStrikeouts = 20,
+                            recentEra = BigDecimal("2.14"),
+                            overallEra = BigDecimal("3.00"),
+                        ),
+                )
+
+            every { recentFormService.getRecentForm(playerId, games, FormType.PITCHING) } returns formDto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/players/$playerId/records/form")
+                        .param("games", games.toString())
+                        .param("type", "PITCHING"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.type").value("PITCHING"))
+                .andExpect(jsonPath("$.data.pitching.totalStrikeouts").value(20))
+                .andExpect(jsonPath("$.data.pitching.inningsPitchedDisplay").value("21.0"))
+        }
+
+        @Test
+        fun `기본값으로 최근 폼을 조회한다`() {
+            // given
+            val playerId = 1L
+            val formDto =
+                RecentFormDto(
+                    playerId = playerId,
+                    playerName = "테스트선수",
+                    type = FormType.BATTING,
+                    gamesRequested = 5,
+                    gamesFound = 5,
+                    trend = FormTrend.DOWN,
+                    trendDescription = "최근 폼 하락",
+                    batting =
+                        RecentBattingFormDto(
+                            games = emptyList(),
+                            totalAtBats = 15,
+                            totalHits = 3,
+                            totalHomeRuns = 0,
+                            totalRbis = 1,
+                            totalRuns = 1,
+                            recentAverage = BigDecimal("0.200"),
+                            overallAverage = BigDecimal("0.280"),
+                        ),
+                    pitching = null,
+                )
+
+            every { recentFormService.getRecentForm(playerId, 5, FormType.BATTING) } returns formDto
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/records/form"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.gamesRequested").value(5))
+                .andExpect(jsonPath("$.data.trend").value("DOWN"))
+        }
+
+        @Test
+        fun `예외 발생 시 에러 응답을 반환한다`() {
+            // given
+            val playerId = 999L
+            every { recentFormService.getRecentForm(playerId, 5, FormType.BATTING) } throws
+                IllegalArgumentException("선수를 찾을 수 없습니다")
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/records/form"))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/PlayerRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/PlayerRecordControllerTest.kt
@@ -74,7 +74,10 @@ class PlayerRecordControllerTest {
                     pitchingStats = null,
                 )
 
-            every { playerRecordService.getPlayerRecord(playerId, RecordScope.CAREER, RecordType.ALL, null, null) } returns recordDto
+            every {
+                playerRecordService.getPlayerRecord(playerId, RecordScope.CAREER, RecordType.ALL, null, null)
+            } returns
+                recordDto
 
             // when & then
             mockMvc

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/TeamStatsControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/TeamStatsControllerTest.kt
@@ -1,0 +1,226 @@
+package com.nextup.api.controller.stats
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.core.service.stats.TeamStatsService
+import com.nextup.core.service.stats.dto.TeamBattingStatsDto
+import com.nextup.core.service.stats.dto.TeamPitchingStatsDto
+import com.nextup.core.service.stats.dto.TeamRecordDto
+import com.nextup.core.service.stats.dto.TeamStatsDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+
+@DisplayName("TeamStatsController 테스트")
+class TeamStatsControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var teamStatsService: TeamStatsService
+
+    @BeforeEach
+    fun setUp() {
+        teamStatsService = mockk()
+
+        val controller = TeamStatsController(teamStatsService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/stats")
+    inner class GetTeamStats {
+        @Test
+        fun `팀 통계를 정상적으로 조회한다`() {
+            // given
+            val teamId = 1L
+            val teamStatsDto =
+                TeamStatsDto(
+                    teamId = teamId,
+                    teamName = "테스트팀",
+                    year = 2026,
+                    competitionId = 10L,
+                    competitionName = "봄시즌리그",
+                    record =
+                        TeamRecordDto(
+                            gamesPlayed = 20,
+                            wins = 12,
+                            losses = 6,
+                            draws = 2,
+                            winningPercentage = BigDecimal("0.667"),
+                        ),
+                    batting =
+                        TeamBattingStatsDto(
+                            totalAtBats = 700,
+                            totalHits = 210,
+                            totalHomeRuns = 25,
+                            totalRunsBattedIn = 95,
+                            totalRuns = 100,
+                            teamBattingAverage = BigDecimal("0.300"),
+                            teamOnBasePercentage = BigDecimal("0.380"),
+                            teamSluggingPercentage = BigDecimal("0.450"),
+                        ),
+                    pitching =
+                        TeamPitchingStatsDto(
+                            totalInningsPitchedOuts = 540,
+                            inningsPitchedDisplay = "180.0",
+                            totalEarnedRuns = 60,
+                            totalStrikeouts = 150,
+                            totalWalksAllowed = 55,
+                            teamEra = BigDecimal("3.00"),
+                            teamWhip = BigDecimal("1.20"),
+                        ),
+                )
+
+            every { teamStatsService.getTeamStats(teamId, null, null) } returns teamStatsDto
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/$teamId/stats"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.teamId").value(teamId))
+                .andExpect(jsonPath("$.data.teamName").value("테스트팀"))
+                .andExpect(jsonPath("$.data.record.gamesPlayed").value(20))
+                .andExpect(jsonPath("$.data.record.wins").value(12))
+                .andExpect(jsonPath("$.data.batting.totalHits").value(210))
+                .andExpect(jsonPath("$.data.pitching.inningsPitchedDisplay").value("180.0"))
+        }
+
+        @Test
+        fun `연도 필터로 팀 통계를 조회한다`() {
+            // given
+            val teamId = 1L
+            val year = 2025
+            val teamStatsDto =
+                TeamStatsDto(
+                    teamId = teamId,
+                    teamName = "테스트팀",
+                    year = year,
+                    competitionId = null,
+                    competitionName = null,
+                    record =
+                        TeamRecordDto(
+                            gamesPlayed = 15,
+                            wins = 8,
+                            losses = 5,
+                            draws = 2,
+                            winningPercentage = BigDecimal("0.615"),
+                        ),
+                    batting =
+                        TeamBattingStatsDto(
+                            totalAtBats = 500,
+                            totalHits = 140,
+                            totalHomeRuns = 15,
+                            totalRunsBattedIn = 60,
+                            totalRuns = 70,
+                            teamBattingAverage = BigDecimal("0.280"),
+                            teamOnBasePercentage = BigDecimal("0.350"),
+                            teamSluggingPercentage = BigDecimal("0.420"),
+                        ),
+                    pitching =
+                        TeamPitchingStatsDto(
+                            totalInningsPitchedOuts = 405,
+                            inningsPitchedDisplay = "135.0",
+                            totalEarnedRuns = 50,
+                            totalStrikeouts = 100,
+                            totalWalksAllowed = 45,
+                            teamEra = BigDecimal("3.33"),
+                            teamWhip = BigDecimal("1.30"),
+                        ),
+                )
+
+            every { teamStatsService.getTeamStats(teamId, year, null) } returns teamStatsDto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/teams/$teamId/stats")
+                        .param("year", year.toString()),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.year").value(year))
+        }
+
+        @Test
+        fun `대회 ID로 팀 통계를 조회한다`() {
+            // given
+            val teamId = 1L
+            val competitionId = 5L
+            val teamStatsDto =
+                TeamStatsDto(
+                    teamId = teamId,
+                    teamName = "테스트팀",
+                    year = null,
+                    competitionId = competitionId,
+                    competitionName = "가을리그",
+                    record =
+                        TeamRecordDto(
+                            gamesPlayed = 10,
+                            wins = 7,
+                            losses = 2,
+                            draws = 1,
+                            winningPercentage = BigDecimal("0.778"),
+                        ),
+                    batting =
+                        TeamBattingStatsDto(
+                            totalAtBats = 350,
+                            totalHits = 100,
+                            totalHomeRuns = 12,
+                            totalRunsBattedIn = 45,
+                            totalRuns = 50,
+                            teamBattingAverage = BigDecimal("0.286"),
+                            teamOnBasePercentage = BigDecimal("0.360"),
+                            teamSluggingPercentage = BigDecimal("0.430"),
+                        ),
+                    pitching =
+                        TeamPitchingStatsDto(
+                            totalInningsPitchedOuts = 270,
+                            inningsPitchedDisplay = "90.0",
+                            totalEarnedRuns = 25,
+                            totalStrikeouts = 80,
+                            totalWalksAllowed = 30,
+                            teamEra = BigDecimal("2.50"),
+                            teamWhip = BigDecimal("1.10"),
+                        ),
+                )
+
+            every { teamStatsService.getTeamStats(teamId, null, competitionId) } returns teamStatsDto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/teams/$teamId/stats")
+                        .param("competitionId", competitionId.toString()),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.competitionId").value(competitionId))
+                .andExpect(jsonPath("$.data.competitionName").value("가을리그"))
+        }
+
+        @Test
+        fun `예외 발생 시 에러 응답을 반환한다`() {
+            // given
+            val teamId = 999L
+            every { teamStatsService.getTeamStats(teamId, null, null) } throws
+                IllegalArgumentException("팀을 찾을 수 없습니다")
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/$teamId/stats"))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/mapper/game/GameTimelineMapperTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/mapper/game/GameTimelineMapperTest.kt
@@ -1,0 +1,145 @@
+package com.nextup.api.mapper.game
+
+import com.nextup.core.service.game.dto.GameTimelineDto
+import com.nextup.core.service.game.dto.TimelineEventDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("GameTimelineMapper 테스트")
+class GameTimelineMapperTest {
+    @Test
+    fun `GameTimelineDto를 GameTimelineResponse로 변환한다`() {
+        // given
+        val dto =
+            GameTimelineDto(
+                gameId = 1L,
+                events =
+                    listOf(
+                        TimelineEventDto(
+                            eventId = 10L,
+                            inning = 1,
+                            isTopInning = true,
+                            inningDisplay = "1회초",
+                            eventType = "PLATE_APPEARANCE",
+                            description = "홍길동 안타",
+                            batterId = 100L,
+                            batterName = "홍길동",
+                            pitcherId = 200L,
+                            pitcherName = "김철수",
+                            plateAppearanceResult = "SINGLE",
+                            runsScored = 0,
+                            outCountBefore = 0,
+                            outCountAfter = 0,
+                            eventTimestamp = Instant.parse("2026-01-01T10:00:00Z"),
+                        ),
+                        TimelineEventDto(
+                            eventId = 11L,
+                            inning = 1,
+                            isTopInning = true,
+                            inningDisplay = "1회초",
+                            eventType = "PLATE_APPEARANCE",
+                            description = "이영희 홈런",
+                            batterId = 101L,
+                            batterName = "이영희",
+                            pitcherId = 200L,
+                            pitcherName = "김철수",
+                            plateAppearanceResult = "HOME_RUN",
+                            runsScored = 2,
+                            outCountBefore = 0,
+                            outCountAfter = 0,
+                            eventTimestamp = Instant.parse("2026-01-01T10:05:00Z"),
+                        ),
+                    ),
+                totalEvents = 2,
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.gameId).isEqualTo(1L)
+        assertThat(response.totalEvents).isEqualTo(2)
+        assertThat(response.events).hasSize(2)
+        assertThat(response.events[0].eventId).isEqualTo(10L)
+        assertThat(response.events[0].inningDisplay).isEqualTo("1회초")
+        assertThat(response.events[0].batterName).isEqualTo("홍길동")
+        assertThat(response.events[1].runsScored).isEqualTo(2)
+    }
+
+    @Test
+    fun `TimelineEventDto를 TimelineEventResponse로 변환한다`() {
+        // given
+        val dto =
+            TimelineEventDto(
+                eventId = 5L,
+                inning = 3,
+                isTopInning = false,
+                inningDisplay = "3회말",
+                eventType = "PLATE_APPEARANCE",
+                description = "삼진 아웃",
+                batterId = 300L,
+                batterName = "박선수",
+                pitcherId = 400L,
+                pitcherName = "최투수",
+                plateAppearanceResult = "STRIKEOUT",
+                runsScored = 0,
+                outCountBefore = 1,
+                outCountAfter = 2,
+                eventTimestamp = Instant.parse("2026-01-01T11:00:00Z"),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.eventId).isEqualTo(5L)
+        assertThat(response.inning).isEqualTo(3)
+        assertThat(response.isTopInning).isFalse()
+        assertThat(response.inningDisplay).isEqualTo("3회말")
+        assertThat(response.eventType).isEqualTo("PLATE_APPEARANCE")
+        assertThat(response.description).isEqualTo("삼진 아웃")
+        assertThat(response.batterId).isEqualTo(300L)
+        assertThat(response.batterName).isEqualTo("박선수")
+        assertThat(response.pitcherId).isEqualTo(400L)
+        assertThat(response.pitcherName).isEqualTo("최투수")
+        assertThat(response.plateAppearanceResult).isEqualTo("STRIKEOUT")
+        assertThat(response.runsScored).isEqualTo(0)
+        assertThat(response.outCountBefore).isEqualTo(1)
+        assertThat(response.outCountAfter).isEqualTo(2)
+    }
+
+    @Test
+    fun `null 값이 포함된 TimelineEventDto를 변환한다`() {
+        // given
+        val dto =
+            TimelineEventDto(
+                eventId = 20L,
+                inning = 5,
+                isTopInning = true,
+                inningDisplay = "5회초",
+                eventType = "INNING_START",
+                description = "5회초 시작",
+                batterId = null,
+                batterName = null,
+                pitcherId = null,
+                pitcherName = null,
+                plateAppearanceResult = null,
+                runsScored = 0,
+                outCountBefore = 0,
+                outCountAfter = 0,
+                eventTimestamp = Instant.parse("2026-01-01T12:00:00Z"),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.batterId).isNull()
+        assertThat(response.batterName).isNull()
+        assertThat(response.pitcherId).isNull()
+        assertThat(response.pitcherName).isNull()
+        assertThat(response.plateAppearanceResult).isNull()
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/mapper/stats/MatchupMapperTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/mapper/stats/MatchupMapperTest.kt
@@ -1,0 +1,162 @@
+package com.nextup.api.mapper.stats
+
+import com.nextup.core.service.stats.dto.MatchupDto
+import com.nextup.core.service.stats.dto.MatchupHistoryDto
+import com.nextup.core.service.stats.dto.MatchupStatsDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("MatchupMapper 테스트")
+class MatchupMapperTest {
+    @Test
+    fun `MatchupDto를 MatchupResponse로 변환한다`() {
+        // given
+        val dto =
+            MatchupDto(
+                pitcherId = 100L,
+                pitcherName = "김투수",
+                batterId = 200L,
+                batterName = "이타자",
+                year = 2026,
+                stats =
+                    MatchupStatsDto(
+                        plateAppearances = 15,
+                        atBats = 12,
+                        hits = 4,
+                        doubles = 1,
+                        triples = 0,
+                        homeRuns = 1,
+                        walks = 2,
+                        strikeouts = 3,
+                        hitByPitch = 1,
+                        sacrificeFlies = 0,
+                        runsBattedIn = 3,
+                        battingAverage = BigDecimal("0.333"),
+                        onBasePercentage = BigDecimal("0.467"),
+                        sluggingPercentage = BigDecimal("0.583"),
+                    ),
+                history =
+                    listOf(
+                        MatchupHistoryDto(
+                            gameId = 1L,
+                            gameDate = "2026-01-15",
+                            result = "안타",
+                            description = "2타수 1안타",
+                        ),
+                    ),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.pitcherId).isEqualTo(100L)
+        assertThat(response.pitcherName).isEqualTo("김투수")
+        assertThat(response.batterId).isEqualTo(200L)
+        assertThat(response.batterName).isEqualTo("이타자")
+        assertThat(response.year).isEqualTo(2026)
+        assertThat(response.history).hasSize(1)
+    }
+
+    @Test
+    fun `MatchupStatsDto를 MatchupStatsResponse로 변환한다`() {
+        // given
+        val dto =
+            MatchupStatsDto(
+                plateAppearances = 20,
+                atBats = 16,
+                hits = 5,
+                doubles = 2,
+                triples = 1,
+                homeRuns = 2,
+                walks = 3,
+                strikeouts = 4,
+                hitByPitch = 1,
+                sacrificeFlies = 0,
+                runsBattedIn = 6,
+                battingAverage = BigDecimal("0.313"),
+                onBasePercentage = BigDecimal("0.450"),
+                sluggingPercentage = BigDecimal("0.750"),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.plateAppearances).isEqualTo(20)
+        assertThat(response.atBats).isEqualTo(16)
+        assertThat(response.hits).isEqualTo(5)
+        assertThat(response.doubles).isEqualTo(2)
+        assertThat(response.triples).isEqualTo(1)
+        assertThat(response.homeRuns).isEqualTo(2)
+        assertThat(response.walks).isEqualTo(3)
+        assertThat(response.strikeouts).isEqualTo(4)
+        assertThat(response.hitByPitch).isEqualTo(1)
+        assertThat(response.sacrificeFlies).isEqualTo(0)
+        assertThat(response.runsBattedIn).isEqualTo(6)
+        assertThat(response.battingAverage).isEqualTo(BigDecimal("0.313"))
+        assertThat(response.onBasePercentage).isEqualTo(BigDecimal("0.450"))
+        assertThat(response.sluggingPercentage).isEqualTo(BigDecimal("0.750"))
+    }
+
+    @Test
+    fun `MatchupHistoryDto를 MatchupHistoryResponse로 변환한다`() {
+        // given
+        val dto =
+            MatchupHistoryDto(
+                gameId = 5L,
+                gameDate = "2026-02-01",
+                result = "홈런",
+                description = "3타수 1안타 (솔로 홈런)",
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.gameId).isEqualTo(5L)
+        assertThat(response.gameDate).isEqualTo("2026-02-01")
+        assertThat(response.result).isEqualTo("홈런")
+        assertThat(response.description).isEqualTo("3타수 1안타 (솔로 홈런)")
+    }
+
+    @Test
+    fun `year가 null인 MatchupDto를 변환한다`() {
+        // given
+        val dto =
+            MatchupDto(
+                pitcherId = 100L,
+                pitcherName = "김투수",
+                batterId = 200L,
+                batterName = "이타자",
+                year = null,
+                stats =
+                    MatchupStatsDto(
+                        plateAppearances = 10,
+                        atBats = 8,
+                        hits = 2,
+                        doubles = 0,
+                        triples = 0,
+                        homeRuns = 0,
+                        walks = 1,
+                        strikeouts = 2,
+                        hitByPitch = 1,
+                        sacrificeFlies = 0,
+                        runsBattedIn = 1,
+                        battingAverage = BigDecimal("0.250"),
+                        onBasePercentage = BigDecimal("0.400"),
+                        sluggingPercentage = BigDecimal("0.250"),
+                    ),
+                history = emptyList(),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.year).isNull()
+        assertThat(response.history).isEmpty()
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/mapper/stats/PlayerRecordMapperTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/mapper/stats/PlayerRecordMapperTest.kt
@@ -1,0 +1,229 @@
+package com.nextup.api.mapper.stats
+
+import com.nextup.core.service.stats.dto.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("PlayerRecordMapper 테스트")
+class PlayerRecordMapperTest {
+    @Test
+    fun `PlayerRecordDto를 PlayerRecordResponse로 변환한다`() {
+        // given
+        val dto =
+            PlayerRecordDto(
+                playerId = 1L,
+                playerName = "홍길동",
+                scope = RecordScope.CAREER,
+                type = RecordType.ALL,
+                year = null,
+                competitionId = null,
+                competitionName = null,
+                battingStats =
+                    BattingStatsDto(
+                        gamesPlayed = 100,
+                        plateAppearances = 450,
+                        atBats = 400,
+                        hits = 120,
+                        doubles = 25,
+                        triples = 3,
+                        homeRuns = 15,
+                        runs = 60,
+                        runsBattedIn = 55,
+                        walks = 40,
+                        strikeouts = 80,
+                        stolenBases = 10,
+                        battingAverage = BigDecimal("0.300"),
+                        onBasePercentage = BigDecimal("0.378"),
+                        sluggingPercentage = BigDecimal("0.485"),
+                        ops = BigDecimal("0.863"),
+                    ),
+                pitchingStats = null,
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.playerId).isEqualTo(1L)
+        assertThat(response.playerName).isEqualTo("홍길동")
+        assertThat(response.scope).isEqualTo(RecordScope.CAREER)
+        assertThat(response.type).isEqualTo(RecordType.ALL)
+        assertThat(response.battingStats).isNotNull
+        assertThat(response.pitchingStats).isNull()
+    }
+
+    @Test
+    fun `BattingStatsDto를 BattingStatsResponse로 변환한다`() {
+        // given
+        val dto =
+            BattingStatsDto(
+                gamesPlayed = 50,
+                plateAppearances = 220,
+                atBats = 200,
+                hits = 60,
+                doubles = 12,
+                triples = 2,
+                homeRuns = 8,
+                runs = 30,
+                runsBattedIn = 28,
+                walks = 15,
+                strikeouts = 40,
+                stolenBases = 5,
+                battingAverage = BigDecimal("0.300"),
+                onBasePercentage = BigDecimal("0.364"),
+                sluggingPercentage = BigDecimal("0.480"),
+                ops = BigDecimal("0.844"),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.gamesPlayed).isEqualTo(50)
+        assertThat(response.plateAppearances).isEqualTo(220)
+        assertThat(response.atBats).isEqualTo(200)
+        assertThat(response.hits).isEqualTo(60)
+        assertThat(response.doubles).isEqualTo(12)
+        assertThat(response.triples).isEqualTo(2)
+        assertThat(response.homeRuns).isEqualTo(8)
+        assertThat(response.runs).isEqualTo(30)
+        assertThat(response.runsBattedIn).isEqualTo(28)
+        assertThat(response.walks).isEqualTo(15)
+        assertThat(response.strikeouts).isEqualTo(40)
+        assertThat(response.stolenBases).isEqualTo(5)
+        assertThat(response.battingAverage).isEqualTo(BigDecimal("0.300"))
+        assertThat(response.onBasePercentage).isEqualTo(BigDecimal("0.364"))
+        assertThat(response.sluggingPercentage).isEqualTo(BigDecimal("0.480"))
+        assertThat(response.ops).isEqualTo(BigDecimal("0.844"))
+    }
+
+    @Test
+    fun `PitchingStatsDto를 PitchingStatsResponse로 변환한다`() {
+        // given
+        val dto =
+            PitchingStatsDto(
+                gamesPlayed = 30,
+                gamesStarted = 25,
+                inningsPitched = "160.2",
+                wins = 10,
+                losses = 5,
+                saves = 0,
+                holds = 0,
+                earnedRuns = 45,
+                hitsAllowed = 140,
+                walksAllowed = 40,
+                strikeouts = 130,
+                homeRunsAllowed = 12,
+                era = BigDecimal("2.52"),
+                whip = BigDecimal("1.12"),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.gamesPlayed).isEqualTo(30)
+        assertThat(response.gamesStarted).isEqualTo(25)
+        assertThat(response.inningsPitched).isEqualTo("160.2")
+        assertThat(response.wins).isEqualTo(10)
+        assertThat(response.losses).isEqualTo(5)
+        assertThat(response.saves).isEqualTo(0)
+        assertThat(response.holds).isEqualTo(0)
+        assertThat(response.earnedRuns).isEqualTo(45)
+        assertThat(response.hitsAllowed).isEqualTo(140)
+        assertThat(response.walksAllowed).isEqualTo(40)
+        assertThat(response.strikeouts).isEqualTo(130)
+        assertThat(response.homeRunsAllowed).isEqualTo(12)
+        assertThat(response.era).isEqualTo(BigDecimal("2.52"))
+        assertThat(response.whip).isEqualTo(BigDecimal("1.12"))
+    }
+
+    @Test
+    fun `투수 기록만 있는 PlayerRecordDto를 변환한다`() {
+        // given
+        val dto =
+            PlayerRecordDto(
+                playerId = 2L,
+                playerName = "김투수",
+                scope = RecordScope.SEASON,
+                type = RecordType.PITCHING,
+                year = 2026,
+                competitionId = null,
+                competitionName = null,
+                battingStats = null,
+                pitchingStats =
+                    PitchingStatsDto(
+                        gamesPlayed = 20,
+                        gamesStarted = 18,
+                        inningsPitched = "120.0",
+                        wins = 8,
+                        losses = 4,
+                        saves = 0,
+                        holds = 0,
+                        earnedRuns = 35,
+                        hitsAllowed = 100,
+                        walksAllowed = 30,
+                        strikeouts = 100,
+                        homeRunsAllowed = 8,
+                        era = BigDecimal("2.63"),
+                        whip = BigDecimal("1.08"),
+                    ),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.playerId).isEqualTo(2L)
+        assertThat(response.scope).isEqualTo(RecordScope.SEASON)
+        assertThat(response.type).isEqualTo(RecordType.PITCHING)
+        assertThat(response.year).isEqualTo(2026)
+        assertThat(response.battingStats).isNull()
+        assertThat(response.pitchingStats).isNotNull
+    }
+
+    @Test
+    fun `대회 범위의 PlayerRecordDto를 변환한다`() {
+        // given
+        val dto =
+            PlayerRecordDto(
+                playerId = 3L,
+                playerName = "박선수",
+                scope = RecordScope.COMPETITION,
+                type = RecordType.BATTING,
+                year = null,
+                competitionId = 10L,
+                competitionName = "봄리그",
+                battingStats =
+                    BattingStatsDto(
+                        gamesPlayed = 15,
+                        plateAppearances = 65,
+                        atBats = 60,
+                        hits = 20,
+                        doubles = 4,
+                        triples = 1,
+                        homeRuns = 3,
+                        runs = 10,
+                        runsBattedIn = 12,
+                        walks = 4,
+                        strikeouts = 10,
+                        stolenBases = 2,
+                        battingAverage = BigDecimal("0.333"),
+                        onBasePercentage = BigDecimal("0.385"),
+                        sluggingPercentage = BigDecimal("0.550"),
+                        ops = BigDecimal("0.935"),
+                    ),
+                pitchingStats = null,
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.scope).isEqualTo(RecordScope.COMPETITION)
+        assertThat(response.competitionId).isEqualTo(10L)
+        assertThat(response.competitionName).isEqualTo("봄리그")
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/mapper/stats/RecentFormMapperTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/mapper/stats/RecentFormMapperTest.kt
@@ -1,0 +1,320 @@
+package com.nextup.api.mapper.stats
+
+import com.nextup.core.service.stats.dto.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("RecentFormMapper 테스트")
+class RecentFormMapperTest {
+    @Test
+    fun `RecentFormDto를 RecentFormResponse로 변환한다 - 타격`() {
+        // given
+        val dto =
+            RecentFormDto(
+                playerId = 1L,
+                playerName = "홍길동",
+                type = FormType.BATTING,
+                gamesRequested = 5,
+                gamesFound = 5,
+                trend = FormTrend.UP,
+                trendDescription = "최근 5경기 타율 상승세",
+                batting =
+                    RecentBattingFormDto(
+                        games =
+                            listOf(
+                                GameBattingDto(
+                                    gameId = 1L,
+                                    gameDate = "2026-01-20",
+                                    opponentName = "상대팀A",
+                                    atBats = 4,
+                                    hits = 2,
+                                    homeRuns = 1,
+                                    rbis = 2,
+                                    runs = 1,
+                                    walks = 0,
+                                    strikeouts = 1,
+                                ),
+                            ),
+                        totalAtBats = 20,
+                        totalHits = 8,
+                        totalHomeRuns = 2,
+                        totalRbis = 5,
+                        totalRuns = 4,
+                        recentAverage = BigDecimal("0.400"),
+                        overallAverage = BigDecimal("0.300"),
+                    ),
+                pitching = null,
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.playerId).isEqualTo(1L)
+        assertThat(response.playerName).isEqualTo("홍길동")
+        assertThat(response.type.name).isEqualTo("BATTING")
+        assertThat(response.gamesRequested).isEqualTo(5)
+        assertThat(response.gamesFound).isEqualTo(5)
+        assertThat(response.trend.name).isEqualTo("UP")
+        assertThat(response.trendDescription).isEqualTo("최근 5경기 타율 상승세")
+        assertThat(response.batting).isNotNull
+        assertThat(response.pitching).isNull()
+    }
+
+    @Test
+    fun `RecentFormDto를 RecentFormResponse로 변환한다 - 투수`() {
+        // given
+        val dto =
+            RecentFormDto(
+                playerId = 2L,
+                playerName = "김투수",
+                type = FormType.PITCHING,
+                gamesRequested = 3,
+                gamesFound = 3,
+                trend = FormTrend.STABLE,
+                trendDescription = "최근 3경기 안정적인 투구",
+                batting = null,
+                pitching =
+                    RecentPitchingFormDto(
+                        games =
+                            listOf(
+                                GamePitchingDto(
+                                    gameId = 10L,
+                                    gameDate = "2026-01-25",
+                                    opponentName = "상대팀B",
+                                    inningsPitched = "7.0",
+                                    earnedRuns = 2,
+                                    strikeouts = 8,
+                                    walksAllowed = 2,
+                                    hitsAllowed = 5,
+                                    decision = "W",
+                                ),
+                            ),
+                        totalInningsPitchedOuts = 63,
+                        inningsPitchedDisplay = "21.0",
+                        totalEarnedRuns = 5,
+                        totalStrikeouts = 20,
+                        recentEra = BigDecimal("2.14"),
+                        overallEra = BigDecimal("3.00"),
+                    ),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.playerId).isEqualTo(2L)
+        assertThat(response.type.name).isEqualTo("PITCHING")
+        assertThat(response.trend.name).isEqualTo("STABLE")
+        assertThat(response.batting).isNull()
+        assertThat(response.pitching).isNotNull
+    }
+
+    @Test
+    fun `FormType을 FormTypeResponse로 변환한다`() {
+        assertThat(FormType.BATTING.toResponse().name).isEqualTo("BATTING")
+        assertThat(FormType.PITCHING.toResponse().name).isEqualTo("PITCHING")
+    }
+
+    @Test
+    fun `FormTrend를 FormTrendResponse로 변환한다`() {
+        assertThat(FormTrend.UP.toResponse().name).isEqualTo("UP")
+        assertThat(FormTrend.DOWN.toResponse().name).isEqualTo("DOWN")
+        assertThat(FormTrend.STABLE.toResponse().name).isEqualTo("STABLE")
+    }
+
+    @Test
+    fun `RecentBattingFormDto를 RecentBattingFormResponse로 변환한다`() {
+        // given
+        val dto =
+            RecentBattingFormDto(
+                games =
+                    listOf(
+                        GameBattingDto(
+                            gameId = 1L,
+                            gameDate = "2026-01-20",
+                            opponentName = "상대팀A",
+                            atBats = 4,
+                            hits = 2,
+                            homeRuns = 1,
+                            rbis = 2,
+                            runs = 1,
+                            walks = 0,
+                            strikeouts = 1,
+                        ),
+                        GameBattingDto(
+                            gameId = 2L,
+                            gameDate = "2026-01-21",
+                            opponentName = "상대팀B",
+                            atBats = 3,
+                            hits = 1,
+                            homeRuns = 0,
+                            rbis = 0,
+                            runs = 0,
+                            walks = 1,
+                            strikeouts = 0,
+                        ),
+                    ),
+                totalAtBats = 7,
+                totalHits = 3,
+                totalHomeRuns = 1,
+                totalRbis = 2,
+                totalRuns = 1,
+                recentAverage = BigDecimal("0.429"),
+                overallAverage = BigDecimal("0.300"),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.games).hasSize(2)
+        assertThat(response.totalAtBats).isEqualTo(7)
+        assertThat(response.totalHits).isEqualTo(3)
+        assertThat(response.totalHomeRuns).isEqualTo(1)
+        assertThat(response.totalRbis).isEqualTo(2)
+        assertThat(response.totalRuns).isEqualTo(1)
+        assertThat(response.recentAverage).isEqualTo(BigDecimal("0.429"))
+        assertThat(response.overallAverage).isEqualTo(BigDecimal("0.300"))
+    }
+
+    @Test
+    fun `GameBattingDto를 GameBattingResponse로 변환한다`() {
+        // given
+        val dto =
+            GameBattingDto(
+                gameId = 5L,
+                gameDate = "2026-02-01",
+                opponentName = "강팀",
+                atBats = 5,
+                hits = 3,
+                homeRuns = 2,
+                rbis = 4,
+                runs = 2,
+                walks = 0,
+                strikeouts = 1,
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.gameId).isEqualTo(5L)
+        assertThat(response.gameDate).isEqualTo("2026-02-01")
+        assertThat(response.opponentName).isEqualTo("강팀")
+        assertThat(response.atBats).isEqualTo(5)
+        assertThat(response.hits).isEqualTo(3)
+        assertThat(response.homeRuns).isEqualTo(2)
+        assertThat(response.rbis).isEqualTo(4)
+        assertThat(response.runs).isEqualTo(2)
+        assertThat(response.walks).isEqualTo(0)
+        assertThat(response.strikeouts).isEqualTo(1)
+    }
+
+    @Test
+    fun `RecentPitchingFormDto를 RecentPitchingFormResponse로 변환한다`() {
+        // given
+        val dto =
+            RecentPitchingFormDto(
+                games =
+                    listOf(
+                        GamePitchingDto(
+                            gameId = 10L,
+                            gameDate = "2026-01-25",
+                            opponentName = "상대팀",
+                            inningsPitched = "6.0",
+                            earnedRuns = 2,
+                            strikeouts = 7,
+                            walksAllowed = 1,
+                            hitsAllowed = 4,
+                            decision = "W",
+                        ),
+                    ),
+                totalInningsPitchedOuts = 18,
+                inningsPitchedDisplay = "6.0",
+                totalEarnedRuns = 2,
+                totalStrikeouts = 7,
+                recentEra = BigDecimal("3.00"),
+                overallEra = BigDecimal("3.50"),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.games).hasSize(1)
+        assertThat(response.totalInningsPitchedOuts).isEqualTo(18)
+        assertThat(response.inningsPitchedDisplay).isEqualTo("6.0")
+        assertThat(response.totalEarnedRuns).isEqualTo(2)
+        assertThat(response.totalStrikeouts).isEqualTo(7)
+        assertThat(response.recentEra).isEqualTo(BigDecimal("3.00"))
+        assertThat(response.overallEra).isEqualTo(BigDecimal("3.50"))
+    }
+
+    @Test
+    fun `GamePitchingDto를 GamePitchingResponse로 변환한다`() {
+        // given
+        val dto =
+            GamePitchingDto(
+                gameId = 20L,
+                gameDate = "2026-02-05",
+                opponentName = "강팀",
+                inningsPitched = "7.2",
+                earnedRuns = 1,
+                strikeouts = 10,
+                walksAllowed = 2,
+                hitsAllowed = 5,
+                decision = "W",
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.gameId).isEqualTo(20L)
+        assertThat(response.gameDate).isEqualTo("2026-02-05")
+        assertThat(response.opponentName).isEqualTo("강팀")
+        assertThat(response.inningsPitched).isEqualTo("7.2")
+        assertThat(response.earnedRuns).isEqualTo(1)
+        assertThat(response.strikeouts).isEqualTo(10)
+        assertThat(response.walksAllowed).isEqualTo(2)
+        assertThat(response.hitsAllowed).isEqualTo(5)
+        assertThat(response.decision).isEqualTo("W")
+    }
+
+    @Test
+    fun `하락세 폼을 변환한다`() {
+        // given
+        val dto =
+            RecentFormDto(
+                playerId = 3L,
+                playerName = "슬럼프",
+                type = FormType.BATTING,
+                gamesRequested = 5,
+                gamesFound = 5,
+                trend = FormTrend.DOWN,
+                trendDescription = "최근 5경기 타율 하락세",
+                batting =
+                    RecentBattingFormDto(
+                        games = emptyList(),
+                        totalAtBats = 20,
+                        totalHits = 3,
+                        totalHomeRuns = 0,
+                        totalRbis = 1,
+                        totalRuns = 0,
+                        recentAverage = BigDecimal("0.150"),
+                        overallAverage = BigDecimal("0.280"),
+                    ),
+                pitching = null,
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.trend.name).isEqualTo("DOWN")
+        assertThat(response.batting?.recentAverage).isEqualTo(BigDecimal("0.150"))
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/mapper/stats/TeamStatsMapperTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/mapper/stats/TeamStatsMapperTest.kt
@@ -1,0 +1,142 @@
+package com.nextup.api.mapper.stats
+
+import com.nextup.core.service.stats.dto.TeamBattingStatsDto
+import com.nextup.core.service.stats.dto.TeamPitchingStatsDto
+import com.nextup.core.service.stats.dto.TeamRecordDto
+import com.nextup.core.service.stats.dto.TeamStatsDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("TeamStatsMapper 테스트")
+class TeamStatsMapperTest {
+    @Test
+    fun `TeamStatsDto를 TeamStatsResponse로 변환한다`() {
+        // given
+        val dto =
+            TeamStatsDto(
+                teamId = 1L,
+                teamName = "테스트팀",
+                year = 2026,
+                competitionId = 10L,
+                competitionName = "봄리그",
+                record =
+                    TeamRecordDto(
+                        gamesPlayed = 20,
+                        wins = 12,
+                        losses = 6,
+                        draws = 2,
+                        winningPercentage = BigDecimal("0.667"),
+                    ),
+                batting =
+                    TeamBattingStatsDto(
+                        totalAtBats = 700,
+                        totalHits = 210,
+                        totalHomeRuns = 25,
+                        totalRunsBattedIn = 95,
+                        totalRuns = 100,
+                        teamBattingAverage = BigDecimal("0.300"),
+                        teamOnBasePercentage = BigDecimal("0.380"),
+                        teamSluggingPercentage = BigDecimal("0.450"),
+                    ),
+                pitching =
+                    TeamPitchingStatsDto(
+                        totalInningsPitchedOuts = 540,
+                        inningsPitchedDisplay = "180.0",
+                        totalEarnedRuns = 60,
+                        totalStrikeouts = 150,
+                        totalWalksAllowed = 55,
+                        teamEra = BigDecimal("3.00"),
+                        teamWhip = BigDecimal("1.20"),
+                    ),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.teamId).isEqualTo(1L)
+        assertThat(response.teamName).isEqualTo("테스트팀")
+        assertThat(response.year).isEqualTo(2026)
+        assertThat(response.competitionId).isEqualTo(10L)
+        assertThat(response.competitionName).isEqualTo("봄리그")
+    }
+
+    @Test
+    fun `TeamRecordDto를 TeamRecordResponse로 변환한다`() {
+        // given
+        val dto =
+            TeamRecordDto(
+                gamesPlayed = 30,
+                wins = 18,
+                losses = 10,
+                draws = 2,
+                winningPercentage = BigDecimal("0.643"),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.gamesPlayed).isEqualTo(30)
+        assertThat(response.wins).isEqualTo(18)
+        assertThat(response.losses).isEqualTo(10)
+        assertThat(response.draws).isEqualTo(2)
+        assertThat(response.winningPercentage).isEqualTo(BigDecimal("0.643"))
+    }
+
+    @Test
+    fun `TeamBattingStatsDto를 TeamBattingStatsResponse로 변환한다`() {
+        // given
+        val dto =
+            TeamBattingStatsDto(
+                totalAtBats = 500,
+                totalHits = 150,
+                totalHomeRuns = 20,
+                totalRunsBattedIn = 70,
+                totalRuns = 80,
+                teamBattingAverage = BigDecimal("0.300"),
+                teamOnBasePercentage = BigDecimal("0.370"),
+                teamSluggingPercentage = BigDecimal("0.460"),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.totalAtBats).isEqualTo(500)
+        assertThat(response.totalHits).isEqualTo(150)
+        assertThat(response.totalHomeRuns).isEqualTo(20)
+        assertThat(response.totalRunsBattedIn).isEqualTo(70)
+        assertThat(response.totalRuns).isEqualTo(80)
+        assertThat(response.teamBattingAverage).isEqualTo(BigDecimal("0.300"))
+    }
+
+    @Test
+    fun `TeamPitchingStatsDto를 TeamPitchingStatsResponse로 변환한다`() {
+        // given
+        val dto =
+            TeamPitchingStatsDto(
+                totalInningsPitchedOuts = 450,
+                inningsPitchedDisplay = "150.0",
+                totalEarnedRuns = 50,
+                totalStrikeouts = 120,
+                totalWalksAllowed = 45,
+                teamEra = BigDecimal("3.00"),
+                teamWhip = BigDecimal("1.15"),
+            )
+
+        // when
+        val response = dto.toResponse()
+
+        // then
+        assertThat(response.totalInningsPitchedOuts).isEqualTo(450)
+        assertThat(response.inningsPitchedDisplay).isEqualTo("150.0")
+        assertThat(response.totalEarnedRuns).isEqualTo(50)
+        assertThat(response.totalStrikeouts).isEqualTo(120)
+        assertThat(response.totalWalksAllowed).isEqualTo(45)
+        assertThat(response.teamEra).isEqualTo(BigDecimal("3.00"))
+        assertThat(response.teamWhip).isEqualTo(BigDecimal("1.15"))
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BattingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BattingRecordRepositoryPort.kt
@@ -85,4 +85,12 @@ interface BattingRecordRepositoryPort {
         playerId: Long,
         year: Int,
     ): List<BattingRecord>
+
+    /**
+     * 팀의 여러 경기 타격 기록을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     */
+    fun findAllByTeamIdAndGameIds(
+        teamId: Long,
+        gameIds: List<Long>,
+    ): List<BattingRecord>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
@@ -15,4 +15,21 @@ interface GameEventRepositoryPort {
     fun findAllByGameIdOrderByEventTimestamp(gameId: Long): List<GameEvent>
 
     fun delete(gameEvent: GameEvent)
+
+    /**
+     * 특정 투수-타자 매치업의 타석 결과를 조회합니다.
+     */
+    fun findPlateAppearancesByPitcherAndBatter(
+        pitcherId: Long,
+        batterId: Long,
+    ): List<GameEvent>
+
+    /**
+     * 특정 연도의 투수-타자 매치업 타석 결과를 조회합니다.
+     */
+    fun findPlateAppearancesByPitcherAndBatterAndYear(
+        pitcherId: Long,
+        batterId: Long,
+        year: Int,
+    ): List<GameEvent>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
@@ -16,4 +16,9 @@ interface GameRepositoryPort {
     fun delete(game: Game)
 
     fun deleteById(id: Long)
+
+    /**
+     * 여러 ID로 Game을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     */
+    fun findAllByIds(ids: List<Long>): List<Game>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameTeamRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameTeamRepositoryPort.kt
@@ -42,4 +42,9 @@ interface GameTeamRepositoryPort {
      * 경기 ID로 GameTeam을 조회합니다.
      */
     fun findAllByGameId(gameId: Long): List<GameTeam>
+
+    /**
+     * 여러 경기 ID로 GameTeam을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     */
+    fun findAllByGameIds(gameIds: List<Long>): List<GameTeam>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameTeamRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameTeamRepositoryPort.kt
@@ -1,0 +1,45 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.game.GameTeam
+
+/**
+ * GameTeam Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface GameTeamRepositoryPort {
+    fun save(gameTeam: GameTeam): GameTeam
+
+    fun findByIdOrNull(id: Long): GameTeam?
+
+    fun findAll(): List<GameTeam>
+
+    fun delete(gameTeam: GameTeam)
+
+    fun deleteById(id: Long)
+
+    /**
+     * 팀 ID로 모든 GameTeam을 조회합니다.
+     */
+    fun findAllByTeamId(teamId: Long): List<GameTeam>
+
+    /**
+     * 팀 ID와 연도로 GameTeam을 조회합니다.
+     */
+    fun findAllByTeamIdAndYear(
+        teamId: Long,
+        year: Int,
+    ): List<GameTeam>
+
+    /**
+     * 팀 ID와 대회 ID로 GameTeam을 조회합니다.
+     */
+    fun findAllByTeamIdAndCompetitionId(
+        teamId: Long,
+        competitionId: Long,
+    ): List<GameTeam>
+
+    /**
+     * 경기 ID로 GameTeam을 조회합니다.
+     */
+    fun findAllByGameId(gameId: Long): List<GameTeam>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchingRecordRepositoryPort.kt
@@ -113,4 +113,12 @@ interface PitchingRecordRepositoryPort {
         playerId: Long,
         year: Int,
     ): List<PitchingRecord>
+
+    /**
+     * 팀의 여러 경기 투수 기록을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     */
+    fun findAllByTeamIdAndGameIds(
+        teamId: Long,
+        gameIds: List<Long>,
+    ): List<PitchingRecord>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameTimelineService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameTimelineService.kt
@@ -1,0 +1,24 @@
+package com.nextup.core.service.game
+
+import com.nextup.core.service.game.dto.GameTimelineDto
+
+/**
+ * 경기 타임라인 서비스 인터페이스
+ *
+ * 경기의 이벤트 타임라인을 조회합니다.
+ */
+interface GameTimelineService {
+    /**
+     * 경기의 타임라인을 조회합니다.
+     *
+     * @param gameId 경기 ID
+     * @param fromInning 시작 이닝 (nullable, 지정하지 않으면 1이닝부터)
+     * @param toInning 종료 이닝 (nullable, 지정하지 않으면 마지막 이닝까지)
+     * @return 경기 타임라인 DTO
+     */
+    fun getTimeline(
+        gameId: Long,
+        fromInning: Int?,
+        toInning: Int?,
+    ): GameTimelineDto
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/GameTimelineDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/GameTimelineDto.kt
@@ -1,0 +1,37 @@
+package com.nextup.core.service.game.dto
+
+import java.time.Instant
+
+/**
+ * 경기 타임라인 DTO
+ *
+ * 경기의 모든 이벤트를 시간 순서대로 제공합니다.
+ */
+data class GameTimelineDto(
+    val gameId: Long,
+    val events: List<TimelineEventDto>,
+    val totalEvents: Int,
+)
+
+/**
+ * 타임라인 이벤트 DTO
+ *
+ * 경기 중 발생한 개별 이벤트 정보를 담습니다.
+ */
+data class TimelineEventDto(
+    val eventId: Long,
+    val inning: Int,
+    val isTopInning: Boolean,
+    val inningDisplay: String,
+    val eventType: String,
+    val description: String,
+    val batterId: Long?,
+    val batterName: String?,
+    val pitcherId: Long?,
+    val pitcherName: String?,
+    val plateAppearanceResult: String?,
+    val runsScored: Int,
+    val outCountBefore: Int,
+    val outCountAfter: Int,
+    val eventTimestamp: Instant,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/MatchupService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/MatchupService.kt
@@ -1,0 +1,12 @@
+package com.nextup.core.service.stats
+
+import com.nextup.core.service.stats.dto.MatchupDto
+
+interface MatchupService {
+    fun getMatchup(
+        pitcherId: Long,
+        batterId: Long,
+        year: Int?,
+        competitionId: Long?,
+    ): MatchupDto
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/PlayerRecordService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/PlayerRecordService.kt
@@ -1,0 +1,30 @@
+package com.nextup.core.service.stats
+
+import com.nextup.core.service.stats.dto.PlayerRecordDto
+import com.nextup.core.service.stats.dto.RecordScope
+import com.nextup.core.service.stats.dto.RecordType
+
+/**
+ * 선수 기록 서비스 인터페이스
+ *
+ * 선수의 타격/투수 기록을 조회하는 서비스입니다.
+ */
+interface PlayerRecordService {
+    /**
+     * 선수 기록을 조회합니다.
+     *
+     * @param playerId 선수 ID
+     * @param scope 조회 범위 (SEASON, CAREER, COMPETITION)
+     * @param type 조회 타입 (BATTING, PITCHING, ALL)
+     * @param year 시즌 연도 (scope=SEASON일 때 필수, null이면 현재 연도)
+     * @param competitionId 대회 ID (scope=COMPETITION일 때 필수)
+     * @return 선수 기록 DTO
+     */
+    fun getPlayerRecord(
+        playerId: Long,
+        scope: RecordScope,
+        type: RecordType,
+        year: Int?,
+        competitionId: Long?,
+    ): PlayerRecordDto
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/RecentFormService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/RecentFormService.kt
@@ -1,0 +1,23 @@
+package com.nextup.core.service.stats
+
+import com.nextup.core.service.stats.dto.FormType
+import com.nextup.core.service.stats.dto.RecentFormDto
+
+/**
+ * 최근 N경기 폼 분석 서비스
+ */
+interface RecentFormService {
+    /**
+     * 선수의 최근 N경기 폼을 분석합니다.
+     *
+     * @param playerId 선수 ID
+     * @param games 조회할 경기 수 (최대 20)
+     * @param type 타격/투수 기록 타입
+     * @return 최근 폼 분석 결과
+     */
+    fun getRecentForm(
+        playerId: Long,
+        games: Int,
+        type: FormType,
+    ): RecentFormDto
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/TeamStatsService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/TeamStatsService.kt
@@ -1,0 +1,24 @@
+package com.nextup.core.service.stats
+
+import com.nextup.core.service.stats.dto.TeamStatsDto
+
+/**
+ * 팀 통계 서비스
+ *
+ * 팀의 전체 통계(성적, 타격, 투수)를 제공합니다.
+ */
+interface TeamStatsService {
+    /**
+     * 팀 통계를 조회합니다.
+     *
+     * @param teamId 팀 ID
+     * @param year 연도 (nullable, 미지정 시 전체 기간)
+     * @param competitionId 대회 ID (nullable, 추후 구현 예정)
+     * @return 팀 통계
+     */
+    fun getTeamStats(
+        teamId: Long,
+        year: Int?,
+        competitionId: Long?,
+    ): TeamStatsDto
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/MatchupDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/MatchupDto.kt
@@ -1,0 +1,37 @@
+package com.nextup.core.service.stats.dto
+
+import java.math.BigDecimal
+
+data class MatchupDto(
+    val pitcherId: Long,
+    val pitcherName: String,
+    val batterId: Long,
+    val batterName: String,
+    val year: Int?,
+    val stats: MatchupStatsDto,
+    val history: List<MatchupHistoryDto>,
+)
+
+data class MatchupStatsDto(
+    val plateAppearances: Int,
+    val atBats: Int,
+    val hits: Int,
+    val doubles: Int,
+    val triples: Int,
+    val homeRuns: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val hitByPitch: Int,
+    val sacrificeFlies: Int,
+    val runsBattedIn: Int,
+    val battingAverage: BigDecimal,
+    val onBasePercentage: BigDecimal,
+    val sluggingPercentage: BigDecimal,
+)
+
+data class MatchupHistoryDto(
+    val gameId: Long,
+    val gameDate: String,
+    val result: String,
+    val description: String,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/PlayerRecordDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/PlayerRecordDto.kt
@@ -1,0 +1,62 @@
+package com.nextup.core.service.stats.dto
+
+import java.math.BigDecimal
+
+/**
+ * 선수 기록 DTO
+ *
+ * 선수의 타격/투수 기록을 통합하여 제공합니다.
+ */
+data class PlayerRecordDto(
+    val playerId: Long,
+    val playerName: String,
+    val scope: RecordScope,
+    val type: RecordType,
+    val year: Int?,
+    val competitionId: Long?,
+    val competitionName: String?,
+    val battingStats: BattingStatsDto?,
+    val pitchingStats: PitchingStatsDto?,
+)
+
+/**
+ * 타격 통계 DTO
+ */
+data class BattingStatsDto(
+    val gamesPlayed: Int,
+    val plateAppearances: Int,
+    val atBats: Int,
+    val hits: Int,
+    val doubles: Int,
+    val triples: Int,
+    val homeRuns: Int,
+    val runs: Int,
+    val runsBattedIn: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val stolenBases: Int,
+    val battingAverage: BigDecimal,
+    val onBasePercentage: BigDecimal,
+    val sluggingPercentage: BigDecimal,
+    val ops: BigDecimal,
+)
+
+/**
+ * 투수 통계 DTO
+ */
+data class PitchingStatsDto(
+    val gamesPlayed: Int,
+    val gamesStarted: Int,
+    val inningsPitched: String,
+    val wins: Int,
+    val losses: Int,
+    val saves: Int,
+    val holds: Int,
+    val earnedRuns: Int,
+    val hitsAllowed: Int,
+    val walksAllowed: Int,
+    val strikeouts: Int,
+    val homeRunsAllowed: Int,
+    val era: BigDecimal,
+    val whip: BigDecimal,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/RecentFormDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/RecentFormDto.kt
@@ -1,0 +1,93 @@
+package com.nextup.core.service.stats.dto
+
+import java.math.BigDecimal
+
+/**
+ * 최근 N경기 폼 분석 결과
+ */
+data class RecentFormDto(
+    val playerId: Long,
+    val playerName: String,
+    val type: FormType,
+    val gamesRequested: Int,
+    val gamesFound: Int,
+    val trend: FormTrend,
+    val trendDescription: String,
+    val batting: RecentBattingFormDto?,
+    val pitching: RecentPitchingFormDto?,
+)
+
+/**
+ * 폼 분석 타입
+ */
+enum class FormType {
+    BATTING,
+    PITCHING,
+}
+
+/**
+ * 폼 트렌드
+ */
+enum class FormTrend {
+    UP, // 상승세
+    DOWN, // 하락세
+    STABLE, // 안정적
+}
+
+/**
+ * 최근 타격 폼
+ */
+data class RecentBattingFormDto(
+    val games: List<GameBattingDto>,
+    val totalAtBats: Int,
+    val totalHits: Int,
+    val totalHomeRuns: Int,
+    val totalRbis: Int,
+    val totalRuns: Int,
+    val recentAverage: BigDecimal, // 최근 N경기 타율
+    val overallAverage: BigDecimal?, // 시즌/통산 타율 (비교용)
+)
+
+/**
+ * 경기별 타격 기록
+ */
+data class GameBattingDto(
+    val gameId: Long,
+    val gameDate: String,
+    val opponentName: String,
+    val atBats: Int,
+    val hits: Int,
+    val homeRuns: Int,
+    val rbis: Int,
+    val runs: Int,
+    val walks: Int,
+    val strikeouts: Int,
+)
+
+/**
+ * 최근 투수 폼
+ */
+data class RecentPitchingFormDto(
+    val games: List<GamePitchingDto>,
+    val totalInningsPitchedOuts: Int,
+    val inningsPitchedDisplay: String,
+    val totalEarnedRuns: Int,
+    val totalStrikeouts: Int,
+    val recentEra: BigDecimal, // 최근 N경기 ERA
+    val overallEra: BigDecimal?, // 시즌/통산 ERA (비교용)
+)
+
+/**
+ * 경기별 투수 기록
+ */
+data class GamePitchingDto(
+    val gameId: Long,
+    val gameDate: String,
+    val opponentName: String,
+    val inningsPitched: String,
+    val earnedRuns: Int,
+    val strikeouts: Int,
+    val walksAllowed: Int,
+    val hitsAllowed: Int,
+    val decision: String?, // 승/패/세/홀 등
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/RecordScope.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/RecordScope.kt
@@ -1,0 +1,23 @@
+package com.nextup.core.service.stats.dto
+
+/**
+ * 기록 조회 범위
+ *
+ * 선수 기록을 조회할 때 시즌별, 통산, 대회별 등의 범위를 지정합니다.
+ */
+enum class RecordScope {
+    /**
+     * 시즌별 통계
+     */
+    SEASON,
+
+    /**
+     * 통산 통계
+     */
+    CAREER,
+
+    /**
+     * 대회별 통계
+     */
+    COMPETITION,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/RecordType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/RecordType.kt
@@ -1,0 +1,23 @@
+package com.nextup.core.service.stats.dto
+
+/**
+ * 기록 조회 타입
+ *
+ * 타격, 투수, 전체 기록을 선택합니다.
+ */
+enum class RecordType {
+    /**
+     * 타격 기록만
+     */
+    BATTING,
+
+    /**
+     * 투수 기록만
+     */
+    PITCHING,
+
+    /**
+     * 전체 기록 (타격 + 투수)
+     */
+    ALL,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/TeamStatsDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/TeamStatsDto.kt
@@ -1,0 +1,43 @@
+package com.nextup.core.service.stats.dto
+
+import java.math.BigDecimal
+
+data class TeamStatsDto(
+    val teamId: Long,
+    val teamName: String,
+    val year: Int?,
+    val competitionId: Long?,
+    val competitionName: String?,
+    val record: TeamRecordDto,
+    val batting: TeamBattingStatsDto,
+    val pitching: TeamPitchingStatsDto,
+)
+
+data class TeamRecordDto(
+    val gamesPlayed: Int,
+    val wins: Int,
+    val losses: Int,
+    val draws: Int,
+    val winningPercentage: BigDecimal, // 승률 (승 / (승 + 패))
+)
+
+data class TeamBattingStatsDto(
+    val totalAtBats: Int,
+    val totalHits: Int,
+    val totalHomeRuns: Int,
+    val totalRunsBattedIn: Int,
+    val totalRuns: Int,
+    val teamBattingAverage: BigDecimal, // 팀 타율
+    val teamOnBasePercentage: BigDecimal, // 팀 출루율
+    val teamSluggingPercentage: BigDecimal, // 팀 장타율
+)
+
+data class TeamPitchingStatsDto(
+    val totalInningsPitchedOuts: Int,
+    val inningsPitchedDisplay: String, // "150.2" 형식
+    val totalEarnedRuns: Int,
+    val totalStrikeouts: Int,
+    val totalWalksAllowed: Int,
+    val teamEra: BigDecimal, // 팀 방어율
+    val teamWhip: BigDecimal, // 팀 WHIP
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/dto/GameDtoTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/dto/GameDtoTest.kt
@@ -1,0 +1,230 @@
+package com.nextup.core.service.game.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("Game DTO 테스트")
+class GameDtoTest {
+    @Nested
+    @DisplayName("GameTimelineDto")
+    inner class GameTimelineDtoTest {
+        @Test
+        fun `GameTimelineDto 생성 및 속성 접근`() {
+            val dto =
+                GameTimelineDto(
+                    gameId = 1L,
+                    events = emptyList(),
+                    totalEvents = 0,
+                )
+
+            assertThat(dto.gameId).isEqualTo(1L)
+            assertThat(dto.events).isEmpty()
+            assertThat(dto.totalEvents).isEqualTo(0)
+        }
+
+        @Test
+        fun `GameTimelineDto with events`() {
+            val events =
+                listOf(
+                    TimelineEventDto(
+                        eventId = 1L,
+                        inning = 1,
+                        isTopInning = true,
+                        inningDisplay = "1회초",
+                        eventType = "PLATE_APPEARANCE",
+                        description = "안타",
+                        batterId = 100L,
+                        batterName = "홍길동",
+                        pitcherId = 200L,
+                        pitcherName = "김철수",
+                        plateAppearanceResult = "SINGLE",
+                        runsScored = 0,
+                        outCountBefore = 0,
+                        outCountAfter = 0,
+                        eventTimestamp = Instant.parse("2026-01-01T10:00:00Z"),
+                    ),
+                )
+
+            val dto =
+                GameTimelineDto(
+                    gameId = 1L,
+                    events = events,
+                    totalEvents = 1,
+                )
+
+            assertThat(dto.events).hasSize(1)
+            assertThat(dto.totalEvents).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("TimelineEventDto")
+    inner class TimelineEventDtoTest {
+        @Test
+        fun `TimelineEventDto 생성 및 속성 접근`() {
+            val dto =
+                TimelineEventDto(
+                    eventId = 10L,
+                    inning = 3,
+                    isTopInning = false,
+                    inningDisplay = "3회말",
+                    eventType = "PLATE_APPEARANCE",
+                    description = "홈런",
+                    batterId = 100L,
+                    batterName = "홍길동",
+                    pitcherId = 200L,
+                    pitcherName = "김철수",
+                    plateAppearanceResult = "HOME_RUN",
+                    runsScored = 2,
+                    outCountBefore = 1,
+                    outCountAfter = 1,
+                    eventTimestamp = Instant.parse("2026-01-01T11:00:00Z"),
+                )
+
+            assertThat(dto.eventId).isEqualTo(10L)
+            assertThat(dto.inning).isEqualTo(3)
+            assertThat(dto.isTopInning).isFalse()
+            assertThat(dto.inningDisplay).isEqualTo("3회말")
+            assertThat(dto.eventType).isEqualTo("PLATE_APPEARANCE")
+            assertThat(dto.description).isEqualTo("홈런")
+            assertThat(dto.batterId).isEqualTo(100L)
+            assertThat(dto.batterName).isEqualTo("홍길동")
+            assertThat(dto.pitcherId).isEqualTo(200L)
+            assertThat(dto.pitcherName).isEqualTo("김철수")
+            assertThat(dto.plateAppearanceResult).isEqualTo("HOME_RUN")
+            assertThat(dto.runsScored).isEqualTo(2)
+            assertThat(dto.outCountBefore).isEqualTo(1)
+            assertThat(dto.outCountAfter).isEqualTo(1)
+        }
+
+        @Test
+        fun `TimelineEventDto with null values`() {
+            val dto =
+                TimelineEventDto(
+                    eventId = 20L,
+                    inning = 5,
+                    isTopInning = true,
+                    inningDisplay = "5회초",
+                    eventType = "INNING_START",
+                    description = "5회초 시작",
+                    batterId = null,
+                    batterName = null,
+                    pitcherId = null,
+                    pitcherName = null,
+                    plateAppearanceResult = null,
+                    runsScored = 0,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventTimestamp = Instant.parse("2026-01-01T12:00:00Z"),
+                )
+
+            assertThat(dto.batterId).isNull()
+            assertThat(dto.batterName).isNull()
+            assertThat(dto.pitcherId).isNull()
+            assertThat(dto.pitcherName).isNull()
+            assertThat(dto.plateAppearanceResult).isNull()
+        }
+
+        @Test
+        fun `TimelineEventDto copy 테스트`() {
+            val original =
+                TimelineEventDto(
+                    eventId = 1L,
+                    inning = 1,
+                    isTopInning = true,
+                    inningDisplay = "1회초",
+                    eventType = "PLATE_APPEARANCE",
+                    description = "안타",
+                    batterId = 100L,
+                    batterName = "홍길동",
+                    pitcherId = 200L,
+                    pitcherName = "김철수",
+                    plateAppearanceResult = "SINGLE",
+                    runsScored = 0,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventTimestamp = Instant.parse("2026-01-01T10:00:00Z"),
+                )
+
+            val copied = original.copy(runsScored = 1)
+
+            assertThat(copied.runsScored).isEqualTo(1)
+            assertThat(copied.eventId).isEqualTo(original.eventId)
+        }
+
+        @Test
+        fun `TimelineEventDto equals 테스트`() {
+            val dto1 =
+                TimelineEventDto(
+                    eventId = 1L,
+                    inning = 1,
+                    isTopInning = true,
+                    inningDisplay = "1회초",
+                    eventType = "PLATE_APPEARANCE",
+                    description = "안타",
+                    batterId = 100L,
+                    batterName = "홍길동",
+                    pitcherId = 200L,
+                    pitcherName = "김철수",
+                    plateAppearanceResult = "SINGLE",
+                    runsScored = 0,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventTimestamp = Instant.parse("2026-01-01T10:00:00Z"),
+                )
+
+            val dto2 =
+                TimelineEventDto(
+                    eventId = 1L,
+                    inning = 1,
+                    isTopInning = true,
+                    inningDisplay = "1회초",
+                    eventType = "PLATE_APPEARANCE",
+                    description = "안타",
+                    batterId = 100L,
+                    batterName = "홍길동",
+                    pitcherId = 200L,
+                    pitcherName = "김철수",
+                    plateAppearanceResult = "SINGLE",
+                    runsScored = 0,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventTimestamp = Instant.parse("2026-01-01T10:00:00Z"),
+                )
+
+            assertThat(dto1).isEqualTo(dto2)
+            assertThat(dto1.hashCode()).isEqualTo(dto2.hashCode())
+        }
+
+        @Test
+        fun `TimelineEventDto toString 테스트`() {
+            val dto =
+                TimelineEventDto(
+                    eventId = 1L,
+                    inning = 1,
+                    isTopInning = true,
+                    inningDisplay = "1회초",
+                    eventType = "PLATE_APPEARANCE",
+                    description = "안타",
+                    batterId = 100L,
+                    batterName = "홍길동",
+                    pitcherId = 200L,
+                    pitcherName = "김철수",
+                    plateAppearanceResult = "SINGLE",
+                    runsScored = 0,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    eventTimestamp = Instant.parse("2026-01-01T10:00:00Z"),
+                )
+
+            val str = dto.toString()
+
+            assertThat(str).contains("eventId=1")
+            assertThat(str).contains("inning=1")
+            assertThat(str).contains("홍길동")
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stats/dto/StatsDtoTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stats/dto/StatsDtoTest.kt
@@ -1,0 +1,497 @@
+package com.nextup.core.service.stats.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("Stats DTO 테스트")
+class StatsDtoTest {
+    @Nested
+    @DisplayName("PlayerRecordDto")
+    inner class PlayerRecordDtoTest {
+        @Test
+        fun `PlayerRecordDto 생성 및 속성 접근`() {
+            val dto =
+                PlayerRecordDto(
+                    playerId = 1L,
+                    playerName = "홍길동",
+                    scope = RecordScope.CAREER,
+                    type = RecordType.ALL,
+                    year = 2026,
+                    competitionId = 10L,
+                    competitionName = "봄리그",
+                    battingStats = null,
+                    pitchingStats = null,
+                )
+
+            assertThat(dto.playerId).isEqualTo(1L)
+            assertThat(dto.playerName).isEqualTo("홍길동")
+            assertThat(dto.scope).isEqualTo(RecordScope.CAREER)
+            assertThat(dto.type).isEqualTo(RecordType.ALL)
+            assertThat(dto.year).isEqualTo(2026)
+            assertThat(dto.competitionId).isEqualTo(10L)
+            assertThat(dto.competitionName).isEqualTo("봄리그")
+        }
+
+        @Test
+        fun `PlayerRecordDto copy 테스트`() {
+            val original =
+                PlayerRecordDto(
+                    playerId = 1L,
+                    playerName = "홍길동",
+                    scope = RecordScope.CAREER,
+                    type = RecordType.ALL,
+                    year = null,
+                    competitionId = null,
+                    competitionName = null,
+                    battingStats = null,
+                    pitchingStats = null,
+                )
+
+            val copied = original.copy(year = 2026)
+
+            assertThat(copied.year).isEqualTo(2026)
+            assertThat(copied.playerId).isEqualTo(original.playerId)
+        }
+    }
+
+    @Nested
+    @DisplayName("BattingStatsDto")
+    inner class BattingStatsDtoTest {
+        @Test
+        fun `BattingStatsDto 생성 및 속성 접근`() {
+            val dto =
+                BattingStatsDto(
+                    gamesPlayed = 100,
+                    plateAppearances = 450,
+                    atBats = 400,
+                    hits = 120,
+                    doubles = 25,
+                    triples = 3,
+                    homeRuns = 15,
+                    runs = 60,
+                    runsBattedIn = 55,
+                    walks = 40,
+                    strikeouts = 80,
+                    stolenBases = 10,
+                    battingAverage = BigDecimal("0.300"),
+                    onBasePercentage = BigDecimal("0.378"),
+                    sluggingPercentage = BigDecimal("0.485"),
+                    ops = BigDecimal("0.863"),
+                )
+
+            assertThat(dto.gamesPlayed).isEqualTo(100)
+            assertThat(dto.hits).isEqualTo(120)
+            assertThat(dto.battingAverage).isEqualTo(BigDecimal("0.300"))
+            assertThat(dto.ops).isEqualTo(BigDecimal("0.863"))
+        }
+    }
+
+    @Nested
+    @DisplayName("PitchingStatsDto")
+    inner class PitchingStatsDtoTest {
+        @Test
+        fun `PitchingStatsDto 생성 및 속성 접근`() {
+            val dto =
+                PitchingStatsDto(
+                    gamesPlayed = 30,
+                    gamesStarted = 25,
+                    inningsPitched = "160.2",
+                    wins = 10,
+                    losses = 5,
+                    saves = 0,
+                    holds = 0,
+                    earnedRuns = 45,
+                    hitsAllowed = 140,
+                    walksAllowed = 40,
+                    strikeouts = 130,
+                    homeRunsAllowed = 12,
+                    era = BigDecimal("2.52"),
+                    whip = BigDecimal("1.12"),
+                )
+
+            assertThat(dto.gamesPlayed).isEqualTo(30)
+            assertThat(dto.wins).isEqualTo(10)
+            assertThat(dto.era).isEqualTo(BigDecimal("2.52"))
+            assertThat(dto.inningsPitched).isEqualTo("160.2")
+        }
+    }
+
+    @Nested
+    @DisplayName("RecordScope & RecordType")
+    inner class EnumTest {
+        @Test
+        fun `RecordScope enum 값 확인`() {
+            assertThat(RecordScope.values()).containsExactly(
+                RecordScope.SEASON,
+                RecordScope.CAREER,
+                RecordScope.COMPETITION,
+            )
+        }
+
+        @Test
+        fun `RecordType enum 값 확인`() {
+            assertThat(RecordType.values()).containsExactly(
+                RecordType.BATTING,
+                RecordType.PITCHING,
+                RecordType.ALL,
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("RecentFormDto")
+    inner class RecentFormDtoTest {
+        @Test
+        fun `RecentFormDto 생성 및 속성 접근`() {
+            val dto =
+                RecentFormDto(
+                    playerId = 1L,
+                    playerName = "홍길동",
+                    type = FormType.BATTING,
+                    gamesRequested = 5,
+                    gamesFound = 5,
+                    trend = FormTrend.UP,
+                    trendDescription = "상승세",
+                    batting = null,
+                    pitching = null,
+                )
+
+            assertThat(dto.playerId).isEqualTo(1L)
+            assertThat(dto.type).isEqualTo(FormType.BATTING)
+            assertThat(dto.trend).isEqualTo(FormTrend.UP)
+        }
+
+        @Test
+        fun `FormType enum 값 확인`() {
+            assertThat(FormType.values()).containsExactly(
+                FormType.BATTING,
+                FormType.PITCHING,
+            )
+        }
+
+        @Test
+        fun `FormTrend enum 값 확인`() {
+            assertThat(FormTrend.values()).containsExactly(
+                FormTrend.UP,
+                FormTrend.DOWN,
+                FormTrend.STABLE,
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("RecentBattingFormDto")
+    inner class RecentBattingFormDtoTest {
+        @Test
+        fun `RecentBattingFormDto 생성 및 속성 접근`() {
+            val dto =
+                RecentBattingFormDto(
+                    games = emptyList(),
+                    totalAtBats = 20,
+                    totalHits = 8,
+                    totalHomeRuns = 2,
+                    totalRbis = 5,
+                    totalRuns = 4,
+                    recentAverage = BigDecimal("0.400"),
+                    overallAverage = BigDecimal("0.300"),
+                )
+
+            assertThat(dto.totalAtBats).isEqualTo(20)
+            assertThat(dto.totalHits).isEqualTo(8)
+            assertThat(dto.recentAverage).isEqualTo(BigDecimal("0.400"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GameBattingDto")
+    inner class GameBattingDtoTest {
+        @Test
+        fun `GameBattingDto 생성 및 속성 접근`() {
+            val dto =
+                GameBattingDto(
+                    gameId = 1L,
+                    gameDate = "2026-01-20",
+                    opponentName = "상대팀",
+                    atBats = 4,
+                    hits = 2,
+                    homeRuns = 1,
+                    rbis = 2,
+                    runs = 1,
+                    walks = 0,
+                    strikeouts = 1,
+                )
+
+            assertThat(dto.gameId).isEqualTo(1L)
+            assertThat(dto.opponentName).isEqualTo("상대팀")
+            assertThat(dto.hits).isEqualTo(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("RecentPitchingFormDto")
+    inner class RecentPitchingFormDtoTest {
+        @Test
+        fun `RecentPitchingFormDto 생성 및 속성 접근`() {
+            val dto =
+                RecentPitchingFormDto(
+                    games = emptyList(),
+                    totalInningsPitchedOuts = 63,
+                    inningsPitchedDisplay = "21.0",
+                    totalEarnedRuns = 5,
+                    totalStrikeouts = 20,
+                    recentEra = BigDecimal("2.14"),
+                    overallEra = BigDecimal("3.00"),
+                )
+
+            assertThat(dto.totalInningsPitchedOuts).isEqualTo(63)
+            assertThat(dto.inningsPitchedDisplay).isEqualTo("21.0")
+            assertThat(dto.recentEra).isEqualTo(BigDecimal("2.14"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GamePitchingDto")
+    inner class GamePitchingDtoTest {
+        @Test
+        fun `GamePitchingDto 생성 및 속성 접근`() {
+            val dto =
+                GamePitchingDto(
+                    gameId = 10L,
+                    gameDate = "2026-01-25",
+                    opponentName = "상대팀",
+                    inningsPitched = "7.0",
+                    earnedRuns = 2,
+                    strikeouts = 8,
+                    walksAllowed = 2,
+                    hitsAllowed = 5,
+                    decision = "W",
+                )
+
+            assertThat(dto.gameId).isEqualTo(10L)
+            assertThat(dto.inningsPitched).isEqualTo("7.0")
+            assertThat(dto.decision).isEqualTo("W")
+        }
+
+        @Test
+        fun `GamePitchingDto with null decision`() {
+            val dto =
+                GamePitchingDto(
+                    gameId = 11L,
+                    gameDate = "2026-01-26",
+                    opponentName = "상대팀",
+                    inningsPitched = "5.0",
+                    earnedRuns = 3,
+                    strikeouts = 5,
+                    walksAllowed = 2,
+                    hitsAllowed = 6,
+                    decision = null,
+                )
+
+            assertThat(dto.decision).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("MatchupDto")
+    inner class MatchupDtoTest {
+        @Test
+        fun `MatchupDto 생성 및 속성 접근`() {
+            val dto =
+                MatchupDto(
+                    pitcherId = 100L,
+                    pitcherName = "김투수",
+                    batterId = 200L,
+                    batterName = "이타자",
+                    year = 2026,
+                    stats =
+                        MatchupStatsDto(
+                            plateAppearances = 10,
+                            atBats = 8,
+                            hits = 3,
+                            doubles = 1,
+                            triples = 0,
+                            homeRuns = 1,
+                            walks = 1,
+                            strikeouts = 2,
+                            hitByPitch = 1,
+                            sacrificeFlies = 0,
+                            runsBattedIn = 2,
+                            battingAverage = BigDecimal("0.375"),
+                            onBasePercentage = BigDecimal("0.500"),
+                            sluggingPercentage = BigDecimal("0.750"),
+                        ),
+                    history = emptyList(),
+                )
+
+            assertThat(dto.pitcherId).isEqualTo(100L)
+            assertThat(dto.batterName).isEqualTo("이타자")
+            assertThat(dto.stats.hits).isEqualTo(3)
+        }
+    }
+
+    @Nested
+    @DisplayName("MatchupStatsDto")
+    inner class MatchupStatsDtoTest {
+        @Test
+        fun `MatchupStatsDto 생성 및 속성 접근`() {
+            val dto =
+                MatchupStatsDto(
+                    plateAppearances = 20,
+                    atBats = 16,
+                    hits = 5,
+                    doubles = 2,
+                    triples = 1,
+                    homeRuns = 2,
+                    walks = 3,
+                    strikeouts = 4,
+                    hitByPitch = 1,
+                    sacrificeFlies = 0,
+                    runsBattedIn = 6,
+                    battingAverage = BigDecimal("0.313"),
+                    onBasePercentage = BigDecimal("0.450"),
+                    sluggingPercentage = BigDecimal("0.750"),
+                )
+
+            assertThat(dto.plateAppearances).isEqualTo(20)
+            assertThat(dto.homeRuns).isEqualTo(2)
+            assertThat(dto.battingAverage).isEqualTo(BigDecimal("0.313"))
+        }
+    }
+
+    @Nested
+    @DisplayName("MatchupHistoryDto")
+    inner class MatchupHistoryDtoTest {
+        @Test
+        fun `MatchupHistoryDto 생성 및 속성 접근`() {
+            val dto =
+                MatchupHistoryDto(
+                    gameId = 1L,
+                    gameDate = "2026-01-15",
+                    result = "안타",
+                    description = "2타수 1안타",
+                )
+
+            assertThat(dto.gameId).isEqualTo(1L)
+            assertThat(dto.result).isEqualTo("안타")
+            assertThat(dto.description).isEqualTo("2타수 1안타")
+        }
+    }
+
+    @Nested
+    @DisplayName("TeamStatsDto")
+    inner class TeamStatsDtoTest {
+        @Test
+        fun `TeamStatsDto 생성 및 속성 접근`() {
+            val dto =
+                TeamStatsDto(
+                    teamId = 1L,
+                    teamName = "테스트팀",
+                    year = 2026,
+                    competitionId = 10L,
+                    competitionName = "봄리그",
+                    record =
+                        TeamRecordDto(
+                            gamesPlayed = 20,
+                            wins = 12,
+                            losses = 6,
+                            draws = 2,
+                            winningPercentage = BigDecimal("0.667"),
+                        ),
+                    batting =
+                        TeamBattingStatsDto(
+                            totalAtBats = 700,
+                            totalHits = 210,
+                            totalHomeRuns = 25,
+                            totalRunsBattedIn = 95,
+                            totalRuns = 100,
+                            teamBattingAverage = BigDecimal("0.300"),
+                            teamOnBasePercentage = BigDecimal("0.380"),
+                            teamSluggingPercentage = BigDecimal("0.450"),
+                        ),
+                    pitching =
+                        TeamPitchingStatsDto(
+                            totalInningsPitchedOuts = 540,
+                            inningsPitchedDisplay = "180.0",
+                            totalEarnedRuns = 60,
+                            totalStrikeouts = 150,
+                            totalWalksAllowed = 55,
+                            teamEra = BigDecimal("3.00"),
+                            teamWhip = BigDecimal("1.20"),
+                        ),
+                )
+
+            assertThat(dto.teamId).isEqualTo(1L)
+            assertThat(dto.teamName).isEqualTo("테스트팀")
+            assertThat(dto.record.wins).isEqualTo(12)
+            assertThat(dto.batting.totalHits).isEqualTo(210)
+            assertThat(dto.pitching.teamEra).isEqualTo(BigDecimal("3.00"))
+        }
+    }
+
+    @Nested
+    @DisplayName("TeamRecordDto")
+    inner class TeamRecordDtoTest {
+        @Test
+        fun `TeamRecordDto 생성 및 속성 접근`() {
+            val dto =
+                TeamRecordDto(
+                    gamesPlayed = 30,
+                    wins = 18,
+                    losses = 10,
+                    draws = 2,
+                    winningPercentage = BigDecimal("0.643"),
+                )
+
+            assertThat(dto.gamesPlayed).isEqualTo(30)
+            assertThat(dto.wins).isEqualTo(18)
+            assertThat(dto.winningPercentage).isEqualTo(BigDecimal("0.643"))
+        }
+    }
+
+    @Nested
+    @DisplayName("TeamBattingStatsDto")
+    inner class TeamBattingStatsDtoTest {
+        @Test
+        fun `TeamBattingStatsDto 생성 및 속성 접근`() {
+            val dto =
+                TeamBattingStatsDto(
+                    totalAtBats = 500,
+                    totalHits = 150,
+                    totalHomeRuns = 20,
+                    totalRunsBattedIn = 70,
+                    totalRuns = 80,
+                    teamBattingAverage = BigDecimal("0.300"),
+                    teamOnBasePercentage = BigDecimal("0.370"),
+                    teamSluggingPercentage = BigDecimal("0.460"),
+                )
+
+            assertThat(dto.totalAtBats).isEqualTo(500)
+            assertThat(dto.teamBattingAverage).isEqualTo(BigDecimal("0.300"))
+        }
+    }
+
+    @Nested
+    @DisplayName("TeamPitchingStatsDto")
+    inner class TeamPitchingStatsDtoTest {
+        @Test
+        fun `TeamPitchingStatsDto 생성 및 속성 접근`() {
+            val dto =
+                TeamPitchingStatsDto(
+                    totalInningsPitchedOuts = 450,
+                    inningsPitchedDisplay = "150.0",
+                    totalEarnedRuns = 50,
+                    totalStrikeouts = 120,
+                    totalWalksAllowed = 45,
+                    teamEra = BigDecimal("3.00"),
+                    teamWhip = BigDecimal("1.15"),
+                )
+
+            assertThat(dto.totalInningsPitchedOuts).isEqualTo(450)
+            assertThat(dto.teamEra).isEqualTo(BigDecimal("3.00"))
+            assertThat(dto.teamWhip).isEqualTo(BigDecimal("1.15"))
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
@@ -162,4 +162,21 @@ interface BattingRecordRepository :
         @Param("playerId") playerId: Long,
         @Param("year") year: Int,
     ): List<BattingRecord>
+
+    /**
+     * 팀의 여러 경기 타격 기록을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     */
+    @Query(
+        """
+        SELECT br FROM BattingRecord br
+        JOIN br.gamePlayer gp
+        JOIN gp.gameTeam gt
+        WHERE gt.team.id = :teamId
+        AND gp.game.id IN :gameIds
+    """,
+    )
+    override fun findAllByTeamIdAndGameIds(
+        @Param("teamId") teamId: Long,
+        @Param("gameIds") gameIds: List<Long>,
+    ): List<BattingRecord>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameEventRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameEventRepository.kt
@@ -1,0 +1,46 @@
+package com.nextup.infrastructure.repository.game
+
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface GameEventRepository :
+    JpaRepository<GameEvent, Long>,
+    GameEventRepositoryPort {
+    override fun findByIdOrNull(id: Long): GameEvent? = findById(id).orElse(null)
+
+    @Query(
+        """
+        SELECT ge FROM GameEvent ge
+        JOIN FETCH ge.game g
+        WHERE ge.pitcher.player.id = :pitcherId
+          AND ge.batter.player.id = :batterId
+          AND ge.eventType = 'PLATE_APPEARANCE'
+          AND ge.plateAppearanceResult IS NOT NULL
+        ORDER BY ge.eventTimestamp
+        """,
+    )
+    override fun findPlateAppearancesByPitcherAndBatter(
+        pitcherId: Long,
+        batterId: Long,
+    ): List<GameEvent>
+
+    @Query(
+        """
+        SELECT ge FROM GameEvent ge
+        JOIN FETCH ge.game g
+        WHERE ge.pitcher.player.id = :pitcherId
+          AND ge.batter.player.id = :batterId
+          AND ge.eventType = 'PLATE_APPEARANCE'
+          AND ge.plateAppearanceResult IS NOT NULL
+          AND YEAR(g.scheduledAt) = :year
+        ORDER BY ge.eventTimestamp
+        """,
+    )
+    override fun findPlateAppearancesByPitcherAndBatterAndYear(
+        pitcherId: Long,
+        batterId: Long,
+        year: Int,
+    ): List<GameEvent>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
@@ -8,4 +8,6 @@ interface GameRepository :
     JpaRepository<Game, Long>,
     GameRepositoryPort {
     override fun findByIdOrNull(id: Long): Game? = findById(id).orElse(null)
+
+    override fun findAllByIds(ids: List<Long>): List<Game> = findAllById(ids)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameTeamRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameTeamRepository.kt
@@ -52,4 +52,8 @@ interface GameTeamRepository :
     ): List<GameTeam>
 
     fun findByGameId(gameId: Long): List<GameTeam>
+
+    override fun findAllByGameIds(gameIds: List<Long>): List<GameTeam> = findByGameIdIn(gameIds)
+
+    fun findByGameIdIn(gameIds: List<Long>): List<GameTeam>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameTeamRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameTeamRepository.kt
@@ -1,0 +1,55 @@
+package com.nextup.infrastructure.repository.game
+
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface GameTeamRepository :
+    JpaRepository<GameTeam, Long>,
+    GameTeamRepositoryPort {
+    override fun findByIdOrNull(id: Long): GameTeam? = findById(id).orElse(null)
+
+    override fun findAllByTeamId(teamId: Long): List<GameTeam> = findByTeamId(teamId)
+
+    override fun findAllByTeamIdAndYear(
+        teamId: Long,
+        year: Int,
+    ): List<GameTeam> = findByTeamIdAndGameScheduledAtYear(teamId, year)
+
+    override fun findAllByTeamIdAndCompetitionId(
+        teamId: Long,
+        competitionId: Long,
+    ): List<GameTeam> = findByTeamIdAndGameCompetitionId(teamId, competitionId)
+
+    override fun findAllByGameId(gameId: Long): List<GameTeam> = findByGameId(gameId)
+
+    // Spring Data JPA 쿼리 메서드
+    fun findByTeamId(teamId: Long): List<GameTeam>
+
+    @Query(
+        """
+        SELECT gt FROM GameTeam gt
+        WHERE gt.team.id = :teamId
+        AND YEAR(gt.game.scheduledAt) = :year
+        """,
+    )
+    fun findByTeamIdAndGameScheduledAtYear(
+        teamId: Long,
+        year: Int,
+    ): List<GameTeam>
+
+    @Query(
+        """
+        SELECT gt FROM GameTeam gt
+        WHERE gt.team.id = :teamId
+        AND gt.game.competition.id = :competitionId
+        """,
+    )
+    fun findByTeamIdAndGameCompetitionId(
+        teamId: Long,
+        competitionId: Long,
+    ): List<GameTeam>
+
+    fun findByGameId(gameId: Long): List<GameTeam>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
@@ -251,4 +251,21 @@ interface PitchingRecordRepository :
         @Param("playerId") playerId: Long,
         @Param("year") year: Int,
     ): List<PitchingRecord>
+
+    /**
+     * 팀의 여러 경기 투수 기록을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     */
+    @Query(
+        """
+        SELECT pr FROM PitchingRecord pr
+        JOIN pr.gamePlayer gp
+        JOIN gp.gameTeam gt
+        WHERE gt.team.id = :teamId
+        AND gp.game.id IN :gameIds
+    """,
+    )
+    override fun findAllByTeamIdAndGameIds(
+        @Param("teamId") teamId: Long,
+        @Param("gameIds") gameIds: List<Long>,
+    ): List<PitchingRecord>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameTimelineServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameTimelineServiceImpl.kt
@@ -1,0 +1,76 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.service.game.GameTimelineService
+import com.nextup.core.service.game.dto.GameTimelineDto
+import com.nextup.core.service.game.dto.TimelineEventDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 경기 타임라인 서비스 구현
+ */
+@Service
+@Transactional(readOnly = true)
+class GameTimelineServiceImpl(
+    private val gameEventRepository: GameEventRepositoryPort,
+) : GameTimelineService {
+    override fun getTimeline(
+        gameId: Long,
+        fromInning: Int?,
+        toInning: Int?,
+    ): GameTimelineDto {
+        val allEvents = gameEventRepository.findAllByGameIdOrderByEventTimestamp(gameId)
+
+        val filteredEvents =
+            allEvents.filter { event ->
+                val inningMatch =
+                    when {
+                        fromInning != null && toInning != null -> event.inning in fromInning..toInning
+                        fromInning != null -> event.inning >= fromInning
+                        toInning != null -> event.inning <= toInning
+                        else -> true
+                    }
+                inningMatch
+            }
+
+        val eventDtos = filteredEvents.map { it.toTimelineEventDto() }
+
+        return GameTimelineDto(
+            gameId = gameId,
+            events = eventDtos,
+            totalEvents = eventDtos.size,
+        )
+    }
+
+    /**
+     * GameEvent를 TimelineEventDto로 변환합니다.
+     */
+    private fun GameEvent.toTimelineEventDto(): TimelineEventDto =
+        TimelineEventDto(
+            eventId = this.id,
+            inning = this.inning,
+            isTopInning = this.isTopInning,
+            inningDisplay = formatInningDisplay(this.inning, this.isTopInning),
+            eventType = this.eventType.displayName,
+            description = this.description,
+            batterId = this.batter?.id,
+            batterName = this.batter?.player?.name,
+            pitcherId = this.pitcher?.id,
+            pitcherName = this.pitcher?.player?.name,
+            plateAppearanceResult = this.plateAppearanceResult?.displayName,
+            runsScored = this.runsScored,
+            outCountBefore = this.outCountBefore,
+            outCountAfter = this.outCountAfter,
+            eventTimestamp = this.eventTimestamp,
+        )
+
+    /**
+     * 이닝 표시 문자열을 생성합니다.
+     */
+    private fun formatInningDisplay(
+        inning: Int,
+        isTopInning: Boolean,
+    ): String = "${inning}회${if (isTopInning) "초" else "말"}"
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/MatchupServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/MatchupServiceImpl.kt
@@ -1,0 +1,162 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.core.domain.game.PlateAppearanceResult
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.service.stats.MatchupService
+import com.nextup.core.service.stats.dto.MatchupDto
+import com.nextup.core.service.stats.dto.MatchupHistoryDto
+import com.nextup.core.service.stats.dto.MatchupStatsDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.format.DateTimeFormatter
+
+@Service
+@Transactional(readOnly = true)
+class MatchupServiceImpl(
+    private val gameEventRepositoryPort: GameEventRepositoryPort,
+    private val playerRepositoryPort: PlayerRepositoryPort,
+) : MatchupService {
+    override fun getMatchup(
+        pitcherId: Long,
+        batterId: Long,
+        year: Int?,
+        competitionId: Long?,
+    ): MatchupDto {
+        // 선수 존재 여부 확인
+        val pitcher =
+            playerRepositoryPort.findByIdOrNull(pitcherId)
+                ?: throw PlayerNotFoundException(pitcherId)
+        val batter =
+            playerRepositoryPort.findByIdOrNull(batterId)
+                ?: throw PlayerNotFoundException(batterId)
+
+        // 매치업 이벤트 조회
+        val events =
+            if (year != null) {
+                gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatterAndYear(
+                    pitcherId,
+                    batterId,
+                    year,
+                )
+            } else {
+                gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatter(
+                    pitcherId,
+                    batterId,
+                )
+            }
+
+        // 통계 계산
+        val stats = calculateStats(events)
+
+        // 히스토리 생성
+        val history =
+            events.map { event ->
+                MatchupHistoryDto(
+                    gameId = event.game.id,
+                    gameDate = event.game.scheduledAt.format(DateTimeFormatter.ISO_LOCAL_DATE),
+                    result = event.plateAppearanceResult?.displayName ?: "기록 없음",
+                    description = event.description,
+                )
+            }
+
+        return MatchupDto(
+            pitcherId = pitcherId,
+            pitcherName = pitcher.name,
+            batterId = batterId,
+            batterName = batter.name,
+            year = year,
+            stats = stats,
+            history = history,
+        )
+    }
+
+    private fun calculateStats(events: List<com.nextup.core.domain.game.GameEvent>): MatchupStatsDto {
+        var plateAppearances = 0
+        var atBats = 0
+        var hits = 0
+        var doubles = 0
+        var triples = 0
+        var homeRuns = 0
+        var walks = 0
+        var strikeouts = 0
+        var hitByPitch = 0
+        var sacrificeFlies = 0
+        var runsBattedIn = 0
+        var totalBases = 0
+
+        events.forEach { event ->
+            val result = event.plateAppearanceResult ?: return@forEach
+
+            plateAppearances++
+            runsBattedIn += event.rbis
+
+            when {
+                result.isAtBat -> {
+                    atBats++
+                    if (result.isHit) {
+                        hits++
+                        totalBases += result.totalBases
+                        when (result) {
+                            PlateAppearanceResult.DOUBLE -> doubles++
+                            PlateAppearanceResult.TRIPLE -> triples++
+                            PlateAppearanceResult.HOME_RUN -> homeRuns++
+                            else -> {} // SINGLE
+                        }
+                    } else if (result.isStrikeout) {
+                        strikeouts++
+                    }
+                }
+                result.isWalk -> walks++
+                result.isHitByPitch -> hitByPitch++
+                result == PlateAppearanceResult.SACRIFICE_FLY -> sacrificeFlies++
+            }
+        }
+
+        // 타율 계산: hits / atBats
+        val battingAverage =
+            if (atBats > 0) {
+                BigDecimal(hits).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal.ZERO
+            }
+
+        // 출루율 계산: (hits + walks + hbp) / (atBats + walks + hbp + sf)
+        val onBaseDenominator = atBats + walks + hitByPitch + sacrificeFlies
+        val onBasePercentage =
+            if (onBaseDenominator > 0) {
+                BigDecimal(hits + walks + hitByPitch)
+                    .divide(BigDecimal(onBaseDenominator), 3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal.ZERO
+            }
+
+        // 장타율 계산: totalBases / atBats
+        val sluggingPercentage =
+            if (atBats > 0) {
+                BigDecimal(totalBases).divide(BigDecimal(atBats), 3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal.ZERO
+            }
+
+        return MatchupStatsDto(
+            plateAppearances = plateAppearances,
+            atBats = atBats,
+            hits = hits,
+            doubles = doubles,
+            triples = triples,
+            homeRuns = homeRuns,
+            walks = walks,
+            strikeouts = strikeouts,
+            hitByPitch = hitByPitch,
+            sacrificeFlies = sacrificeFlies,
+            runsBattedIn = runsBattedIn,
+            battingAverage = battingAverage,
+            onBasePercentage = onBasePercentage,
+            sluggingPercentage = sluggingPercentage,
+        )
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/PlayerRecordServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/PlayerRecordServiceImpl.kt
@@ -1,0 +1,198 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.common.exception.NotFoundException
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.service.stats.PlayerRecordService
+import com.nextup.core.service.stats.PlayerStatsService
+import com.nextup.core.service.stats.dto.BattingStatsDto
+import com.nextup.core.service.stats.dto.PitchingStatsDto
+import com.nextup.core.service.stats.dto.PlayerRecordDto
+import com.nextup.core.service.stats.dto.RecordScope
+import com.nextup.core.service.stats.dto.RecordType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+/**
+ * 선수 기록 서비스 구현체
+ */
+@Service
+@Transactional(readOnly = true)
+class PlayerRecordServiceImpl(
+    private val playerRepository: PlayerRepositoryPort,
+    private val playerStatsService: PlayerStatsService,
+) : PlayerRecordService {
+    override fun getPlayerRecord(
+        playerId: Long,
+        scope: RecordScope,
+        type: RecordType,
+        year: Int?,
+        competitionId: Long?,
+    ): PlayerRecordDto {
+        // 선수 존재 여부 확인
+        val player =
+            playerRepository.findByIdOrNull(playerId)
+                ?: throw NotFoundException("PLAYER_NOT_FOUND", "선수를 찾을 수 없습니다. (ID: $playerId)")
+
+        return when (scope) {
+            RecordScope.SEASON -> getSeasonRecord(player.id, player.name, type, year)
+            RecordScope.CAREER -> getCareerRecord(player.id, player.name, type)
+            RecordScope.COMPETITION -> throw InvalidInputException(
+                "NOT_IMPLEMENTED",
+                "대회별 통계는 추후 구현 예정입니다.",
+            )
+        }
+    }
+
+    private fun getSeasonRecord(
+        playerId: Long,
+        playerName: String,
+        type: RecordType,
+        year: Int?,
+    ): PlayerRecordDto {
+        val targetYear = year ?: LocalDate.now().year
+
+        val battingStats =
+            if (type == RecordType.BATTING || type == RecordType.ALL) {
+                try {
+                    val stats = playerStatsService.getSeasonBattingStats(playerId, targetYear)
+                    BattingStatsDto(
+                        gamesPlayed = stats.gamesPlayed,
+                        plateAppearances = stats.plateAppearances,
+                        atBats = stats.atBats,
+                        hits = stats.hits,
+                        doubles = stats.doubles,
+                        triples = stats.triples,
+                        homeRuns = stats.homeRuns,
+                        runs = stats.runs,
+                        runsBattedIn = stats.runsBattedIn,
+                        walks = stats.walks,
+                        strikeouts = stats.strikeouts,
+                        stolenBases = stats.stolenBases,
+                        battingAverage = stats.battingAverage,
+                        onBasePercentage = stats.onBasePercentage,
+                        sluggingPercentage = stats.sluggingPercentage,
+                        ops = stats.ops,
+                    )
+                } catch (e: IllegalArgumentException) {
+                    null
+                }
+            } else {
+                null
+            }
+
+        val pitchingStats =
+            if (type == RecordType.PITCHING || type == RecordType.ALL) {
+                try {
+                    val stats = playerStatsService.getSeasonPitchingStats(playerId, targetYear)
+                    PitchingStatsDto(
+                        gamesPlayed = stats.gamesPlayed,
+                        gamesStarted = stats.gamesStarted,
+                        inningsPitched = stats.inningsPitchedDisplay,
+                        wins = stats.wins,
+                        losses = stats.losses,
+                        saves = stats.saves,
+                        holds = stats.holds,
+                        earnedRuns = stats.earnedRuns,
+                        hitsAllowed = stats.hitsAllowed,
+                        walksAllowed = stats.walksAllowed,
+                        strikeouts = stats.strikeouts,
+                        homeRunsAllowed = stats.homeRunsAllowed,
+                        era = stats.earnedRunAverage,
+                        whip = stats.whip,
+                    )
+                } catch (e: IllegalArgumentException) {
+                    null
+                }
+            } else {
+                null
+            }
+
+        return PlayerRecordDto(
+            playerId = playerId,
+            playerName = playerName,
+            scope = RecordScope.SEASON,
+            type = type,
+            year = targetYear,
+            competitionId = null,
+            competitionName = null,
+            battingStats = battingStats,
+            pitchingStats = pitchingStats,
+        )
+    }
+
+    private fun getCareerRecord(
+        playerId: Long,
+        playerName: String,
+        type: RecordType,
+    ): PlayerRecordDto {
+        val battingStats =
+            if (type == RecordType.BATTING || type == RecordType.ALL) {
+                try {
+                    val stats = playerStatsService.getCareerBattingStats(playerId)
+                    BattingStatsDto(
+                        gamesPlayed = stats.gamesPlayed,
+                        plateAppearances = stats.plateAppearances,
+                        atBats = stats.atBats,
+                        hits = stats.hits,
+                        doubles = stats.doubles,
+                        triples = stats.triples,
+                        homeRuns = stats.homeRuns,
+                        runs = stats.runs,
+                        runsBattedIn = stats.runsBattedIn,
+                        walks = stats.walks,
+                        strikeouts = stats.strikeouts,
+                        stolenBases = stats.stolenBases,
+                        battingAverage = stats.battingAverage,
+                        onBasePercentage = stats.onBasePercentage,
+                        sluggingPercentage = stats.sluggingPercentage,
+                        ops = stats.ops,
+                    )
+                } catch (e: IllegalArgumentException) {
+                    null
+                }
+            } else {
+                null
+            }
+
+        val pitchingStats =
+            if (type == RecordType.PITCHING || type == RecordType.ALL) {
+                try {
+                    val stats = playerStatsService.getCareerPitchingStats(playerId)
+                    PitchingStatsDto(
+                        gamesPlayed = stats.gamesPlayed,
+                        gamesStarted = stats.gamesStarted,
+                        inningsPitched = stats.inningsPitchedDisplay,
+                        wins = stats.wins,
+                        losses = stats.losses,
+                        saves = stats.saves,
+                        holds = stats.holds,
+                        earnedRuns = stats.earnedRuns,
+                        hitsAllowed = stats.hitsAllowed,
+                        walksAllowed = stats.walksAllowed,
+                        strikeouts = stats.strikeouts,
+                        homeRunsAllowed = stats.homeRunsAllowed,
+                        era = stats.earnedRunAverage,
+                        whip = stats.whip,
+                    )
+                } catch (e: IllegalArgumentException) {
+                    null
+                }
+            } else {
+                null
+            }
+
+        return PlayerRecordDto(
+            playerId = playerId,
+            playerName = playerName,
+            scope = RecordScope.CAREER,
+            type = type,
+            year = null,
+            competitionId = null,
+            competitionName = null,
+            battingStats = battingStats,
+            pitchingStats = pitchingStats,
+        )
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/PlayerRecordServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/PlayerRecordServiceImpl.kt
@@ -10,6 +10,7 @@ import com.nextup.core.service.stats.dto.PitchingStatsDto
 import com.nextup.core.service.stats.dto.PlayerRecordDto
 import com.nextup.core.service.stats.dto.RecordScope
 import com.nextup.core.service.stats.dto.RecordType
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -23,6 +24,9 @@ class PlayerRecordServiceImpl(
     private val playerRepository: PlayerRepositoryPort,
     private val playerStatsService: PlayerStatsService,
 ) : PlayerRecordService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
     override fun getPlayerRecord(
         playerId: Long,
         scope: RecordScope,
@@ -76,6 +80,7 @@ class PlayerRecordServiceImpl(
                         ops = stats.ops,
                     )
                 } catch (e: IllegalArgumentException) {
+                    log.debug("선수 시즌 타격 기록 없음: playerId={}, year={}, message={}", playerId, targetYear, e.message)
                     null
                 }
             } else {
@@ -103,6 +108,7 @@ class PlayerRecordServiceImpl(
                         whip = stats.whip,
                     )
                 } catch (e: IllegalArgumentException) {
+                    log.debug("선수 시즌 투수 기록 없음: playerId={}, year={}, message={}", playerId, targetYear, e.message)
                     null
                 }
             } else {
@@ -150,6 +156,7 @@ class PlayerRecordServiceImpl(
                         ops = stats.ops,
                     )
                 } catch (e: IllegalArgumentException) {
+                    log.debug("선수 통산 타격 기록 없음: playerId={}, message={}", playerId, e.message)
                     null
                 }
             } else {
@@ -177,6 +184,7 @@ class PlayerRecordServiceImpl(
                         whip = stats.whip,
                     )
                 } catch (e: IllegalArgumentException) {
+                    log.debug("선수 통산 투수 기록 없음: playerId={}, message={}", playerId, e.message)
                     null
                 }
             } else {

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/RecentFormServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/RecentFormServiceImpl.kt
@@ -1,0 +1,365 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.service.stats.RecentFormService
+import com.nextup.core.service.stats.dto.*
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * 최근 N경기 폼 분석 서비스 구현
+ */
+@Service
+@Transactional(readOnly = true)
+class RecentFormServiceImpl(
+    private val playerRepositoryPort: PlayerRepositoryPort,
+    private val battingRecordRepositoryPort: BattingRecordRepositoryPort,
+    private val pitchingRecordRepositoryPort: PitchingRecordRepositoryPort,
+    private val gameRepositoryPort: GameRepositoryPort,
+    private val gameTeamRepositoryPort: GameTeamRepositoryPort,
+) : RecentFormService {
+    companion object {
+        private const val MAX_GAMES = 20
+    }
+
+    override fun getRecentForm(
+        playerId: Long,
+        games: Int,
+        type: FormType,
+    ): RecentFormDto {
+        require(games in 1..MAX_GAMES) { "조회할 경기 수는 1~$MAX_GAMES 사이여야 합니다." }
+
+        val player =
+            playerRepositoryPort.findByIdOrNull(playerId)
+                ?: throw PlayerNotFoundException(playerId)
+
+        return when (type) {
+            FormType.BATTING -> analyzeBattingForm(player.id, player.name, games)
+            FormType.PITCHING -> analyzePitchingForm(player.id, player.name, games)
+        }
+    }
+
+    private fun analyzeBattingForm(
+        playerId: Long,
+        playerName: String,
+        gamesRequested: Int,
+    ): RecentFormDto {
+        val records = battingRecordRepositoryPort.findRecentByPlayerId(playerId, gamesRequested)
+
+        if (records.isEmpty()) {
+            throw InvalidInputException("NO_BATTING_RECORDS", "타격 기록이 없습니다.")
+        }
+
+        val gamesFound = records.size
+        val gameBattingDtos = records.map { it.toGameBattingDto() }
+
+        val totalAtBats = records.sumOf { it.atBats }
+        val totalHits = records.sumOf { it.hits }
+        val totalHomeRuns = records.sumOf { it.homeRuns }
+        val totalRbis = records.sumOf { it.runsBattedIn }
+        val totalRuns = records.sumOf { it.runs }
+
+        val recentAverage =
+            if (totalAtBats == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(totalHits).divide(BigDecimal(totalAtBats), 3, RoundingMode.HALF_UP)
+            }
+
+        // 전체 통산 타율 계산 (비교용)
+        val allRecords = battingRecordRepositoryPort.findAllByPlayerId(playerId)
+        val overallAtBats = allRecords.sumOf { it.atBats }
+        val overallHits = allRecords.sumOf { it.hits }
+        val overallAverage =
+            if (overallAtBats == 0) {
+                null
+            } else {
+                BigDecimal(overallHits).divide(BigDecimal(overallAtBats), 3, RoundingMode.HALF_UP)
+            }
+
+        val trend = calculateBattingTrend(records)
+        val trendDescription = generateBattingTrendDescription(trend, recentAverage, records)
+
+        val battingForm =
+            RecentBattingFormDto(
+                games = gameBattingDtos,
+                totalAtBats = totalAtBats,
+                totalHits = totalHits,
+                totalHomeRuns = totalHomeRuns,
+                totalRbis = totalRbis,
+                totalRuns = totalRuns,
+                recentAverage = recentAverage,
+                overallAverage = overallAverage,
+            )
+
+        return RecentFormDto(
+            playerId = playerId,
+            playerName = playerName,
+            type = FormType.BATTING,
+            gamesRequested = gamesRequested,
+            gamesFound = gamesFound,
+            trend = trend,
+            trendDescription = trendDescription,
+            batting = battingForm,
+            pitching = null,
+        )
+    }
+
+    private fun analyzePitchingForm(
+        playerId: Long,
+        playerName: String,
+        gamesRequested: Int,
+    ): RecentFormDto {
+        val records = pitchingRecordRepositoryPort.findRecentByPlayerId(playerId, gamesRequested)
+
+        if (records.isEmpty()) {
+            throw InvalidInputException("NO_PITCHING_RECORDS", "투수 기록이 없습니다.")
+        }
+
+        val gamesFound = records.size
+        val gamePitchingDtos = records.map { it.toGamePitchingDto() }
+
+        val totalInningsPitchedOuts = records.sumOf { it.inningsPitchedOuts }
+        val totalEarnedRuns = records.sumOf { it.earnedRuns }
+        val totalStrikeouts = records.sumOf { it.strikeouts }
+
+        val inningsPitchedDisplay = formatInningsPitched(totalInningsPitchedOuts)
+
+        val recentEra =
+            if (totalInningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings = BigDecimal(totalInningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(totalEarnedRuns)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
+
+        // 전체 통산 ERA 계산 (비교용)
+        val allRecords = pitchingRecordRepositoryPort.findAllByPlayerId(playerId)
+        val overallInningsPitchedOuts = allRecords.sumOf { it.inningsPitchedOuts }
+        val overallEarnedRuns = allRecords.sumOf { it.earnedRuns }
+        val overallEra =
+            if (overallInningsPitchedOuts == 0) {
+                null
+            } else {
+                val innings = BigDecimal(overallInningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(overallEarnedRuns)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
+
+        val trend = calculatePitchingTrend(records)
+        val trendDescription = generatePitchingTrendDescription(trend, recentEra, records)
+
+        val pitchingForm =
+            RecentPitchingFormDto(
+                games = gamePitchingDtos,
+                totalInningsPitchedOuts = totalInningsPitchedOuts,
+                inningsPitchedDisplay = inningsPitchedDisplay,
+                totalEarnedRuns = totalEarnedRuns,
+                totalStrikeouts = totalStrikeouts,
+                recentEra = recentEra,
+                overallEra = overallEra,
+            )
+
+        return RecentFormDto(
+            playerId = playerId,
+            playerName = playerName,
+            type = FormType.PITCHING,
+            gamesRequested = gamesRequested,
+            gamesFound = gamesFound,
+            trend = trend,
+            trendDescription = trendDescription,
+            batting = null,
+            pitching = pitchingForm,
+        )
+    }
+
+    private fun calculateBattingTrend(records: List<BattingRecord>): FormTrend {
+        if (records.size <= 1) {
+            return FormTrend.STABLE
+        }
+
+        val halfSize = records.size / 2
+        val recentHalf = records.take(halfSize)
+        val earlierHalf = records.drop(halfSize)
+
+        val recentAtBats = recentHalf.sumOf { it.atBats }
+        val recentHits = recentHalf.sumOf { it.hits }
+        val earlierAtBats = earlierHalf.sumOf { it.atBats }
+        val earlierHits = earlierHalf.sumOf { it.hits }
+
+        if (recentAtBats == 0 || earlierAtBats == 0) {
+            return FormTrend.STABLE
+        }
+
+        val recentAvg = BigDecimal(recentHits).divide(BigDecimal(recentAtBats), 10, RoundingMode.HALF_UP)
+        val earlierAvg = BigDecimal(earlierHits).divide(BigDecimal(earlierAtBats), 10, RoundingMode.HALF_UP)
+
+        return when {
+            recentAvg >= earlierAvg.multiply(BigDecimal("1.1")) -> FormTrend.UP
+            recentAvg <= earlierAvg.multiply(BigDecimal("0.9")) -> FormTrend.DOWN
+            else -> FormTrend.STABLE
+        }
+    }
+
+    private fun calculatePitchingTrend(records: List<PitchingRecord>): FormTrend {
+        if (records.size <= 1) {
+            return FormTrend.STABLE
+        }
+
+        val halfSize = records.size / 2
+        val recentHalf = records.take(halfSize)
+        val earlierHalf = records.drop(halfSize)
+
+        val recentInnings = recentHalf.sumOf { it.inningsPitchedOuts }
+        val recentER = recentHalf.sumOf { it.earnedRuns }
+        val earlierInnings = earlierHalf.sumOf { it.inningsPitchedOuts }
+        val earlierER = earlierHalf.sumOf { it.earnedRuns }
+
+        if (recentInnings == 0 || earlierInnings == 0) {
+            return FormTrend.STABLE
+        }
+
+        val recentEra = calculateEra(recentER, recentInnings)
+        val earlierEra = calculateEra(earlierER, earlierInnings)
+
+        // ERA는 낮을수록 좋음
+        return when {
+            recentEra <= earlierEra.multiply(BigDecimal("0.9")) -> FormTrend.UP
+            recentEra >= earlierEra.multiply(BigDecimal("1.1")) -> FormTrend.DOWN
+            else -> FormTrend.STABLE
+        }
+    }
+
+    private fun calculateEra(
+        earnedRuns: Int,
+        inningsPitchedOuts: Int,
+    ): BigDecimal {
+        if (inningsPitchedOuts == 0) {
+            return BigDecimal.ZERO
+        }
+        val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+        return BigDecimal(earnedRuns)
+            .multiply(BigDecimal(9))
+            .divide(innings, 10, RoundingMode.HALF_UP)
+    }
+
+    private fun generateBattingTrendDescription(
+        trend: FormTrend,
+        recentAverage: BigDecimal,
+        records: List<BattingRecord>,
+    ): String {
+        if (records.size <= 1) {
+            return "최근 ${records.size}경기 기록입니다."
+        }
+
+        val halfSize = records.size / 2
+        val earlierHalf = records.drop(halfSize)
+        val earlierAtBats = earlierHalf.sumOf { it.atBats }
+        val earlierHits = earlierHalf.sumOf { it.hits }
+        val earlierAvg =
+            if (earlierAtBats == 0) {
+                BigDecimal.ZERO
+            } else {
+                BigDecimal(earlierHits).divide(BigDecimal(earlierAtBats), 3, RoundingMode.HALF_UP)
+            }
+
+        return when (trend) {
+            FormTrend.UP -> "최근 ${records.size}경기 상승세입니다. 타율 $recentAverage (이전 $earlierAvg)"
+            FormTrend.DOWN -> "최근 ${records.size}경기 하락세입니다. 타율 $recentAverage (이전 $earlierAvg)"
+            FormTrend.STABLE -> "최근 ${records.size}경기 안정적인 폼을 유지하고 있습니다."
+        }
+    }
+
+    private fun generatePitchingTrendDescription(
+        trend: FormTrend,
+        recentEra: BigDecimal,
+        records: List<PitchingRecord>,
+    ): String {
+        if (records.size <= 1) {
+            return "최근 ${records.size}경기 기록입니다."
+        }
+
+        val halfSize = records.size / 2
+        val earlierHalf = records.drop(halfSize)
+        val earlierInnings = earlierHalf.sumOf { it.inningsPitchedOuts }
+        val earlierER = earlierHalf.sumOf { it.earnedRuns }
+        val earlierEra = calculateEra(earlierER, earlierInnings)
+
+        return when (trend) {
+            FormTrend.UP -> "최근 ${records.size}경기 상승세입니다. ERA $recentEra (이전 $earlierEra)"
+            FormTrend.DOWN -> "최근 ${records.size}경기 하락세입니다. ERA $recentEra (이전 $earlierEra)"
+            FormTrend.STABLE -> "최근 ${records.size}경기 안정적인 폼을 유지하고 있습니다."
+        }
+    }
+
+    private fun formatInningsPitched(outs: Int): String {
+        val completeInnings = outs / 3
+        val remainingOuts = outs % 3
+        return "$completeInnings.$remainingOuts"
+    }
+
+    private fun BattingRecord.toGameBattingDto(): GameBattingDto {
+        val game = gameRepositoryPort.findByIdOrNull(this.gamePlayer.gameTeam.game.id)
+        val gameDate = game?.scheduledAt?.toLocalDate()?.toString() ?: "Unknown"
+
+        // 상대팀 정보 가져오기
+        val myTeamId = this.gamePlayer.gameTeam.team.id
+        val opponentName = getOpponentTeamName(this.gamePlayer.gameTeam.game.id, myTeamId)
+
+        return GameBattingDto(
+            gameId = this.gamePlayer.gameTeam.game.id,
+            gameDate = gameDate,
+            opponentName = opponentName,
+            atBats = this.atBats,
+            hits = this.hits,
+            homeRuns = this.homeRuns,
+            rbis = this.runsBattedIn,
+            runs = this.runs,
+            walks = this.walks,
+            strikeouts = this.strikeouts,
+        )
+    }
+
+    private fun PitchingRecord.toGamePitchingDto(): GamePitchingDto {
+        val game = gameRepositoryPort.findByIdOrNull(this.gamePlayer.gameTeam.game.id)
+        val gameDate = game?.scheduledAt?.toLocalDate()?.toString() ?: "Unknown"
+
+        // 상대팀 정보 가져오기
+        val myTeamId = this.gamePlayer.gameTeam.team.id
+        val opponentName = getOpponentTeamName(this.gamePlayer.gameTeam.game.id, myTeamId)
+
+        return GamePitchingDto(
+            gameId = this.gamePlayer.gameTeam.game.id,
+            gameDate = gameDate,
+            opponentName = opponentName,
+            inningsPitched = this.inningsPitchedDisplay,
+            earnedRuns = this.earnedRuns,
+            strikeouts = this.strikeouts,
+            walksAllowed = this.walksAllowed,
+            hitsAllowed = this.hitsAllowed,
+            decision = this.decision.name,
+        )
+    }
+
+    private fun getOpponentTeamName(
+        gameId: Long,
+        myTeamId: Long,
+    ): String {
+        val gameTeams = gameTeamRepositoryPort.findAllByGameId(gameId)
+        val opponentTeam = gameTeams.find { it.team.id != myTeamId }
+        return opponentTeam?.team?.name ?: "상대팀"
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/RecentFormServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/RecentFormServiceImpl.kt
@@ -3,6 +3,8 @@ package com.nextup.infrastructure.service.stats
 import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.PlayerNotFoundException
 import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameTeam
 import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
@@ -60,8 +62,13 @@ class RecentFormServiceImpl(
             throw InvalidInputException("NO_BATTING_RECORDS", "타격 기록이 없습니다.")
         }
 
+        // 배치 로드: 모든 gameId를 수집하여 한 번에 조회 (N+1 방지)
+        val gameIds = records.map { it.gamePlayer.gameTeam.game.id }.distinct()
+        val gamesMap = gameRepositoryPort.findAllByIds(gameIds).associateBy { it.id }
+        val gameTeamsMap = gameTeamRepositoryPort.findAllByGameIds(gameIds).groupBy { it.game.id }
+
         val gamesFound = records.size
-        val gameBattingDtos = records.map { it.toGameBattingDto() }
+        val gameBattingDtos = records.map { it.toGameBattingDto(gamesMap, gameTeamsMap) }
 
         val totalAtBats = records.sumOf { it.atBats }
         val totalHits = records.sumOf { it.hits }
@@ -126,8 +133,13 @@ class RecentFormServiceImpl(
             throw InvalidInputException("NO_PITCHING_RECORDS", "투수 기록이 없습니다.")
         }
 
+        // 배치 로드: 모든 gameId를 수집하여 한 번에 조회 (N+1 방지)
+        val gameIds = records.map { it.gamePlayer.gameTeam.game.id }.distinct()
+        val gamesMap = gameRepositoryPort.findAllByIds(gameIds).associateBy { it.id }
+        val gameTeamsMap = gameTeamRepositoryPort.findAllByGameIds(gameIds).groupBy { it.game.id }
+
         val gamesFound = records.size
-        val gamePitchingDtos = records.map { it.toGamePitchingDto() }
+        val gamePitchingDtos = records.map { it.toGamePitchingDto(gamesMap, gameTeamsMap) }
 
         val totalInningsPitchedOuts = records.sumOf { it.inningsPitchedOuts }
         val totalEarnedRuns = records.sumOf { it.earnedRuns }
@@ -311,16 +323,20 @@ class RecentFormServiceImpl(
         return "$completeInnings.$remainingOuts"
     }
 
-    private fun BattingRecord.toGameBattingDto(): GameBattingDto {
-        val game = gameRepositoryPort.findByIdOrNull(this.gamePlayer.gameTeam.game.id)
+    private fun BattingRecord.toGameBattingDto(
+        gamesMap: Map<Long, Game>,
+        gameTeamsMap: Map<Long, List<GameTeam>>,
+    ): GameBattingDto {
+        val gameId = this.gamePlayer.gameTeam.game.id
+        val game = gamesMap[gameId]
         val gameDate = game?.scheduledAt?.toLocalDate()?.toString() ?: "Unknown"
 
-        // 상대팀 정보 가져오기
+        // 상대팀 정보 가져오기 (배치 로드된 데이터 사용)
         val myTeamId = this.gamePlayer.gameTeam.team.id
-        val opponentName = getOpponentTeamName(this.gamePlayer.gameTeam.game.id, myTeamId)
+        val opponentName = getOpponentTeamName(gameTeamsMap[gameId], myTeamId)
 
         return GameBattingDto(
-            gameId = this.gamePlayer.gameTeam.game.id,
+            gameId = gameId,
             gameDate = gameDate,
             opponentName = opponentName,
             atBats = this.atBats,
@@ -333,16 +349,20 @@ class RecentFormServiceImpl(
         )
     }
 
-    private fun PitchingRecord.toGamePitchingDto(): GamePitchingDto {
-        val game = gameRepositoryPort.findByIdOrNull(this.gamePlayer.gameTeam.game.id)
+    private fun PitchingRecord.toGamePitchingDto(
+        gamesMap: Map<Long, Game>,
+        gameTeamsMap: Map<Long, List<GameTeam>>,
+    ): GamePitchingDto {
+        val gameId = this.gamePlayer.gameTeam.game.id
+        val game = gamesMap[gameId]
         val gameDate = game?.scheduledAt?.toLocalDate()?.toString() ?: "Unknown"
 
-        // 상대팀 정보 가져오기
+        // 상대팀 정보 가져오기 (배치 로드된 데이터 사용)
         val myTeamId = this.gamePlayer.gameTeam.team.id
-        val opponentName = getOpponentTeamName(this.gamePlayer.gameTeam.game.id, myTeamId)
+        val opponentName = getOpponentTeamName(gameTeamsMap[gameId], myTeamId)
 
         return GamePitchingDto(
-            gameId = this.gamePlayer.gameTeam.game.id,
+            gameId = gameId,
             gameDate = gameDate,
             opponentName = opponentName,
             inningsPitched = this.inningsPitchedDisplay,
@@ -355,11 +375,10 @@ class RecentFormServiceImpl(
     }
 
     private fun getOpponentTeamName(
-        gameId: Long,
+        gameTeams: List<GameTeam>?,
         myTeamId: Long,
     ): String {
-        val gameTeams = gameTeamRepositoryPort.findAllByGameId(gameId)
-        val opponentTeam = gameTeams.find { it.team.id != myTeamId }
+        val opponentTeam = gameTeams?.find { it.team.id != myTeamId }
         return opponentTeam?.team?.name ?: "상대팀"
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/TeamStatsServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/TeamStatsServiceImpl.kt
@@ -1,0 +1,230 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.game.GameResult
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.stats.TeamStatsService
+import com.nextup.core.service.stats.dto.TeamBattingStatsDto
+import com.nextup.core.service.stats.dto.TeamPitchingStatsDto
+import com.nextup.core.service.stats.dto.TeamRecordDto
+import com.nextup.core.service.stats.dto.TeamStatsDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Service
+@Transactional(readOnly = true)
+class TeamStatsServiceImpl(
+    private val teamRepositoryPort: TeamRepositoryPort,
+    private val gameTeamRepositoryPort: GameTeamRepositoryPort,
+    private val battingRecordRepositoryPort: BattingRecordRepositoryPort,
+    private val pitchingRecordRepositoryPort: PitchingRecordRepositoryPort,
+) : TeamStatsService {
+    override fun getTeamStats(
+        teamId: Long,
+        year: Int?,
+        competitionId: Long?,
+    ): TeamStatsDto {
+        // 팀 존재 여부 확인
+        val team =
+            teamRepositoryPort.findByIdWithLeague(teamId)
+                ?: throw TeamNotFoundException(teamId)
+
+        // GameTeam 조회 (year 필터링)
+        val gameTeams =
+            if (year != null) {
+                gameTeamRepositoryPort.findAllByTeamIdAndYear(teamId, year)
+            } else {
+                gameTeamRepositoryPort.findAllByTeamId(teamId)
+            }
+
+        // 경기 결과 집계
+        val record = calculateTeamRecord(gameTeams)
+
+        // 타격 통계 계산
+        val battingStats = calculateBattingStats(gameTeams, year)
+
+        // 투수 통계 계산
+        val pitchingStats = calculatePitchingStats(gameTeams, year)
+
+        return TeamStatsDto(
+            teamId = team.id,
+            teamName = team.name,
+            year = year,
+            competitionId = competitionId,
+            competitionName = null, // TODO: Competition 연결 시 구현
+            record = record,
+            batting = battingStats,
+            pitching = pitchingStats,
+        )
+    }
+
+    private fun calculateTeamRecord(gameTeams: List<com.nextup.core.domain.game.GameTeam>): TeamRecordDto {
+        val wins = gameTeams.count { it.result == GameResult.WIN }
+        val losses = gameTeams.count { it.result == GameResult.LOSS }
+        val draws = gameTeams.count { it.result == GameResult.DRAW }
+        val gamesPlayed = wins + losses + draws
+
+        val winningPercentage =
+            if (wins + losses == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(wins)
+                    .divide(BigDecimal(wins + losses), 3, RoundingMode.HALF_UP)
+            }
+
+        return TeamRecordDto(
+            gamesPlayed = gamesPlayed,
+            wins = wins,
+            losses = losses,
+            draws = draws,
+            winningPercentage = winningPercentage,
+        )
+    }
+
+    private fun calculateBattingStats(
+        gameTeams: List<com.nextup.core.domain.game.GameTeam>,
+        year: Int?,
+    ): TeamBattingStatsDto {
+        // GameTeam에서 Game을 거쳐 BattingRecord 조회
+        val teamId = gameTeams.firstOrNull()?.team?.id ?: return emptyBattingStats()
+        val gameIds = gameTeams.map { it.game.id }.distinct()
+
+        // 배치 쿼리로 모든 경기의 타격 기록을 한 번에 조회 (N+1 방지)
+        val battingRecords = battingRecordRepositoryPort.findAllByTeamIdAndGameIds(teamId, gameIds)
+
+        val totalAtBats = battingRecords.sumOf { it.atBats }
+        val totalHits = battingRecords.sumOf { it.hits }
+        val totalHomeRuns = battingRecords.sumOf { it.homeRuns }
+        val totalRunsBattedIn = battingRecords.sumOf { it.runsBattedIn }
+        val totalRuns = battingRecords.sumOf { it.runs }
+        val totalWalks = battingRecords.sumOf { it.totalWalks }
+        val totalHitByPitch = battingRecords.sumOf { it.hitByPitch }
+        val totalSacrificeFlies = battingRecords.sumOf { it.sacrificeFlies }
+        val totalBases = battingRecords.sumOf { it.totalBases }
+
+        // 팀 타율 계산
+        val teamBattingAverage =
+            if (totalAtBats == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(totalHits)
+                    .divide(BigDecimal(totalAtBats), 3, RoundingMode.HALF_UP)
+            }
+
+        // 팀 출루율 계산
+        val obpDenominator = totalAtBats + totalWalks + totalHitByPitch + totalSacrificeFlies
+        val teamOnBasePercentage =
+            if (obpDenominator == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(totalHits + totalWalks + totalHitByPitch)
+                    .divide(BigDecimal(obpDenominator), 3, RoundingMode.HALF_UP)
+            }
+
+        // 팀 장타율 계산
+        val teamSluggingPercentage =
+            if (totalAtBats == 0) {
+                BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal(totalBases)
+                    .divide(BigDecimal(totalAtBats), 3, RoundingMode.HALF_UP)
+            }
+
+        return TeamBattingStatsDto(
+            totalAtBats = totalAtBats,
+            totalHits = totalHits,
+            totalHomeRuns = totalHomeRuns,
+            totalRunsBattedIn = totalRunsBattedIn,
+            totalRuns = totalRuns,
+            teamBattingAverage = teamBattingAverage,
+            teamOnBasePercentage = teamOnBasePercentage,
+            teamSluggingPercentage = teamSluggingPercentage,
+        )
+    }
+
+    private fun calculatePitchingStats(
+        gameTeams: List<com.nextup.core.domain.game.GameTeam>,
+        year: Int?,
+    ): TeamPitchingStatsDto {
+        // GameTeam에서 Game을 거쳐 PitchingRecord 조회
+        val teamId = gameTeams.firstOrNull()?.team?.id ?: return emptyPitchingStats()
+        val gameIds = gameTeams.map { it.game.id }.distinct()
+
+        // 배치 쿼리로 모든 경기의 투수 기록을 한 번에 조회 (N+1 방지)
+        val pitchingRecords = pitchingRecordRepositoryPort.findAllByTeamIdAndGameIds(teamId, gameIds)
+
+        val totalInningsPitchedOuts = pitchingRecords.sumOf { it.inningsPitchedOuts }
+        val totalEarnedRuns = pitchingRecords.sumOf { it.earnedRuns }
+        val totalStrikeouts = pitchingRecords.sumOf { it.strikeouts }
+        val totalWalksAllowed = pitchingRecords.sumOf { it.walksAllowed }
+        val totalHitsAllowed = pitchingRecords.sumOf { it.hitsAllowed }
+
+        // 이닝 표시 문자열 생성
+        val completeInnings = totalInningsPitchedOuts / 3
+        val remainingOuts = totalInningsPitchedOuts % 3
+        val inningsPitchedDisplay = "$completeInnings.$remainingOuts"
+
+        // 팀 ERA 계산
+        val teamEra =
+            if (totalInningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings =
+                    BigDecimal(totalInningsPitchedOuts)
+                        .divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(totalEarnedRuns)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
+
+        // 팀 WHIP 계산
+        val teamWhip =
+            if (totalInningsPitchedOuts == 0) {
+                BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+            } else {
+                val innings =
+                    BigDecimal(totalInningsPitchedOuts)
+                        .divide(BigDecimal(3), 10, RoundingMode.HALF_UP)
+                BigDecimal(totalHitsAllowed + totalWalksAllowed)
+                    .divide(innings, 2, RoundingMode.HALF_UP)
+            }
+
+        return TeamPitchingStatsDto(
+            totalInningsPitchedOuts = totalInningsPitchedOuts,
+            inningsPitchedDisplay = inningsPitchedDisplay,
+            totalEarnedRuns = totalEarnedRuns,
+            totalStrikeouts = totalStrikeouts,
+            totalWalksAllowed = totalWalksAllowed,
+            teamEra = teamEra,
+            teamWhip = teamWhip,
+        )
+    }
+
+    private fun emptyBattingStats(): TeamBattingStatsDto =
+        TeamBattingStatsDto(
+            totalAtBats = 0,
+            totalHits = 0,
+            totalHomeRuns = 0,
+            totalRunsBattedIn = 0,
+            totalRuns = 0,
+            teamBattingAverage = BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP),
+            teamOnBasePercentage = BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP),
+            teamSluggingPercentage = BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP),
+        )
+
+    private fun emptyPitchingStats(): TeamPitchingStatsDto =
+        TeamPitchingStatsDto(
+            totalInningsPitchedOuts = 0,
+            inningsPitchedDisplay = "0.0",
+            totalEarnedRuns = 0,
+            totalStrikeouts = 0,
+            totalWalksAllowed = 0,
+            teamEra = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+            teamWhip = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
+        )
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/MatchupServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/MatchupServiceImplTest.kt
@@ -1,0 +1,358 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.PlateAppearanceResult
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("MatchupServiceImpl 테스트")
+class MatchupServiceImplTest {
+    private lateinit var gameEventRepositoryPort: GameEventRepositoryPort
+    private lateinit var playerRepositoryPort: PlayerRepositoryPort
+    private lateinit var matchupService: MatchupServiceImpl
+
+    private lateinit var pitcher: Player
+    private lateinit var batter: Player
+
+    @BeforeEach
+    fun setUp() {
+        gameEventRepositoryPort = mockk()
+        playerRepositoryPort = mockk()
+        matchupService = MatchupServiceImpl(gameEventRepositoryPort, playerRepositoryPort)
+
+        pitcher =
+            Player(
+                name = "김투수",
+                birthDate = LocalDate.of(1995, 1, 1),
+                primaryPosition = Position.STARTING_PITCHER,
+            )
+        batter =
+            Player(
+                name = "이타자",
+                birthDate = LocalDate.of(1996, 5, 15),
+                primaryPosition = Position.SHORTSTOP,
+            )
+    }
+
+    @Nested
+    @DisplayName("getMatchup")
+    inner class GetMatchup {
+        @Test
+        fun `투수가 존재하지 않으면 예외를 발생시킨다`() {
+            // given
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns null
+
+            // when & then
+            assertThatThrownBy { matchupService.getMatchup(1L, 2L, null, null) }
+                .isInstanceOf(PlayerNotFoundException::class.java)
+        }
+
+        @Test
+        fun `타자가 존재하지 않으면 예외를 발생시킨다`() {
+            // given
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns pitcher
+            every { playerRepositoryPort.findByIdOrNull(2L) } returns null
+
+            // when & then
+            assertThatThrownBy { matchupService.getMatchup(1L, 2L, null, null) }
+                .isInstanceOf(PlayerNotFoundException::class.java)
+        }
+
+        @Test
+        fun `매치업 기록이 없으면 빈 통계를 반환한다`() {
+            // given
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns pitcher
+            every { playerRepositoryPort.findByIdOrNull(2L) } returns batter
+            every { gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatter(1L, 2L) } returns emptyList()
+
+            // when
+            val result = matchupService.getMatchup(1L, 2L, null, null)
+
+            // then
+            assertThat(result.pitcherId).isEqualTo(1L)
+            assertThat(result.pitcherName).isEqualTo("김투수")
+            assertThat(result.batterId).isEqualTo(2L)
+            assertThat(result.batterName).isEqualTo("이타자")
+            assertThat(result.stats.plateAppearances).isEqualTo(0)
+            assertThat(result.stats.atBats).isEqualTo(0)
+            assertThat(result.history).isEmpty()
+        }
+
+        @Test
+        fun `연도 필터를 적용하여 매치업을 조회할 수 있다`() {
+            // given
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns pitcher
+            every { playerRepositoryPort.findByIdOrNull(2L) } returns batter
+            every {
+                gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatterAndYear(1L, 2L, 2025)
+            } returns emptyList()
+
+            // when
+            val result = matchupService.getMatchup(1L, 2L, 2025, null)
+
+            // then
+            assertThat(result.year).isEqualTo(2025)
+            assertThat(result.stats.plateAppearances).isEqualTo(0)
+        }
+
+        @Test
+        fun `안타 기록을 집계하여 타율을 계산한다`() {
+            // given
+            val game = mockk<Game>(relaxed = true)
+            every { game.id } returns 1L
+            every { game.scheduledAt } returns LocalDateTime.of(2025, 4, 15, 14, 0)
+
+            val event1 =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.SINGLE
+                    every { rbis } returns 0
+                    every { description } returns "좌전 안타"
+                }
+            val event2 =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.STRIKEOUT
+                    every { rbis } returns 0
+                    every { description } returns "삼진"
+                }
+            val event3 =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.SINGLE
+                    every { rbis } returns 1
+                    every { description } returns "적시타"
+                }
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns pitcher
+            every { playerRepositoryPort.findByIdOrNull(2L) } returns batter
+            every {
+                gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatter(1L, 2L)
+            } returns listOf(event1, event2, event3)
+
+            // when
+            val result = matchupService.getMatchup(1L, 2L, null, null)
+
+            // then
+            assertThat(result.stats.plateAppearances).isEqualTo(3)
+            assertThat(result.stats.atBats).isEqualTo(3)
+            assertThat(result.stats.hits).isEqualTo(2)
+            assertThat(result.stats.strikeouts).isEqualTo(1)
+            assertThat(result.stats.runsBattedIn).isEqualTo(1)
+            assertThat(result.stats.battingAverage).isEqualTo(BigDecimal("0.667"))
+        }
+
+        @Test
+        fun `2루타, 3루타, 홈런을 집계한다`() {
+            // given
+            val game = mockk<Game>(relaxed = true)
+            every { game.id } returns 1L
+            every { game.scheduledAt } returns LocalDateTime.of(2025, 4, 15, 14, 0)
+
+            val event1 =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.DOUBLE
+                    every { rbis } returns 1
+                    every { description } returns "2루타"
+                }
+            val event2 =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.TRIPLE
+                    every { rbis } returns 2
+                    every { description } returns "3루타"
+                }
+            val event3 =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.HOME_RUN
+                    every { rbis } returns 3
+                    every { description } returns "홈런"
+                }
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns pitcher
+            every { playerRepositoryPort.findByIdOrNull(2L) } returns batter
+            every {
+                gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatter(1L, 2L)
+            } returns listOf(event1, event2, event3)
+
+            // when
+            val result = matchupService.getMatchup(1L, 2L, null, null)
+
+            // then
+            assertThat(result.stats.hits).isEqualTo(3)
+            assertThat(result.stats.doubles).isEqualTo(1)
+            assertThat(result.stats.triples).isEqualTo(1)
+            assertThat(result.stats.homeRuns).isEqualTo(1)
+            assertThat(result.stats.runsBattedIn).isEqualTo(6)
+            // 총 루타: 2 + 3 + 4 = 9, 타수: 3
+            assertThat(result.stats.sluggingPercentage).isEqualTo(BigDecimal("3.000"))
+        }
+
+        @Test
+        fun `볼넷과 사구를 집계한다`() {
+            // given
+            val game = mockk<Game>(relaxed = true)
+            every { game.id } returns 1L
+            every { game.scheduledAt } returns LocalDateTime.of(2025, 4, 15, 14, 0)
+
+            val event1 =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.WALK
+                    every { rbis } returns 0
+                    every { description } returns "볼넷"
+                }
+            val event2 =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.HIT_BY_PITCH
+                    every { rbis } returns 0
+                    every { description } returns "사구"
+                }
+            val event3 =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.INTENTIONAL_WALK
+                    every { rbis } returns 0
+                    every { description } returns "고의사구"
+                }
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns pitcher
+            every { playerRepositoryPort.findByIdOrNull(2L) } returns batter
+            every {
+                gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatter(1L, 2L)
+            } returns listOf(event1, event2, event3)
+
+            // when
+            val result = matchupService.getMatchup(1L, 2L, null, null)
+
+            // then
+            assertThat(result.stats.plateAppearances).isEqualTo(3)
+            assertThat(result.stats.atBats).isEqualTo(0)
+            assertThat(result.stats.walks).isEqualTo(2)
+            assertThat(result.stats.hitByPitch).isEqualTo(1)
+            assertThat(result.stats.battingAverage).isEqualTo(BigDecimal.ZERO)
+            // 출루율: (0 + 2 + 1) / (0 + 2 + 1 + 0) = 1.000
+            assertThat(result.stats.onBasePercentage).isEqualTo(BigDecimal("1.000"))
+        }
+
+        @Test
+        fun `희생플라이를 집계한다`() {
+            // given
+            val game = mockk<Game>(relaxed = true)
+            every { game.id } returns 1L
+            every { game.scheduledAt } returns LocalDateTime.of(2025, 4, 15, 14, 0)
+
+            val event =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.SACRIFICE_FLY
+                    every { rbis } returns 1
+                    every { description } returns "희생플라이"
+                }
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns pitcher
+            every { playerRepositoryPort.findByIdOrNull(2L) } returns batter
+            every { gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatter(1L, 2L) } returns listOf(event)
+
+            // when
+            val result = matchupService.getMatchup(1L, 2L, null, null)
+
+            // then
+            assertThat(result.stats.plateAppearances).isEqualTo(1)
+            assertThat(result.stats.atBats).isEqualTo(0)
+            assertThat(result.stats.sacrificeFlies).isEqualTo(1)
+            assertThat(result.stats.runsBattedIn).isEqualTo(1)
+        }
+
+        @Test
+        fun `히스토리를 생성한다`() {
+            // given
+            val game = mockk<Game>(relaxed = true)
+            every { game.id } returns 100L
+            every { game.scheduledAt } returns LocalDateTime.of(2025, 4, 15, 14, 0)
+
+            val event =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns PlateAppearanceResult.SINGLE
+                    every { rbis } returns 0
+                    every { description } returns "좌전 안타"
+                }
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns pitcher
+            every { playerRepositoryPort.findByIdOrNull(2L) } returns batter
+            every { gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatter(1L, 2L) } returns listOf(event)
+
+            // when
+            val result = matchupService.getMatchup(1L, 2L, null, null)
+
+            // then
+            assertThat(result.history).hasSize(1)
+            assertThat(result.history[0].gameId).isEqualTo(100L)
+            assertThat(result.history[0].gameDate).isEqualTo("2025-04-15")
+            assertThat(result.history[0].result).isEqualTo("1루타")
+            assertThat(result.history[0].description).isEqualTo("좌전 안타")
+        }
+
+        @Test
+        fun `타석 결과가 null인 이벤트는 건너뛴다`() {
+            // given
+            val game = mockk<Game>(relaxed = true)
+            every { game.id } returns 1L
+            every { game.scheduledAt } returns LocalDateTime.of(2025, 4, 15, 14, 0)
+
+            val event =
+                mockk<GameEvent>(relaxed = true).apply {
+                    every { this@apply.game } returns game
+                    every { plateAppearanceResult } returns null
+                    every { rbis } returns 0
+                    every { description } returns "투구"
+                }
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns pitcher
+            every { playerRepositoryPort.findByIdOrNull(2L) } returns batter
+            every { gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatter(1L, 2L) } returns listOf(event)
+
+            // when
+            val result = matchupService.getMatchup(1L, 2L, null, null)
+
+            // then
+            assertThat(result.stats.plateAppearances).isEqualTo(0)
+            assertThat(result.history).hasSize(1)
+            assertThat(result.history[0].result).isEqualTo("기록 없음")
+        }
+
+        @Test
+        fun `출루율의 분모가 0이면 0을 반환한다`() {
+            // given
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns pitcher
+            every { playerRepositoryPort.findByIdOrNull(2L) } returns batter
+            every { gameEventRepositoryPort.findPlateAppearancesByPitcherAndBatter(1L, 2L) } returns emptyList()
+
+            // when
+            val result = matchupService.getMatchup(1L, 2L, null, null)
+
+            // then
+            assertThat(result.stats.onBasePercentage).isEqualTo(BigDecimal.ZERO)
+            assertThat(result.stats.sluggingPercentage).isEqualTo(BigDecimal.ZERO)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/PlayerRecordServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/PlayerRecordServiceImplTest.kt
@@ -1,0 +1,321 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.common.exception.NotFoundException
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.stats.CareerBattingStats
+import com.nextup.core.domain.stats.CareerPitchingStats
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.service.stats.PlayerStatsService
+import com.nextup.core.service.stats.dto.RecordScope
+import com.nextup.core.service.stats.dto.RecordType
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DisplayName("PlayerRecordServiceImpl 테스트")
+class PlayerRecordServiceImplTest {
+    private lateinit var playerRepository: PlayerRepositoryPort
+    private lateinit var playerStatsService: PlayerStatsService
+    private lateinit var playerRecordService: PlayerRecordServiceImpl
+
+    private lateinit var player: Player
+
+    @BeforeEach
+    fun setUp() {
+        playerRepository = mockk()
+        playerStatsService = mockk()
+        playerRecordService = PlayerRecordServiceImpl(playerRepository, playerStatsService)
+
+        player =
+            mockk<Player>().apply {
+                every { id } returns 1L
+                every { name } returns "홍길동"
+            }
+    }
+
+    private fun createMockSeasonBattingStats(): SeasonBattingStats =
+        mockk<SeasonBattingStats>().apply {
+            every { gamesPlayed } returns 50
+            every { plateAppearances } returns 200
+            every { atBats } returns 180
+            every { hits } returns 54
+            every { doubles } returns 10
+            every { triples } returns 2
+            every { homeRuns } returns 5
+            every { runs } returns 25
+            every { runsBattedIn } returns 30
+            every { walks } returns 15
+            every { strikeouts } returns 35
+            every { stolenBases } returns 5
+            every { battingAverage } returns BigDecimal("0.300")
+            every { onBasePercentage } returns BigDecimal("0.370")
+            every { sluggingPercentage } returns BigDecimal("0.450")
+            every { ops } returns BigDecimal("0.820")
+        }
+
+    private fun createMockSeasonPitchingStats(): SeasonPitchingStats =
+        mockk<SeasonPitchingStats>().apply {
+            every { gamesPlayed } returns 20
+            every { gamesStarted } returns 18
+            every { inningsPitchedDisplay } returns "120.0"
+            every { wins } returns 10
+            every { losses } returns 5
+            every { saves } returns 0
+            every { holds } returns 0
+            every { earnedRuns } returns 35
+            every { hitsAllowed } returns 100
+            every { walksAllowed } returns 30
+            every { strikeouts } returns 100
+            every { homeRunsAllowed } returns 8
+            every { earnedRunAverage } returns BigDecimal("2.63")
+            every { whip } returns BigDecimal("1.08")
+        }
+
+    private fun createMockCareerBattingStats(): CareerBattingStats =
+        mockk<CareerBattingStats>().apply {
+            every { gamesPlayed } returns 300
+            every { plateAppearances } returns 1200
+            every { atBats } returns 1000
+            every { hits } returns 300
+            every { doubles } returns 60
+            every { triples } returns 10
+            every { homeRuns } returns 30
+            every { runs } returns 150
+            every { runsBattedIn } returns 180
+            every { walks } returns 150
+            every { strikeouts } returns 200
+            every { stolenBases } returns 30
+            every { battingAverage } returns BigDecimal("0.300")
+            every { onBasePercentage } returns BigDecimal("0.400")
+            every { sluggingPercentage } returns BigDecimal("0.500")
+            every { ops } returns BigDecimal("0.900")
+        }
+
+    private fun createMockCareerPitchingStats(): CareerPitchingStats =
+        mockk<CareerPitchingStats>().apply {
+            every { gamesPlayed } returns 100
+            every { gamesStarted } returns 80
+            every { inningsPitchedDisplay } returns "500.0"
+            every { wins } returns 40
+            every { losses } returns 25
+            every { saves } returns 0
+            every { holds } returns 0
+            every { earnedRuns } returns 150
+            every { hitsAllowed } returns 450
+            every { walksAllowed } returns 100
+            every { strikeouts } returns 400
+            every { homeRunsAllowed } returns 40
+            every { earnedRunAverage } returns BigDecimal("2.70")
+            every { whip } returns BigDecimal("1.10")
+        }
+
+    @Nested
+    @DisplayName("getPlayerRecord")
+    inner class GetPlayerRecord {
+        @Test
+        fun `선수가 존재하지 않으면 예외를 발생시킨다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                playerRecordService.getPlayerRecord(1L, RecordScope.CAREER, RecordType.ALL, null, null)
+            }.isInstanceOf(NotFoundException::class.java)
+                .hasMessageContaining("선수를 찾을 수 없습니다")
+        }
+
+        @Test
+        fun `대회 범위는 아직 구현되지 않아 예외를 발생시킨다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns player
+
+            // when & then
+            assertThatThrownBy {
+                playerRecordService.getPlayerRecord(1L, RecordScope.COMPETITION, RecordType.ALL, null, null)
+            }.isInstanceOf(InvalidInputException::class.java)
+                .hasMessageContaining("대회별 통계는 추후 구현 예정")
+        }
+    }
+
+    @Nested
+    @DisplayName("시즌 기록 조회")
+    inner class SeasonRecord {
+        @Test
+        fun `시즌 타격 기록을 조회한다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every { playerStatsService.getSeasonBattingStats(1L, 2025) } returns createMockSeasonBattingStats()
+
+            // when
+            val result = playerRecordService.getPlayerRecord(1L, RecordScope.SEASON, RecordType.BATTING, 2025, null)
+
+            // then
+            assertThat(result.playerName).isEqualTo("홍길동")
+            assertThat(result.scope).isEqualTo(RecordScope.SEASON)
+            assertThat(result.type).isEqualTo(RecordType.BATTING)
+            assertThat(result.year).isEqualTo(2025)
+            assertThat(result.battingStats).isNotNull
+            assertThat(result.battingStats?.gamesPlayed).isEqualTo(50)
+            assertThat(result.battingStats?.hits).isEqualTo(54)
+            assertThat(result.pitchingStats).isNull()
+        }
+
+        @Test
+        fun `시즌 투수 기록을 조회한다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every { playerStatsService.getSeasonPitchingStats(1L, 2025) } returns createMockSeasonPitchingStats()
+
+            // when
+            val result = playerRecordService.getPlayerRecord(1L, RecordScope.SEASON, RecordType.PITCHING, 2025, null)
+
+            // then
+            assertThat(result.scope).isEqualTo(RecordScope.SEASON)
+            assertThat(result.type).isEqualTo(RecordType.PITCHING)
+            assertThat(result.battingStats).isNull()
+            assertThat(result.pitchingStats).isNotNull
+            assertThat(result.pitchingStats?.gamesPlayed).isEqualTo(20)
+            assertThat(result.pitchingStats?.wins).isEqualTo(10)
+        }
+
+        @Test
+        fun `시즌 ALL 타입으로 타격과 투수 기록을 모두 조회한다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every { playerStatsService.getSeasonBattingStats(1L, 2025) } returns createMockSeasonBattingStats()
+            every { playerStatsService.getSeasonPitchingStats(1L, 2025) } returns createMockSeasonPitchingStats()
+
+            // when
+            val result = playerRecordService.getPlayerRecord(1L, RecordScope.SEASON, RecordType.ALL, 2025, null)
+
+            // then
+            assertThat(result.type).isEqualTo(RecordType.ALL)
+            assertThat(result.battingStats).isNotNull
+            assertThat(result.pitchingStats).isNotNull
+        }
+
+        @Test
+        fun `시즌 타격 기록이 없으면 null을 반환한다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every {
+                playerStatsService.getSeasonBattingStats(1L, 2025)
+            } throws IllegalArgumentException("통계가 없습니다")
+
+            // when
+            val result = playerRecordService.getPlayerRecord(1L, RecordScope.SEASON, RecordType.BATTING, 2025, null)
+
+            // then
+            assertThat(result.battingStats).isNull()
+        }
+
+        @Test
+        fun `연도를 지정하지 않으면 현재 연도를 사용한다`() {
+            // given
+            val currentYear = LocalDate.now().year
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every { playerStatsService.getSeasonBattingStats(1L, currentYear) } returns createMockSeasonBattingStats()
+
+            // when
+            val result = playerRecordService.getPlayerRecord(1L, RecordScope.SEASON, RecordType.BATTING, null, null)
+
+            // then
+            assertThat(result.year).isEqualTo(currentYear)
+        }
+    }
+
+    @Nested
+    @DisplayName("통산 기록 조회")
+    inner class CareerRecord {
+        @Test
+        fun `통산 타격 기록을 조회한다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every { playerStatsService.getCareerBattingStats(1L) } returns createMockCareerBattingStats()
+
+            // when
+            val result = playerRecordService.getPlayerRecord(1L, RecordScope.CAREER, RecordType.BATTING, null, null)
+
+            // then
+            assertThat(result.scope).isEqualTo(RecordScope.CAREER)
+            assertThat(result.type).isEqualTo(RecordType.BATTING)
+            assertThat(result.year).isNull()
+            assertThat(result.battingStats).isNotNull
+            assertThat(result.battingStats?.gamesPlayed).isEqualTo(300)
+            assertThat(result.pitchingStats).isNull()
+        }
+
+        @Test
+        fun `통산 투수 기록을 조회한다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every { playerStatsService.getCareerPitchingStats(1L) } returns createMockCareerPitchingStats()
+
+            // when
+            val result = playerRecordService.getPlayerRecord(1L, RecordScope.CAREER, RecordType.PITCHING, null, null)
+
+            // then
+            assertThat(result.scope).isEqualTo(RecordScope.CAREER)
+            assertThat(result.type).isEqualTo(RecordType.PITCHING)
+            assertThat(result.pitchingStats).isNotNull
+            assertThat(result.pitchingStats?.gamesPlayed).isEqualTo(100)
+            assertThat(result.battingStats).isNull()
+        }
+
+        @Test
+        fun `통산 타격 기록이 없으면 null을 반환한다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every {
+                playerStatsService.getCareerBattingStats(1L)
+            } throws IllegalArgumentException("통계가 없습니다")
+
+            // when
+            val result = playerRecordService.getPlayerRecord(1L, RecordScope.CAREER, RecordType.BATTING, null, null)
+
+            // then
+            assertThat(result.battingStats).isNull()
+        }
+
+        @Test
+        fun `통산 투수 기록이 없으면 null을 반환한다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every {
+                playerStatsService.getCareerPitchingStats(1L)
+            } throws IllegalArgumentException("통계가 없습니다")
+
+            // when
+            val result = playerRecordService.getPlayerRecord(1L, RecordScope.CAREER, RecordType.PITCHING, null, null)
+
+            // then
+            assertThat(result.pitchingStats).isNull()
+        }
+
+        @Test
+        fun `통산 ALL 타입으로 타격과 투수 기록을 모두 조회한다`() {
+            // given
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every { playerStatsService.getCareerBattingStats(1L) } returns createMockCareerBattingStats()
+            every { playerStatsService.getCareerPitchingStats(1L) } returns createMockCareerPitchingStats()
+
+            // when
+            val result = playerRecordService.getPlayerRecord(1L, RecordScope.CAREER, RecordType.ALL, null, null)
+
+            // then
+            assertThat(result.type).isEqualTo(RecordType.ALL)
+            assertThat(result.battingStats).isNotNull
+            assertThat(result.pitchingStats).isNotNull
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/RecentFormServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/RecentFormServiceImplTest.kt
@@ -1,0 +1,449 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.PitchingDecision
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.service.stats.dto.FormTrend
+import com.nextup.core.service.stats.dto.FormType
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+@DisplayName("RecentFormServiceImpl 테스트")
+class RecentFormServiceImplTest {
+    private lateinit var playerRepositoryPort: PlayerRepositoryPort
+    private lateinit var battingRecordRepositoryPort: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepositoryPort: PitchingRecordRepositoryPort
+    private lateinit var gameRepositoryPort: GameRepositoryPort
+    private lateinit var gameTeamRepositoryPort: GameTeamRepositoryPort
+    private lateinit var recentFormService: RecentFormServiceImpl
+
+    private lateinit var player: Player
+
+    @BeforeEach
+    fun setUp() {
+        playerRepositoryPort = mockk()
+        battingRecordRepositoryPort = mockk()
+        pitchingRecordRepositoryPort = mockk()
+        gameRepositoryPort = mockk()
+        gameTeamRepositoryPort = mockk()
+        recentFormService =
+            RecentFormServiceImpl(
+                playerRepositoryPort,
+                battingRecordRepositoryPort,
+                pitchingRecordRepositoryPort,
+                gameRepositoryPort,
+                gameTeamRepositoryPort,
+            )
+
+        player =
+            mockk<Player>().apply {
+                every { id } returns 1L
+                every { name } returns "홍길동"
+            }
+    }
+
+    private fun createMockTeam(
+        teamId: Long,
+        teamName: String = "테스트팀",
+    ): Team =
+        mockk<Team>().apply {
+            every { id } returns teamId
+            every { name } returns teamName
+        }
+
+    private fun createMockGame(
+        gameId: Long,
+        scheduledAt: LocalDateTime = LocalDateTime.now(),
+    ): Game =
+        mockk<Game>().apply {
+            every { id } returns gameId
+            every { this@apply.scheduledAt } returns scheduledAt
+        }
+
+    private fun createMockGameTeam(
+        game: Game,
+        team: Team,
+    ): GameTeam =
+        mockk<GameTeam>().apply {
+            every { this@apply.game } returns game
+            every { this@apply.team } returns team
+        }
+
+    private fun createMockGamePlayer(gameTeam: GameTeam): GamePlayer =
+        mockk<GamePlayer>().apply {
+            every { this@apply.gameTeam } returns gameTeam
+        }
+
+    private fun createMockBattingRecord(
+        gamePlayer: GamePlayer,
+        atBats: Int,
+        hits: Int,
+        homeRuns: Int = 0,
+        rbi: Int = 0,
+        runs: Int = 0,
+        walks: Int = 0,
+        strikeouts: Int = 0,
+    ): BattingRecord =
+        mockk<BattingRecord>().apply {
+            every { this@apply.gamePlayer } returns gamePlayer
+            every { this@apply.atBats } returns atBats
+            every { this@apply.hits } returns hits
+            every { this@apply.homeRuns } returns homeRuns
+            every { this@apply.runsBattedIn } returns rbi
+            every { this@apply.runs } returns runs
+            every { this@apply.walks } returns walks
+            every { this@apply.strikeouts } returns strikeouts
+        }
+
+    private fun createMockPitchingRecord(
+        gamePlayer: GamePlayer,
+        inningsPitchedOuts: Int,
+        earnedRuns: Int,
+        strikeouts: Int = 0,
+        walksAllowed: Int = 0,
+        hitsAllowed: Int = 0,
+        decision: PitchingDecision = PitchingDecision.NONE,
+    ): PitchingRecord =
+        mockk<PitchingRecord>().apply {
+            every { this@apply.gamePlayer } returns gamePlayer
+            every { this@apply.inningsPitchedOuts } returns inningsPitchedOuts
+            every { inningsPitchedDisplay } returns "${inningsPitchedOuts / 3}.${inningsPitchedOuts % 3}"
+            every { this@apply.earnedRuns } returns earnedRuns
+            every { this@apply.strikeouts } returns strikeouts
+            every { this@apply.walksAllowed } returns walksAllowed
+            every { this@apply.hitsAllowed } returns hitsAllowed
+            every { this@apply.decision } returns decision
+        }
+
+    @Nested
+    @DisplayName("getRecentForm 공통")
+    inner class GetRecentFormCommon {
+        @Test
+        fun `조회할 경기 수가 0 이하이면 예외를 발생시킨다`() {
+            // when & then
+            assertThatThrownBy {
+                recentFormService.getRecentForm(1L, 0, FormType.BATTING)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("1~20 사이")
+        }
+
+        @Test
+        fun `조회할 경기 수가 20 초과이면 예외를 발생시킨다`() {
+            // when & then
+            assertThatThrownBy {
+                recentFormService.getRecentForm(1L, 21, FormType.BATTING)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("1~20 사이")
+        }
+
+        @Test
+        fun `선수가 존재하지 않으면 예외를 발생시킨다`() {
+            // given
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                recentFormService.getRecentForm(1L, 5, FormType.BATTING)
+            }.isInstanceOf(PlayerNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("타격 폼 분석")
+    inner class BattingForm {
+        @Test
+        fun `타격 기록이 없으면 예외를 발생시킨다`() {
+            // given
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns player
+            every { battingRecordRepositoryPort.findRecentByPlayerId(1L, 5) } returns emptyList()
+
+            // when & then
+            assertThatThrownBy {
+                recentFormService.getRecentForm(1L, 5, FormType.BATTING)
+            }.isInstanceOf(InvalidInputException::class.java)
+                .hasMessageContaining("타격 기록이 없습니다")
+        }
+
+        @Test
+        fun `타격 폼을 분석하여 반환한다`() {
+            // given
+            val team = createMockTeam(10L, "테스트팀")
+            val opponentTeam = createMockTeam(20L, "상대팀")
+            val game = createMockGame(1L, LocalDateTime.of(2025, 4, 15, 14, 0))
+            val gameTeam = createMockGameTeam(game, team)
+            val opponentGameTeam = createMockGameTeam(game, opponentTeam)
+            val gamePlayer = createMockGamePlayer(gameTeam)
+
+            val battingRecord = createMockBattingRecord(gamePlayer, 4, 2, 1, 2, 1, 0, 1)
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns player
+            every { battingRecordRepositoryPort.findRecentByPlayerId(1L, 5) } returns listOf(battingRecord)
+            every { battingRecordRepositoryPort.findAllByPlayerId(1L) } returns listOf(battingRecord)
+            every { gameRepositoryPort.findAllByIds(listOf(1L)) } returns listOf(game)
+            every { gameTeamRepositoryPort.findAllByGameIds(listOf(1L)) } returns listOf(gameTeam, opponentGameTeam)
+
+            // when
+            val result = recentFormService.getRecentForm(1L, 5, FormType.BATTING)
+
+            // then
+            assertThat(result.playerName).isEqualTo("홍길동")
+            assertThat(result.type).isEqualTo(FormType.BATTING)
+            assertThat(result.gamesRequested).isEqualTo(5)
+            assertThat(result.gamesFound).isEqualTo(1)
+            assertThat(result.batting).isNotNull
+            assertThat(result.batting?.totalAtBats).isEqualTo(4)
+            assertThat(result.batting?.totalHits).isEqualTo(2)
+            assertThat(result.pitching).isNull()
+        }
+
+        @Test
+        fun `기록이 1개 이하이면 STABLE 트렌드를 반환한다`() {
+            // given
+            val team = createMockTeam(10L)
+            val game = createMockGame(1L)
+            val gameTeam = createMockGameTeam(game, team)
+            val gamePlayer = createMockGamePlayer(gameTeam)
+            val battingRecord = createMockBattingRecord(gamePlayer, 4, 2)
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns player
+            every { battingRecordRepositoryPort.findRecentByPlayerId(1L, 5) } returns listOf(battingRecord)
+            every { battingRecordRepositoryPort.findAllByPlayerId(1L) } returns listOf(battingRecord)
+            every { gameRepositoryPort.findAllByIds(listOf(1L)) } returns listOf(game)
+            every { gameTeamRepositoryPort.findAllByGameIds(listOf(1L)) } returns listOf(gameTeam)
+
+            // when
+            val result = recentFormService.getRecentForm(1L, 5, FormType.BATTING)
+
+            // then
+            assertThat(result.trend).isEqualTo(FormTrend.STABLE)
+        }
+
+        @Test
+        fun `최근 타율이 이전보다 높으면 UP 트렌드를 반환한다`() {
+            // given
+            val team = createMockTeam(10L)
+            val game1 = createMockGame(1L, LocalDateTime.of(2025, 4, 16, 14, 0))
+            val game2 = createMockGame(2L, LocalDateTime.of(2025, 4, 15, 14, 0))
+            val gameTeam1 = createMockGameTeam(game1, team)
+            val gameTeam2 = createMockGameTeam(game2, team)
+            val gamePlayer1 = createMockGamePlayer(gameTeam1)
+            val gamePlayer2 = createMockGamePlayer(gameTeam2)
+
+            // 최근 경기: 높은 타율 (3/4 = 0.750)
+            val recentRecord = createMockBattingRecord(gamePlayer1, 4, 3)
+            // 이전 경기: 낮은 타율 (1/4 = 0.250)
+            val earlierRecord = createMockBattingRecord(gamePlayer2, 4, 1)
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns player
+            every {
+                battingRecordRepositoryPort.findRecentByPlayerId(1L, 5)
+            } returns listOf(recentRecord, earlierRecord)
+            every { battingRecordRepositoryPort.findAllByPlayerId(1L) } returns listOf(recentRecord, earlierRecord)
+            every { gameRepositoryPort.findAllByIds(listOf(1L, 2L)) } returns listOf(game1, game2)
+            every { gameTeamRepositoryPort.findAllByGameIds(listOf(1L, 2L)) } returns listOf(gameTeam1, gameTeam2)
+
+            // when
+            val result = recentFormService.getRecentForm(1L, 5, FormType.BATTING)
+
+            // then
+            assertThat(result.trend).isEqualTo(FormTrend.UP)
+            assertThat(result.trendDescription).contains("상승세")
+        }
+
+        @Test
+        fun `최근 타율이 이전보다 낮으면 DOWN 트렌드를 반환한다`() {
+            // given
+            val team = createMockTeam(10L)
+            val game1 = createMockGame(1L, LocalDateTime.of(2025, 4, 16, 14, 0))
+            val game2 = createMockGame(2L, LocalDateTime.of(2025, 4, 15, 14, 0))
+            val gameTeam1 = createMockGameTeam(game1, team)
+            val gameTeam2 = createMockGameTeam(game2, team)
+            val gamePlayer1 = createMockGamePlayer(gameTeam1)
+            val gamePlayer2 = createMockGamePlayer(gameTeam2)
+
+            // 최근 경기: 낮은 타율 (1/4 = 0.250)
+            val recentRecord = createMockBattingRecord(gamePlayer1, 4, 1)
+            // 이전 경기: 높은 타율 (3/4 = 0.750)
+            val earlierRecord = createMockBattingRecord(gamePlayer2, 4, 3)
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns player
+            every {
+                battingRecordRepositoryPort.findRecentByPlayerId(1L, 5)
+            } returns listOf(recentRecord, earlierRecord)
+            every { battingRecordRepositoryPort.findAllByPlayerId(1L) } returns listOf(recentRecord, earlierRecord)
+            every { gameRepositoryPort.findAllByIds(listOf(1L, 2L)) } returns listOf(game1, game2)
+            every { gameTeamRepositoryPort.findAllByGameIds(listOf(1L, 2L)) } returns listOf(gameTeam1, gameTeam2)
+
+            // when
+            val result = recentFormService.getRecentForm(1L, 5, FormType.BATTING)
+
+            // then
+            assertThat(result.trend).isEqualTo(FormTrend.DOWN)
+            assertThat(result.trendDescription).contains("하락세")
+        }
+    }
+
+    @Nested
+    @DisplayName("투수 폼 분석")
+    inner class PitchingForm {
+        @Test
+        fun `투수 기록이 없으면 예외를 발생시킨다`() {
+            // given
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns player
+            every { pitchingRecordRepositoryPort.findRecentByPlayerId(1L, 5) } returns emptyList()
+
+            // when & then
+            assertThatThrownBy {
+                recentFormService.getRecentForm(1L, 5, FormType.PITCHING)
+            }.isInstanceOf(InvalidInputException::class.java)
+                .hasMessageContaining("투수 기록이 없습니다")
+        }
+
+        @Test
+        fun `투수 폼을 분석하여 반환한다`() {
+            // given
+            val team = createMockTeam(10L, "테스트팀")
+            val opponentTeam = createMockTeam(20L, "상대팀")
+            val game = createMockGame(1L, LocalDateTime.of(2025, 4, 15, 14, 0))
+            val gameTeam = createMockGameTeam(game, team)
+            val opponentGameTeam = createMockGameTeam(game, opponentTeam)
+            val gamePlayer = createMockGamePlayer(gameTeam)
+
+            val pitchingRecord = createMockPitchingRecord(gamePlayer, 21, 2, 8, 2, 5, PitchingDecision.WIN)
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns player
+            every { pitchingRecordRepositoryPort.findRecentByPlayerId(1L, 5) } returns listOf(pitchingRecord)
+            every { pitchingRecordRepositoryPort.findAllByPlayerId(1L) } returns listOf(pitchingRecord)
+            every { gameRepositoryPort.findAllByIds(listOf(1L)) } returns listOf(game)
+            every { gameTeamRepositoryPort.findAllByGameIds(listOf(1L)) } returns listOf(gameTeam, opponentGameTeam)
+
+            // when
+            val result = recentFormService.getRecentForm(1L, 5, FormType.PITCHING)
+
+            // then
+            assertThat(result.playerName).isEqualTo("홍길동")
+            assertThat(result.type).isEqualTo(FormType.PITCHING)
+            assertThat(result.gamesRequested).isEqualTo(5)
+            assertThat(result.gamesFound).isEqualTo(1)
+            assertThat(result.pitching).isNotNull
+            assertThat(result.pitching?.totalInningsPitchedOuts).isEqualTo(21)
+            assertThat(result.pitching?.totalEarnedRuns).isEqualTo(2)
+            assertThat(result.pitching?.totalStrikeouts).isEqualTo(8)
+            assertThat(result.batting).isNull()
+        }
+
+        @Test
+        fun `최근 ERA가 이전보다 낮으면 UP 트렌드를 반환한다`() {
+            // given
+            val team = createMockTeam(10L)
+            val game1 = createMockGame(1L, LocalDateTime.of(2025, 4, 16, 14, 0))
+            val game2 = createMockGame(2L, LocalDateTime.of(2025, 4, 15, 14, 0))
+            val gameTeam1 = createMockGameTeam(game1, team)
+            val gameTeam2 = createMockGameTeam(game2, team)
+            val gamePlayer1 = createMockGamePlayer(gameTeam1)
+            val gamePlayer2 = createMockGamePlayer(gameTeam2)
+
+            // 최근 경기: 낮은 ERA (1 ER / 7 IP)
+            val recentRecord = createMockPitchingRecord(gamePlayer1, 21, 1, 8, 1, 4, PitchingDecision.WIN)
+            // 이전 경기: 높은 ERA (5 ER / 7 IP)
+            val earlierRecord = createMockPitchingRecord(gamePlayer2, 21, 5, 4, 3, 8, PitchingDecision.LOSS)
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns player
+            every {
+                pitchingRecordRepositoryPort.findRecentByPlayerId(1L, 5)
+            } returns listOf(recentRecord, earlierRecord)
+            every { pitchingRecordRepositoryPort.findAllByPlayerId(1L) } returns listOf(recentRecord, earlierRecord)
+            every { gameRepositoryPort.findAllByIds(listOf(1L, 2L)) } returns listOf(game1, game2)
+            every { gameTeamRepositoryPort.findAllByGameIds(listOf(1L, 2L)) } returns listOf(gameTeam1, gameTeam2)
+
+            // when
+            val result = recentFormService.getRecentForm(1L, 5, FormType.PITCHING)
+
+            // then
+            assertThat(result.trend).isEqualTo(FormTrend.UP)
+            assertThat(result.trendDescription).contains("상승세")
+        }
+
+        @Test
+        fun `최근 ERA가 이전보다 높으면 DOWN 트렌드를 반환한다`() {
+            // given
+            val team = createMockTeam(10L)
+            val game1 = createMockGame(1L, LocalDateTime.of(2025, 4, 16, 14, 0))
+            val game2 = createMockGame(2L, LocalDateTime.of(2025, 4, 15, 14, 0))
+            val gameTeam1 = createMockGameTeam(game1, team)
+            val gameTeam2 = createMockGameTeam(game2, team)
+            val gamePlayer1 = createMockGamePlayer(gameTeam1)
+            val gamePlayer2 = createMockGamePlayer(gameTeam2)
+
+            // 최근 경기: 높은 ERA (5 ER / 7 IP)
+            val recentRecord = createMockPitchingRecord(gamePlayer1, 21, 5, 4, 3, 8, PitchingDecision.LOSS)
+            // 이전 경기: 낮은 ERA (1 ER / 7 IP)
+            val earlierRecord = createMockPitchingRecord(gamePlayer2, 21, 1, 8, 1, 4, PitchingDecision.WIN)
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns player
+            every {
+                pitchingRecordRepositoryPort.findRecentByPlayerId(1L, 5)
+            } returns listOf(recentRecord, earlierRecord)
+            every { pitchingRecordRepositoryPort.findAllByPlayerId(1L) } returns listOf(recentRecord, earlierRecord)
+            every { gameRepositoryPort.findAllByIds(listOf(1L, 2L)) } returns listOf(game1, game2)
+            every { gameTeamRepositoryPort.findAllByGameIds(listOf(1L, 2L)) } returns listOf(gameTeam1, gameTeam2)
+
+            // when
+            val result = recentFormService.getRecentForm(1L, 5, FormType.PITCHING)
+
+            // then
+            assertThat(result.trend).isEqualTo(FormTrend.DOWN)
+            assertThat(result.trendDescription).contains("하락세")
+        }
+
+        @Test
+        fun `이닝이 0이면 STABLE 트렌드를 반환한다`() {
+            // given
+            val team = createMockTeam(10L)
+            val game1 = createMockGame(1L, LocalDateTime.of(2025, 4, 16, 14, 0))
+            val game2 = createMockGame(2L, LocalDateTime.of(2025, 4, 15, 14, 0))
+            val gameTeam1 = createMockGameTeam(game1, team)
+            val gameTeam2 = createMockGameTeam(game2, team)
+            val gamePlayer1 = createMockGamePlayer(gameTeam1)
+            val gamePlayer2 = createMockGamePlayer(gameTeam2)
+
+            // 최근 경기: 0이닝
+            val recentRecord = createMockPitchingRecord(gamePlayer1, 0, 0, 0, 0, 0, PitchingDecision.NONE)
+            // 이전 경기
+            val earlierRecord = createMockPitchingRecord(gamePlayer2, 21, 2, 6, 2, 5, PitchingDecision.WIN)
+
+            every { playerRepositoryPort.findByIdOrNull(1L) } returns player
+            every {
+                pitchingRecordRepositoryPort.findRecentByPlayerId(1L, 5)
+            } returns listOf(recentRecord, earlierRecord)
+            every { pitchingRecordRepositoryPort.findAllByPlayerId(1L) } returns listOf(recentRecord, earlierRecord)
+            every { gameRepositoryPort.findAllByIds(listOf(1L, 2L)) } returns listOf(game1, game2)
+            every { gameTeamRepositoryPort.findAllByGameIds(listOf(1L, 2L)) } returns listOf(gameTeam1, gameTeam2)
+
+            // when
+            val result = recentFormService.getRecentForm(1L, 5, FormType.PITCHING)
+
+            // then
+            assertThat(result.trend).isEqualTo(FormTrend.STABLE)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/TeamStatsServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/TeamStatsServiceImplTest.kt
@@ -1,0 +1,326 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameResult
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("TeamStatsServiceImpl 테스트")
+class TeamStatsServiceImplTest {
+    private lateinit var teamRepositoryPort: TeamRepositoryPort
+    private lateinit var gameTeamRepositoryPort: GameTeamRepositoryPort
+    private lateinit var battingRecordRepositoryPort: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepositoryPort: PitchingRecordRepositoryPort
+    private lateinit var teamStatsService: TeamStatsServiceImpl
+
+    private lateinit var association: Association
+    private lateinit var league: League
+    private lateinit var team: Team
+
+    @BeforeEach
+    fun setUp() {
+        teamRepositoryPort = mockk()
+        gameTeamRepositoryPort = mockk()
+        battingRecordRepositoryPort = mockk()
+        pitchingRecordRepositoryPort = mockk()
+        teamStatsService =
+            TeamStatsServiceImpl(
+                teamRepositoryPort,
+                gameTeamRepositoryPort,
+                battingRecordRepositoryPort,
+                pitchingRecordRepositoryPort,
+            )
+
+        association = Association(name = "서울시야구협회", region = "서울")
+        league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        team = Team(league = league, name = "테스트팀", city = "서울", foundedYear = 2020)
+    }
+
+    private fun createMockTeam(teamId: Long): Team =
+        mockk<Team>(relaxed = true).apply {
+            every { id } returns teamId
+        }
+
+    private fun createMockGameTeam(
+        teamMock: Team,
+        gameMock: Game,
+        gameResult: GameResult,
+    ): GameTeam =
+        mockk<GameTeam>(relaxed = true).apply {
+            every { team } returns teamMock
+            every { game } returns gameMock
+            every { result } returns gameResult
+        }
+
+    @Nested
+    @DisplayName("getTeamStats")
+    inner class GetTeamStats {
+        @Test
+        fun `팀이 존재하지 않으면 예외를 발생시킨다`() {
+            // given
+            every { teamRepositoryPort.findByIdWithLeague(1L) } returns null
+
+            // when & then
+            assertThatThrownBy { teamStatsService.getTeamStats(1L, null, null) }
+                .isInstanceOf(TeamNotFoundException::class.java)
+        }
+
+        @Test
+        fun `경기 기록이 없는 팀의 통계를 조회하면 빈 통계를 반환한다`() {
+            // given
+            every { teamRepositoryPort.findByIdWithLeague(1L) } returns team
+            every { gameTeamRepositoryPort.findAllByTeamId(1L) } returns emptyList()
+
+            // when
+            val result = teamStatsService.getTeamStats(1L, null, null)
+
+            // then
+            assertThat(result.teamId).isEqualTo(0L)
+            assertThat(result.teamName).isEqualTo("테스트팀")
+            assertThat(result.record.gamesPlayed).isEqualTo(0)
+            assertThat(result.record.wins).isEqualTo(0)
+            assertThat(result.record.losses).isEqualTo(0)
+            assertThat(result.batting.totalAtBats).isEqualTo(0)
+            assertThat(result.pitching.totalInningsPitchedOuts).isEqualTo(0)
+        }
+
+        @Test
+        fun `연도 필터를 적용하여 팀 통계를 조회할 수 있다`() {
+            // given
+            every { teamRepositoryPort.findByIdWithLeague(1L) } returns team
+            every { gameTeamRepositoryPort.findAllByTeamIdAndYear(1L, 2025) } returns emptyList()
+
+            // when
+            val result = teamStatsService.getTeamStats(1L, 2025, null)
+
+            // then
+            assertThat(result.year).isEqualTo(2025)
+            assertThat(result.record.gamesPlayed).isEqualTo(0)
+        }
+
+        @Test
+        fun `경기 결과를 집계하여 승률을 계산한다`() {
+            // given
+            val mockTeam = createMockTeam(1L)
+
+            val game1 = mockk<Game>(relaxed = true).apply { every { id } returns 1L }
+            val game2 = mockk<Game>(relaxed = true).apply { every { id } returns 2L }
+            val game3 = mockk<Game>(relaxed = true).apply { every { id } returns 3L }
+
+            val gameTeam1 = createMockGameTeam(mockTeam, game1, GameResult.WIN)
+            val gameTeam2 = createMockGameTeam(mockTeam, game2, GameResult.LOSS)
+            val gameTeam3 = createMockGameTeam(mockTeam, game3, GameResult.WIN)
+
+            every { teamRepositoryPort.findByIdWithLeague(1L) } returns team
+            every { gameTeamRepositoryPort.findAllByTeamId(1L) } returns listOf(gameTeam1, gameTeam2, gameTeam3)
+            every { battingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, any()) } returns emptyList()
+            every { pitchingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, any()) } returns emptyList()
+
+            // when
+            val result = teamStatsService.getTeamStats(1L, null, null)
+
+            // then
+            assertThat(result.record.gamesPlayed).isEqualTo(3)
+            assertThat(result.record.wins).isEqualTo(2)
+            assertThat(result.record.losses).isEqualTo(1)
+            assertThat(result.record.winningPercentage).isEqualTo(BigDecimal("0.667"))
+        }
+
+        @Test
+        fun `무승부를 포함한 경기 결과를 집계한다`() {
+            // given
+            val mockTeam = createMockTeam(1L)
+
+            val game1 = mockk<Game>(relaxed = true).apply { every { id } returns 1L }
+            val game2 = mockk<Game>(relaxed = true).apply { every { id } returns 2L }
+
+            val gameTeam1 = createMockGameTeam(mockTeam, game1, GameResult.DRAW)
+            val gameTeam2 = createMockGameTeam(mockTeam, game2, GameResult.DRAW)
+
+            every { teamRepositoryPort.findByIdWithLeague(1L) } returns team
+            every { gameTeamRepositoryPort.findAllByTeamId(1L) } returns listOf(gameTeam1, gameTeam2)
+            every { battingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, any()) } returns emptyList()
+            every { pitchingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, any()) } returns emptyList()
+
+            // when
+            val result = teamStatsService.getTeamStats(1L, null, null)
+
+            // then
+            assertThat(result.record.gamesPlayed).isEqualTo(2)
+            assertThat(result.record.draws).isEqualTo(2)
+            assertThat(result.record.winningPercentage).isEqualTo(BigDecimal("0.000"))
+        }
+
+        @Test
+        fun `타격 통계를 계산한다`() {
+            // given
+            val mockTeam = createMockTeam(1L)
+            val game = mockk<Game>(relaxed = true).apply { every { id } returns 1L }
+            val gameTeam = createMockGameTeam(mockTeam, game, GameResult.WIN)
+
+            val battingRecord1 =
+                mockk<BattingRecord>(relaxed = true).apply {
+                    every { atBats } returns 4
+                    every { hits } returns 2
+                    every { homeRuns } returns 1
+                    every { runsBattedIn } returns 2
+                    every { runs } returns 1
+                    every { totalWalks } returns 1
+                    every { hitByPitch } returns 0
+                    every { sacrificeFlies } returns 0
+                    every { totalBases } returns 5
+                }
+
+            val battingRecord2 =
+                mockk<BattingRecord>(relaxed = true).apply {
+                    every { atBats } returns 3
+                    every { hits } returns 1
+                    every { homeRuns } returns 0
+                    every { runsBattedIn } returns 0
+                    every { runs } returns 1
+                    every { totalWalks } returns 1
+                    every { hitByPitch } returns 1
+                    every { sacrificeFlies } returns 1
+                    every { totalBases } returns 1
+                }
+
+            every { teamRepositoryPort.findByIdWithLeague(1L) } returns team
+            every { gameTeamRepositoryPort.findAllByTeamId(1L) } returns listOf(gameTeam)
+            every {
+                battingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, listOf(1L))
+            } returns listOf(battingRecord1, battingRecord2)
+            every { pitchingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, listOf(1L)) } returns emptyList()
+
+            // when
+            val result = teamStatsService.getTeamStats(1L, null, null)
+
+            // then
+            assertThat(result.batting.totalAtBats).isEqualTo(7)
+            assertThat(result.batting.totalHits).isEqualTo(3)
+            assertThat(result.batting.totalHomeRuns).isEqualTo(1)
+            assertThat(result.batting.totalRunsBattedIn).isEqualTo(2)
+            assertThat(result.batting.totalRuns).isEqualTo(2)
+            assertThat(result.batting.teamBattingAverage).isEqualTo(BigDecimal("0.429"))
+        }
+
+        @Test
+        fun `투수 통계를 계산한다`() {
+            // given
+            val mockTeam = createMockTeam(1L)
+            val game = mockk<Game>(relaxed = true).apply { every { id } returns 1L }
+            val gameTeam = createMockGameTeam(mockTeam, game, GameResult.WIN)
+
+            val pitchingRecord =
+                mockk<PitchingRecord>(relaxed = true).apply {
+                    every { inningsPitchedOuts } returns 21 // 7이닝
+                    every { earnedRuns } returns 3
+                    every { strikeouts } returns 8
+                    every { walksAllowed } returns 2
+                    every { hitsAllowed } returns 6
+                }
+
+            every { teamRepositoryPort.findByIdWithLeague(1L) } returns team
+            every { gameTeamRepositoryPort.findAllByTeamId(1L) } returns listOf(gameTeam)
+            every { battingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, listOf(1L)) } returns emptyList()
+            every {
+                pitchingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, listOf(1L))
+            } returns listOf(pitchingRecord)
+
+            // when
+            val result = teamStatsService.getTeamStats(1L, null, null)
+
+            // then
+            assertThat(result.pitching.totalInningsPitchedOuts).isEqualTo(21)
+            assertThat(result.pitching.inningsPitchedDisplay).isEqualTo("7.0")
+            assertThat(result.pitching.totalEarnedRuns).isEqualTo(3)
+            assertThat(result.pitching.totalStrikeouts).isEqualTo(8)
+            assertThat(result.pitching.teamEra).isEqualTo(BigDecimal("3.86"))
+            assertThat(result.pitching.teamWhip).isEqualTo(BigDecimal("1.14"))
+        }
+
+        @Test
+        fun `이닝이 0일 때 투수 통계는 0을 반환한다`() {
+            // given
+            val mockTeam = createMockTeam(1L)
+            val game = mockk<Game>(relaxed = true).apply { every { id } returns 1L }
+            val gameTeam = createMockGameTeam(mockTeam, game, GameResult.WIN)
+
+            val pitchingRecord =
+                mockk<PitchingRecord>(relaxed = true).apply {
+                    every { inningsPitchedOuts } returns 0
+                    every { earnedRuns } returns 0
+                    every { strikeouts } returns 0
+                    every { walksAllowed } returns 0
+                    every { hitsAllowed } returns 0
+                }
+
+            every { teamRepositoryPort.findByIdWithLeague(1L) } returns team
+            every { gameTeamRepositoryPort.findAllByTeamId(1L) } returns listOf(gameTeam)
+            every { battingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, listOf(1L)) } returns emptyList()
+            every {
+                pitchingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, listOf(1L))
+            } returns listOf(pitchingRecord)
+
+            // when
+            val result = teamStatsService.getTeamStats(1L, null, null)
+
+            // then
+            assertThat(result.pitching.teamEra).isEqualTo(BigDecimal("0.00"))
+            assertThat(result.pitching.teamWhip).isEqualTo(BigDecimal("0.00"))
+        }
+
+        @Test
+        fun `타석이 0일 때 타격 통계는 0을 반환한다`() {
+            // given
+            val mockTeam = createMockTeam(1L)
+            val game = mockk<Game>(relaxed = true).apply { every { id } returns 1L }
+            val gameTeam = createMockGameTeam(mockTeam, game, GameResult.WIN)
+
+            val battingRecord =
+                mockk<BattingRecord>(relaxed = true).apply {
+                    every { atBats } returns 0
+                    every { hits } returns 0
+                    every { homeRuns } returns 0
+                    every { runsBattedIn } returns 0
+                    every { runs } returns 0
+                    every { totalWalks } returns 0
+                    every { hitByPitch } returns 0
+                    every { sacrificeFlies } returns 0
+                    every { totalBases } returns 0
+                }
+
+            every { teamRepositoryPort.findByIdWithLeague(1L) } returns team
+            every { gameTeamRepositoryPort.findAllByTeamId(1L) } returns listOf(gameTeam)
+            every {
+                battingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, listOf(1L))
+            } returns listOf(battingRecord)
+            every { pitchingRecordRepositoryPort.findAllByTeamIdAndGameIds(1L, listOf(1L)) } returns emptyList()
+
+            // when
+            val result = teamStatsService.getTeamStats(1L, null, null)
+
+            // then
+            assertThat(result.batting.teamBattingAverage).isEqualTo(BigDecimal("0.000"))
+            assertThat(result.batting.teamOnBasePercentage).isEqualTo(BigDecimal("0.000"))
+            assertThat(result.batting.teamSluggingPercentage).isEqualTo(BigDecimal("0.000"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #55

Phase 2: 조회/통계 API 고도화 구현

## Tasks

- [x] 선수 기록실 통합 API 구현 (PlayerRecordController)
- [x] 경기 타임라인 API 구현 (GameTimelineController)
- [x] 팀 통계 API 구현 (TeamStatsController)
- [x] 투수 vs 타자 매치업 API 구현 (MatchupController)
- [x] 최근 폼 조회 API 구현 (RecentFormService)
- [x] 코드 리뷰 HIGH 이슈 수정
- [x] PR 컨벤션 문서 업데이트
- [x] 테스트 커버리지 80% 달성

## To Reviewer

- Core 모듈 커버리지: **84%** ✅ (79% → 84%)
- API 모듈 커버리지: **98%** ✅ (70% → 98%)
- 빌드/테스트: ✅ 통과
- Zero Entity Leak: ✅ 준수
- ApiResponse 래핑: ✅ 적용

## Screenshot

N/A (API 전용)