### PR TITLE
feat(#64): 라인업 빌더 API 구현

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/lineup/LineupController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/lineup/LineupController.kt
@@ -1,0 +1,152 @@
+package com.nextup.api.controller.lineup
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.lineup.AddLineupEntryRequest
+import com.nextup.api.dto.lineup.CreateLineupRequest
+import com.nextup.api.dto.lineup.LineupEntryResponse
+import com.nextup.api.dto.lineup.LineupSubmissionResponse
+import com.nextup.api.dto.lineup.LineupSubmissionSummaryResponse
+import com.nextup.api.dto.lineup.SetLineupEntriesRequest
+import com.nextup.core.service.lineup.LineupService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 팀 감독용 라인업 컨트롤러
+ *
+ * 팀 관리자(감독)가 경기 전 라인업을 작성하고 제출하는 API를 제공합니다.
+ * - 라인업 생성, 수정, 제출은 이 컨트롤러에서 처리
+ * - 제출 후 확인/반려는 nextup-scorer 모듈에서 처리
+ */
+@RestController
+@RequestMapping("/api/v1/lineups")
+class LineupController(
+    private val lineupService: LineupService,
+) {
+    /**
+     * 라인업 제출을 생성합니다.
+     */
+    @PostMapping
+    fun createLineup(
+        @Valid @RequestBody request: CreateLineupRequest,
+        @RequestHeader("X-User-Id") userId: Long,
+    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
+        val submission =
+            lineupService.createLineupSubmission(
+                gameId = request.gameId,
+                teamId = request.teamId,
+                submittedByUserId = userId,
+            )
+        val entries = lineupService.getLineupEntries(submission.id)
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
+    }
+
+    /**
+     * 라인업 제출을 조회합니다.
+     */
+    @GetMapping("/{submissionId}")
+    fun getLineup(
+        @PathVariable submissionId: Long,
+    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
+        val submission = lineupService.getLineupSubmission(submissionId)
+        val entries = lineupService.getLineupEntries(submissionId)
+
+        return ResponseEntity.ok(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
+    }
+
+    /**
+     * 경기의 모든 라인업 제출을 조회합니다.
+     */
+    @GetMapping
+    fun getLineupsByGame(
+        @RequestParam gameId: Long,
+    ): ResponseEntity<ApiResponse<List<LineupSubmissionSummaryResponse>>> {
+        val submissions = lineupService.getLineupSubmissionsByGame(gameId)
+        val responses =
+            submissions.map { submission ->
+                val entries = lineupService.getLineupEntries(submission.id)
+                val starterCount = entries.count { it.isStarter }
+                LineupSubmissionSummaryResponse.from(submission, starterCount)
+            }
+
+        return ResponseEntity.ok(ApiResponse.success(responses))
+    }
+
+    /**
+     * 라인업 엔트리를 추가합니다.
+     */
+    @PostMapping("/{submissionId}/entries")
+    fun addLineupEntry(
+        @PathVariable submissionId: Long,
+        @Valid @RequestBody request: AddLineupEntryRequest,
+    ): ResponseEntity<ApiResponse<LineupEntryResponse>> {
+        val entry =
+            lineupService.addLineupEntry(
+                submissionId = submissionId,
+                playerId = request.playerId,
+                position = request.position,
+                battingOrder = request.battingOrder,
+                backNumber = request.backNumber,
+                isStarter = request.isStarter,
+            )
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(LineupEntryResponse.from(entry)))
+    }
+
+    /**
+     * 라인업 엔트리를 일괄 설정합니다.
+     */
+    @PutMapping("/{submissionId}/entries")
+    fun setLineupEntries(
+        @PathVariable submissionId: Long,
+        @Valid @RequestBody request: SetLineupEntriesRequest,
+    ): ResponseEntity<ApiResponse<List<LineupEntryResponse>>> {
+        val entries =
+            lineupService.setLineupEntries(
+                submissionId = submissionId,
+                entries = request.entries.map { it.toInput() },
+            )
+
+        return ResponseEntity.ok(ApiResponse.success(entries.map { LineupEntryResponse.from(it) }))
+    }
+
+    /**
+     * 라인업 엔트리를 조회합니다.
+     */
+    @GetMapping("/{submissionId}/entries")
+    fun getLineupEntries(
+        @PathVariable submissionId: Long,
+    ): ResponseEntity<ApiResponse<List<LineupEntryResponse>>> {
+        val entries = lineupService.getLineupEntries(submissionId)
+
+        return ResponseEntity.ok(ApiResponse.success(entries.map { LineupEntryResponse.from(it) }))
+    }
+
+    /**
+     * 라인업을 기록원에게 제출합니다.
+     */
+    @PostMapping("/{submissionId}/submit")
+    fun submitLineup(
+        @PathVariable submissionId: Long,
+    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
+        val submission = lineupService.submitLineup(submissionId)
+        val entries = lineupService.getLineupEntries(submissionId)
+
+        return ResponseEntity.ok(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/lineup/LineupRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/lineup/LineupRequest.kt
@@ -1,4 +1,4 @@
-package com.nextup.scorer.dto.lineup
+package com.nextup.api.dto.lineup
 
 import com.nextup.core.domain.player.Position
 import com.nextup.core.service.lineup.LineupEntryInput
@@ -67,12 +67,3 @@ data class LineupEntryDto(
             isStarter = isStarter,
         )
 }
-
-/**
- * 라인업 반려 요청 DTO
- */
-data class RejectLineupRequest(
-    @field:NotEmpty(message = "반려 사유는 필수입니다.")
-    @field:Size(max = 500, message = "반려 사유는 500자 이하여야 합니다.")
-    val reason: String,
-)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/lineup/LineupResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/lineup/LineupResponse.kt
@@ -1,0 +1,114 @@
+package com.nextup.api.dto.lineup
+
+import com.nextup.core.domain.game.LineupEntry
+import com.nextup.core.domain.game.LineupSubmission
+import com.nextup.core.domain.game.LineupSubmissionStatus
+import com.nextup.core.domain.player.Position
+import java.time.Instant
+
+/**
+ * 라인업 제출 응답 DTO
+ * NOTE: nextup-scorer의 LineupSubmissionResponse와 동일한 구조 유지
+ */
+data class LineupSubmissionResponse(
+    val id: Long,
+    val gameId: Long,
+    val teamId: Long,
+    val teamName: String,
+    val submittedById: Long,
+    val submittedByName: String,
+    val status: LineupSubmissionStatus,
+    val statusDisplayName: String,
+    val submittedAt: Instant?,
+    val confirmedAt: Instant?,
+    val confirmedById: Long?,
+    val confirmedByName: String?,
+    val rejectionReason: String?,
+    val rejectedById: Long?,
+    val rejectedByName: String?,
+    val entries: List<LineupEntryResponse>,
+) {
+    companion object {
+        fun from(
+            submission: LineupSubmission,
+            entries: List<LineupEntry>,
+        ): LineupSubmissionResponse =
+            LineupSubmissionResponse(
+                id = submission.id,
+                gameId = submission.game.id,
+                teamId = submission.team.id,
+                teamName = submission.team.name,
+                submittedById = submission.submittedBy.id,
+                submittedByName = submission.submittedBy.nickname,
+                status = submission.status,
+                statusDisplayName = submission.status.displayName,
+                submittedAt = submission.submittedAt,
+                confirmedAt = submission.confirmedAt,
+                confirmedById = submission.confirmedBy?.id,
+                confirmedByName = submission.confirmedBy?.nickname,
+                rejectionReason = submission.rejectionReason,
+                rejectedById = submission.rejectedBy?.id,
+                rejectedByName = submission.rejectedBy?.nickname,
+                entries = entries.map { LineupEntryResponse.from(it) },
+            )
+    }
+}
+
+/**
+ * 라인업 엔트리 응답 DTO
+ */
+data class LineupEntryResponse(
+    val id: Long,
+    val playerId: Long,
+    val playerName: String,
+    val position: Position,
+    val positionDisplayName: String,
+    val battingOrder: Int?,
+    val backNumber: Int?,
+    val isStarter: Boolean,
+) {
+    companion object {
+        fun from(entry: LineupEntry): LineupEntryResponse =
+            LineupEntryResponse(
+                id = entry.id,
+                playerId = entry.player.id,
+                playerName = entry.player.name,
+                position = entry.position,
+                positionDisplayName = entry.position.displayName,
+                battingOrder = entry.battingOrder,
+                backNumber = entry.backNumber,
+                isStarter = entry.isStarter,
+            )
+    }
+}
+
+/**
+ * 라인업 제출 요약 응답 DTO (목록 조회용)
+ */
+data class LineupSubmissionSummaryResponse(
+    val id: Long,
+    val gameId: Long,
+    val teamId: Long,
+    val teamName: String,
+    val status: LineupSubmissionStatus,
+    val statusDisplayName: String,
+    val starterCount: Int,
+    val submittedAt: Instant?,
+) {
+    companion object {
+        fun from(
+            submission: LineupSubmission,
+            starterCount: Int,
+        ): LineupSubmissionSummaryResponse =
+            LineupSubmissionSummaryResponse(
+                id = submission.id,
+                gameId = submission.game.id,
+                teamId = submission.team.id,
+                teamName = submission.team.name,
+                status = submission.status,
+                statusDisplayName = submission.status.displayName,
+                starterCount = starterCount,
+                submittedAt = submission.submittedAt,
+            )
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/lineup/LineupControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/lineup/LineupControllerTest.kt
@@ -1,0 +1,271 @@
+package com.nextup.api.controller.lineup
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.core.domain.game.LineupEntry
+import com.nextup.core.domain.game.LineupSubmission
+import com.nextup.core.domain.game.LineupSubmissionStatus
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.lineup.LineupService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class LineupControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var lineupService: LineupService
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var mockSubmission: LineupSubmission
+    private lateinit var mockEntry: LineupEntry
+
+    @BeforeEach
+    fun setUp() {
+        lineupService = mockk()
+        objectMapper = ObjectMapper()
+
+        val controller = LineupController(lineupService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+
+        // Mock submission
+        mockSubmission =
+            mockk<LineupSubmission>().apply {
+                every { id } returns 1L
+                every { game.id } returns 1L
+                every { team.id } returns 1L
+                every { team.name } returns "Tigers"
+                every { submittedBy.id } returns 1L
+                every { submittedBy.nickname } returns "감독"
+                every { status } returns LineupSubmissionStatus.DRAFT
+                every { submittedAt } returns null
+                every { confirmedAt } returns null
+                every { confirmedBy } returns null
+                every { rejectionReason } returns null
+                every { rejectedBy } returns null
+            }
+
+        // Mock entry
+        mockEntry =
+            mockk<LineupEntry>().apply {
+                every { id } returns 1L
+                every { player.id } returns 1L
+                every { player.name } returns "홍길동"
+                every { position } returns Position.SHORTSTOP
+                every { battingOrder } returns 1
+                every { backNumber } returns 7
+                every { isStarter } returns true
+            }
+    }
+
+    @Nested
+    inner class CreateLineupTest {
+        @Test
+        fun `should create lineup successfully`() {
+            // given
+            val request =
+                mapOf(
+                    "gameId" to 1L,
+                    "teamId" to 1L,
+                )
+
+            every {
+                lineupService.createLineupSubmission(
+                    gameId = 1L,
+                    teamId = 1L,
+                    submittedByUserId = 1L,
+                )
+            } returns mockSubmission
+            every { lineupService.getLineupEntries(1L) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/lineups")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-User-Id", 1L)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.teamName").value("Tigers"))
+                .andExpect(jsonPath("$.data.status").value("DRAFT"))
+        }
+    }
+
+    @Nested
+    inner class GetLineupTest {
+        @Test
+        fun `should get lineup by id`() {
+            // given
+            every { lineupService.getLineupSubmission(1L) } returns mockSubmission
+            every { lineupService.getLineupEntries(1L) } returns listOf(mockEntry)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/lineups/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.entries[0].playerName").value("홍길동"))
+        }
+    }
+
+    @Nested
+    inner class GetLineupsByGameTest {
+        @Test
+        fun `should get lineups by game`() {
+            // given
+            every { lineupService.getLineupSubmissionsByGame(1L) } returns listOf(mockSubmission)
+            every { lineupService.getLineupEntries(any()) } returns listOf(mockEntry)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/lineups").param("gameId", "1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].starterCount").value(1))
+        }
+    }
+
+    @Nested
+    inner class AddLineupEntryTest {
+        @Test
+        fun `should add lineup entry`() {
+            // given
+            val request =
+                mapOf(
+                    "playerId" to 1L,
+                    "position" to "SHORTSTOP",
+                    "battingOrder" to 1,
+                    "backNumber" to 7,
+                    "isStarter" to true,
+                )
+
+            every {
+                lineupService.addLineupEntry(
+                    submissionId = 1L,
+                    playerId = 1L,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 1,
+                    backNumber = 7,
+                    isStarter = true,
+                )
+            } returns mockEntry
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/lineups/1/entries")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.playerName").value("홍길동"))
+                .andExpect(jsonPath("$.data.position").value("SHORTSTOP"))
+        }
+    }
+
+    @Nested
+    inner class SetLineupEntriesTest {
+        @Test
+        fun `should set lineup entries`() {
+            // given
+            val entries =
+                (1..9).map { order ->
+                    mapOf(
+                        "playerId" to order.toLong(),
+                        "position" to Position.SHORTSTOP.name,
+                        "battingOrder" to order,
+                        "backNumber" to order,
+                        "isStarter" to true,
+                    )
+                }
+            val request = mapOf("entries" to entries)
+
+            val mockEntries =
+                (1..9).map { order ->
+                    mockk<LineupEntry>().apply {
+                        every { id } returns order.toLong()
+                        every { player.id } returns order.toLong()
+                        every { player.name } returns "선수$order"
+                        every { position } returns Position.SHORTSTOP
+                        every { battingOrder } returns order
+                        every { backNumber } returns order
+                        every { isStarter } returns true
+                    }
+                }
+
+            every { lineupService.setLineupEntries(1L, any()) } returns mockEntries
+
+            // when & then
+            mockMvc
+                .perform(
+                    put("/api/v1/lineups/1/entries")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(9))
+                .andExpect(jsonPath("$.data[0].playerName").value("선수1"))
+        }
+    }
+
+    @Nested
+    inner class GetLineupEntriesTest {
+        @Test
+        fun `should get lineup entries`() {
+            // given
+            every { lineupService.getLineupEntries(1L) } returns listOf(mockEntry)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/lineups/1/entries"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].playerName").value("홍길동"))
+        }
+    }
+
+    @Nested
+    inner class SubmitLineupTest {
+        @Test
+        fun `should submit lineup`() {
+            // given
+            val submittedSubmission =
+                mockk<LineupSubmission>().apply {
+                    every { id } returns 1L
+                    every { game.id } returns 1L
+                    every { team.id } returns 1L
+                    every { team.name } returns "Tigers"
+                    every { submittedBy.id } returns 1L
+                    every { submittedBy.nickname } returns "감독"
+                    every { status } returns LineupSubmissionStatus.SUBMITTED
+                    every { submittedAt } returns java.time.Instant.now()
+                    every { confirmedAt } returns null
+                    every { confirmedBy } returns null
+                    every { rejectionReason } returns null
+                    every { rejectedBy } returns null
+                }
+
+            every { lineupService.submitLineup(1L) } returns submittedSubmission
+            every { lineupService.getLineupEntries(1L) } returns listOf(mockEntry)
+
+            // when & then
+            mockMvc
+                .perform(post("/api/v1/lineups/1/submit"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("SUBMITTED"))
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/LineupEntryRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/LineupEntryRepositoryPort.kt
@@ -1,0 +1,31 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.game.LineupEntry
+
+/**
+ * LineupEntry Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface LineupEntryRepositoryPort {
+    fun save(entry: LineupEntry): LineupEntry
+
+    fun saveAll(entries: List<LineupEntry>): List<LineupEntry>
+
+    fun findByIdOrNull(id: Long): LineupEntry?
+
+    fun findAllBySubmissionId(submissionId: Long): List<LineupEntry>
+
+    fun findBySubmissionIdAndPlayerId(
+        submissionId: Long,
+        playerId: Long,
+    ): LineupEntry?
+
+    fun findBySubmissionIdAndBattingOrder(
+        submissionId: Long,
+        battingOrder: Int,
+    ): LineupEntry?
+
+    fun delete(entry: LineupEntry)
+
+    fun deleteAllBySubmissionId(submissionId: Long)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/LineupSubmissionRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/LineupSubmissionRepositoryPort.kt
@@ -1,0 +1,37 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.game.LineupSubmission
+import com.nextup.core.domain.game.LineupSubmissionStatus
+
+/**
+ * LineupSubmission Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface LineupSubmissionRepositoryPort {
+    fun save(submission: LineupSubmission): LineupSubmission
+
+    fun findByIdOrNull(id: Long): LineupSubmission?
+
+    fun findByGameIdAndTeamId(
+        gameId: Long,
+        teamId: Long,
+    ): LineupSubmission?
+
+    fun findAllByGameId(gameId: Long): List<LineupSubmission>
+
+    fun findAllByTeamId(teamId: Long): List<LineupSubmission>
+
+    fun findAllByTeamIdAndStatus(
+        teamId: Long,
+        status: LineupSubmissionStatus,
+    ): List<LineupSubmission>
+
+    fun findAllByGameIdAndStatus(
+        gameId: Long,
+        status: LineupSubmissionStatus,
+    ): List<LineupSubmission>
+
+    fun delete(submission: LineupSubmission)
+
+    fun deleteById(id: Long)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamRepositoryPort.kt
@@ -11,6 +11,8 @@ interface TeamRepositoryPort {
 
     fun findAll(): List<Team>
 
+    fun findByIdOrNull(id: Long): Team?
+
     fun delete(team: Team)
 
     fun deleteById(id: Long)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/lineup/LineupService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/lineup/LineupService.kt
@@ -1,0 +1,303 @@
+package com.nextup.core.service.lineup
+
+import com.nextup.core.domain.game.LineupEntry
+import com.nextup.core.domain.game.LineupSubmission
+import com.nextup.core.domain.game.LineupSubmissionStatus
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.PositionCategory
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.LineupEntryRepositoryPort
+import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.port.repository.UserRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 라인업 서비스
+ *
+ * 라인업 작성, 제출, 확인, 반려 등의 워크플로우를 관리합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class LineupService(
+    private val lineupSubmissionRepository: LineupSubmissionRepositoryPort,
+    private val lineupEntryRepository: LineupEntryRepositoryPort,
+    private val gameRepository: GameRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+    private val playerRepository: PlayerRepositoryPort,
+    private val userRepository: UserRepositoryPort,
+) {
+    // ========== 라인업 제출 관리 ==========
+
+    /**
+     * 라인업 제출을 생성합니다.
+     *
+     * @throws IllegalArgumentException 이미 해당 경기/팀의 라인업이 존재할 때
+     */
+    @Transactional
+    fun createLineupSubmission(
+        gameId: Long,
+        teamId: Long,
+        submittedByUserId: Long,
+    ): LineupSubmission {
+        val game =
+            gameRepository.findByIdOrNull(gameId)
+                ?: throw IllegalArgumentException("경기 ID $gameId 를 찾을 수 없습니다.")
+
+        val team =
+            teamRepository.findByIdOrNull(teamId)
+                ?: throw IllegalArgumentException("팀 ID $teamId 를 찾을 수 없습니다.")
+
+        val user =
+            userRepository.findByIdOrNull(submittedByUserId)
+                ?: throw IllegalArgumentException("사용자 ID $submittedByUserId 를 찾을 수 없습니다.")
+
+        // 이미 존재하는 라인업 확인
+        lineupSubmissionRepository.findByGameIdAndTeamId(gameId, teamId)?.let {
+            throw IllegalArgumentException("이미 해당 경기/팀의 라인업이 존재합니다. (ID: ${it.id})")
+        }
+
+        val submission = LineupSubmission.create(game, team, user)
+        return lineupSubmissionRepository.save(submission)
+    }
+
+    /**
+     * 라인업 제출을 조회합니다.
+     */
+    fun getLineupSubmission(submissionId: Long): LineupSubmission =
+        lineupSubmissionRepository.findByIdOrNull(submissionId)
+            ?: throw IllegalArgumentException("라인업 제출 ID $submissionId 를 찾을 수 없습니다.")
+
+    /**
+     * 경기의 모든 라인업 제출을 조회합니다.
+     */
+    fun getLineupSubmissionsByGame(gameId: Long): List<LineupSubmission> =
+        lineupSubmissionRepository.findAllByGameId(gameId)
+
+    /**
+     * 팀의 모든 라인업 제출을 조회합니다.
+     */
+    fun getLineupSubmissionsByTeam(teamId: Long): List<LineupSubmission> =
+        lineupSubmissionRepository.findAllByTeamId(teamId)
+
+    /**
+     * 경기/팀으로 라인업 제출을 조회합니다.
+     */
+    fun getLineupSubmissionByGameAndTeam(
+        gameId: Long,
+        teamId: Long,
+    ): LineupSubmission? = lineupSubmissionRepository.findByGameIdAndTeamId(gameId, teamId)
+
+    /**
+     * 경기의 제출된 라인업을 조회합니다. (기록원용)
+     */
+    fun getSubmittedLineupsByGame(gameId: Long): List<LineupSubmission> =
+        lineupSubmissionRepository.findAllByGameIdAndStatus(gameId, LineupSubmissionStatus.SUBMITTED)
+
+    // ========== 라인업 엔트리 관리 ==========
+
+    /**
+     * 라인업 엔트리를 추가합니다.
+     *
+     * @throws IllegalArgumentException 중복 선수 또는 중복 타순일 때
+     */
+    @Transactional
+    fun addLineupEntry(
+        submissionId: Long,
+        playerId: Long,
+        position: Position,
+        battingOrder: Int?,
+        backNumber: Int?,
+        isStarter: Boolean = true,
+    ): LineupEntry {
+        val submission = getLineupSubmission(submissionId)
+
+        val player =
+            playerRepository.findByIdOrNull(playerId)
+                ?: throw IllegalArgumentException("선수 ID $playerId 를 찾을 수 없습니다.")
+
+        // 중복 선수 검증
+        lineupEntryRepository.findBySubmissionIdAndPlayerId(submissionId, playerId)?.let {
+            throw IllegalArgumentException("이미 라인업에 등록된 선수입니다. (선수: ${player.name})")
+        }
+
+        // 중복 타순 검증 (선발인 경우에만)
+        if (isStarter && battingOrder != null) {
+            lineupEntryRepository.findBySubmissionIdAndBattingOrder(submissionId, battingOrder)?.let {
+                throw IllegalArgumentException("이미 해당 타순에 선수가 등록되어 있습니다. (타순: $battingOrder)")
+            }
+        }
+
+        val entry =
+            LineupEntry(
+                submission = submission,
+                player = player,
+                position = position,
+                battingOrder = battingOrder,
+                backNumber = backNumber,
+                isStarter = isStarter,
+            )
+
+        submission.addEntry(entry)
+        return lineupEntryRepository.save(entry)
+    }
+
+    /**
+     * 라인업 엔트리 목록을 일괄 추가합니다.
+     */
+    @Transactional
+    fun setLineupEntries(
+        submissionId: Long,
+        entries: List<LineupEntryInput>,
+    ): List<LineupEntry> {
+        val submission = getLineupSubmission(submissionId)
+
+        // 기존 엔트리 삭제
+        submission.clearEntries()
+        lineupEntryRepository.deleteAllBySubmissionId(submissionId)
+
+        // 검증
+        validateLineupEntries(entries)
+
+        // 새 엔트리 추가
+        return entries.map { input ->
+            val player =
+                playerRepository.findByIdOrNull(input.playerId)
+                    ?: throw IllegalArgumentException("선수 ID ${input.playerId} 를 찾을 수 없습니다.")
+
+            val entry =
+                LineupEntry(
+                    submission = submission,
+                    player = player,
+                    position = input.position,
+                    battingOrder = input.battingOrder,
+                    backNumber = input.backNumber,
+                    isStarter = input.isStarter,
+                )
+
+            submission.addEntry(entry)
+            lineupEntryRepository.save(entry)
+        }
+    }
+
+    /**
+     * 라인업 엔트리를 조회합니다.
+     */
+    fun getLineupEntries(submissionId: Long): List<LineupEntry> =
+        lineupEntryRepository.findAllBySubmissionId(submissionId)
+
+    // ========== 워크플로우 ==========
+
+    /**
+     * 라인업을 기록원에게 제출합니다.
+     */
+    @Transactional
+    fun submitLineup(submissionId: Long): LineupSubmission {
+        val submission = getLineupSubmission(submissionId)
+        val entries = lineupEntryRepository.findAllBySubmissionId(submissionId)
+
+        // 최소 인원 검증 (9명 이상)
+        val starters = entries.filter { it.isStarter }
+        require(starters.size >= 9) {
+            "선발 라인업은 최소 9명이 필요합니다. (현재: ${starters.size}명)"
+        }
+
+        // 포지션 검증 (필수 포지션 확인)
+        validateRequiredPositions(starters)
+
+        submission.submit()
+        return lineupSubmissionRepository.save(submission)
+    }
+
+    /**
+     * 기록원이 라인업을 확인합니다.
+     */
+    @Transactional
+    fun confirmLineup(
+        submissionId: Long,
+        scorerUserId: Long,
+    ): LineupSubmission {
+        val submission = getLineupSubmission(submissionId)
+
+        val scorer =
+            userRepository.findByIdOrNull(scorerUserId)
+                ?: throw IllegalArgumentException("기록원 ID $scorerUserId 를 찾을 수 없습니다.")
+
+        submission.confirm(scorer)
+        return lineupSubmissionRepository.save(submission)
+    }
+
+    /**
+     * 기록원이 라인업을 반려합니다.
+     */
+    @Transactional
+    fun rejectLineup(
+        submissionId: Long,
+        scorerUserId: Long,
+        reason: String,
+    ): LineupSubmission {
+        val submission = getLineupSubmission(submissionId)
+
+        val scorer =
+            userRepository.findByIdOrNull(scorerUserId)
+                ?: throw IllegalArgumentException("기록원 ID $scorerUserId 를 찾을 수 없습니다.")
+
+        submission.reject(scorer, reason)
+        return lineupSubmissionRepository.save(submission)
+    }
+
+    // ========== 검증 헬퍼 ==========
+
+    /**
+     * 라인업 엔트리 입력을 검증합니다.
+     */
+    private fun validateLineupEntries(entries: List<LineupEntryInput>) {
+        // 중복 선수 검증
+        val playerIds = entries.map { it.playerId }
+        val uniquePlayerIds = playerIds.toSet()
+        require(playerIds.size == uniquePlayerIds.size) {
+            "라인업에 중복된 선수가 있습니다."
+        }
+
+        // 중복 타순 검증 (선발만)
+        val starterBattingOrders =
+            entries
+                .filter { it.isStarter && it.battingOrder != null }
+                .map { it.battingOrder }
+        val uniqueBattingOrders = starterBattingOrders.toSet()
+        require(starterBattingOrders.size == uniqueBattingOrders.size) {
+            "라인업에 중복된 타순이 있습니다."
+        }
+    }
+
+    /**
+     * 필수 포지션 검증
+     * 야구에서 필수적인 포지션들이 모두 채워졌는지 확인합니다.
+     */
+    private fun validateRequiredPositions(starters: List<LineupEntry>) {
+        val positionCategories = starters.map { it.position.category }.toSet()
+
+        // 투수는 필수
+        require(positionCategories.contains(PositionCategory.PITCHER)) {
+            "투수가 지정되지 않았습니다."
+        }
+
+        // 포수는 필수
+        require(positionCategories.contains(PositionCategory.CATCHER)) {
+            "포수가 지정되지 않았습니다."
+        }
+    }
+}
+
+/**
+ * 라인업 엔트리 입력 데이터 클래스
+ */
+data class LineupEntryInput(
+    val playerId: Long,
+    val position: Position,
+    val battingOrder: Int?,
+    val backNumber: Int?,
+    val isStarter: Boolean = true,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/lineup/LineupServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/lineup/LineupServiceTest.kt
@@ -1,0 +1,670 @@
+package com.nextup.core.service.lineup
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.LineupEntry
+import com.nextup.core.domain.game.LineupSubmission
+import com.nextup.core.domain.game.LineupSubmissionStatus
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.user.User
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.LineupEntryRepositoryPort
+import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.port.repository.UserRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class LineupServiceTest {
+    private lateinit var lineupSubmissionRepository: LineupSubmissionRepositoryPort
+    private lateinit var lineupEntryRepository: LineupEntryRepositoryPort
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var playerRepository: PlayerRepositoryPort
+    private lateinit var userRepository: UserRepositoryPort
+    private lateinit var lineupService: LineupService
+
+    private lateinit var game: Game
+    private lateinit var team: Team
+    private lateinit var user: User
+    private lateinit var player: Player
+
+    @BeforeEach
+    fun setUp() {
+        lineupSubmissionRepository = mockk()
+        lineupEntryRepository = mockk()
+        gameRepository = mockk()
+        teamRepository = mockk()
+        playerRepository = mockk()
+        userRepository = mockk()
+
+        lineupService =
+            LineupService(
+                lineupSubmissionRepository = lineupSubmissionRepository,
+                lineupEntryRepository = lineupEntryRepository,
+                gameRepository = gameRepository,
+                teamRepository = teamRepository,
+                playerRepository = playerRepository,
+                userRepository = userRepository,
+            )
+
+        // Setup test data
+        val association = Association(name = "서울시야구협회", abbreviation = "서야협", region = "서울")
+        val league = League(association = association, name = "서울시 리그", foundedYear = 2020)
+        val competition =
+            Competition(
+                league = league,
+                name = "2024 시즌",
+                year = 2024,
+                startDate = LocalDate.now().minusDays(30),
+                endDate = LocalDate.now().plusDays(30),
+            )
+
+        game = Game(competition = competition, scheduledAt = LocalDateTime.now().plusDays(1), location = "서울야구장")
+        team = Team(league = league, name = "Tigers", city = "서울", foundedYear = 2020)
+        user = User.createLocalUser(email = "test@test.com", encodedPassword = "encoded", nickname = "테스트")
+        player =
+            mockk<Player>().apply {
+                every { id } returns 1L
+                every { name } returns "홍길동"
+            }
+    }
+
+    @Nested
+    inner class CreateLineupSubmissionTest {
+        @Test
+        fun `should create lineup submission successfully`() {
+            // given
+            every { gameRepository.findByIdOrNull(any()) } returns game
+            every { teamRepository.findByIdOrNull(any()) } returns team
+            every { userRepository.findByIdOrNull(any()) } returns user
+            every { lineupSubmissionRepository.findByGameIdAndTeamId(any(), any()) } returns null
+
+            val submissionSlot = slot<LineupSubmission>()
+            every { lineupSubmissionRepository.save(capture(submissionSlot)) } answers { submissionSlot.captured }
+
+            // when
+            val result = lineupService.createLineupSubmission(1L, 1L, 1L)
+
+            // then
+            assertThat(result.status).isEqualTo(LineupSubmissionStatus.DRAFT)
+            verify { lineupSubmissionRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when game not found`() {
+            // given
+            every { gameRepository.findByIdOrNull(any()) } returns null
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.createLineupSubmission(1L, 1L, 1L)
+                }
+            assertThat(exception.message).contains("경기 ID")
+        }
+
+        @Test
+        fun `should throw exception when team not found`() {
+            // given
+            every { gameRepository.findByIdOrNull(any()) } returns game
+            every { teamRepository.findByIdOrNull(any()) } returns null
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.createLineupSubmission(1L, 1L, 1L)
+                }
+            assertThat(exception.message).contains("팀 ID")
+        }
+
+        @Test
+        fun `should throw exception when user not found`() {
+            // given
+            every { gameRepository.findByIdOrNull(any()) } returns game
+            every { teamRepository.findByIdOrNull(any()) } returns team
+            every { userRepository.findByIdOrNull(any()) } returns null
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.createLineupSubmission(1L, 1L, 1L)
+                }
+            assertThat(exception.message).contains("사용자 ID")
+        }
+
+        @Test
+        fun `should throw exception when lineup already exists`() {
+            // given
+            val existingSubmission = LineupSubmission.create(game, team, user)
+            every { gameRepository.findByIdOrNull(any()) } returns game
+            every { teamRepository.findByIdOrNull(any()) } returns team
+            every { userRepository.findByIdOrNull(any()) } returns user
+            every { lineupSubmissionRepository.findByGameIdAndTeamId(any(), any()) } returns existingSubmission
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.createLineupSubmission(1L, 1L, 1L)
+                }
+            assertThat(exception.message).contains("이미 해당 경기/팀의 라인업이 존재합니다")
+        }
+    }
+
+    @Nested
+    inner class GetLineupSubmissionTest {
+        @Test
+        fun `should get lineup submission by id`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            every { lineupSubmissionRepository.findByIdOrNull(1L) } returns submission
+
+            // when
+            val result = lineupService.getLineupSubmission(1L)
+
+            // then
+            assertThat(result).isEqualTo(submission)
+        }
+
+        @Test
+        fun `should throw exception when submission not found`() {
+            // given
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns null
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.getLineupSubmission(1L)
+                }
+            assertThat(exception.message).contains("라인업 제출 ID")
+        }
+    }
+
+    @Nested
+    inner class AddLineupEntryTest {
+        @Test
+        fun `should add lineup entry successfully`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { playerRepository.findByIdOrNull(any()) } returns player
+            every { lineupEntryRepository.findBySubmissionIdAndPlayerId(any(), any()) } returns null
+            every { lineupEntryRepository.findBySubmissionIdAndBattingOrder(any(), any()) } returns null
+
+            val entrySlot = slot<LineupEntry>()
+            every { lineupEntryRepository.save(capture(entrySlot)) } answers { entrySlot.captured }
+
+            // when
+            val result =
+                lineupService.addLineupEntry(
+                    submissionId = 1L,
+                    playerId = 1L,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 1,
+                    backNumber = 7,
+                    isStarter = true,
+                )
+
+            // then
+            assertThat(result.position).isEqualTo(Position.SHORTSTOP)
+            assertThat(result.battingOrder).isEqualTo(1)
+            verify { lineupEntryRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when player already in lineup`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            val existingEntry = mockk<LineupEntry>()
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { playerRepository.findByIdOrNull(any()) } returns player
+            every { lineupEntryRepository.findBySubmissionIdAndPlayerId(any(), any()) } returns existingEntry
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.addLineupEntry(1L, 1L, Position.SHORTSTOP, 1, 7, true)
+                }
+            assertThat(exception.message).contains("이미 라인업에 등록된 선수입니다")
+        }
+
+        @Test
+        fun `should throw exception when batting order already taken`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            val existingEntry = mockk<LineupEntry>()
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { playerRepository.findByIdOrNull(any()) } returns player
+            every { lineupEntryRepository.findBySubmissionIdAndPlayerId(any(), any()) } returns null
+            every { lineupEntryRepository.findBySubmissionIdAndBattingOrder(any(), any()) } returns existingEntry
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.addLineupEntry(1L, 1L, Position.SHORTSTOP, 1, 7, true)
+                }
+            assertThat(exception.message).contains("이미 해당 타순에 선수가 등록되어 있습니다")
+        }
+    }
+
+    @Nested
+    inner class SetLineupEntriesTest {
+        @Test
+        fun `should set lineup entries successfully`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { lineupEntryRepository.deleteAllBySubmissionId(any()) } returns Unit
+            every { playerRepository.findByIdOrNull(any()) } returns player
+
+            val entrySlot = slot<LineupEntry>()
+            every { lineupEntryRepository.save(capture(entrySlot)) } answers { entrySlot.captured }
+
+            val entries =
+                listOf(
+                    LineupEntryInput(
+                        playerId = 1L,
+                        position = Position.STARTING_PITCHER,
+                        battingOrder = 1,
+                        backNumber = 1,
+                        isStarter = true,
+                    ),
+                    LineupEntryInput(
+                        playerId = 2L,
+                        position = Position.CATCHER,
+                        battingOrder = 2,
+                        backNumber = 2,
+                        isStarter = true,
+                    ),
+                )
+
+            // when
+            val result = lineupService.setLineupEntries(1L, entries)
+
+            // then
+            assertThat(result).hasSize(2)
+            verify { lineupEntryRepository.deleteAllBySubmissionId(any()) }
+        }
+
+        @Test
+        fun `should throw exception when duplicate players`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { lineupEntryRepository.deleteAllBySubmissionId(any()) } returns Unit
+
+            val entries =
+                listOf(
+                    LineupEntryInput(
+                        playerId = 1L,
+                        position = Position.STARTING_PITCHER,
+                        battingOrder = 1,
+                        backNumber = 1,
+                        isStarter = true,
+                    ),
+                    LineupEntryInput(
+                        playerId = 1L,
+                        position = Position.CATCHER,
+                        battingOrder = 2,
+                        backNumber = 2,
+                        isStarter = true,
+                    ),
+                )
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.setLineupEntries(1L, entries)
+                }
+            assertThat(exception.message).contains("중복된 선수")
+        }
+
+        @Test
+        fun `should throw exception when duplicate batting order`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { lineupEntryRepository.deleteAllBySubmissionId(any()) } returns Unit
+
+            val entries =
+                listOf(
+                    LineupEntryInput(
+                        playerId = 1L,
+                        position = Position.STARTING_PITCHER,
+                        battingOrder = 1,
+                        backNumber = 1,
+                        isStarter = true,
+                    ),
+                    LineupEntryInput(
+                        playerId = 2L,
+                        position = Position.CATCHER,
+                        battingOrder = 1,
+                        backNumber = 2,
+                        isStarter = true,
+                    ),
+                )
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.setLineupEntries(1L, entries)
+                }
+            assertThat(exception.message).contains("중복된 타순")
+        }
+    }
+
+    @Nested
+    inner class SubmitLineupTest {
+        @Test
+        fun `should submit lineup successfully with 9 starters`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            val entries = createMinimalLineup(submission)
+
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { lineupEntryRepository.findAllBySubmissionId(any()) } returns entries
+
+            val submissionSlot = slot<LineupSubmission>()
+            every { lineupSubmissionRepository.save(capture(submissionSlot)) } answers { submissionSlot.captured }
+
+            // when
+            val result = lineupService.submitLineup(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(LineupSubmissionStatus.SUBMITTED)
+        }
+
+        @Test
+        fun `should throw exception when less than 9 starters`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            val entries =
+                listOf(
+                    createMockEntry(submission, Position.STARTING_PITCHER, 1),
+                    createMockEntry(submission, Position.CATCHER, 2),
+                )
+
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { lineupEntryRepository.findAllBySubmissionId(any()) } returns entries
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.submitLineup(1L)
+                }
+            assertThat(exception.message).contains("선발 라인업은 최소 9명이 필요합니다")
+        }
+
+        @Test
+        fun `should throw exception when no pitcher`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            val entries = createMinimalLineupWithoutPitcher(submission)
+
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { lineupEntryRepository.findAllBySubmissionId(any()) } returns entries
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.submitLineup(1L)
+                }
+            assertThat(exception.message).contains("투수가 지정되지 않았습니다")
+        }
+
+        @Test
+        fun `should throw exception when no catcher`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            val entries = createMinimalLineupWithoutCatcher(submission)
+
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { lineupEntryRepository.findAllBySubmissionId(any()) } returns entries
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.submitLineup(1L)
+                }
+            assertThat(exception.message).contains("포수가 지정되지 않았습니다")
+        }
+    }
+
+    @Nested
+    inner class ConfirmLineupTest {
+        @Test
+        fun `should confirm lineup successfully`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user).apply { submit() }
+            val scorer = User.createLocalUser(email = "scorer@test.com", encodedPassword = "encoded", nickname = "기록원")
+
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { userRepository.findByIdOrNull(any()) } returns scorer
+
+            val submissionSlot = slot<LineupSubmission>()
+            every { lineupSubmissionRepository.save(capture(submissionSlot)) } answers { submissionSlot.captured }
+
+            // when
+            val result = lineupService.confirmLineup(1L, 1L)
+
+            // then
+            assertThat(result.status).isEqualTo(LineupSubmissionStatus.CONFIRMED)
+        }
+
+        @Test
+        fun `should throw exception when scorer not found`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user).apply { submit() }
+
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { userRepository.findByIdOrNull(any()) } returns null
+
+            // when & then
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    lineupService.confirmLineup(1L, 1L)
+                }
+            assertThat(exception.message).contains("기록원 ID")
+        }
+    }
+
+    @Nested
+    inner class RejectLineupTest {
+        @Test
+        fun `should reject lineup successfully`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user).apply { submit() }
+            val scorer = User.createLocalUser(email = "scorer@test.com", encodedPassword = "encoded", nickname = "기록원")
+
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every { userRepository.findByIdOrNull(any()) } returns scorer
+
+            val submissionSlot = slot<LineupSubmission>()
+            every { lineupSubmissionRepository.save(capture(submissionSlot)) } answers { submissionSlot.captured }
+
+            // when
+            val result = lineupService.rejectLineup(1L, 1L, "선수 등록번호 확인 필요")
+
+            // then
+            assertThat(result.status).isEqualTo(LineupSubmissionStatus.REJECTED)
+            assertThat(result.rejectionReason).isEqualTo("선수 등록번호 확인 필요")
+        }
+    }
+
+    @Nested
+    inner class GetLineupSubmissionsByGameTest {
+        @Test
+        fun `should get all lineup submissions by game`() {
+            // given
+            val submissions =
+                listOf(
+                    LineupSubmission.create(game, team, user),
+                )
+            every { lineupSubmissionRepository.findAllByGameId(any()) } returns submissions
+
+            // when
+            val result = lineupService.getLineupSubmissionsByGame(1L)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
+    }
+
+    @Nested
+    inner class GetLineupSubmissionsByTeamTest {
+        @Test
+        fun `should get all lineup submissions by team`() {
+            // given
+            val submissions =
+                listOf(
+                    LineupSubmission.create(game, team, user),
+                )
+            every { lineupSubmissionRepository.findAllByTeamId(any()) } returns submissions
+
+            // when
+            val result = lineupService.getLineupSubmissionsByTeam(1L)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
+    }
+
+    @Nested
+    inner class GetSubmittedLineupsByGameTest {
+        @Test
+        fun `should get submitted lineups by game`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user).apply { submit() }
+            every {
+                lineupSubmissionRepository.findAllByGameIdAndStatus(any(), LineupSubmissionStatus.SUBMITTED)
+            } returns
+                listOf(submission)
+
+            // when
+            val result = lineupService.getSubmittedLineupsByGame(1L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].status).isEqualTo(LineupSubmissionStatus.SUBMITTED)
+        }
+    }
+
+    @Nested
+    inner class GetLineupEntriesTest {
+        @Test
+        fun `should get lineup entries by submission id`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            val entries = listOf(createMockEntry(submission, Position.STARTING_PITCHER, 1))
+            every { lineupEntryRepository.findAllBySubmissionId(any()) } returns entries
+
+            // when
+            val result = lineupService.getLineupEntries(1L)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
+    }
+
+    @Nested
+    inner class GetLineupSubmissionByGameAndTeamTest {
+        @Test
+        fun `should get lineup submission by game and team`() {
+            // given
+            val submission = LineupSubmission.create(game, team, user)
+            every { lineupSubmissionRepository.findByGameIdAndTeamId(1L, 1L) } returns submission
+
+            // when
+            val result = lineupService.getLineupSubmissionByGameAndTeam(1L, 1L)
+
+            // then
+            assertThat(result).isNotNull
+        }
+
+        @Test
+        fun `should return null when no submission found`() {
+            // given
+            every { lineupSubmissionRepository.findByGameIdAndTeamId(1L, 1L) } returns null
+
+            // when
+            val result = lineupService.getLineupSubmissionByGameAndTeam(1L, 1L)
+
+            // then
+            assertThat(result).isNull()
+        }
+    }
+
+    // Helper methods
+    private fun createMockEntry(
+        submission: LineupSubmission,
+        position: Position,
+        battingOrder: Int,
+    ): LineupEntry {
+        val mockPlayer =
+            mockk<Player>().apply {
+                every { id } returns battingOrder.toLong()
+                every { name } returns "선수$battingOrder"
+            }
+        return LineupEntry(
+            submission = submission,
+            player = mockPlayer,
+            position = position,
+            battingOrder = battingOrder,
+            backNumber = battingOrder,
+            isStarter = true,
+        )
+    }
+
+    private fun createMinimalLineup(submission: LineupSubmission): List<LineupEntry> =
+        listOf(
+            createMockEntry(submission, Position.STARTING_PITCHER, 1),
+            createMockEntry(submission, Position.CATCHER, 2),
+            createMockEntry(submission, Position.FIRST_BASE, 3),
+            createMockEntry(submission, Position.SECOND_BASE, 4),
+            createMockEntry(submission, Position.THIRD_BASE, 5),
+            createMockEntry(submission, Position.SHORTSTOP, 6),
+            createMockEntry(submission, Position.LEFT_FIELD, 7),
+            createMockEntry(submission, Position.CENTER_FIELD, 8),
+            createMockEntry(submission, Position.RIGHT_FIELD, 9),
+        )
+
+    private fun createMinimalLineupWithoutPitcher(submission: LineupSubmission): List<LineupEntry> =
+        listOf(
+            createMockEntry(submission, Position.CATCHER, 1),
+            createMockEntry(submission, Position.FIRST_BASE, 2),
+            createMockEntry(submission, Position.SECOND_BASE, 3),
+            createMockEntry(submission, Position.THIRD_BASE, 4),
+            createMockEntry(submission, Position.SHORTSTOP, 5),
+            createMockEntry(submission, Position.LEFT_FIELD, 6),
+            createMockEntry(submission, Position.CENTER_FIELD, 7),
+            createMockEntry(submission, Position.RIGHT_FIELD, 8),
+            createMockEntry(submission, Position.DESIGNATED_HITTER, 9),
+        )
+
+    private fun createMinimalLineupWithoutCatcher(submission: LineupSubmission): List<LineupEntry> =
+        listOf(
+            createMockEntry(submission, Position.STARTING_PITCHER, 1),
+            createMockEntry(submission, Position.FIRST_BASE, 2),
+            createMockEntry(submission, Position.SECOND_BASE, 3),
+            createMockEntry(submission, Position.THIRD_BASE, 4),
+            createMockEntry(submission, Position.SHORTSTOP, 5),
+            createMockEntry(submission, Position.LEFT_FIELD, 6),
+            createMockEntry(submission, Position.CENTER_FIELD, 7),
+            createMockEntry(submission, Position.RIGHT_FIELD, 8),
+            createMockEntry(submission, Position.DESIGNATED_HITTER, 9),
+        )
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamRepository.kt
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query
 interface TeamRepository :
     JpaRepository<Team, Long>,
     TeamRepositoryPort {
+    override fun findByIdOrNull(id: Long): Team? = findById(id).orElse(null)
+
     override fun findByName(name: String): Team?
 
     override fun findByLeagueId(leagueId: Long): List<Team>

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/LineupEntryRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/LineupEntryRepository.kt
@@ -1,0 +1,35 @@
+package com.nextup.infrastructure.repository.game
+
+import com.nextup.core.domain.game.LineupEntry
+import com.nextup.core.port.repository.LineupEntryRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+
+interface LineupEntryRepository :
+    JpaRepository<LineupEntry, Long>,
+    LineupEntryRepositoryPort {
+    override fun findByIdOrNull(id: Long): LineupEntry? = findById(id).orElse(null)
+
+    @Query(
+        "SELECT le FROM LineupEntry le WHERE le.submission.id = :submissionId " +
+            "ORDER BY le.battingOrder ASC NULLS LAST",
+    )
+    override fun findAllBySubmissionId(submissionId: Long): List<LineupEntry>
+
+    @Query("SELECT le FROM LineupEntry le WHERE le.submission.id = :submissionId AND le.player.id = :playerId")
+    override fun findBySubmissionIdAndPlayerId(
+        submissionId: Long,
+        playerId: Long,
+    ): LineupEntry?
+
+    @Query("SELECT le FROM LineupEntry le WHERE le.submission.id = :submissionId AND le.battingOrder = :battingOrder")
+    override fun findBySubmissionIdAndBattingOrder(
+        submissionId: Long,
+        battingOrder: Int,
+    ): LineupEntry?
+
+    @Modifying
+    @Query("DELETE FROM LineupEntry le WHERE le.submission.id = :submissionId")
+    override fun deleteAllBySubmissionId(submissionId: Long)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/LineupSubmissionRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/LineupSubmissionRepository.kt
@@ -1,0 +1,37 @@
+package com.nextup.infrastructure.repository.game
+
+import com.nextup.core.domain.game.LineupSubmission
+import com.nextup.core.domain.game.LineupSubmissionStatus
+import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface LineupSubmissionRepository :
+    JpaRepository<LineupSubmission, Long>,
+    LineupSubmissionRepositoryPort {
+    override fun findByIdOrNull(id: Long): LineupSubmission? = findById(id).orElse(null)
+
+    @Query("SELECT ls FROM LineupSubmission ls WHERE ls.game.id = :gameId AND ls.team.id = :teamId")
+    override fun findByGameIdAndTeamId(
+        gameId: Long,
+        teamId: Long,
+    ): LineupSubmission?
+
+    @Query("SELECT ls FROM LineupSubmission ls WHERE ls.game.id = :gameId")
+    override fun findAllByGameId(gameId: Long): List<LineupSubmission>
+
+    @Query("SELECT ls FROM LineupSubmission ls WHERE ls.team.id = :teamId")
+    override fun findAllByTeamId(teamId: Long): List<LineupSubmission>
+
+    @Query("SELECT ls FROM LineupSubmission ls WHERE ls.team.id = :teamId AND ls.status = :status")
+    override fun findAllByTeamIdAndStatus(
+        teamId: Long,
+        status: LineupSubmissionStatus,
+    ): List<LineupSubmission>
+
+    @Query("SELECT ls FROM LineupSubmission ls WHERE ls.game.id = :gameId AND ls.status = :status")
+    override fun findAllByGameIdAndStatus(
+        gameId: Long,
+        status: LineupSubmissionStatus,
+    ): List<LineupSubmission>
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/lineup/LineupScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/lineup/LineupScorerController.kt
@@ -2,20 +2,14 @@ package com.nextup.scorer.controller.lineup
 
 import com.nextup.core.service.lineup.LineupService
 import com.nextup.scorer.dto.common.ApiResponse
-import com.nextup.scorer.dto.lineup.AddLineupEntryRequest
-import com.nextup.scorer.dto.lineup.CreateLineupRequest
 import com.nextup.scorer.dto.lineup.LineupEntryResponse
 import com.nextup.scorer.dto.lineup.LineupSubmissionResponse
-import com.nextup.scorer.dto.lineup.LineupSubmissionSummaryResponse
 import com.nextup.scorer.dto.lineup.RejectLineupRequest
-import com.nextup.scorer.dto.lineup.SetLineupEntriesRequest
 import jakarta.validation.Valid
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
@@ -25,65 +19,14 @@ import org.springframework.web.bind.annotation.RestController
 /**
  * 라인업 기록원 컨트롤러
  *
- * 기록원이 경기 전 라인업을 확인하고 승인/반려하는 API를 제공합니다.
+ * 기록원이 경기 전 제출된 라인업을 확인하고 승인/반려하는 API를 제공합니다.
+ * 라인업 작성 및 제출은 nextup-api 모듈의 LineupController에서 처리합니다.
  */
 @RestController
 @RequestMapping("/api/v1/scorer/lineups")
 class LineupScorerController(
     private val lineupService: LineupService,
 ) {
-    /**
-     * 라인업 제출을 생성합니다.
-     */
-    @PostMapping
-    fun createLineup(
-        @Valid @RequestBody request: CreateLineupRequest,
-        @RequestHeader("X-User-Id") userId: Long,
-    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
-        val submission =
-            lineupService.createLineupSubmission(
-                gameId = request.gameId,
-                teamId = request.teamId,
-                submittedByUserId = userId,
-            )
-        val entries = lineupService.getLineupEntries(submission.id)
-
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
-    }
-
-    /**
-     * 라인업 제출을 조회합니다.
-     */
-    @GetMapping("/{submissionId}")
-    fun getLineup(
-        @PathVariable submissionId: Long,
-    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
-        val submission = lineupService.getLineupSubmission(submissionId)
-        val entries = lineupService.getLineupEntries(submissionId)
-
-        return ResponseEntity.ok(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
-    }
-
-    /**
-     * 경기의 모든 라인업 제출을 조회합니다.
-     */
-    @GetMapping
-    fun getLineupsByGame(
-        @RequestParam gameId: Long,
-    ): ResponseEntity<ApiResponse<List<LineupSubmissionSummaryResponse>>> {
-        val submissions = lineupService.getLineupSubmissionsByGame(gameId)
-        val responses =
-            submissions.map { submission ->
-                val entries = lineupService.getLineupEntries(submission.id)
-                val starterCount = entries.count { it.isStarter }
-                LineupSubmissionSummaryResponse.from(submission, starterCount)
-            }
-
-        return ResponseEntity.ok(ApiResponse.success(responses))
-    }
-
     /**
      * 경기의 제출된 라인업을 조회합니다. (기록원 확인용)
      */
@@ -102,43 +45,16 @@ class LineupScorerController(
     }
 
     /**
-     * 라인업 엔트리를 추가합니다.
+     * 라인업 제출을 조회합니다.
      */
-    @PostMapping("/{submissionId}/entries")
-    fun addLineupEntry(
+    @GetMapping("/{submissionId}")
+    fun getLineup(
         @PathVariable submissionId: Long,
-        @Valid @RequestBody request: AddLineupEntryRequest,
-    ): ResponseEntity<ApiResponse<LineupEntryResponse>> {
-        val entry =
-            lineupService.addLineupEntry(
-                submissionId = submissionId,
-                playerId = request.playerId,
-                position = request.position,
-                battingOrder = request.battingOrder,
-                backNumber = request.backNumber,
-                isStarter = request.isStarter,
-            )
+    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
+        val submission = lineupService.getLineupSubmission(submissionId)
+        val entries = lineupService.getLineupEntries(submissionId)
 
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(ApiResponse.success(LineupEntryResponse.from(entry)))
-    }
-
-    /**
-     * 라인업 엔트리를 일괄 설정합니다.
-     */
-    @PutMapping("/{submissionId}/entries")
-    fun setLineupEntries(
-        @PathVariable submissionId: Long,
-        @Valid @RequestBody request: SetLineupEntriesRequest,
-    ): ResponseEntity<ApiResponse<List<LineupEntryResponse>>> {
-        val entries =
-            lineupService.setLineupEntries(
-                submissionId = submissionId,
-                entries = request.entries.map { it.toInput() },
-            )
-
-        return ResponseEntity.ok(ApiResponse.success(entries.map { LineupEntryResponse.from(it) }))
+        return ResponseEntity.ok(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
     }
 
     /**
@@ -151,19 +67,6 @@ class LineupScorerController(
         val entries = lineupService.getLineupEntries(submissionId)
 
         return ResponseEntity.ok(ApiResponse.success(entries.map { LineupEntryResponse.from(it) }))
-    }
-
-    /**
-     * 라인업을 기록원에게 제출합니다.
-     */
-    @PostMapping("/{submissionId}/submit")
-    fun submitLineup(
-        @PathVariable submissionId: Long,
-    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
-        val submission = lineupService.submitLineup(submissionId)
-        val entries = lineupService.getLineupEntries(submissionId)
-
-        return ResponseEntity.ok(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
     }
 
     /**

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/lineup/LineupScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/lineup/LineupScorerController.kt
@@ -1,0 +1,197 @@
+package com.nextup.scorer.controller.lineup
+
+import com.nextup.core.service.lineup.LineupService
+import com.nextup.scorer.dto.common.ApiResponse
+import com.nextup.scorer.dto.lineup.AddLineupEntryRequest
+import com.nextup.scorer.dto.lineup.CreateLineupRequest
+import com.nextup.scorer.dto.lineup.LineupEntryResponse
+import com.nextup.scorer.dto.lineup.LineupSubmissionResponse
+import com.nextup.scorer.dto.lineup.LineupSubmissionSummaryResponse
+import com.nextup.scorer.dto.lineup.RejectLineupRequest
+import com.nextup.scorer.dto.lineup.SetLineupEntriesRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 라인업 기록원 컨트롤러
+ *
+ * 기록원이 경기 전 라인업을 확인하고 승인/반려하는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/scorer/lineups")
+class LineupScorerController(
+    private val lineupService: LineupService,
+) {
+    /**
+     * 라인업 제출을 생성합니다.
+     */
+    @PostMapping
+    fun createLineup(
+        @Valid @RequestBody request: CreateLineupRequest,
+        @RequestHeader("X-User-Id") userId: Long,
+    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
+        val submission =
+            lineupService.createLineupSubmission(
+                gameId = request.gameId,
+                teamId = request.teamId,
+                submittedByUserId = userId,
+            )
+        val entries = lineupService.getLineupEntries(submission.id)
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
+    }
+
+    /**
+     * 라인업 제출을 조회합니다.
+     */
+    @GetMapping("/{submissionId}")
+    fun getLineup(
+        @PathVariable submissionId: Long,
+    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
+        val submission = lineupService.getLineupSubmission(submissionId)
+        val entries = lineupService.getLineupEntries(submissionId)
+
+        return ResponseEntity.ok(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
+    }
+
+    /**
+     * 경기의 모든 라인업 제출을 조회합니다.
+     */
+    @GetMapping
+    fun getLineupsByGame(
+        @RequestParam gameId: Long,
+    ): ResponseEntity<ApiResponse<List<LineupSubmissionSummaryResponse>>> {
+        val submissions = lineupService.getLineupSubmissionsByGame(gameId)
+        val responses =
+            submissions.map { submission ->
+                val entries = lineupService.getLineupEntries(submission.id)
+                val starterCount = entries.count { it.isStarter }
+                LineupSubmissionSummaryResponse.from(submission, starterCount)
+            }
+
+        return ResponseEntity.ok(ApiResponse.success(responses))
+    }
+
+    /**
+     * 경기의 제출된 라인업을 조회합니다. (기록원 확인용)
+     */
+    @GetMapping("/submitted")
+    fun getSubmittedLineups(
+        @RequestParam gameId: Long,
+    ): ResponseEntity<ApiResponse<List<LineupSubmissionResponse>>> {
+        val submissions = lineupService.getSubmittedLineupsByGame(gameId)
+        val responses =
+            submissions.map { submission ->
+                val entries = lineupService.getLineupEntries(submission.id)
+                LineupSubmissionResponse.from(submission, entries)
+            }
+
+        return ResponseEntity.ok(ApiResponse.success(responses))
+    }
+
+    /**
+     * 라인업 엔트리를 추가합니다.
+     */
+    @PostMapping("/{submissionId}/entries")
+    fun addLineupEntry(
+        @PathVariable submissionId: Long,
+        @Valid @RequestBody request: AddLineupEntryRequest,
+    ): ResponseEntity<ApiResponse<LineupEntryResponse>> {
+        val entry =
+            lineupService.addLineupEntry(
+                submissionId = submissionId,
+                playerId = request.playerId,
+                position = request.position,
+                battingOrder = request.battingOrder,
+                backNumber = request.backNumber,
+                isStarter = request.isStarter,
+            )
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(LineupEntryResponse.from(entry)))
+    }
+
+    /**
+     * 라인업 엔트리를 일괄 설정합니다.
+     */
+    @PutMapping("/{submissionId}/entries")
+    fun setLineupEntries(
+        @PathVariable submissionId: Long,
+        @Valid @RequestBody request: SetLineupEntriesRequest,
+    ): ResponseEntity<ApiResponse<List<LineupEntryResponse>>> {
+        val entries =
+            lineupService.setLineupEntries(
+                submissionId = submissionId,
+                entries = request.entries.map { it.toInput() },
+            )
+
+        return ResponseEntity.ok(ApiResponse.success(entries.map { LineupEntryResponse.from(it) }))
+    }
+
+    /**
+     * 라인업 엔트리를 조회합니다.
+     */
+    @GetMapping("/{submissionId}/entries")
+    fun getLineupEntries(
+        @PathVariable submissionId: Long,
+    ): ResponseEntity<ApiResponse<List<LineupEntryResponse>>> {
+        val entries = lineupService.getLineupEntries(submissionId)
+
+        return ResponseEntity.ok(ApiResponse.success(entries.map { LineupEntryResponse.from(it) }))
+    }
+
+    /**
+     * 라인업을 기록원에게 제출합니다.
+     */
+    @PostMapping("/{submissionId}/submit")
+    fun submitLineup(
+        @PathVariable submissionId: Long,
+    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
+        val submission = lineupService.submitLineup(submissionId)
+        val entries = lineupService.getLineupEntries(submissionId)
+
+        return ResponseEntity.ok(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
+    }
+
+    /**
+     * 기록원이 라인업을 확인합니다.
+     */
+    @PostMapping("/{submissionId}/confirm")
+    fun confirmLineup(
+        @PathVariable submissionId: Long,
+        @RequestHeader("X-User-Id") scorerUserId: Long,
+    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
+        val submission = lineupService.confirmLineup(submissionId, scorerUserId)
+        val entries = lineupService.getLineupEntries(submissionId)
+
+        return ResponseEntity.ok(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
+    }
+
+    /**
+     * 기록원이 라인업을 반려합니다.
+     */
+    @PostMapping("/{submissionId}/reject")
+    fun rejectLineup(
+        @PathVariable submissionId: Long,
+        @RequestHeader("X-User-Id") scorerUserId: Long,
+        @Valid @RequestBody request: RejectLineupRequest,
+    ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {
+        val submission = lineupService.rejectLineup(submissionId, scorerUserId, request.reason)
+        val entries = lineupService.getLineupEntries(submissionId)
+
+        return ResponseEntity.ok(ApiResponse.success(LineupSubmissionResponse.from(submission, entries)))
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/lineup/LineupRequest.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/lineup/LineupRequest.kt
@@ -1,0 +1,78 @@
+package com.nextup.scorer.dto.lineup
+
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.lineup.LineupEntryInput
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+/**
+ * 라인업 생성 요청 DTO
+ */
+data class CreateLineupRequest(
+    @field:NotNull(message = "경기 ID는 필수입니다.")
+    val gameId: Long,
+    @field:NotNull(message = "팀 ID는 필수입니다.")
+    val teamId: Long,
+)
+
+/**
+ * 라인업 엔트리 추가 요청 DTO
+ */
+data class AddLineupEntryRequest(
+    @field:NotNull(message = "선수 ID는 필수입니다.")
+    val playerId: Long,
+    @field:NotNull(message = "포지션은 필수입니다.")
+    val position: Position,
+    @field:Min(value = 1, message = "타순은 1 이상이어야 합니다.")
+    @field:Max(value = 10, message = "타순은 10 이하여야 합니다.")
+    val battingOrder: Int?,
+    val backNumber: Int?,
+    val isStarter: Boolean = true,
+)
+
+/**
+ * 라인업 엔트리 일괄 설정 요청 DTO
+ */
+data class SetLineupEntriesRequest(
+    @field:NotEmpty(message = "라인업 엔트리는 필수입니다.")
+    @field:Size(min = 9, max = 30, message = "라인업은 9명 이상 30명 이하여야 합니다.")
+    @field:Valid
+    val entries: List<LineupEntryDto>,
+)
+
+/**
+ * 라인업 엔트리 DTO
+ */
+data class LineupEntryDto(
+    @field:NotNull(message = "선수 ID는 필수입니다.")
+    val playerId: Long,
+    @field:NotNull(message = "포지션은 필수입니다.")
+    val position: Position,
+    @field:Min(value = 1, message = "타순은 1 이상이어야 합니다.")
+    @field:Max(value = 10, message = "타순은 10 이하여야 합니다.")
+    val battingOrder: Int?,
+    val backNumber: Int?,
+    val isStarter: Boolean = true,
+) {
+    fun toInput(): LineupEntryInput =
+        LineupEntryInput(
+            playerId = playerId,
+            position = position,
+            battingOrder = battingOrder,
+            backNumber = backNumber,
+            isStarter = isStarter,
+        )
+}
+
+/**
+ * 라인업 반려 요청 DTO
+ */
+data class RejectLineupRequest(
+    @field:NotEmpty(message = "반려 사유는 필수입니다.")
+    @field:Size(max = 500, message = "반려 사유는 500자 이하여야 합니다.")
+    val reason: String,
+)

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/lineup/LineupResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/lineup/LineupResponse.kt
@@ -1,0 +1,113 @@
+package com.nextup.scorer.dto.lineup
+
+import com.nextup.core.domain.game.LineupEntry
+import com.nextup.core.domain.game.LineupSubmission
+import com.nextup.core.domain.game.LineupSubmissionStatus
+import com.nextup.core.domain.player.Position
+import java.time.Instant
+
+/**
+ * 라인업 제출 응답 DTO
+ */
+data class LineupSubmissionResponse(
+    val id: Long,
+    val gameId: Long,
+    val teamId: Long,
+    val teamName: String,
+    val submittedById: Long,
+    val submittedByName: String,
+    val status: LineupSubmissionStatus,
+    val statusDisplayName: String,
+    val submittedAt: Instant?,
+    val confirmedAt: Instant?,
+    val confirmedById: Long?,
+    val confirmedByName: String?,
+    val rejectionReason: String?,
+    val rejectedById: Long?,
+    val rejectedByName: String?,
+    val entries: List<LineupEntryResponse>,
+) {
+    companion object {
+        fun from(
+            submission: LineupSubmission,
+            entries: List<LineupEntry>,
+        ): LineupSubmissionResponse =
+            LineupSubmissionResponse(
+                id = submission.id,
+                gameId = submission.game.id,
+                teamId = submission.team.id,
+                teamName = submission.team.name,
+                submittedById = submission.submittedBy.id,
+                submittedByName = submission.submittedBy.nickname,
+                status = submission.status,
+                statusDisplayName = submission.status.displayName,
+                submittedAt = submission.submittedAt,
+                confirmedAt = submission.confirmedAt,
+                confirmedById = submission.confirmedBy?.id,
+                confirmedByName = submission.confirmedBy?.nickname,
+                rejectionReason = submission.rejectionReason,
+                rejectedById = submission.rejectedBy?.id,
+                rejectedByName = submission.rejectedBy?.nickname,
+                entries = entries.map { LineupEntryResponse.from(it) },
+            )
+    }
+}
+
+/**
+ * 라인업 엔트리 응답 DTO
+ */
+data class LineupEntryResponse(
+    val id: Long,
+    val playerId: Long,
+    val playerName: String,
+    val position: Position,
+    val positionDisplayName: String,
+    val battingOrder: Int?,
+    val backNumber: Int?,
+    val isStarter: Boolean,
+) {
+    companion object {
+        fun from(entry: LineupEntry): LineupEntryResponse =
+            LineupEntryResponse(
+                id = entry.id,
+                playerId = entry.player.id,
+                playerName = entry.player.name,
+                position = entry.position,
+                positionDisplayName = entry.position.displayName,
+                battingOrder = entry.battingOrder,
+                backNumber = entry.backNumber,
+                isStarter = entry.isStarter,
+            )
+    }
+}
+
+/**
+ * 라인업 제출 요약 응답 DTO (목록 조회용)
+ */
+data class LineupSubmissionSummaryResponse(
+    val id: Long,
+    val gameId: Long,
+    val teamId: Long,
+    val teamName: String,
+    val status: LineupSubmissionStatus,
+    val statusDisplayName: String,
+    val starterCount: Int,
+    val submittedAt: Instant?,
+) {
+    companion object {
+        fun from(
+            submission: LineupSubmission,
+            starterCount: Int,
+        ): LineupSubmissionSummaryResponse =
+            LineupSubmissionSummaryResponse(
+                id = submission.id,
+                gameId = submission.game.id,
+                teamId = submission.team.id,
+                teamName = submission.team.name,
+                status = submission.status,
+                statusDisplayName = submission.status.displayName,
+                starterCount = starterCount,
+                submittedAt = submission.submittedAt,
+            )
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/lineup/RejectLineupRequest.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/lineup/RejectLineupRequest.kt
@@ -1,0 +1,13 @@
+package com.nextup.scorer.dto.lineup
+
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Size
+
+/**
+ * 라인업 반려 요청 DTO
+ */
+data class RejectLineupRequest(
+    @field:NotEmpty(message = "반려 사유는 필수입니다.")
+    @field:Size(max = 500, message = "반려 사유는 500자 이하여야 합니다.")
+    val reason: String,
+)

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/lineup/LineupScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/lineup/LineupScorerControllerTest.kt
@@ -8,7 +8,6 @@ import com.nextup.core.domain.player.Position
 import com.nextup.core.service.lineup.LineupService
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -16,7 +15,6 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
@@ -68,31 +66,6 @@ class LineupScorerControllerTest {
     }
 
     @Nested
-    inner class CreateLineupTest {
-        @Test
-        fun `should create lineup successfully`() {
-            // given
-            every { lineupService.createLineupSubmission(any(), any(), any()) } returns mockSubmission
-            every { lineupService.getLineupEntries(any()) } returns emptyList()
-
-            val request = mapOf("gameId" to 1, "teamId" to 1)
-
-            // when & then
-            mockMvc
-                .perform(
-                    post("/api/v1/scorer/lineups")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header("X-User-Id", 1L)
-                        .content(objectMapper.writeValueAsString(request)),
-                ).andExpect(status().isCreated)
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.id").value(1))
-
-            verify { lineupService.createLineupSubmission(1L, 1L, 1L) }
-        }
-    }
-
-    @Nested
     inner class GetLineupTest {
         @Test
         fun `should get lineup by id`() {
@@ -107,23 +80,6 @@ class LineupScorerControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.entries[0].playerName").value("홍길동"))
-        }
-    }
-
-    @Nested
-    inner class GetLineupsByGameTest {
-        @Test
-        fun `should get lineups by game`() {
-            // given
-            every { lineupService.getLineupSubmissionsByGame(1L) } returns listOf(mockSubmission)
-            every { lineupService.getLineupEntries(any()) } returns listOf(mockEntry)
-
-            // when & then
-            mockMvc
-                .perform(get("/api/v1/scorer/lineups").param("gameId", "1"))
-                .andExpect(status().isOk)
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data[0].id").value(1))
         }
     }
 
@@ -161,86 +117,6 @@ class LineupScorerControllerTest {
     }
 
     @Nested
-    inner class AddLineupEntryTest {
-        @Test
-        fun `should add lineup entry`() {
-            // given
-            every {
-                lineupService.addLineupEntry(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                )
-            } returns mockEntry
-
-            val request =
-                mapOf(
-                    "playerId" to 1,
-                    "position" to "SHORTSTOP",
-                    "battingOrder" to 1,
-                    "backNumber" to 7,
-                    "isStarter" to true,
-                )
-
-            // when & then
-            mockMvc
-                .perform(
-                    post("/api/v1/scorer/lineups/1/entries")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)),
-                ).andExpect(status().isCreated)
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.playerName").value("홍길동"))
-        }
-    }
-
-    @Nested
-    inner class SetLineupEntriesTest {
-        @Test
-        fun `should set lineup entries`() {
-            // given
-            every { lineupService.setLineupEntries(any(), any()) } returns listOf(mockEntry)
-
-            val request =
-                mapOf(
-                    "entries" to
-                        (1..9).map { i ->
-                            mapOf(
-                                "playerId" to i,
-                                "position" to
-                                    when (i) {
-                                        1 -> "STARTING_PITCHER"
-                                        2 -> "CATCHER"
-                                        3 -> "FIRST_BASE"
-                                        4 -> "SECOND_BASE"
-                                        5 -> "THIRD_BASE"
-                                        6 -> "SHORTSTOP"
-                                        7 -> "LEFT_FIELD"
-                                        8 -> "CENTER_FIELD"
-                                        else -> "RIGHT_FIELD"
-                                    },
-                                "battingOrder" to i,
-                                "backNumber" to i,
-                                "isStarter" to true,
-                            )
-                        },
-                )
-
-            // when & then
-            mockMvc
-                .perform(
-                    put("/api/v1/scorer/lineups/1/entries")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)),
-                ).andExpect(status().isOk)
-                .andExpect(jsonPath("$.success").value(true))
-        }
-    }
-
-    @Nested
     inner class GetLineupEntriesTest {
         @Test
         fun `should get lineup entries`() {
@@ -253,39 +129,6 @@ class LineupScorerControllerTest {
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data[0].playerName").value("홍길동"))
-        }
-    }
-
-    @Nested
-    inner class SubmitLineupTest {
-        @Test
-        fun `should submit lineup`() {
-            // given
-            val submittedSubmission =
-                mockk<LineupSubmission>().apply {
-                    every { id } returns 1L
-                    every { game.id } returns 1L
-                    every { team.id } returns 1L
-                    every { team.name } returns "Tigers"
-                    every { submittedBy.id } returns 1L
-                    every { submittedBy.nickname } returns "감독"
-                    every { status } returns LineupSubmissionStatus.SUBMITTED
-                    every { submittedAt } returns java.time.Instant.now()
-                    every { confirmedAt } returns null
-                    every { confirmedBy } returns null
-                    every { rejectionReason } returns null
-                    every { rejectedBy } returns null
-                }
-
-            every { lineupService.submitLineup(1L) } returns submittedSubmission
-            every { lineupService.getLineupEntries(1L) } returns listOf(mockEntry)
-
-            // when & then
-            mockMvc
-                .perform(post("/api/v1/scorer/lineups/1/submit"))
-                .andExpect(status().isOk)
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.status").value("SUBMITTED"))
         }
     }
 

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/lineup/LineupScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/lineup/LineupScorerControllerTest.kt
@@ -1,0 +1,368 @@
+package com.nextup.scorer.controller.lineup
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.core.domain.game.LineupEntry
+import com.nextup.core.domain.game.LineupSubmission
+import com.nextup.core.domain.game.LineupSubmissionStatus
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.lineup.LineupService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class LineupScorerControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var lineupService: LineupService
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var mockSubmission: LineupSubmission
+    private lateinit var mockEntry: LineupEntry
+
+    @BeforeEach
+    fun setUp() {
+        lineupService = mockk()
+        objectMapper = ObjectMapper()
+
+        val controller = LineupScorerController(lineupService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+
+        // Mock submission
+        mockSubmission =
+            mockk<LineupSubmission>().apply {
+                every { id } returns 1L
+                every { game.id } returns 1L
+                every { team.id } returns 1L
+                every { team.name } returns "Tigers"
+                every { submittedBy.id } returns 1L
+                every { submittedBy.nickname } returns "감독"
+                every { status } returns LineupSubmissionStatus.DRAFT
+                every { submittedAt } returns null
+                every { confirmedAt } returns null
+                every { confirmedBy } returns null
+                every { rejectionReason } returns null
+                every { rejectedBy } returns null
+            }
+
+        // Mock entry
+        mockEntry =
+            mockk<LineupEntry>().apply {
+                every { id } returns 1L
+                every { player.id } returns 1L
+                every { player.name } returns "홍길동"
+                every { position } returns Position.SHORTSTOP
+                every { battingOrder } returns 1
+                every { backNumber } returns 7
+                every { isStarter } returns true
+            }
+    }
+
+    @Nested
+    inner class CreateLineupTest {
+        @Test
+        fun `should create lineup successfully`() {
+            // given
+            every { lineupService.createLineupSubmission(any(), any(), any()) } returns mockSubmission
+            every { lineupService.getLineupEntries(any()) } returns emptyList()
+
+            val request = mapOf("gameId" to 1, "teamId" to 1)
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/scorer/lineups")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-User-Id", 1L)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+
+            verify { lineupService.createLineupSubmission(1L, 1L, 1L) }
+        }
+    }
+
+    @Nested
+    inner class GetLineupTest {
+        @Test
+        fun `should get lineup by id`() {
+            // given
+            every { lineupService.getLineupSubmission(1L) } returns mockSubmission
+            every { lineupService.getLineupEntries(1L) } returns listOf(mockEntry)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/scorer/lineups/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.entries[0].playerName").value("홍길동"))
+        }
+    }
+
+    @Nested
+    inner class GetLineupsByGameTest {
+        @Test
+        fun `should get lineups by game`() {
+            // given
+            every { lineupService.getLineupSubmissionsByGame(1L) } returns listOf(mockSubmission)
+            every { lineupService.getLineupEntries(any()) } returns listOf(mockEntry)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/scorer/lineups").param("gameId", "1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].id").value(1))
+        }
+    }
+
+    @Nested
+    inner class GetSubmittedLineupsTest {
+        @Test
+        fun `should get submitted lineups`() {
+            // given
+            val submittedSubmission =
+                mockk<LineupSubmission>().apply {
+                    every { id } returns 1L
+                    every { game.id } returns 1L
+                    every { team.id } returns 1L
+                    every { team.name } returns "Tigers"
+                    every { submittedBy.id } returns 1L
+                    every { submittedBy.nickname } returns "감독"
+                    every { status } returns LineupSubmissionStatus.SUBMITTED
+                    every { submittedAt } returns java.time.Instant.now()
+                    every { confirmedAt } returns null
+                    every { confirmedBy } returns null
+                    every { rejectionReason } returns null
+                    every { rejectedBy } returns null
+                }
+
+            every { lineupService.getSubmittedLineupsByGame(1L) } returns listOf(submittedSubmission)
+            every { lineupService.getLineupEntries(any()) } returns listOf(mockEntry)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/scorer/lineups/submitted").param("gameId", "1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].status").value("SUBMITTED"))
+        }
+    }
+
+    @Nested
+    inner class AddLineupEntryTest {
+        @Test
+        fun `should add lineup entry`() {
+            // given
+            every {
+                lineupService.addLineupEntry(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns mockEntry
+
+            val request =
+                mapOf(
+                    "playerId" to 1,
+                    "position" to "SHORTSTOP",
+                    "battingOrder" to 1,
+                    "backNumber" to 7,
+                    "isStarter" to true,
+                )
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/scorer/lineups/1/entries")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.playerName").value("홍길동"))
+        }
+    }
+
+    @Nested
+    inner class SetLineupEntriesTest {
+        @Test
+        fun `should set lineup entries`() {
+            // given
+            every { lineupService.setLineupEntries(any(), any()) } returns listOf(mockEntry)
+
+            val request =
+                mapOf(
+                    "entries" to
+                        (1..9).map { i ->
+                            mapOf(
+                                "playerId" to i,
+                                "position" to
+                                    when (i) {
+                                        1 -> "STARTING_PITCHER"
+                                        2 -> "CATCHER"
+                                        3 -> "FIRST_BASE"
+                                        4 -> "SECOND_BASE"
+                                        5 -> "THIRD_BASE"
+                                        6 -> "SHORTSTOP"
+                                        7 -> "LEFT_FIELD"
+                                        8 -> "CENTER_FIELD"
+                                        else -> "RIGHT_FIELD"
+                                    },
+                                "battingOrder" to i,
+                                "backNumber" to i,
+                                "isStarter" to true,
+                            )
+                        },
+                )
+
+            // when & then
+            mockMvc
+                .perform(
+                    put("/api/v1/scorer/lineups/1/entries")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+        }
+    }
+
+    @Nested
+    inner class GetLineupEntriesTest {
+        @Test
+        fun `should get lineup entries`() {
+            // given
+            every { lineupService.getLineupEntries(1L) } returns listOf(mockEntry)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/scorer/lineups/1/entries"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].playerName").value("홍길동"))
+        }
+    }
+
+    @Nested
+    inner class SubmitLineupTest {
+        @Test
+        fun `should submit lineup`() {
+            // given
+            val submittedSubmission =
+                mockk<LineupSubmission>().apply {
+                    every { id } returns 1L
+                    every { game.id } returns 1L
+                    every { team.id } returns 1L
+                    every { team.name } returns "Tigers"
+                    every { submittedBy.id } returns 1L
+                    every { submittedBy.nickname } returns "감독"
+                    every { status } returns LineupSubmissionStatus.SUBMITTED
+                    every { submittedAt } returns java.time.Instant.now()
+                    every { confirmedAt } returns null
+                    every { confirmedBy } returns null
+                    every { rejectionReason } returns null
+                    every { rejectedBy } returns null
+                }
+
+            every { lineupService.submitLineup(1L) } returns submittedSubmission
+            every { lineupService.getLineupEntries(1L) } returns listOf(mockEntry)
+
+            // when & then
+            mockMvc
+                .perform(post("/api/v1/scorer/lineups/1/submit"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("SUBMITTED"))
+        }
+    }
+
+    @Nested
+    inner class ConfirmLineupTest {
+        @Test
+        fun `should confirm lineup`() {
+            // given
+            val confirmedSubmission =
+                mockk<LineupSubmission>().apply {
+                    every { id } returns 1L
+                    every { game.id } returns 1L
+                    every { team.id } returns 1L
+                    every { team.name } returns "Tigers"
+                    every { submittedBy.id } returns 1L
+                    every { submittedBy.nickname } returns "감독"
+                    every { status } returns LineupSubmissionStatus.CONFIRMED
+                    every { submittedAt } returns java.time.Instant.now()
+                    every { confirmedAt } returns java.time.Instant.now()
+                    every { confirmedBy?.id } returns 2L
+                    every { confirmedBy?.nickname } returns "기록원"
+                    every { rejectionReason } returns null
+                    every { rejectedBy } returns null
+                }
+
+            every { lineupService.confirmLineup(1L, 2L) } returns confirmedSubmission
+            every { lineupService.getLineupEntries(1L) } returns listOf(mockEntry)
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/scorer/lineups/1/confirm")
+                        .header("X-User-Id", 2L),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("CONFIRMED"))
+        }
+    }
+
+    @Nested
+    inner class RejectLineupTest {
+        @Test
+        fun `should reject lineup`() {
+            // given
+            val rejectedSubmission =
+                mockk<LineupSubmission>().apply {
+                    every { id } returns 1L
+                    every { game.id } returns 1L
+                    every { team.id } returns 1L
+                    every { team.name } returns "Tigers"
+                    every { submittedBy.id } returns 1L
+                    every { submittedBy.nickname } returns "감독"
+                    every { status } returns LineupSubmissionStatus.REJECTED
+                    every { submittedAt } returns java.time.Instant.now()
+                    every { confirmedAt } returns null
+                    every { confirmedBy } returns null
+                    every { rejectionReason } returns "선수 등록번호 확인 필요"
+                    every { rejectedBy?.id } returns 2L
+                    every { rejectedBy?.nickname } returns "기록원"
+                }
+
+            every { lineupService.rejectLineup(1L, 2L, "선수 등록번호 확인 필요") } returns rejectedSubmission
+            every { lineupService.getLineupEntries(1L) } returns listOf(mockEntry)
+
+            val request = mapOf("reason" to "선수 등록번호 확인 필요")
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/scorer/lineups/1/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-User-Id", 2L)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("REJECTED"))
+                .andExpect(jsonPath("$.data.rejectionReason").value("선수 등록번호 확인 필요"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

> Closes #64

라인업 빌더 API를 **역할 기반으로 모듈 분리**하여 시나리오(02_MATCH_PREP_LINEUP.md)에 맞게 재설계했습니다.

- **nextup-api**: 팀 관리자(감독)용 라인업 생성/수정/제출 API
- **nextup-scorer**: 기록원용 라인업 확인/반려 API

## Tasks

### nextup-api (신규 추가)
- `LineupController` - 팀 감독용 라인업 API (7개 엔드포인트)
- `LineupRequest.kt` - 요청 DTO (CreateLineupRequest, AddLineupEntryRequest 등)
- `LineupResponse.kt` - 응답 DTO (scorer와 동일 구조)
- `LineupControllerTest.kt` - 컨트롤러 테스트

### nextup-scorer (기록원 전용으로 축소)
- `LineupScorerController` - 기록원 전용 기능만 유지 (5개 엔드포인트)
- 팀 관련 Request DTO 제거, `RejectLineupRequest`만 유지
- 테스트 코드 정리

### nextup-core / nextup-infrastructure (변경 없음)
- 기존 `LineupService`, Repository 재사용

## API Endpoints

### nextup-api (port 8080) - 팀 감독용
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/v1/lineups` | 라인업 생성 |
| GET | `/api/v1/lineups/{submissionId}` | 라인업 조회 |
| GET | `/api/v1/lineups?gameId={gameId}` | 경기별 라인업 목록 |
| POST | `/api/v1/lineups/{submissionId}/entries` | 엔트리 추가 |
| PUT | `/api/v1/lineups/{submissionId}/entries` | 엔트리 일괄 설정 |
| GET | `/api/v1/lineups/{submissionId}/entries` | 엔트리 조회 |
| POST | `/api/v1/lineups/{submissionId}/submit` | 라인업 제출 |

### nextup-scorer (port 8082) - 기록원 전용
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/scorer/lineups/submitted?gameId={gameId}` | 제출된 라인업 조회 |
| GET | `/api/v1/scorer/lineups/{submissionId}` | 라인업 상세 조회 |
| GET | `/api/v1/scorer/lineups/{submissionId}/entries` | 엔트리 조회 |
| POST | `/api/v1/scorer/lineups/{submissionId}/confirm` | 라인업 확인 |
| POST | `/api/v1/scorer/lineups/{submissionId}/reject` | 라인업 반려 |

## To Reviewer

**아키텍처 원칙 준수 확인:**
- ✅ Zero Entity Leak - 모든 응답 DTO 사용
- ✅ ApiResponse 래퍼 사용
- ✅ 모듈간 의존성 규칙 준수 (api/scorer 간 상호 의존 없음)
- ✅ 시나리오 기반 역할 분리 (팀 감독 vs 기록원)

**DTO 중복 전략:**
- nextup-api와 nextup-scorer의 Response DTO는 동일한 구조를 유지하지만, CLAUDE.md의 "API 계층 모듈간 상호 의존 금지" 규칙에 따라 별도 정의

🤖 Generated with [Claude Code](https://claude.com/claude-code)