### PR TITLE
feat: Phase 4 - 기록/증명/출석 시스템 구현 (#96, #97, #98, #99)

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/ElectionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/ElectionController.kt
@@ -1,0 +1,123 @@
+package com.nextup.api.controller
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.election.CastVoteApiRequest
+import com.nextup.api.dto.election.CreateElectionApiRequest
+import com.nextup.api.dto.election.RegisterCandidateApiRequest
+import com.nextup.api.dto.election.toServiceRequest
+import com.nextup.core.service.election.ElectionService
+import com.nextup.core.service.election.dto.CandidateResponse
+import com.nextup.core.service.election.dto.ElectionResponse
+import com.nextup.core.service.election.dto.ElectionResultResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+/**
+ * Election API Controller
+ *
+ * 팀 내 선거/투표 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/teams/{teamId}/elections")
+class ElectionController(
+    private val electionService: ElectionService,
+) {
+    /**
+     * 선거를 생성합니다.
+     */
+    @PostMapping
+    fun createElection(
+        @PathVariable teamId: Long,
+        @RequestBody @Valid request: CreateElectionApiRequest,
+    ): ResponseEntity<ApiResponse<ElectionResponse>> {
+        val response = electionService.createElection(request.toServiceRequest(teamId))
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(response))
+    }
+
+    /**
+     * 팀의 모든 선거를 조회합니다.
+     */
+    @GetMapping
+    fun getElectionsByTeam(
+        @PathVariable teamId: Long,
+    ): ApiResponse<List<ElectionResponse>> = ApiResponse.success(electionService.getElectionsByTeam(teamId))
+
+    /**
+     * 선거를 ID로 조회합니다.
+     */
+    @GetMapping("/{electionId}")
+    fun getElection(
+        @PathVariable teamId: Long,
+        @PathVariable electionId: Long,
+    ): ApiResponse<ElectionResponse> = ApiResponse.success(electionService.getElectionById(electionId))
+
+    /**
+     * 선거를 시작합니다.
+     */
+    @PutMapping("/{electionId}/start")
+    fun startElection(
+        @PathVariable teamId: Long,
+        @PathVariable electionId: Long,
+    ): ApiResponse<ElectionResponse> = ApiResponse.success(electionService.startElection(electionId))
+
+    /**
+     * 선거를 완료합니다.
+     */
+    @PutMapping("/{electionId}/complete")
+    fun completeElection(
+        @PathVariable teamId: Long,
+        @PathVariable electionId: Long,
+    ): ApiResponse<ElectionResponse> = ApiResponse.success(electionService.completeElection(electionId))
+
+    /**
+     * 선거를 취소합니다.
+     */
+    @PutMapping("/{electionId}/cancel")
+    fun cancelElection(
+        @PathVariable teamId: Long,
+        @PathVariable electionId: Long,
+    ): ApiResponse<ElectionResponse> = ApiResponse.success(electionService.cancelElection(electionId))
+
+    /**
+     * 후보자를 등록합니다.
+     */
+    @PostMapping("/{electionId}/candidates")
+    fun registerCandidate(
+        @PathVariable teamId: Long,
+        @PathVariable electionId: Long,
+        @RequestBody @Valid request: RegisterCandidateApiRequest,
+    ): ResponseEntity<ApiResponse<CandidateResponse>> {
+        val response = electionService.registerCandidate(request.toServiceRequest(electionId))
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(response))
+    }
+
+    /**
+     * 투표합니다.
+     */
+    @PostMapping("/{electionId}/votes")
+    fun castVote(
+        @PathVariable teamId: Long,
+        @PathVariable electionId: Long,
+        @RequestBody @Valid request: CastVoteApiRequest,
+    ): ResponseEntity<ApiResponse<CandidateResponse>> {
+        val response = electionService.vote(request.toServiceRequest(electionId))
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(response))
+    }
+
+    /**
+     * 선거 결과를 조회합니다.
+     */
+    @GetMapping("/{electionId}/results")
+    fun getResults(
+        @PathVariable teamId: Long,
+        @PathVariable electionId: Long,
+    ): ApiResponse<ElectionResultResponse> = ApiResponse.success(electionService.getResults(electionId))
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/PitchEventController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/PitchEventController.kt
@@ -1,0 +1,80 @@
+package com.nextup.api.controller
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.pitch.BallCountResponse
+import com.nextup.api.dto.pitch.PitchEventResponse
+import com.nextup.api.dto.pitch.PitcherStatsResponse
+import com.nextup.api.dto.pitch.toResponse
+import com.nextup.core.service.PitchEventService
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 투구 이벤트 조회 Controller (Public API)
+ *
+ * 일반 사용자가 투구 이벤트를 조회하는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/games/{gameId}")
+class PitchEventController(
+    private val pitchEventService: PitchEventService,
+) {
+    /**
+     * 경기의 모든 투구 이벤트를 조회합니다.
+     */
+    @GetMapping("/pitch-events")
+    fun getGamePitchEvents(
+        @PathVariable gameId: Long,
+    ): ApiResponse<List<PitchEventResponse>> {
+        val pitchEvents = pitchEventService.getGamePitchEvents(gameId)
+        return ApiResponse.success(pitchEvents.toResponse())
+    }
+
+    /**
+     * 경기의 현재 볼카운트를 조회합니다.
+     */
+    @GetMapping("/ball-count")
+    fun getCurrentBallCount(
+        @PathVariable gameId: Long,
+    ): ApiResponse<BallCountResponse> {
+        val (balls, strikes) = pitchEventService.getCurrentBallCount(gameId)
+        return ApiResponse.success(BallCountResponse.of(balls, strikes))
+    }
+
+    /**
+     * 특정 이닝의 투구 이벤트를 조회합니다.
+     */
+    @GetMapping("/pitch-events/inning/{inning}")
+    fun getInningPitchEvents(
+        @PathVariable gameId: Long,
+        @PathVariable inning: Int,
+        @RequestParam(required = true) isTopInning: Boolean,
+    ): ApiResponse<List<PitchEventResponse>> {
+        val pitchEvents =
+            pitchEventService.getInningPitchEvents(
+                gameId = gameId,
+                inning = inning,
+                isTopInning = isTopInning,
+            )
+        return ApiResponse.success(pitchEvents.toResponse())
+    }
+}
+
+/**
+ * 투수 투구 통계 Controller (Public API)
+ */
+@RestController
+@RequestMapping("/api/v1/game-players/{gamePlayerId}/pitch-stats")
+class PitcherStatsController(
+    private val pitchEventService: PitchEventService,
+) {
+    /**
+     * 투수의 투구 통계를 조회합니다.
+     */
+    @GetMapping
+    fun getPitcherStats(
+        @PathVariable gamePlayerId: Long,
+    ): ApiResponse<PitcherStatsResponse> {
+        val stats = pitchEventService.calculatePitcherStats(gamePlayerId)
+        return ApiResponse.success(stats.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/appeal/AppealController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/appeal/AppealController.kt
@@ -1,0 +1,67 @@
+package com.nextup.api.controller.appeal
+
+import com.nextup.api.dto.appeal.AppealResponse
+import com.nextup.api.dto.appeal.CreateAppealApiRequest
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.core.service.appeal.AppealService
+import com.nextup.core.service.appeal.dto.CreateAppealRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 이의 제기 API Controller (공개 API)
+ *
+ * 선수/감독의 이의 제기 신청 및 조회
+ */
+@RestController
+@RequestMapping("/api/v1")
+class AppealController(
+    private val appealService: AppealService,
+) {
+    /**
+     * 경기에 대한 이의 제기를 신청합니다.
+     */
+    @PostMapping("/games/{gameId}/appeals")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createAppeal(
+        @PathVariable gameId: Long,
+        @Valid @RequestBody request: CreateAppealApiRequest,
+    ): ApiResponse<AppealResponse> {
+        val appeal =
+            appealService.createAppeal(
+                CreateAppealRequest(
+                    gameId = gameId,
+                    appealerId = request.appealerId,
+                    appealerName = request.appealerName,
+                    type = request.type,
+                    title = request.title,
+                    description = request.description,
+                ),
+            )
+
+        return ApiResponse.success(AppealResponse.from(appeal))
+    }
+
+    /**
+     * 내 이의 제기 목록을 조회합니다.
+     */
+    @GetMapping("/appeals")
+    fun getMyAppeals(
+        @RequestParam appealerId: Long,
+    ): ApiResponse<List<AppealResponse>> {
+        val appeals = appealService.getAppealsByAppealer(appealerId)
+        return ApiResponse.success(appeals.map { AppealResponse.from(it) })
+    }
+
+    /**
+     * 경기별 이의 제기 목록을 조회합니다.
+     */
+    @GetMapping("/games/{gameId}/appeals")
+    fun getGameAppeals(
+        @PathVariable gameId: Long,
+    ): ApiResponse<List<AppealResponse>> {
+        val appeals = appealService.getAppealsByGame(gameId)
+        return ApiResponse.success(appeals.map { AppealResponse.from(it) })
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/AttendanceController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/AttendanceController.kt
@@ -1,0 +1,34 @@
+package com.nextup.api.controller.attendance
+
+import com.nextup.api.dto.attendance.NudgeRequest
+import com.nextup.api.dto.attendance.NudgeResponse
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.core.service.attendance.NudgeService
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 출석 관리 API Controller
+ *
+ * 경기 출석 투표 및 재촉 기능을 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/games/{gameId}/attendance")
+class AttendanceController(
+    private val nudgeService: NudgeService,
+) {
+    /**
+     * 미투표자에게 출석 투표 독려 알림을 전송합니다.
+     *
+     * @param gameId 경기 ID
+     * @param request 재촉 요청 (선택적 메시지 포함)
+     * @return 알림 전송 결과
+     */
+    @PostMapping("/nudge")
+    fun nudgeNonVoters(
+        @PathVariable gameId: Long,
+        @RequestBody request: NudgeRequest = NudgeRequest(),
+    ): ApiResponse<NudgeResponse> {
+        val result = nudgeService.nudgeNonVoters(gameId, request.message)
+        return ApiResponse.success(NudgeResponse.from(result))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/TeamActivityController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/TeamActivityController.kt
@@ -1,0 +1,97 @@
+package com.nextup.api.controller.attendance
+
+import com.nextup.api.dto.attendance.ActivityScoreResponse
+import com.nextup.api.dto.attendance.UpdateActivityScoreRequest
+import com.nextup.api.dto.attendance.toResponse
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.core.service.attendance.ActivityService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 팀 활동 점수 관리 컨트롤러
+ *
+ * 팀원의 활동 점수(경기 참여율, 연습 참석률, 기여도)를 관리합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/teams/{teamId}/members")
+class TeamActivityController(
+    private val activityService: ActivityService,
+) {
+    /**
+     * 팀원의 활동 점수를 조회합니다.
+     */
+    @GetMapping("/{memberId}/activity")
+    fun getActivity(
+        @PathVariable teamId: Long,
+        @PathVariable memberId: Long,
+    ): ApiResponse<ActivityScoreResponse> {
+        val activityScore = activityService.getActivityScore(teamId, memberId)
+        return ApiResponse.success(activityScore.toResponse())
+    }
+
+    /**
+     * 팀의 모든 활동 점수를 조회합니다.
+     */
+    @GetMapping("/activity")
+    fun listActivities(
+        @PathVariable teamId: Long,
+    ): ApiResponse<List<ActivityScoreResponse>> {
+        val activityScores = activityService.listActivityScores(teamId)
+        return ApiResponse.success(activityScores.map { it.toResponse() })
+    }
+
+    /**
+     * 경기 참여율을 업데이트합니다.
+     */
+    @PutMapping("/{memberId}/activity/game-participation")
+    fun updateGameParticipation(
+        @PathVariable teamId: Long,
+        @PathVariable memberId: Long,
+        @RequestBody @Valid request: UpdateActivityScoreRequest,
+    ): ApiResponse<ActivityScoreResponse> {
+        val activityScore =
+            activityService.updateGameParticipationRate(
+                teamId = teamId,
+                memberId = memberId,
+                rate = request.score,
+            )
+        return ApiResponse.success(activityScore.toResponse())
+    }
+
+    /**
+     * 연습 참석률을 업데이트합니다.
+     */
+    @PutMapping("/{memberId}/activity/practice-attendance")
+    fun updatePracticeAttendance(
+        @PathVariable teamId: Long,
+        @PathVariable memberId: Long,
+        @RequestBody @Valid request: UpdateActivityScoreRequest,
+    ): ApiResponse<ActivityScoreResponse> {
+        val activityScore =
+            activityService.updatePracticeAttendanceRate(
+                teamId = teamId,
+                memberId = memberId,
+                rate = request.score,
+            )
+        return ApiResponse.success(activityScore.toResponse())
+    }
+
+    /**
+     * 기여도 점수를 업데이트합니다.
+     */
+    @PutMapping("/{memberId}/activity/contribution")
+    fun updateContribution(
+        @PathVariable teamId: Long,
+        @PathVariable memberId: Long,
+        @RequestBody @Valid request: UpdateActivityScoreRequest,
+    ): ApiResponse<ActivityScoreResponse> {
+        val activityScore =
+            activityService.updateContributionScore(
+                teamId = teamId,
+                memberId = memberId,
+                score = request.score,
+            )
+        return ApiResponse.success(activityScore.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/TeamAttendancePollController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/TeamAttendancePollController.kt
@@ -1,0 +1,122 @@
+package com.nextup.api.controller.attendance
+
+import com.nextup.api.dto.attendance.*
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.core.domain.attendance.PollStatus
+import com.nextup.core.service.attendance.AttendanceService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.time.format.DateTimeFormatter
+
+/**
+ * 팀 출석 투표 관리 컨트롤러
+ *
+ * 팀의 출석 투표 생성 및 투표 응답을 관리합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/teams/{teamId}/attendance-polls")
+class TeamAttendancePollController(
+    private val attendanceService: AttendanceService,
+) {
+    /**
+     * 출석 투표를 생성합니다.
+     */
+    @PostMapping
+    fun createPoll(
+        @PathVariable teamId: Long,
+        @RequestBody @Valid request: CreatePollRequest,
+    ): ResponseEntity<ApiResponse<PollResponse>> {
+        val poll =
+            attendanceService.createPoll(
+                teamId = teamId,
+                title = request.title,
+                eventDate = request.eventDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                deadline = request.deadline.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+            )
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(poll.toResponse()))
+    }
+
+    /**
+     * 팀의 출석 투표 목록을 조회합니다.
+     */
+    @GetMapping
+    fun listPolls(
+        @PathVariable teamId: Long,
+        @RequestParam(required = false) status: PollStatus?,
+    ): ApiResponse<List<PollResponse>> {
+        val polls = attendanceService.listPolls(teamId, status)
+        return ApiResponse.success(polls.map { it.toResponse() })
+    }
+
+    /**
+     * 출석 투표를 조회합니다.
+     */
+    @GetMapping("/{pollId}")
+    fun getPoll(
+        @PathVariable teamId: Long,
+        @PathVariable pollId: Long,
+    ): ApiResponse<PollResponse> {
+        val poll = attendanceService.getPoll(pollId)
+        return ApiResponse.success(poll.toResponse())
+    }
+
+    /**
+     * 출석 투표에 응답합니다.
+     */
+    @PutMapping("/{pollId}/vote")
+    fun submitVote(
+        @PathVariable teamId: Long,
+        @PathVariable pollId: Long,
+        @RequestBody @Valid request: SubmitVoteRequest,
+    ): ApiResponse<VoteResponse> {
+        val vote =
+            attendanceService.submitVote(
+                pollId = pollId,
+                playerId = request.playerId,
+                voteType = request.voteType,
+            )
+
+        return ApiResponse.success(vote.toResponse())
+    }
+
+    /**
+     * 출석 투표를 마감합니다.
+     */
+    @PutMapping("/{pollId}/close")
+    fun closePoll(
+        @PathVariable teamId: Long,
+        @PathVariable pollId: Long,
+    ): ApiResponse<PollResponse> {
+        val poll = attendanceService.closePoll(pollId)
+        return ApiResponse.success(poll.toResponse())
+    }
+
+    /**
+     * 출석 투표의 응답 목록을 조회합니다.
+     */
+    @GetMapping("/{pollId}/votes")
+    fun listVotes(
+        @PathVariable teamId: Long,
+        @PathVariable pollId: Long,
+    ): ApiResponse<List<VoteResponse>> {
+        val votes = attendanceService.listVotes(pollId)
+        return ApiResponse.success(votes.map { it.toResponse() })
+    }
+
+    /**
+     * 출석 투표 통계를 조회합니다.
+     */
+    @GetMapping("/{pollId}/statistics")
+    fun getPollStatistics(
+        @PathVariable teamId: Long,
+        @PathVariable pollId: Long,
+    ): ApiResponse<PollStatisticsResponse> {
+        val votes = attendanceService.listVotes(pollId)
+        return ApiResponse.success(votes.toStatistics(pollId))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/bracket/BracketController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/bracket/BracketController.kt
@@ -1,0 +1,24 @@
+package com.nextup.api.controller.bracket
+
+import com.nextup.api.dto.bracket.BracketResponse
+import com.nextup.api.dto.bracket.toBracketResponse
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.core.service.bracket.BracketGeneratorService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/competitions/{competitionId}/bracket")
+class BracketController(
+    private val bracketGeneratorService: BracketGeneratorService,
+) {
+    @GetMapping
+    fun getBracket(
+        @PathVariable competitionId: Long,
+    ): ApiResponse<BracketResponse> {
+        val entries = bracketGeneratorService.getBracket(competitionId)
+        return ApiResponse.success(entries.toBracketResponse(competitionId))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/certificate/CertificateController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/certificate/CertificateController.kt
@@ -1,0 +1,106 @@
+package com.nextup.api.controller.certificate
+
+import com.nextup.api.dto.certificate.CertificateResponse
+import com.nextup.api.dto.certificate.CertificateVerificationResponse
+import com.nextup.api.dto.certificate.IssueCertificateRequest
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.mapper.certificate.toResponse
+import com.nextup.core.service.certificate.CertificateService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 기록 증명서 API
+ *
+ * 선수의 기록 증명서 발급, 조회, 검증 기능을 제공합니다.
+ * 모든 응답은 ApiResponse로 래핑됩니다.
+ */
+@RestController
+@RequestMapping("/api/v1")
+class CertificateController(
+    private val certificateService: CertificateService,
+) {
+    /**
+     * 선수의 기록 증명서를 발급합니다.
+     *
+     * POST /api/v1/players/{playerId}/certificate
+     *
+     * @param playerId 선수 ID
+     * @param request 증명서 발급 요청 (유효 기간)
+     * @return 발급된 증명서
+     */
+    @PostMapping("/players/{playerId}/certificate")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun issueCertificate(
+        @PathVariable playerId: Long,
+        @RequestBody @Valid request: IssueCertificateRequest = IssueCertificateRequest(),
+    ): ApiResponse<CertificateResponse> {
+        val certificate = certificateService.issueCertificate(playerId, request.validityDays)
+        return ApiResponse.success(certificate.toResponse())
+    }
+
+    /**
+     * 증명서를 조회합니다.
+     *
+     * GET /api/v1/certificates/{certificateId}
+     *
+     * @param certificateId 증명서 ID
+     * @return 증명서 정보
+     */
+    @GetMapping("/certificates/{certificateId}")
+    fun getCertificate(
+        @PathVariable certificateId: Long,
+    ): ApiResponse<CertificateResponse> {
+        val certificate = certificateService.getCertificate(certificateId)
+        return ApiResponse.success(certificate.toResponse())
+    }
+
+    /**
+     * 증명서의 유효성을 검증합니다.
+     *
+     * GET /api/v1/certificates/{issueNumber}/verify
+     *
+     * @param issueNumber 발급 번호 (UUID)
+     * @return 검증 결과
+     */
+    @GetMapping("/certificates/{issueNumber}/verify")
+    fun verifyCertificate(
+        @PathVariable issueNumber: String,
+    ): ApiResponse<CertificateVerificationResponse> {
+        val verification = certificateService.verifyCertificate(issueNumber)
+        return ApiResponse.success(verification.toResponse())
+    }
+
+    /**
+     * 선수의 모든 증명서를 조회합니다.
+     *
+     * GET /api/v1/players/{playerId}/certificates
+     *
+     * @param playerId 선수 ID
+     * @return 증명서 리스트
+     */
+    @GetMapping("/players/{playerId}/certificates")
+    fun getPlayerCertificates(
+        @PathVariable playerId: Long,
+    ): ApiResponse<List<CertificateResponse>> {
+        val certificates = certificateService.getPlayerCertificates(playerId)
+        return ApiResponse.success(certificates.toResponse())
+    }
+
+    /**
+     * 증명서를 취소합니다.
+     *
+     * DELETE /api/v1/certificates/{certificateId}
+     *
+     * @param certificateId 증명서 ID
+     */
+    @DeleteMapping("/certificates/{certificateId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun revokeCertificate(
+        @PathVariable certificateId: Long,
+    ): ApiResponse<Unit> {
+        certificateService.revokeCertificate(certificateId)
+        return ApiResponse.success(Unit)
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
@@ -61,7 +61,13 @@ class CompetitionController(
     fun getStandings(
         @PathVariable id: Long,
     ): ApiResponse<StandingsResponse> {
+        val competition = competitionService.getById(id)
         val standings = standingsService.getStandings(id)
-        return ApiResponse.success(StandingsResponse.from(standings))
+        return ApiResponse.success(
+            StandingsResponse.from(
+                dto = standings,
+                playoffCutoff = competition.playoffTeams,
+            ),
+        )
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/discipline/DisciplineController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/discipline/DisciplineController.kt
@@ -1,0 +1,72 @@
+package com.nextup.api.controller.discipline
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.discipline.DisciplineResponse
+import com.nextup.api.dto.discipline.PlayerDisciplineHistoryResponse
+import com.nextup.core.service.discipline.DisciplineService
+import com.nextup.core.service.player.PlayerService
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 징계 조회 API Controller (공개 API)
+ *
+ * 조회 전용
+ */
+@RestController
+@RequestMapping("/api/v1/disciplines")
+class DisciplineController(
+    private val disciplineService: DisciplineService,
+    private val playerService: PlayerService,
+) {
+    /**
+     * 선수의 징계 이력을 조회합니다.
+     */
+    @GetMapping("/players/{playerId}")
+    fun getPlayerDisciplines(
+        @PathVariable playerId: Long,
+        @RequestParam(required = false) competitionId: Long?,
+    ): ApiResponse<PlayerDisciplineHistoryResponse> {
+        val player = playerService.getById(playerId)
+
+        val disciplines =
+            if (competitionId != null) {
+                disciplineService.getDisciplinesByPlayerAndCompetition(playerId, competitionId)
+            } else {
+                disciplineService.getDisciplinesByPlayer(playerId)
+            }
+
+        val activeDisciplines = disciplines.filter { it.isEffective() }
+
+        val response =
+            PlayerDisciplineHistoryResponse(
+                playerId = player.id,
+                playerName = player.name,
+                totalDisciplines = disciplines.size,
+                activeDisciplines = activeDisciplines.size,
+                disciplines = disciplines.map { DisciplineResponse.from(it) },
+            )
+
+        return ApiResponse.success(response)
+    }
+
+    /**
+     * 선수가 출장 가능한지 확인합니다.
+     */
+    @GetMapping("/players/{playerId}/eligibility")
+    fun checkPlayerEligibility(
+        @PathVariable playerId: Long,
+        @RequestParam competitionId: Long,
+    ): ApiResponse<Map<String, Any>> {
+        val canPlay = disciplineService.canPlayerPlay(playerId, competitionId)
+        val activeDisciplines =
+            disciplineService.getActiveDisciplines(playerId, competitionId)
+
+        return ApiResponse.success(
+            mapOf(
+                "canPlay" to canPlay,
+                "activeDisciplinesCount" to activeDisciplines.size,
+                "disciplines" to activeDisciplines.map { DisciplineResponse.from(it) },
+            )
+        )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/GameScheduleController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/GameScheduleController.kt
@@ -1,0 +1,78 @@
+package com.nextup.api.controller.game
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.game.GameDetailResponse
+import com.nextup.api.dto.game.GameSummaryResponse
+import com.nextup.core.service.game.GameScheduleService
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+/**
+ * 경기 일정 조회 API Controller (일반 사용자 - 조회 전용)
+ */
+@RestController
+@RequestMapping("/api/v1")
+class GameScheduleController(
+    private val gameScheduleService: GameScheduleService,
+) {
+    /**
+     * 경기 목록을 조회합니다. (날짜/팀/대회 필터, 페이징)
+     */
+    @GetMapping("/games")
+    fun getGames(
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate?,
+        @RequestParam(required = false) teamId: Long?,
+        @RequestParam(required = false) competitionId: Long?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+    ): ApiResponse<List<GameSummaryResponse>> {
+        val games =
+            gameScheduleService.getGames(
+                date = date,
+                teamId = teamId,
+                competitionId = competitionId,
+                page = page,
+                size = size,
+            )
+        return ApiResponse.success(games.map { GameSummaryResponse.from(it) })
+    }
+
+    /**
+     * 경기 상세 정보를 조회합니다.
+     */
+    @GetMapping("/games/{gameId}")
+    fun getGameDetail(
+        @PathVariable gameId: Long,
+    ): ApiResponse<GameDetailResponse> {
+        val detail = gameScheduleService.getGameDetail(gameId)
+        return ApiResponse.success(GameDetailResponse.from(detail))
+    }
+
+    /**
+     * 팀별 경기 일정을 조회합니다.
+     */
+    @GetMapping("/teams/{teamId}/games")
+    fun getGamesByTeam(
+        @PathVariable teamId: Long,
+    ): ApiResponse<List<GameSummaryResponse>> {
+        val games = gameScheduleService.getGamesByTeam(teamId)
+        return ApiResponse.success(games.map { GameSummaryResponse.from(it) })
+    }
+
+    /**
+     * 팀의 다가오는 경기를 조회합니다.
+     */
+    @GetMapping("/teams/{teamId}/games/upcoming")
+    fun getUpcomingGames(
+        @PathVariable teamId: Long,
+        @RequestParam(defaultValue = "5") limit: Int,
+    ): ApiResponse<List<GameSummaryResponse>> {
+        val games = gameScheduleService.getUpcomingGamesByTeam(teamId, limit)
+        return ApiResponse.success(games.map { GameSummaryResponse.from(it) })
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/ScoresheetController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/ScoresheetController.kt
@@ -1,0 +1,64 @@
+package com.nextup.api.controller.game
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.game.ScoresheetResponse
+import com.nextup.api.mapper.game.toResponse
+import com.nextup.core.port.PdfGeneratorPort
+import com.nextup.core.service.game.ScoresheetService
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 공식 기록지 API 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/v1/games/{gameId}/scoresheet")
+class ScoresheetController(
+    private val scoresheetService: ScoresheetService,
+    private val pdfGenerator: PdfGeneratorPort,
+) {
+    /**
+     * 경기의 공식 기록지 데이터를 조회합니다.
+     *
+     * @param gameId 경기 ID
+     * @return 공식 기록지 데이터
+     */
+    @GetMapping
+    fun getScoresheet(
+        @PathVariable gameId: Long,
+    ): ApiResponse<ScoresheetResponse> {
+        val scoresheet = scoresheetService.getScoresheet(gameId)
+        return ApiResponse.success(scoresheet.toResponse())
+    }
+
+    /**
+     * 경기의 공식 기록지를 PDF로 다운로드합니다.
+     *
+     * @param gameId 경기 ID
+     * @return PDF 파일
+     */
+    @GetMapping("/pdf")
+    fun downloadScoresheetPdf(
+        @PathVariable gameId: Long,
+    ): ResponseEntity<ByteArray> {
+        val scoresheet = scoresheetService.getScoresheet(gameId)
+        val pdfBytes = pdfGenerator.generateScoresheetPdf(scoresheet)
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_PDF
+        headers.setContentDispositionFormData(
+            "attachment",
+            "scoresheet_game_$gameId.pdf",
+        )
+
+        return ResponseEntity
+            .ok()
+            .headers(headers)
+            .body(pdfBytes)
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/match/MatchRequestController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/match/MatchRequestController.kt
@@ -1,0 +1,114 @@
+package com.nextup.api.controller.match
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.match.CreateMatchRequestApiRequest
+import com.nextup.api.dto.match.MatchRequestDetailResponse
+import com.nextup.api.dto.match.MatchRequestResponse
+import com.nextup.api.dto.match.MatchResponseResponse
+import com.nextup.api.dto.match.RespondToMatchRequestApiRequest
+import com.nextup.core.service.match.MatchingService
+import com.nextup.core.service.match.dto.CreateMatchRequestDto
+import com.nextup.core.service.match.dto.CreateMatchResponseDto
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 매칭 요청 API Controller (공개 API)
+ *
+ * 팀 간 연습 경기 매칭을 위한 API
+ */
+@RestController
+@RequestMapping("/api/v1/match-requests")
+class MatchRequestController(
+    private val matchingService: MatchingService,
+) {
+    /**
+     * 매칭 요청을 생성합니다.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createMatchRequest(
+        @Valid @RequestBody request: CreateMatchRequestApiRequest,
+    ): ApiResponse<MatchRequestResponse> {
+        val matchRequest =
+            matchingService.createRequest(
+                CreateMatchRequestDto(
+                    teamId = request.teamId,
+                    preferredDate = request.preferredDate,
+                    preferredTime = request.preferredTime,
+                    preferredLocation = request.preferredLocation,
+                    message = request.message,
+                    skillLevel = request.skillLevel,
+                ),
+            )
+
+        return ApiResponse.success(MatchRequestResponse.from(matchRequest))
+    }
+
+    /**
+     * OPEN 상태의 모든 매칭 요청을 조회합니다.
+     */
+    @GetMapping
+    fun getOpenMatchRequests(): ApiResponse<List<MatchRequestResponse>> {
+        val matchRequests = matchingService.getOpenRequests()
+        return ApiResponse.success(matchRequests.map { MatchRequestResponse.from(it) })
+    }
+
+    /**
+     * 매칭 요청 상세 정보를 조회합니다 (응답 목록 포함).
+     */
+    @GetMapping("/{id}")
+    fun getMatchRequestDetail(
+        @PathVariable id: Long,
+    ): ApiResponse<MatchRequestDetailResponse> {
+        val matchRequest = matchingService.getRequestById(id)
+        val responses = matchingService.getResponsesByRequest(id)
+
+        return ApiResponse.success(MatchRequestDetailResponse.from(matchRequest, responses))
+    }
+
+    /**
+     * 매칭 요청에 응답합니다.
+     */
+    @PostMapping("/{id}/respond")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun respondToMatchRequest(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: RespondToMatchRequestApiRequest,
+    ): ApiResponse<MatchResponseResponse> {
+        val matchResponse =
+            matchingService.respondToRequest(
+                CreateMatchResponseDto(
+                    matchRequestId = id,
+                    respondTeamId = request.respondTeamId,
+                    message = request.message,
+                ),
+            )
+
+        return ApiResponse.success(MatchResponseResponse.from(matchResponse))
+    }
+
+    /**
+     * 매칭 응답을 수락합니다.
+     */
+    @PutMapping("/{id}/accept/{responseId}")
+    fun acceptMatchResponse(
+        @PathVariable id: Long,
+        @PathVariable responseId: Long,
+    ): ApiResponse<MatchRequestResponse> {
+        val matchRequest = matchingService.acceptResponse(id, responseId)
+        return ApiResponse.success(MatchRequestResponse.from(matchRequest))
+    }
+
+    /**
+     * 매칭 요청을 취소합니다.
+     */
+    @DeleteMapping("/{id}")
+    fun cancelMatchRequest(
+        @PathVariable id: Long,
+    ): ApiResponse<MatchRequestResponse> {
+        val matchRequest = matchingService.cancelRequest(id)
+        return ApiResponse.success(MatchRequestResponse.from(matchRequest))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
@@ -1,0 +1,113 @@
+package com.nextup.api.controller.notification
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.notification.DeviceTokenResponse
+import com.nextup.api.dto.notification.NotificationPreferenceResponse
+import com.nextup.api.dto.notification.NotificationResponse
+import com.nextup.api.dto.notification.RegisterDeviceApiRequest
+import com.nextup.api.dto.notification.UpdatePreferenceApiRequest
+import com.nextup.core.service.notification.NotificationService
+import com.nextup.core.service.notification.dto.RegisterDeviceRequest
+import com.nextup.core.service.notification.dto.UpdatePreferenceRequest
+import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 알림 API Controller
+ *
+ * 사용자의 알림 조회, 디바이스 관리, 알림 설정 관리
+ */
+@RestController
+@RequestMapping("/api/v1")
+class NotificationController(
+    private val notificationService: NotificationService,
+) {
+    /**
+     * 디바이스 토큰을 등록합니다.
+     */
+    @PostMapping("/devices")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun registerDevice(
+        @RequestParam userId: Long,
+        @Valid @RequestBody request: RegisterDeviceApiRequest,
+    ): ApiResponse<DeviceTokenResponse> {
+        val deviceToken =
+            notificationService.registerDevice(
+                RegisterDeviceRequest(
+                    userId = userId,
+                    token = request.token,
+                    platform = request.platform,
+                ),
+            )
+
+        return ApiResponse.success(DeviceTokenResponse.from(deviceToken))
+    }
+
+    /**
+     * 디바이스 토큰을 삭제합니다.
+     */
+    @DeleteMapping("/devices/{tokenId}")
+    fun removeDevice(
+        @PathVariable tokenId: Long,
+    ): ApiResponse<Unit> {
+        notificationService.removeDevice(tokenId)
+        return ApiResponse.success(Unit)
+    }
+
+    /**
+     * 사용자의 알림 목록을 조회합니다.
+     */
+    @GetMapping("/notifications")
+    fun getNotifications(
+        @RequestParam userId: Long,
+        @PageableDefault(size = 20) pageable: Pageable,
+    ): ApiResponse<List<NotificationResponse>> {
+        val notifications = notificationService.getUserNotifications(userId, pageable)
+        return ApiResponse.success(notifications.content.map { NotificationResponse.from(it) })
+    }
+
+    /**
+     * 알림을 읽음 처리합니다.
+     */
+    @PutMapping("/notifications/{id}/read")
+    fun markAsRead(
+        @PathVariable id: Long,
+    ): ApiResponse<NotificationResponse> {
+        val notification = notificationService.markAsRead(id)
+        return ApiResponse.success(NotificationResponse.from(notification))
+    }
+
+    /**
+     * 알림 설정을 수정합니다.
+     */
+    @PutMapping("/notifications/preferences")
+    fun updatePreference(
+        @RequestParam userId: Long,
+        @Valid @RequestBody request: UpdatePreferenceApiRequest,
+    ): ApiResponse<NotificationPreferenceResponse> {
+        val preference =
+            notificationService.updatePreference(
+                UpdatePreferenceRequest(
+                    userId = userId,
+                    type = request.type,
+                    enabled = request.enabled,
+                ),
+            )
+
+        return ApiResponse.success(NotificationPreferenceResponse.from(preference))
+    }
+
+    /**
+     * 사용자의 알림 설정 목록을 조회합니다.
+     */
+    @GetMapping("/notifications/preferences")
+    fun getPreferences(
+        @RequestParam userId: Long,
+    ): ApiResponse<List<NotificationPreferenceResponse>> {
+        val preferences = notificationService.getUserPreferences(userId)
+        return ApiResponse.success(preferences.map { NotificationPreferenceResponse.from(it) })
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/recruitment/RecruitmentController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/recruitment/RecruitmentController.kt
@@ -1,0 +1,106 @@
+package com.nextup.api.controller.recruitment
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.recruitment.CreateRecruitmentApiRequest
+import com.nextup.api.dto.recruitment.RecruitmentResponse
+import com.nextup.api.dto.recruitment.UpdateRecruitmentApiRequest
+import com.nextup.core.service.recruitment.TeamRecruitmentService
+import com.nextup.core.service.recruitment.dto.CreateRecruitmentRequest
+import com.nextup.core.service.recruitment.dto.UpdateRecruitmentRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 팀 모집 공고 API Controller (공개 API)
+ *
+ * 팀의 선수 모집 공고 관리
+ */
+@RestController
+@RequestMapping("/api/v1")
+class RecruitmentController(
+    private val recruitmentService: TeamRecruitmentService,
+) {
+    /**
+     * 모든 진행 중인 모집 공고를 조회합니다.
+     */
+    @GetMapping("/recruitments")
+    fun getAllOpenRecruitments(): ApiResponse<List<RecruitmentResponse>> {
+        val recruitments = recruitmentService.getAllOpen()
+        return ApiResponse.success(recruitments.map { RecruitmentResponse.from(it) })
+    }
+
+    /**
+     * 모집 공고 상세를 조회합니다.
+     */
+    @GetMapping("/recruitments/{id}")
+    fun getRecruitment(
+        @PathVariable id: Long,
+    ): ApiResponse<RecruitmentResponse> {
+        val recruitment = recruitmentService.getById(id)
+        return ApiResponse.success(RecruitmentResponse.from(recruitment))
+    }
+
+    /**
+     * 팀의 모집 공고를 생성합니다.
+     */
+    @PostMapping("/teams/{teamId}/recruitments")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createRecruitment(
+        @PathVariable teamId: Long,
+        @Valid @RequestBody request: CreateRecruitmentApiRequest,
+    ): ApiResponse<RecruitmentResponse> {
+        val recruitment =
+            recruitmentService.createRecruitment(
+                CreateRecruitmentRequest(
+                    teamId = teamId,
+                    title = request.title,
+                    description = request.description,
+                    positionsNeeded = request.positionsNeeded,
+                    ageRange = request.ageRange,
+                    skillLevel = request.skillLevel,
+                    location = request.location,
+                    deadline = request.deadline,
+                ),
+            )
+
+        return ApiResponse.success(RecruitmentResponse.from(recruitment))
+    }
+
+    /**
+     * 팀의 모집 공고를 수정합니다.
+     */
+    @PutMapping("/teams/{teamId}/recruitments/{id}")
+    fun updateRecruitment(
+        @PathVariable teamId: Long,
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateRecruitmentApiRequest,
+    ): ApiResponse<RecruitmentResponse> {
+        val recruitment =
+            recruitmentService.updateRecruitment(
+                id = id,
+                request =
+                    UpdateRecruitmentRequest(
+                        title = request.title,
+                        description = request.description,
+                        positionsNeeded = request.positionsNeeded,
+                        deadline = request.deadline,
+                    ),
+            )
+
+        return ApiResponse.success(RecruitmentResponse.from(recruitment))
+    }
+
+    /**
+     * 팀의 모집 공고를 삭제합니다.
+     */
+    @DeleteMapping("/teams/{teamId}/recruitments/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteRecruitment(
+        @PathVariable teamId: Long,
+        @PathVariable id: Long,
+    ): ApiResponse<Unit> {
+        recruitmentService.deleteRecruitment(id)
+        return ApiResponse.success(Unit)
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/report/CompetitionReportController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/report/CompetitionReportController.kt
@@ -1,0 +1,48 @@
+package com.nextup.api.controller.report
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.report.CompetitionReportResponse
+import com.nextup.api.dto.report.CompetitionSummaryResponse
+import com.nextup.api.dto.report.toResponse
+import com.nextup.core.service.report.CompetitionReportService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 대회 리포트 API 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/v1/competitions")
+class CompetitionReportController(
+    private val competitionReportService: CompetitionReportService,
+) {
+    /**
+     * 대회의 전체 리포트를 조회합니다.
+     *
+     * @param competitionId 대회 ID
+     * @return 대회 리포트 (순위표, 요약 통계 포함)
+     */
+    @GetMapping("/{competitionId}/report")
+    fun getReport(
+        @PathVariable competitionId: Long,
+    ): ApiResponse<CompetitionReportResponse> {
+        val report = competitionReportService.getReport(competitionId)
+        return ApiResponse.success(report.toResponse())
+    }
+
+    /**
+     * 대회의 요약 정보만 조회합니다.
+     *
+     * @param competitionId 대회 ID
+     * @return 대회 요약 통계
+     */
+    @GetMapping("/{competitionId}/report/summary")
+    fun getReportSummary(
+        @PathVariable competitionId: Long,
+    ): ApiResponse<CompetitionSummaryResponse> {
+        val summary = competitionReportService.getReportSummary(competitionId)
+        return ApiResponse.success(summary.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/schedule/ScheduleController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/schedule/ScheduleController.kt
@@ -1,0 +1,43 @@
+package com.nextup.api.controller.schedule
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.schedule.ScheduleResponse
+import com.nextup.core.service.schedule.LeagueScheduleService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 대진표 조회 API Controller (일반 사용자용)
+ *
+ * 대회별 대진표 조회 기능을 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/competitions/{competitionId}/schedule")
+class ScheduleController(
+    private val scheduleService: LeagueScheduleService,
+) {
+    /**
+     * 대회의 전체 대진표를 조회합니다.
+     */
+    @GetMapping
+    fun getSchedules(
+        @PathVariable competitionId: Long,
+    ): ApiResponse<List<ScheduleResponse>> {
+        val schedules = scheduleService.getSchedulesByCompetition(competitionId)
+        return ApiResponse.success(schedules.map { ScheduleResponse.from(it) })
+    }
+
+    /**
+     * 대회의 라운드별 대진표를 조회합니다.
+     */
+    @GetMapping("/round/{round}")
+    fun getSchedulesByRound(
+        @PathVariable competitionId: Long,
+        @PathVariable round: Int,
+    ): ApiResponse<List<ScheduleResponse>> {
+        val schedules = scheduleService.getSchedulesByRound(competitionId, round)
+        return ApiResponse.success(schedules.map { ScheduleResponse.from(it) })
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/BookingController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/BookingController.kt
@@ -1,0 +1,50 @@
+package com.nextup.api.controller.stadium
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.stadium.BookingResponse
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.service.stadium.StadiumService
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 구장 예약 관리 API Controller (일반 사용자용)
+ */
+@RestController
+@RequestMapping("/api/v1/bookings")
+class BookingController(
+    private val stadiumService: StadiumService,
+) {
+    /**
+     * 팀의 예약 목록을 조회합니다.
+     */
+    @GetMapping("/team/{teamId}")
+    fun getTeamBookings(
+        @PathVariable teamId: Long,
+        @RequestParam(required = false) status: BookingStatus?,
+    ): ApiResponse<List<BookingResponse>> {
+        val bookings = stadiumService.getTeamBookings(teamId, status)
+        return ApiResponse.success(bookings.map { BookingResponse.from(it) })
+    }
+
+    /**
+     * 예약을 취소합니다.
+     */
+    @DeleteMapping("/{id}")
+    fun cancelBooking(
+        @PathVariable id: Long,
+    ): ApiResponse<BookingResponse> {
+        val booking = stadiumService.cancelBooking(id)
+        return ApiResponse.success(BookingResponse.from(booking))
+    }
+
+    /**
+     * 예약을 완료 처리합니다.
+     */
+    @PutMapping("/{id}/complete")
+    fun completeBooking(
+        @PathVariable id: Long,
+    ): ApiResponse<BookingResponse> {
+        val booking = stadiumService.completeBooking(id)
+        return ApiResponse.success(BookingResponse.from(booking))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/StadiumController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/StadiumController.kt
@@ -1,0 +1,68 @@
+package com.nextup.api.controller.stadium
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.stadium.BookingResponse
+import com.nextup.api.dto.stadium.StadiumResponse
+import com.nextup.api.dto.stadium.StadiumSlotResponse
+import com.nextup.core.service.stadium.StadiumService
+import com.nextup.core.service.stadium.dto.BookSlotRequest
+import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
+
+/**
+ * 구장 조회 및 예약 API Controller (일반 사용자용)
+ */
+@RestController
+@RequestMapping("/api/v1/stadiums")
+class StadiumController(
+    private val stadiumService: StadiumService,
+) {
+    /**
+     * 위치 기반으로 근처 구장을 검색합니다.
+     */
+    @GetMapping("/search")
+    fun searchStadiums(
+        @RequestParam latitude: Double,
+        @RequestParam longitude: Double,
+        @RequestParam(defaultValue = "10.0") radiusKm: Double,
+    ): ApiResponse<List<StadiumResponse>> {
+        val stadiums = stadiumService.searchStadiums(latitude, longitude, radiusKm)
+        return ApiResponse.success(stadiums.map { StadiumResponse.from(it) })
+    }
+
+    /**
+     * 구장 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getStadium(
+        @PathVariable id: Long,
+    ): ApiResponse<StadiumResponse> {
+        val stadium = stadiumService.getById(id)
+        return ApiResponse.success(StadiumResponse.from(stadium))
+    }
+
+    /**
+     * 구장의 특정 날짜에 사용 가능한 슬롯을 조회합니다.
+     */
+    @GetMapping("/{id}/slots")
+    fun getAvailableSlots(
+        @PathVariable id: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+    ): ApiResponse<List<StadiumSlotResponse>> {
+        val slots = stadiumService.getAvailableSlots(id, date)
+        return ApiResponse.success(slots.map { StadiumSlotResponse.from(it) })
+    }
+
+    /**
+     * 구장 슬롯을 예약합니다.
+     */
+    @PostMapping("/book")
+    fun bookSlot(
+        @RequestBody @Valid request: BookSlotRequest,
+    ): ApiResponse<BookingResponse> {
+        val booking = stadiumService.bookSlot(request)
+        return ApiResponse.success(BookingResponse.from(booking))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/LeaderboardController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/LeaderboardController.kt
@@ -1,0 +1,56 @@
+package com.nextup.api.controller.stats
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.stats.BattingLeaderResponse
+import com.nextup.api.dto.stats.PitchingLeaderResponse
+import com.nextup.api.mapper.stats.toBattingLeaderResponse
+import com.nextup.api.mapper.stats.toPitchingLeaderResponse
+import com.nextup.core.service.stats.IndividualRankingService
+import com.nextup.core.service.stats.dto.BattingCategory
+import com.nextup.core.service.stats.dto.PitchingCategory
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 개인 타이틀 리더보드 API
+ *
+ * 대회별 카테고리 TOP N 리더보드를 조회합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/competitions/{competitionId}/leaderboard")
+class LeaderboardController(
+    private val individualRankingService: IndividualRankingService,
+) {
+    /**
+     * 타격 리더보드 조회
+     *
+     * GET /api/v1/competitions/{competitionId}/leaderboard/batting?category=BATTING_AVG
+     */
+    @GetMapping("/batting")
+    fun getBattingLeaders(
+        @PathVariable competitionId: Long,
+        @RequestParam category: BattingCategory,
+        @RequestParam(defaultValue = "10") limit: Int,
+    ): ApiResponse<List<BattingLeaderResponse>> {
+        val leaders = individualRankingService.getBattingLeaders(competitionId, category, limit)
+        return ApiResponse.success(leaders.toBattingLeaderResponse())
+    }
+
+    /**
+     * 투수 리더보드 조회
+     *
+     * GET /api/v1/competitions/{competitionId}/leaderboard/pitching?category=ERA
+     */
+    @GetMapping("/pitching")
+    fun getPitchingLeaders(
+        @PathVariable competitionId: Long,
+        @RequestParam category: PitchingCategory,
+        @RequestParam(defaultValue = "10") limit: Int,
+    ): ApiResponse<List<PitchingLeaderResponse>> {
+        val leaders = individualRankingService.getPitchingLeaders(competitionId, category, limit)
+        return ApiResponse.success(leaders.toPitchingLeaderResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamController.kt
@@ -1,0 +1,188 @@
+package com.nextup.api.controller.team
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.team.CreateTeamRequest
+import com.nextup.api.dto.team.TeamDetailResponse
+import com.nextup.api.dto.team.TeamSummaryResponse
+import com.nextup.api.dto.team.UpdateTeamRequest
+import com.nextup.common.exception.InsufficientTeamRoleException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.LeagueRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.team.TeamMembershipService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+/**
+ * 사용자 셀프서비스 팀 CRUD API
+ *
+ * 일반 사용자가 팀을 생성/수정/삭제/조회합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/teams")
+class TeamController(
+    private val teamMembershipService: TeamMembershipService,
+    private val teamRepository: TeamRepositoryPort,
+    private val leagueRepository: LeagueRepositoryPort,
+) {
+    /**
+     * 팀을 생성합니다. 생성자가 OWNER로 자동 등록됩니다.
+     *
+     * POST /api/v1/teams
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createTeam(
+        @RequestBody @Valid request: CreateTeamRequest,
+        @AuthenticationPrincipal userId: Long,
+    ): ApiResponse<TeamDetailResponse> {
+        val league =
+            request.leagueId?.let { leagueId ->
+                leagueRepository.findByIdOrNull(leagueId)
+                    ?: throw IllegalArgumentException("리그를 찾을 수 없습니다: $leagueId")
+            } ?: throw IllegalArgumentException("리그 ID는 필수입니다")
+
+        val team =
+            Team(
+                league = league,
+                name = request.name,
+                city = request.city,
+                abbreviation = request.abbreviation,
+                foundedYear = LocalDate.now().year,
+            )
+
+        val savedTeam =
+            teamMembershipService.createTeamWithOwner(
+                userId = userId,
+                team = team,
+                uniformNumber = request.uniformNumber,
+            )
+
+        val memberCount = teamMembershipService.getTeamMemberCount(savedTeam.id)
+
+        return ApiResponse.success(savedTeam.toDetailResponse(memberCount))
+    }
+
+    /**
+     * 팀 정보를 수정합니다. OWNER만 가능합니다.
+     *
+     * PUT /api/v1/teams/{teamId}
+     */
+    @PutMapping("/{teamId}")
+    fun updateTeam(
+        @PathVariable teamId: Long,
+        @RequestBody @Valid request: UpdateTeamRequest,
+        @AuthenticationPrincipal userId: Long,
+    ): ApiResponse<TeamDetailResponse> {
+        val member =
+            teamMembershipService.getMember(teamId, userId)
+                ?: throw InsufficientTeamRoleException("OWNER", "NONE")
+        if (!member.isOwner()) {
+            throw InsufficientTeamRoleException("OWNER", member.role.name)
+        }
+
+        val team =
+            teamRepository.findByIdWithLeague(teamId)
+                ?: throw TeamNotFoundException(teamId)
+
+        team.updateBasicInfo(
+            name = request.name,
+            city = request.city,
+            abbreviation = request.abbreviation,
+        )
+
+        val savedTeam = teamRepository.save(team)
+        val memberCount = teamMembershipService.getTeamMemberCount(teamId)
+
+        return ApiResponse.success(savedTeam.toDetailResponse(memberCount))
+    }
+
+    /**
+     * 팀 상세 정보를 조회합니다.
+     *
+     * GET /api/v1/teams/{teamId}
+     */
+    @GetMapping("/{teamId}")
+    fun getTeam(
+        @PathVariable teamId: Long,
+    ): ApiResponse<TeamDetailResponse> {
+        val team =
+            teamRepository.findByIdWithLeague(teamId)
+                ?: throw TeamNotFoundException(teamId)
+        val memberCount = teamMembershipService.getTeamMemberCount(teamId)
+
+        return ApiResponse.success(team.toDetailResponse(memberCount))
+    }
+
+    /**
+     * 팀 목록을 조회합니다. 이름, 도시로 필터링 가능합니다.
+     *
+     * GET /api/v1/teams?name=타이거즈&city=서울
+     */
+    @GetMapping
+    fun getTeams(
+        @RequestParam(required = false) name: String?,
+        @RequestParam(required = false) city: String?,
+    ): ApiResponse<List<TeamSummaryResponse>> {
+        val teams = teamRepository.findActiveTeams()
+
+        val filtered =
+            teams.filter { team ->
+                val nameMatch = name == null || team.name.contains(name, ignoreCase = true)
+                val cityMatch = city == null || team.city.contains(city, ignoreCase = true)
+                nameMatch && cityMatch
+            }
+
+        val responses =
+            filtered.map { team ->
+                val memberCount = teamMembershipService.getTeamMemberCount(team.id)
+                TeamSummaryResponse(
+                    teamId = team.id,
+                    name = team.name,
+                    city = team.city,
+                    abbreviation = team.abbreviation,
+                    memberCount = memberCount,
+                )
+            }
+
+        return ApiResponse.success(responses)
+    }
+
+    /**
+     * 팀을 삭제합니다. OWNER만 가능하며, 멤버가 1명일 때만 삭제 가능합니다.
+     *
+     * DELETE /api/v1/teams/{teamId}
+     */
+    @DeleteMapping("/{teamId}")
+    fun deleteTeam(
+        @PathVariable teamId: Long,
+        @AuthenticationPrincipal userId: Long,
+    ): ApiResponse<Unit> {
+        teamMembershipService.deleteTeam(teamId, userId)
+        return ApiResponse.success(Unit)
+    }
+
+    private fun Team.toDetailResponse(memberCount: Int): TeamDetailResponse =
+        TeamDetailResponse(
+            teamId = this.id,
+            name = this.name,
+            city = this.city,
+            abbreviation = this.abbreviation,
+            leagueName = this.league.name,
+            foundedYear = this.foundedYear,
+            memberCount = memberCount,
+        )
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamController.kt
@@ -6,6 +6,8 @@ import com.nextup.api.dto.team.TeamDetailResponse
 import com.nextup.api.dto.team.TeamSummaryResponse
 import com.nextup.api.dto.team.UpdateTeamRequest
 import com.nextup.common.exception.InsufficientTeamRoleException
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.common.exception.LeagueNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.LeagueRepositoryPort
@@ -49,11 +51,12 @@ class TeamController(
         @RequestBody @Valid request: CreateTeamRequest,
         @AuthenticationPrincipal userId: Long,
     ): ApiResponse<TeamDetailResponse> {
+        val leagueId =
+            request.leagueId
+                ?: throw InvalidInputException("INVALID_INPUT", "리그 ID는 필수입니다")
         val league =
-            request.leagueId?.let { leagueId ->
-                leagueRepository.findByIdOrNull(leagueId)
-                    ?: throw IllegalArgumentException("리그를 찾을 수 없습니다: $leagueId")
-            } ?: throw IllegalArgumentException("리그 ID는 필수입니다")
+            leagueRepository.findByIdOrNull(leagueId)
+                ?: throw LeagueNotFoundException(leagueId)
 
         val team =
             Team(

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMatchupController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMatchupController.kt
@@ -1,0 +1,75 @@
+package com.nextup.api.controller.team
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.team.TeamMatchupGameResponse
+import com.nextup.api.dto.team.TeamMatchupResponse
+import com.nextup.api.dto.team.toResponse
+import com.nextup.core.service.team.TeamMatchupService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 팀 간 상대 전적 API
+ *
+ * 두 팀 간의 대결 전적 및 최근 경기 기록을 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/teams")
+class TeamMatchupController(
+    private val teamMatchupService: TeamMatchupService,
+) {
+    /**
+     * 두 팀 간의 상대 전적을 조회합니다.
+     *
+     * GET /api/v1/teams/{teamId}/matchup/{opponentId}
+     *
+     * @param teamId 조회 대상 팀 ID
+     * @param opponentId 상대 팀 ID
+     * @param competitionId 대회 ID 필터 (선택사항)
+     * @return 팀 간 상대 전적 정보
+     */
+    @GetMapping("/{teamId}/matchup/{opponentId}")
+    fun getTeamMatchup(
+        @PathVariable teamId: Long,
+        @PathVariable opponentId: Long,
+        @RequestParam(required = false) competitionId: Long?,
+    ): ApiResponse<TeamMatchupResponse> {
+        val matchup =
+            teamMatchupService.getTeamMatchup(
+                teamId = teamId,
+                opponentId = opponentId,
+                competitionId = competitionId,
+            )
+        return ApiResponse.success(matchup.toResponse())
+    }
+
+    /**
+     * 두 팀 간의 최근 경기 목록을 조회합니다.
+     *
+     * GET /api/v1/teams/{teamId}/matchup/{opponentId}/games
+     *
+     * @param teamId 조회 대상 팀 ID
+     * @param opponentId 상대 팀 ID
+     * @param limit 조회할 경기 수 (기본값: 10, 최대: 50)
+     * @return 최근 교전 경기 목록
+     */
+    @GetMapping("/{teamId}/matchup/{opponentId}/games")
+    fun getRecentGames(
+        @PathVariable teamId: Long,
+        @PathVariable opponentId: Long,
+        @RequestParam(defaultValue = "10") limit: Int,
+    ): ApiResponse<List<TeamMatchupGameResponse>> {
+        val validatedLimit = limit.coerceIn(1, 50)
+
+        val games =
+            teamMatchupService.getRecentGames(
+                teamId = teamId,
+                opponentId = opponentId,
+                limit = validatedLimit,
+            )
+        return ApiResponse.success(games.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/title/TitleController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/title/TitleController.kt
@@ -1,0 +1,55 @@
+package com.nextup.api.controller.title
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.title.TitleListResponse
+import com.nextup.api.dto.title.TitleResponse
+import com.nextup.api.dto.title.toListResponse
+import com.nextup.api.dto.title.toResponse
+import com.nextup.core.service.title.TitleCategory
+import com.nextup.core.service.title.TitleService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 타이틀 컨트롤러
+ *
+ * 대회별 개인 타이틀(타격왕, 홈런왕 등) 조회 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/competitions/{competitionId}/titles")
+class TitleController(
+    private val titleService: TitleService,
+) {
+    /**
+     * 대회의 모든 타이틀을 조회합니다.
+     *
+     * @param competitionId 대회 ID
+     * @return 타이틀 목록
+     */
+    @GetMapping
+    fun getTitles(
+        @PathVariable competitionId: Long,
+    ): ApiResponse<TitleListResponse> {
+        val titles = titleService.getTitles(competitionId)
+        return ApiResponse.success(titles.toListResponse(competitionId))
+    }
+
+    /**
+     * 대회의 특정 카테고리 타이틀을 조회합니다.
+     *
+     * @param competitionId 대회 ID
+     * @param category 타이틀 카테고리 (BATTING_AVG, HOME_RUNS, RBI, STOLEN_BASES, HITS, WINS, ERA, SAVES, STRIKEOUTS)
+     * @return 타이틀 정보
+     */
+    @GetMapping("/{category}")
+    fun getTitleByCategory(
+        @PathVariable competitionId: Long,
+        @PathVariable category: String,
+    ): ApiResponse<TitleResponse> {
+        val titleCategory = TitleCategory.valueOf(category.uppercase())
+        val title = titleService.getTitleByCategory(competitionId, titleCategory)
+        return ApiResponse.success(title.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/appeal/AppealResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/appeal/AppealResponse.kt
@@ -1,0 +1,43 @@
+package com.nextup.api.dto.appeal
+
+import com.nextup.core.domain.appeal.Appeal
+import com.nextup.core.domain.appeal.AppealStatus
+import com.nextup.core.domain.appeal.AppealType
+import java.time.Instant
+import java.time.LocalDateTime
+
+/**
+ * 이의 제기 응답 DTO (공개 API용)
+ */
+data class AppealResponse(
+    val id: Long,
+    val gameId: Long,
+    val appealerId: Long,
+    val appealerName: String,
+    val type: AppealType,
+    val title: String,
+    val description: String,
+    val status: AppealStatus,
+    val reviewerId: Long?,
+    val reviewerComment: String?,
+    val reviewedAt: LocalDateTime?,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(appeal: Appeal): AppealResponse =
+            AppealResponse(
+                id = appeal.id,
+                gameId = appeal.game.id,
+                appealerId = appeal.appealerId,
+                appealerName = appeal.appealerName,
+                type = appeal.type,
+                title = appeal.title,
+                description = appeal.description,
+                status = appeal.status,
+                reviewerId = appeal.reviewerId,
+                reviewerComment = appeal.reviewerComment,
+                reviewedAt = appeal.reviewedAt,
+                createdAt = appeal.createdAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/appeal/CreateAppealApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/appeal/CreateAppealApiRequest.kt
@@ -1,0 +1,23 @@
+package com.nextup.api.dto.appeal
+
+import com.nextup.core.domain.appeal.AppealType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+
+/**
+ * 이의 제기 생성 요청 DTO (API)
+ */
+data class CreateAppealApiRequest(
+    @field:NotNull(message = "신청자 ID는 필수입니다")
+    @field:Positive(message = "신청자 ID는 양수여야 합니다")
+    val appealerId: Long,
+    @field:NotBlank(message = "신청자 이름은 필수입니다")
+    val appealerName: String,
+    @field:NotNull(message = "이의 제기 유형은 필수입니다")
+    val type: AppealType,
+    @field:NotBlank(message = "제목은 필수입니다")
+    val title: String,
+    @field:NotBlank(message = "상세 설명은 필수입니다")
+    val description: String,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/ActivityDto.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/ActivityDto.kt
@@ -1,0 +1,50 @@
+package com.nextup.api.dto.attendance
+
+import com.nextup.core.domain.attendance.ActivityScore
+import jakarta.validation.constraints.DecimalMax
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+
+/**
+ * 활동 점수 응답 DTO
+ */
+data class ActivityScoreResponse(
+    val id: Long,
+    val teamId: Long,
+    val memberId: Long,
+    val memberName: String,
+    val gameParticipationRate: BigDecimal,
+    val practiceAttendanceRate: BigDecimal,
+    val contributionScore: BigDecimal,
+    val totalScore: BigDecimal,
+    val createdAt: String,
+    val updatedAt: String,
+)
+
+/**
+ * 활동 점수 업데이트 요청 DTO
+ */
+data class UpdateActivityScoreRequest(
+    @field:NotNull(message = "점수는 필수입니다")
+    @field:DecimalMin(value = "0.00", message = "점수는 0 이상이어야 합니다")
+    @field:DecimalMax(value = "100.00", message = "점수는 100 이하여야 합니다")
+    val score: BigDecimal,
+)
+
+/**
+ * Extension Functions for Mapping
+ */
+fun ActivityScore.toResponse(): ActivityScoreResponse =
+    ActivityScoreResponse(
+        id = this.id,
+        teamId = this.team.id,
+        memberId = this.member.id,
+        memberName = this.member.player.name,
+        gameParticipationRate = this.gameParticipationRate,
+        practiceAttendanceRate = this.practiceAttendanceRate,
+        contributionScore = this.contributionScore,
+        totalScore = this.calculateTotalScore(),
+        createdAt = this.createdAt.toString(),
+        updatedAt = this.updatedAt.toString(),
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/AttendanceDto.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/AttendanceDto.kt
@@ -1,0 +1,108 @@
+package com.nextup.api.dto.attendance
+
+import com.nextup.core.domain.attendance.AttendancePoll
+import com.nextup.core.domain.attendance.AttendanceVote
+import com.nextup.core.domain.attendance.PollStatus
+import com.nextup.core.domain.attendance.VoteType
+import jakarta.validation.constraints.Future
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
+
+/**
+ * 출석 투표 생성 요청 DTO
+ */
+data class CreatePollRequest(
+    @field:NotBlank(message = "제목은 필수입니다")
+    val title: String,
+    @field:NotNull(message = "이벤트 날짜는 필수입니다")
+    @field:Future(message = "이벤트 날짜는 미래여야 합니다")
+    val eventDate: LocalDateTime,
+    @field:NotNull(message = "마감 시간은 필수입니다")
+    val deadline: LocalDateTime,
+)
+
+/**
+ * 출석 투표 응답 DTO
+ */
+data class PollResponse(
+    val id: Long,
+    val teamId: Long,
+    val title: String,
+    val eventDate: LocalDateTime,
+    val deadline: LocalDateTime,
+    val status: PollStatus,
+    val isExpired: Boolean,
+    val canVote: Boolean,
+    val createdAt: String,
+)
+
+/**
+ * 투표 제출 요청 DTO
+ */
+data class SubmitVoteRequest(
+    @field:NotNull(message = "선수 ID는 필수입니다")
+    val playerId: Long,
+    @field:NotNull(message = "투표 유형은 필수입니다")
+    val voteType: VoteType,
+)
+
+/**
+ * 투표 응답 DTO
+ */
+data class VoteResponse(
+    val id: Long,
+    val pollId: Long,
+    val playerId: Long,
+    val playerName: String,
+    val voteType: VoteType,
+    val createdAt: String,
+    val updatedAt: String,
+)
+
+/**
+ * 투표 통계 DTO
+ */
+data class PollStatisticsResponse(
+    val pollId: Long,
+    val totalVotes: Int,
+    val attendCount: Int,
+    val absentCount: Int,
+    val undecidedCount: Int,
+)
+
+/**
+ * Extension Functions for Mapping
+ */
+fun AttendancePoll.toResponse(): PollResponse =
+    PollResponse(
+        id = this.id,
+        teamId = this.team.id,
+        title = this.title,
+        eventDate = this.eventDate,
+        deadline = this.deadline,
+        status = this.status,
+        isExpired = this.isExpired(),
+        canVote = this.canVote(),
+        createdAt = this.createdAt.toString(),
+    )
+
+fun AttendanceVote.toResponse(): VoteResponse =
+    VoteResponse(
+        id = this.id,
+        pollId = this.poll.id,
+        playerId = this.player.id,
+        playerName = this.player.name,
+        voteType = this.voteType,
+        createdAt = this.createdAt.toString(),
+        updatedAt = this.updatedAt.toString(),
+    )
+
+fun List<AttendanceVote>.toStatistics(pollId: Long): PollStatisticsResponse =
+    PollStatisticsResponse(
+        pollId = pollId,
+        totalVotes = this.size,
+        attendCount = this.count { it.voteType == VoteType.ATTEND },
+        absentCount = this.count { it.voteType == VoteType.ABSENT },
+        undecidedCount = this.count { it.voteType == VoteType.UNDECIDED },
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/NudgeRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/NudgeRequest.kt
@@ -1,0 +1,8 @@
+package com.nextup.api.dto.attendance
+
+/**
+ * 출석 재촉 요청 DTO
+ */
+data class NudgeRequest(
+    val message: String? = null,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/NudgeResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/NudgeResponse.kt
@@ -1,0 +1,19 @@
+package com.nextup.api.dto.attendance
+
+import com.nextup.core.service.attendance.NudgeResult
+
+/**
+ * 출석 재촉 응답 DTO
+ */
+data class NudgeResponse(
+    val notifiedCount: Int,
+    val nonVoterNames: List<String>,
+) {
+    companion object {
+        fun from(result: NudgeResult): NudgeResponse =
+            NudgeResponse(
+                notifiedCount = result.notifiedCount,
+                nonVoterNames = result.nonVoterNames,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/bracket/BracketEntryResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/bracket/BracketEntryResponse.kt
@@ -1,0 +1,27 @@
+package com.nextup.api.dto.bracket
+
+data class BracketEntryResponse(
+    val id: Long,
+    val competitionId: Long,
+    val roundNumber: Int,
+    val matchNumber: Int,
+    val team1: TeamBriefResponse?,
+    val team2: TeamBriefResponse?,
+    val winner: TeamBriefResponse?,
+    val bracketType: String,
+    val seed1: Int?,
+    val seed2: Int?,
+    val isBye: Boolean,
+    val isCompleted: Boolean,
+)
+
+data class TeamBriefResponse(
+    val id: Long,
+    val name: String,
+    val city: String,
+)
+
+data class BracketResponse(
+    val competitionId: Long,
+    val entries: List<BracketEntryResponse>,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/bracket/BracketMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/bracket/BracketMapper.kt
@@ -1,0 +1,33 @@
+package com.nextup.api.dto.bracket
+
+import com.nextup.core.domain.competition.BracketEntry
+import com.nextup.core.domain.team.Team
+
+fun BracketEntry.toResponse(): BracketEntryResponse =
+    BracketEntryResponse(
+        id = this.id,
+        competitionId = this.competition.id,
+        roundNumber = this.roundNumber,
+        matchNumber = this.matchNumber,
+        team1 = this.team1?.toBriefResponse(),
+        team2 = this.team2?.toBriefResponse(),
+        winner = this.winner?.toBriefResponse(),
+        bracketType = this.bracketType,
+        seed1 = this.seed1,
+        seed2 = this.seed2,
+        isBye = this.isBye(),
+        isCompleted = this.isCompleted(),
+    )
+
+fun Team.toBriefResponse(): TeamBriefResponse =
+    TeamBriefResponse(
+        id = this.id,
+        name = this.name,
+        city = this.city,
+    )
+
+fun List<BracketEntry>.toBracketResponse(competitionId: Long): BracketResponse =
+    BracketResponse(
+        competitionId = competitionId,
+        entries = this.map { it.toResponse() },
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/certificate/CertificateResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/certificate/CertificateResponse.kt
@@ -1,0 +1,93 @@
+package com.nextup.api.dto.certificate
+
+import com.nextup.core.domain.certificate.CertificateStatus
+import java.time.Instant
+
+/**
+ * 증명서 발급 요청
+ */
+data class IssueCertificateRequest(
+    val validityDays: Long = 365,
+)
+
+/**
+ * 증명서 응답
+ */
+data class CertificateResponse(
+    val id: Long,
+    val issueNumber: String,
+    val playerId: Long,
+    val playerName: String,
+    val issuedAt: Instant,
+    val expiresAt: Instant,
+    val status: CertificateStatus,
+    val playerCareer: PlayerCareerResponse,
+    val qrCodeData: String,
+)
+
+/**
+ * 선수 경력 응답
+ */
+data class PlayerCareerResponse(
+    val totalGames: Int,
+    val battingStats: CareerBattingStatsResponse?,
+    val pitchingStats: CareerPitchingStatsResponse?,
+    val competitionHistory: List<CompetitionHistoryResponse>,
+)
+
+/**
+ * 통산 타격 기록 응답
+ */
+data class CareerBattingStatsResponse(
+    val games: Int,
+    val plateAppearances: Int,
+    val atBats: Int,
+    val hits: Int,
+    val doubles: Int,
+    val triples: Int,
+    val homeRuns: Int,
+    val runsBattedIn: Int,
+    val stolenBases: Int,
+    val battingAverage: Double,
+    val onBasePercentage: Double,
+    val sluggingPercentage: Double,
+)
+
+/**
+ * 통산 투수 기록 응답
+ */
+data class CareerPitchingStatsResponse(
+    val games: Int,
+    val wins: Int,
+    val losses: Int,
+    val saves: Int,
+    val holds: Int,
+    val inningsPitched: Double,
+    val strikeouts: Int,
+    val walks: Int,
+    val earnedRuns: Int,
+    val earnedRunAverage: Double,
+    val walksAndHitsPerInningPitched: Double,
+)
+
+/**
+ * 대회 이력 응답
+ */
+data class CompetitionHistoryResponse(
+    val year: Int,
+    val competitionName: String,
+    val teamName: String,
+    val games: Int,
+)
+
+/**
+ * 증명서 검증 응답
+ */
+data class CertificateVerificationResponse(
+    val valid: Boolean,
+    val issueNumber: String,
+    val playerName: String,
+    val issuedAt: Instant,
+    val expiresAt: Instant,
+    val status: CertificateStatus,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/competition/CompetitionResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/competition/CompetitionResponse.kt
@@ -23,6 +23,7 @@ data class CompetitionResponse(
     val status: CompetitionStatus,
     val description: String?,
     val maxTeams: Int?,
+    val playoffTeams: Int?,
 ) {
     companion object {
         fun from(competition: Competition): CompetitionResponse =
@@ -39,6 +40,7 @@ data class CompetitionResponse(
                 status = competition.status,
                 description = competition.description,
                 maxTeams = competition.maxTeams,
+                playoffTeams = competition.playoffTeams,
             )
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/discipline/DisciplineResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/discipline/DisciplineResponse.kt
@@ -1,0 +1,49 @@
+package com.nextup.api.dto.discipline
+
+import com.nextup.core.domain.discipline.Discipline
+import com.nextup.core.domain.discipline.DisciplineStatus
+import com.nextup.core.domain.discipline.DisciplineType
+import java.time.LocalDateTime
+
+/**
+ * 징계 응답 DTO (공개 API용)
+ *
+ * api 모듈에 독립적으로 존재
+ */
+data class DisciplineResponse(
+    val id: Long,
+    val type: DisciplineType,
+    val reason: String,
+    val suspensionGames: Int?,
+    val servedGames: Int,
+    val issuedAt: LocalDateTime,
+    val expiresAt: LocalDateTime?,
+    val status: DisciplineStatus,
+    val isEffective: Boolean,
+) {
+    companion object {
+        fun from(discipline: Discipline): DisciplineResponse =
+            DisciplineResponse(
+                id = discipline.id,
+                type = discipline.type,
+                reason = discipline.reason,
+                suspensionGames = discipline.suspensionGames,
+                servedGames = discipline.servedGames,
+                issuedAt = discipline.issuedAt,
+                expiresAt = discipline.expiresAt,
+                status = discipline.status,
+                isEffective = discipline.isEffective(),
+            )
+    }
+}
+
+/**
+ * 선수 징계 이력 응답 DTO
+ */
+data class PlayerDisciplineHistoryResponse(
+    val playerId: Long,
+    val playerName: String,
+    val totalDisciplines: Int,
+    val activeDisciplines: Int,
+    val disciplines: List<DisciplineResponse>,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/election/CastVoteApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/election/CastVoteApiRequest.kt
@@ -1,0 +1,24 @@
+package com.nextup.api.dto.election
+
+import com.nextup.core.service.election.dto.CastVoteRequest
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 투표 API 요청 DTO
+ */
+data class CastVoteApiRequest(
+    @field:NotNull(message = "투표자 ID는 필수입니다")
+    val voterId: Long,
+    @field:NotNull(message = "후보자 ID는 필수입니다")
+    val candidateId: Long,
+)
+
+/**
+ * API 요청을 Service 요청으로 변환합니다.
+ */
+fun CastVoteApiRequest.toServiceRequest(electionId: Long): CastVoteRequest =
+    CastVoteRequest(
+        electionId = electionId,
+        voterId = this.voterId,
+        candidateId = this.candidateId,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/election/CreateElectionApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/election/CreateElectionApiRequest.kt
@@ -1,0 +1,38 @@
+package com.nextup.api.dto.election
+
+import com.nextup.core.domain.election.ElectionType
+import com.nextup.core.service.election.dto.CreateElectionRequest
+import jakarta.validation.constraints.Future
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.Instant
+
+/**
+ * 선거 생성 API 요청 DTO
+ */
+data class CreateElectionApiRequest(
+    @field:NotBlank(message = "제목은 필수입니다")
+    val title: String,
+    val description: String?,
+    @field:NotNull(message = "선거 유형은 필수입니다")
+    val electionType: ElectionType,
+    @field:NotNull(message = "시작 시간은 필수입니다")
+    @field:Future(message = "시작 시간은 미래여야 합니다")
+    val startAt: Instant,
+    @field:NotNull(message = "종료 시간은 필수입니다")
+    @field:Future(message = "종료 시간은 미래여야 합니다")
+    val endAt: Instant,
+)
+
+/**
+ * API 요청을 Service 요청으로 변환합니다.
+ */
+fun CreateElectionApiRequest.toServiceRequest(teamId: Long): CreateElectionRequest =
+    CreateElectionRequest(
+        teamId = teamId,
+        title = this.title,
+        description = this.description,
+        electionType = this.electionType,
+        startAt = this.startAt,
+        endAt = this.endAt,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/election/RegisterCandidateApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/election/RegisterCandidateApiRequest.kt
@@ -1,0 +1,27 @@
+package com.nextup.api.dto.election
+
+import com.nextup.core.service.election.dto.RegisterCandidateRequest
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 후보자 등록 API 요청 DTO
+ */
+data class RegisterCandidateApiRequest(
+    @field:NotNull(message = "회원 ID는 필수입니다")
+    val memberId: Long,
+    @field:NotBlank(message = "회원 이름은 필수입니다")
+    val memberName: String,
+    val statement: String?,
+)
+
+/**
+ * API 요청을 Service 요청으로 변환합니다.
+ */
+fun RegisterCandidateApiRequest.toServiceRequest(electionId: Long): RegisterCandidateRequest =
+    RegisterCandidateRequest(
+        electionId = electionId,
+        memberId = this.memberId,
+        memberName = this.memberName,
+        statement = this.statement,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/GameScheduleResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/GameScheduleResponse.kt
@@ -1,0 +1,113 @@
+package com.nextup.api.dto.game
+
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.service.game.dto.GameDetailDto
+import com.nextup.core.service.game.dto.GameSummaryDto
+import java.time.LocalDateTime
+
+/**
+ * 경기 요약 응답 DTO
+ */
+data class GameSummaryResponse(
+    val gameId: Long,
+    val competitionId: Long,
+    val competitionName: String,
+    val homeTeam: GameTeamSummary,
+    val awayTeam: GameTeamSummary,
+    val scheduledAt: LocalDateTime,
+    val status: GameStatus,
+    val statusDisplayName: String,
+    val location: String?,
+    val fieldName: String?,
+) {
+    companion object {
+        fun from(dto: GameSummaryDto): GameSummaryResponse =
+            GameSummaryResponse(
+                gameId = dto.gameId,
+                competitionId = dto.competitionId,
+                competitionName = dto.competitionName,
+                homeTeam =
+                    GameTeamSummary(
+                        teamId = dto.homeTeamId,
+                        teamName = dto.homeTeamName,
+                        score = dto.homeScore,
+                    ),
+                awayTeam =
+                    GameTeamSummary(
+                        teamId = dto.awayTeamId,
+                        teamName = dto.awayTeamName,
+                        score = dto.awayScore,
+                    ),
+                scheduledAt = dto.scheduledAt,
+                status = dto.status,
+                statusDisplayName = dto.status.displayName,
+                location = dto.location,
+                fieldName = dto.fieldName,
+            )
+    }
+}
+
+/**
+ * 경기 참여 팀 요약
+ */
+data class GameTeamSummary(
+    val teamId: Long,
+    val teamName: String,
+    val score: Int,
+)
+
+/**
+ * 경기 상세 응답 DTO
+ */
+data class GameDetailResponse(
+    val gameId: Long,
+    val competitionId: Long,
+    val competitionName: String,
+    val homeTeam: GameTeamSummary,
+    val awayTeam: GameTeamSummary,
+    val scheduledAt: LocalDateTime,
+    val status: GameStatus,
+    val statusDisplayName: String,
+    val location: String?,
+    val fieldName: String?,
+    val gameNumber: Int?,
+    val currentInning: String,
+    val totalInnings: Int,
+    val startedAt: LocalDateTime?,
+    val endedAt: LocalDateTime?,
+    val note: String?,
+    val forfeitReason: String?,
+) {
+    companion object {
+        fun from(dto: GameDetailDto): GameDetailResponse =
+            GameDetailResponse(
+                gameId = dto.gameId,
+                competitionId = dto.competitionId,
+                competitionName = dto.competitionName,
+                homeTeam =
+                    GameTeamSummary(
+                        teamId = dto.homeTeamId,
+                        teamName = dto.homeTeamName,
+                        score = dto.homeScore,
+                    ),
+                awayTeam =
+                    GameTeamSummary(
+                        teamId = dto.awayTeamId,
+                        teamName = dto.awayTeamName,
+                        score = dto.awayScore,
+                    ),
+                scheduledAt = dto.scheduledAt,
+                status = dto.status,
+                statusDisplayName = dto.status.displayName,
+                location = dto.location,
+                fieldName = dto.fieldName,
+                gameNumber = dto.gameNumber,
+                currentInning = dto.currentInning,
+                totalInnings = dto.totalInnings,
+                startedAt = dto.startedAt,
+                endedAt = dto.endedAt,
+                note = dto.note,
+                forfeitReason = dto.forfeitReason,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/ScoresheetResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/ScoresheetResponse.kt
@@ -1,0 +1,128 @@
+package com.nextup.api.dto.game
+
+import java.time.LocalDateTime
+
+/**
+ * 공식 기록지 응답 DTO
+ */
+data class ScoresheetResponse(
+    val gameInfo: GameInfoResponse,
+    val teams: TeamsResponse,
+    val inningScores: InningScoresResponse,
+    val battingRecords: BattingRecordsResponse,
+    val pitchingRecords: PitchingRecordsResponse,
+    val keyEvents: List<KeyEventResponse>,
+)
+
+/**
+ * 경기 기본 정보 응답
+ */
+data class GameInfoResponse(
+    val gameId: Long,
+    val competitionName: String,
+    val gameNumber: Int?,
+    val scheduledAt: LocalDateTime,
+    val startedAt: LocalDateTime?,
+    val endedAt: LocalDateTime?,
+    val location: String?,
+    val fieldName: String?,
+    val status: String,
+    val currentInning: String,
+    val totalInnings: Int,
+)
+
+/**
+ * 양 팀 정보 응답
+ */
+data class TeamsResponse(
+    val home: TeamScoresheetResponse,
+    val away: TeamScoresheetResponse,
+)
+
+/**
+ * 팀 기록지 정보 응답
+ */
+data class TeamScoresheetResponse(
+    val teamId: Long,
+    val teamName: String,
+    val totalScore: Int,
+    val totalHits: Int,
+    val totalErrors: Int,
+    val result: String,
+)
+
+/**
+ * 이닝별 점수 응답
+ */
+data class InningScoresResponse(
+    val innings: Int,
+    val homeScores: List<Int>,
+    val awayScores: List<Int>,
+)
+
+/**
+ * 타격 기록 응답
+ */
+data class BattingRecordsResponse(
+    val home: List<BatterScoresheetResponse>,
+    val away: List<BatterScoresheetResponse>,
+)
+
+/**
+ * 타자 기록지 정보 응답
+ */
+data class BatterScoresheetResponse(
+    val playerId: Long,
+    val name: String,
+    val backNumber: Int?,
+    val position: String,
+    val battingOrder: Int?,
+    val plateAppearances: Int,
+    val atBats: Int,
+    val runs: Int,
+    val hits: Int,
+    val doubles: Int,
+    val triples: Int,
+    val homeRuns: Int,
+    val rbis: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val stolenBases: Int,
+    val avg: String,
+)
+
+/**
+ * 투수 기록 응답
+ */
+data class PitchingRecordsResponse(
+    val home: List<PitcherScoresheetResponse>,
+    val away: List<PitcherScoresheetResponse>,
+)
+
+/**
+ * 투수 기록지 정보 응답
+ */
+data class PitcherScoresheetResponse(
+    val playerId: Long,
+    val name: String,
+    val backNumber: Int?,
+    val isStartingPitcher: Boolean,
+    val inningsPitched: String,
+    val hitsAllowed: Int,
+    val runsAllowed: Int,
+    val earnedRuns: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val homeRunsAllowed: Int,
+    val decision: String?,
+    val era: String,
+)
+
+/**
+ * 주요 이벤트 응답
+ */
+data class KeyEventResponse(
+    val inning: String,
+    val description: String,
+    val timestamp: String,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/match/CreateMatchRequestApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/match/CreateMatchRequestApiRequest.kt
@@ -1,0 +1,17 @@
+package com.nextup.api.dto.match
+
+import com.nextup.core.domain.match.SkillLevel
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class CreateMatchRequestApiRequest(
+    @field:NotNull(message = "팀 ID는 필수입니다")
+    val teamId: Long,
+    @field:NotNull(message = "선호 날짜는 필수입니다")
+    val preferredDate: LocalDate,
+    val preferredTime: String?,
+    val preferredLocation: String?,
+    val message: String?,
+    @field:NotNull(message = "실력 수준은 필수입니다")
+    val skillLevel: SkillLevel,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/match/MatchRequestDetailResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/match/MatchRequestDetailResponse.kt
@@ -1,0 +1,42 @@
+package com.nextup.api.dto.match
+
+import com.nextup.core.domain.match.MatchRequest
+import com.nextup.core.domain.match.MatchRequestStatus
+import com.nextup.core.domain.match.MatchResponse
+import com.nextup.core.domain.match.SkillLevel
+import java.time.Instant
+import java.time.LocalDate
+
+data class MatchRequestDetailResponse(
+    val id: Long,
+    val teamId: Long,
+    val teamName: String,
+    val preferredDate: LocalDate,
+    val preferredTime: String?,
+    val preferredLocation: String?,
+    val message: String?,
+    val skillLevel: SkillLevel,
+    val status: MatchRequestStatus,
+    val createdAt: Instant,
+    val responses: List<MatchResponseResponse>,
+) {
+    companion object {
+        fun from(
+            matchRequest: MatchRequest,
+            responses: List<MatchResponse>,
+        ): MatchRequestDetailResponse =
+            MatchRequestDetailResponse(
+                id = matchRequest.id,
+                teamId = matchRequest.team.id,
+                teamName = matchRequest.team.name,
+                preferredDate = matchRequest.preferredDate,
+                preferredTime = matchRequest.preferredTime,
+                preferredLocation = matchRequest.preferredLocation,
+                message = matchRequest.message,
+                skillLevel = matchRequest.skillLevel,
+                status = matchRequest.status,
+                createdAt = matchRequest.createdAt,
+                responses = responses.map { MatchResponseResponse.from(it) },
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/match/MatchRequestResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/match/MatchRequestResponse.kt
@@ -1,0 +1,36 @@
+package com.nextup.api.dto.match
+
+import com.nextup.core.domain.match.MatchRequest
+import com.nextup.core.domain.match.MatchRequestStatus
+import com.nextup.core.domain.match.SkillLevel
+import java.time.Instant
+import java.time.LocalDate
+
+data class MatchRequestResponse(
+    val id: Long,
+    val teamId: Long,
+    val teamName: String,
+    val preferredDate: LocalDate,
+    val preferredTime: String?,
+    val preferredLocation: String?,
+    val message: String?,
+    val skillLevel: SkillLevel,
+    val status: MatchRequestStatus,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(matchRequest: MatchRequest): MatchRequestResponse =
+            MatchRequestResponse(
+                id = matchRequest.id,
+                teamId = matchRequest.team.id,
+                teamName = matchRequest.team.name,
+                preferredDate = matchRequest.preferredDate,
+                preferredTime = matchRequest.preferredTime,
+                preferredLocation = matchRequest.preferredLocation,
+                message = matchRequest.message,
+                skillLevel = matchRequest.skillLevel,
+                status = matchRequest.status,
+                createdAt = matchRequest.createdAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/match/MatchResponseResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/match/MatchResponseResponse.kt
@@ -1,0 +1,28 @@
+package com.nextup.api.dto.match
+
+import com.nextup.core.domain.match.MatchResponse
+import com.nextup.core.domain.match.MatchResponseStatus
+import java.time.Instant
+
+data class MatchResponseResponse(
+    val id: Long,
+    val matchRequestId: Long,
+    val respondTeamId: Long,
+    val respondTeamName: String,
+    val message: String?,
+    val status: MatchResponseStatus,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(matchResponse: MatchResponse): MatchResponseResponse =
+            MatchResponseResponse(
+                id = matchResponse.id,
+                matchRequestId = matchResponse.matchRequest.id,
+                respondTeamId = matchResponse.respondTeam.id,
+                respondTeamName = matchResponse.respondTeam.name,
+                message = matchResponse.message,
+                status = matchResponse.status,
+                createdAt = matchResponse.createdAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/match/RespondToMatchRequestApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/match/RespondToMatchRequestApiRequest.kt
@@ -1,0 +1,9 @@
+package com.nextup.api.dto.match
+
+import jakarta.validation.constraints.NotNull
+
+data class RespondToMatchRequestApiRequest(
+    @field:NotNull(message = "응답 팀 ID는 필수입니다")
+    val respondTeamId: Long,
+    val message: String?,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/DeviceTokenResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/DeviceTokenResponse.kt
@@ -1,0 +1,27 @@
+package com.nextup.api.dto.notification
+
+import com.nextup.core.domain.notification.DevicePlatform
+import com.nextup.core.domain.notification.DeviceToken
+import java.time.Instant
+
+/**
+ * 디바이스 토큰 응답 DTO
+ */
+data class DeviceTokenResponse(
+    val id: Long,
+    val userId: Long,
+    val token: String,
+    val platform: DevicePlatform,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(deviceToken: DeviceToken): DeviceTokenResponse =
+            DeviceTokenResponse(
+                id = deviceToken.id,
+                userId = deviceToken.userId,
+                token = deviceToken.token,
+                platform = deviceToken.platform,
+                createdAt = deviceToken.createdAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/NotificationPreferenceResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/NotificationPreferenceResponse.kt
@@ -1,0 +1,27 @@
+package com.nextup.api.dto.notification
+
+import com.nextup.core.domain.notification.NotificationPreference
+import com.nextup.core.domain.notification.NotificationType
+import java.time.Instant
+
+/**
+ * 알림 설정 응답 DTO
+ */
+data class NotificationPreferenceResponse(
+    val id: Long,
+    val userId: Long,
+    val type: NotificationType,
+    val enabled: Boolean,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(preference: NotificationPreference): NotificationPreferenceResponse =
+            NotificationPreferenceResponse(
+                id = preference.id,
+                userId = preference.userId,
+                type = preference.type,
+                enabled = preference.enabled,
+                createdAt = preference.createdAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/NotificationResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/NotificationResponse.kt
@@ -1,0 +1,36 @@
+package com.nextup.api.dto.notification
+
+import com.nextup.core.domain.notification.Notification
+import com.nextup.core.domain.notification.NotificationType
+import java.time.Instant
+import java.time.LocalDateTime
+
+/**
+ * 알림 응답 DTO
+ */
+data class NotificationResponse(
+    val id: Long,
+    val userId: Long,
+    val type: NotificationType,
+    val title: String,
+    val body: String,
+    val data: String?,
+    val readAt: LocalDateTime?,
+    val sentAt: LocalDateTime?,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(notification: Notification): NotificationResponse =
+            NotificationResponse(
+                id = notification.id,
+                userId = notification.userId,
+                type = notification.type,
+                title = notification.title,
+                body = notification.body,
+                data = notification.data,
+                readAt = notification.readAt,
+                sentAt = notification.sentAt,
+                createdAt = notification.createdAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/RegisterDeviceApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/RegisterDeviceApiRequest.kt
@@ -1,0 +1,15 @@
+package com.nextup.api.dto.notification
+
+import com.nextup.core.domain.notification.DevicePlatform
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 디바이스 토큰 등록 요청 DTO
+ */
+data class RegisterDeviceApiRequest(
+    @field:NotBlank(message = "토큰은 필수입니다")
+    val token: String,
+    @field:NotNull(message = "플랫폼은 필수입니다")
+    val platform: DevicePlatform,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/UpdatePreferenceApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/UpdatePreferenceApiRequest.kt
@@ -1,0 +1,14 @@
+package com.nextup.api.dto.notification
+
+import com.nextup.core.domain.notification.NotificationType
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 알림 설정 수정 요청 DTO
+ */
+data class UpdatePreferenceApiRequest(
+    @field:NotNull(message = "알림 타입은 필수입니다")
+    val type: NotificationType,
+    @field:NotNull(message = "활성화 여부는 필수입니다")
+    val enabled: Boolean,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/pitch/BallCountResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/pitch/BallCountResponse.kt
@@ -1,0 +1,22 @@
+package com.nextup.api.dto.pitch
+
+/**
+ * 볼카운트 응답 DTO
+ */
+data class BallCountResponse(
+    val balls: Int,
+    val strikes: Int,
+    val countDisplay: String,
+) {
+    companion object {
+        fun of(
+            balls: Int,
+            strikes: Int,
+        ): BallCountResponse =
+            BallCountResponse(
+                balls = balls,
+                strikes = strikes,
+                countDisplay = "${balls}B-${strikes}S",
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/pitch/PitchEventResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/pitch/PitchEventResponse.kt
@@ -1,0 +1,45 @@
+package com.nextup.api.dto.pitch
+
+import com.nextup.core.domain.game.PitchEvent
+import com.nextup.core.domain.game.PitchResult
+import java.time.Instant
+
+/**
+ * 투구 이벤트 응답 DTO (Public API)
+ */
+data class PitchEventResponse(
+    val id: Long,
+    val gameId: Long,
+    val inning: Int,
+    val isTopInning: Boolean,
+    val pitchNumber: Int,
+    val result: PitchResult,
+    val ballCount: Int,
+    val strikeCount: Int,
+    val description: String?,
+    val countDisplay: String,
+    val createdAt: Instant,
+)
+
+/**
+ * Entity → Response DTO 변환
+ */
+fun PitchEvent.toResponse(): PitchEventResponse =
+    PitchEventResponse(
+        id = this.id,
+        gameId = this.game.id,
+        inning = this.inning,
+        isTopInning = this.isTopInning,
+        pitchNumber = this.pitchNumber,
+        result = this.result,
+        ballCount = this.ballCount,
+        strikeCount = this.strikeCount,
+        description = this.description,
+        countDisplay = this.countDisplay,
+        createdAt = this.createdAt,
+    )
+
+/**
+ * List 변환
+ */
+fun List<PitchEvent>.toResponse(): List<PitchEventResponse> = this.map { it.toResponse() }

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/pitch/PitcherStatsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/pitch/PitcherStatsResponse.kt
@@ -1,0 +1,30 @@
+package com.nextup.api.dto.pitch
+
+import com.nextup.core.service.PitcherPitchStats
+
+/**
+ * 투수 투구 통계 응답 DTO
+ */
+data class PitcherStatsResponse(
+    val totalPitches: Int,
+    val strikes: Int,
+    val balls: Int,
+    val fouls: Int,
+    val inPlayPitches: Int,
+    val strikePercentage: Double,
+    val avgPitchesPerAtBat: Double,
+)
+
+/**
+ * PitcherPitchStats → Response DTO 변환
+ */
+fun PitcherPitchStats.toResponse(): PitcherStatsResponse =
+    PitcherStatsResponse(
+        totalPitches = this.totalPitches,
+        strikes = this.strikes,
+        balls = this.balls,
+        fouls = this.fouls,
+        inPlayPitches = this.inPlayPitches,
+        strikePercentage = this.strikePercentage,
+        avgPitchesPerAtBat = this.avgPitchesPerAtBat,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/recruitment/CreateRecruitmentApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/recruitment/CreateRecruitmentApiRequest.kt
@@ -1,0 +1,24 @@
+package com.nextup.api.dto.recruitment
+
+import jakarta.validation.constraints.Future
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+/**
+ * 팀 모집 공고 생성 요청 DTO (API)
+ */
+data class CreateRecruitmentApiRequest(
+    @field:NotBlank(message = "제목은 필수입니다")
+    val title: String,
+    @field:NotBlank(message = "설명은 필수입니다")
+    val description: String,
+    @field:NotBlank(message = "모집 포지션은 필수입니다")
+    val positionsNeeded: String,
+    val ageRange: String?,
+    val skillLevel: String?,
+    val location: String?,
+    @field:NotNull(message = "마감일은 필수입니다")
+    @field:Future(message = "마감일은 현재 날짜보다 이후여야 합니다")
+    val deadline: LocalDate,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/recruitment/RecruitmentResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/recruitment/RecruitmentResponse.kt
@@ -1,0 +1,44 @@
+package com.nextup.api.dto.recruitment
+
+import com.nextup.core.domain.recruitment.RecruitmentStatus
+import com.nextup.core.domain.recruitment.TeamRecruitment
+import java.time.Instant
+import java.time.LocalDate
+
+/**
+ * 팀 모집 공고 응답 DTO (공개 API용)
+ */
+data class RecruitmentResponse(
+    val id: Long,
+    val teamId: Long,
+    val teamName: String,
+    val title: String,
+    val description: String,
+    val positionsNeeded: String,
+    val ageRange: String?,
+    val skillLevel: String?,
+    val location: String?,
+    val deadline: LocalDate,
+    val status: RecruitmentStatus,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(recruitment: TeamRecruitment): RecruitmentResponse =
+            RecruitmentResponse(
+                id = recruitment.id,
+                teamId = recruitment.team.id,
+                teamName = recruitment.team.name,
+                title = recruitment.title,
+                description = recruitment.description,
+                positionsNeeded = recruitment.positionsNeeded,
+                ageRange = recruitment.ageRange,
+                skillLevel = recruitment.skillLevel,
+                location = recruitment.location,
+                deadline = recruitment.deadline,
+                status = recruitment.status,
+                createdAt = recruitment.createdAt,
+                updatedAt = recruitment.updatedAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/recruitment/UpdateRecruitmentApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/recruitment/UpdateRecruitmentApiRequest.kt
@@ -1,0 +1,15 @@
+package com.nextup.api.dto.recruitment
+
+import jakarta.validation.constraints.Future
+import java.time.LocalDate
+
+/**
+ * 팀 모집 공고 수정 요청 DTO (API)
+ */
+data class UpdateRecruitmentApiRequest(
+    val title: String?,
+    val description: String?,
+    val positionsNeeded: String?,
+    @field:Future(message = "마감일은 현재 날짜보다 이후여야 합니다")
+    val deadline: LocalDate?,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/report/CompetitionReportMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/report/CompetitionReportMapper.kt
@@ -1,0 +1,57 @@
+package com.nextup.api.dto.report
+
+import com.nextup.api.dto.standings.TeamStandingResponse
+import com.nextup.core.service.report.dto.CompetitionReportDto
+import com.nextup.core.service.report.dto.CompetitionSummaryDto
+import com.nextup.core.service.report.dto.HighScoringGameDto
+import com.nextup.core.service.report.dto.WinStreakDto
+
+/**
+ * CompetitionReportDto → CompetitionReportResponse 변환
+ */
+fun CompetitionReportDto.toResponse(): CompetitionReportResponse =
+    CompetitionReportResponse(
+        competitionId = this.competitionId,
+        competitionName = this.competitionName,
+        season = this.season,
+        standings = this.standings.map { TeamStandingResponse.from(it) },
+        summary = this.summary.toResponse(),
+    )
+
+/**
+ * CompetitionSummaryDto → CompetitionSummaryResponse 변환
+ */
+fun CompetitionSummaryDto.toResponse(): CompetitionSummaryResponse =
+    CompetitionSummaryResponse(
+        competitionId = this.competitionId,
+        totalGames = this.totalGames,
+        completedGames = this.completedGames,
+        totalRuns = this.totalRuns,
+        averageRunsPerGame = this.averageRunsPerGame,
+        totalHits = this.totalHits,
+        totalHomeRuns = this.totalHomeRuns,
+        totalStrikeouts = this.totalStrikeouts,
+        highestScoringGame = this.highestScoringGame?.toResponse(),
+        longestWinStreak = this.longestWinStreak?.toResponse(),
+    )
+
+/**
+ * HighScoringGameDto → HighScoringGameResponse 변환
+ */
+fun HighScoringGameDto.toResponse(): HighScoringGameResponse =
+    HighScoringGameResponse(
+        gameId = this.gameId,
+        homeTeamName = this.homeTeamName,
+        awayTeamName = this.awayTeamName,
+        totalRuns = this.totalRuns,
+        date = this.date,
+    )
+
+/**
+ * WinStreakDto → WinStreakResponse 변환
+ */
+fun WinStreakDto.toResponse(): WinStreakResponse =
+    WinStreakResponse(
+        teamName = this.teamName,
+        streakLength = this.streakLength,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/report/CompetitionReportResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/report/CompetitionReportResponse.kt
@@ -1,0 +1,14 @@
+package com.nextup.api.dto.report
+
+import com.nextup.api.dto.standings.TeamStandingResponse
+
+/**
+ * 대회 리포트 응답 DTO
+ */
+data class CompetitionReportResponse(
+    val competitionId: Long,
+    val competitionName: String,
+    val season: Int,
+    val standings: List<TeamStandingResponse>,
+    val summary: CompetitionSummaryResponse,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/report/CompetitionSummaryResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/report/CompetitionSummaryResponse.kt
@@ -1,0 +1,17 @@
+package com.nextup.api.dto.report
+
+/**
+ * 대회 요약 응답 DTO
+ */
+data class CompetitionSummaryResponse(
+    val competitionId: Long,
+    val totalGames: Int,
+    val completedGames: Int,
+    val totalRuns: Int,
+    val averageRunsPerGame: Double,
+    val totalHits: Int,
+    val totalHomeRuns: Int,
+    val totalStrikeouts: Int,
+    val highestScoringGame: HighScoringGameResponse?,
+    val longestWinStreak: WinStreakResponse?,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/report/HighScoringGameResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/report/HighScoringGameResponse.kt
@@ -1,0 +1,14 @@
+package com.nextup.api.dto.report
+
+import java.time.LocalDate
+
+/**
+ * 최다 득점 경기 응답 DTO
+ */
+data class HighScoringGameResponse(
+    val gameId: Long,
+    val homeTeamName: String,
+    val awayTeamName: String,
+    val totalRuns: Int,
+    val date: LocalDate,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/report/WinStreakResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/report/WinStreakResponse.kt
@@ -1,0 +1,9 @@
+package com.nextup.api.dto.report
+
+/**
+ * 연승 기록 응답 DTO
+ */
+data class WinStreakResponse(
+    val teamName: String,
+    val streakLength: Int,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/schedule/ScheduleResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/schedule/ScheduleResponse.kt
@@ -1,0 +1,61 @@
+package com.nextup.api.dto.schedule
+
+import com.nextup.core.domain.schedule.LeagueSchedule
+import com.nextup.core.domain.schedule.ScheduleStatus
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 대진표 응답 DTO (API - 조회 전용)
+ *
+ * 일반 사용자용 대진표 정보
+ */
+data class ScheduleResponse(
+    val id: Long,
+    val competitionId: Long,
+    val round: Int,
+    val matchNumber: Int,
+    val homeTeam: ScheduleTeamResponse,
+    val awayTeam: ScheduleTeamResponse,
+    val scheduledDate: LocalDate,
+    val scheduledTime: LocalTime?,
+    val venue: String?,
+    val status: ScheduleStatus,
+    val gameId: Long?,
+) {
+    companion object {
+        fun from(schedule: LeagueSchedule): ScheduleResponse =
+            ScheduleResponse(
+                id = schedule.id,
+                competitionId = schedule.competition.id,
+                round = schedule.round,
+                matchNumber = schedule.matchNumber,
+                homeTeam =
+                    ScheduleTeamResponse(
+                        id = schedule.homeTeam.id,
+                        name = schedule.homeTeam.name,
+                        abbreviation = schedule.homeTeam.abbreviation,
+                    ),
+                awayTeam =
+                    ScheduleTeamResponse(
+                        id = schedule.awayTeam.id,
+                        name = schedule.awayTeam.name,
+                        abbreviation = schedule.awayTeam.abbreviation,
+                    ),
+                scheduledDate = schedule.scheduledDate,
+                scheduledTime = schedule.scheduledTime,
+                venue = schedule.venue,
+                status = schedule.status,
+                gameId = schedule.game?.id,
+            )
+    }
+}
+
+/**
+ * 대진표 내 팀 정보
+ */
+data class ScheduleTeamResponse(
+    val id: Long,
+    val name: String,
+    val abbreviation: String?,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/BookingResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/BookingResponse.kt
@@ -1,0 +1,33 @@
+package com.nextup.api.dto.stadium
+
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.domain.stadium.StadiumBooking
+import java.time.Instant
+
+/**
+ * 구장 예약 응답 DTO
+ */
+data class BookingResponse(
+    val id: Long,
+    val slotId: Long,
+    val teamId: Long,
+    val bookedBy: Long,
+    val status: BookingStatus,
+    val bookedAt: Instant,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(booking: StadiumBooking): BookingResponse =
+            BookingResponse(
+                id = booking.id,
+                slotId = booking.slot.id,
+                teamId = booking.teamId,
+                bookedBy = booking.bookedBy,
+                status = booking.status,
+                bookedAt = booking.bookedAt,
+                createdAt = booking.createdAt,
+                updatedAt = booking.updatedAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/StadiumResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/StadiumResponse.kt
@@ -1,0 +1,40 @@
+package com.nextup.api.dto.stadium
+
+import com.nextup.core.domain.stadium.Stadium
+import java.time.Instant
+
+/**
+ * 구장 응답 DTO
+ */
+data class StadiumResponse(
+    val id: Long,
+    val name: String,
+    val address: String,
+    val latitude: Double,
+    val longitude: Double,
+    val capacity: Int?,
+    val facilities: String?,
+    val contactInfo: String?,
+    val imageUrls: String?,
+    val isActive: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(stadium: Stadium): StadiumResponse =
+            StadiumResponse(
+                id = stadium.id,
+                name = stadium.name,
+                address = stadium.address,
+                latitude = stadium.latitude,
+                longitude = stadium.longitude,
+                capacity = stadium.capacity,
+                facilities = stadium.facilities,
+                contactInfo = stadium.contactInfo,
+                imageUrls = stadium.imageUrls,
+                isActive = stadium.isActive,
+                createdAt = stadium.createdAt,
+                updatedAt = stadium.updatedAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/StadiumSlotResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/StadiumSlotResponse.kt
@@ -1,0 +1,40 @@
+package com.nextup.api.dto.stadium
+
+import com.nextup.core.domain.stadium.SlotStatus
+import com.nextup.core.domain.stadium.StadiumSlot
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 구장 슬롯 응답 DTO
+ */
+data class StadiumSlotResponse(
+    val id: Long,
+    val stadiumId: Long,
+    val stadiumName: String,
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val price: BigDecimal?,
+    val status: SlotStatus,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(slot: StadiumSlot): StadiumSlotResponse =
+            StadiumSlotResponse(
+                id = slot.id,
+                stadiumId = slot.stadium.id,
+                stadiumName = slot.stadium.name,
+                date = slot.date,
+                startTime = slot.startTime,
+                endTime = slot.endTime,
+                price = slot.price,
+                status = slot.status,
+                createdAt = slot.createdAt,
+                updatedAt = slot.updatedAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/standings/StandingsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/standings/StandingsResponse.kt
@@ -16,15 +16,26 @@ data class StandingsResponse(
     val totalGamesPerTeam: Int,
     val standings: List<TeamStandingResponse>,
     val lastUpdated: LocalDateTime,
+    val playoffCutoff: Int?,
 ) {
     companion object {
-        fun from(dto: StandingsDto): StandingsResponse =
+        fun from(
+            dto: StandingsDto,
+            playoffCutoff: Int? = null,
+        ): StandingsResponse =
             StandingsResponse(
                 competitionId = dto.competitionId,
                 competitionName = dto.competitionName,
                 totalGamesPerTeam = dto.totalGamesPerTeam,
-                standings = dto.standings.map { TeamStandingResponse.from(it) },
+                standings =
+                    dto.standings.map { standing ->
+                        TeamStandingResponse.from(
+                            dto = standing,
+                            isPlayoffPosition = playoffCutoff != null && standing.rank <= playoffCutoff,
+                        )
+                    },
                 lastUpdated = dto.lastUpdated,
+                playoffCutoff = playoffCutoff,
             )
     }
 }
@@ -46,9 +57,13 @@ data class TeamStandingResponse(
     val runsScored: Int,
     val runsAllowed: Int,
     val runDifferential: Int,
+    val isPlayoffPosition: Boolean,
 ) {
     companion object {
-        fun from(dto: TeamStandingDto): TeamStandingResponse =
+        fun from(
+            dto: TeamStandingDto,
+            isPlayoffPosition: Boolean = false,
+        ): TeamStandingResponse =
             TeamStandingResponse(
                 rank = dto.rank,
                 teamId = dto.teamId,
@@ -63,6 +78,7 @@ data class TeamStandingResponse(
                 runsScored = dto.runsScored,
                 runsAllowed = dto.runsAllowed,
                 runDifferential = dto.runDifferential,
+                isPlayoffPosition = isPlayoffPosition,
             )
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/LeaderboardResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/LeaderboardResponse.kt
@@ -1,0 +1,21 @@
+package com.nextup.api.dto.stats
+
+data class BattingLeaderResponse(
+    val rank: Int,
+    val playerId: Long,
+    val playerName: String,
+    val teamName: String,
+    val value: Double,
+    val games: Int,
+    val plateAppearances: Int,
+)
+
+data class PitchingLeaderResponse(
+    val rank: Int,
+    val playerId: Long,
+    val playerName: String,
+    val teamName: String,
+    val value: Double,
+    val games: Int,
+    val inningsPitched: Double,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/team/TeamMatchupResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/team/TeamMatchupResponse.kt
@@ -1,0 +1,108 @@
+package com.nextup.api.dto.team
+
+import com.nextup.core.service.team.dto.TeamMatchupDto
+import com.nextup.core.service.team.dto.TeamMatchupGameDto
+import java.time.LocalDate
+
+/**
+ * 팀 간 상대 전적 응답 DTO
+ */
+data class TeamMatchupResponse(
+    val teamId: Long,
+    val teamName: String,
+    val opponentId: Long,
+    val opponentName: String,
+    val record: RecordSummary,
+    val runs: RunsSummary,
+)
+
+/**
+ * 전적 요약
+ */
+data class RecordSummary(
+    val wins: Int,
+    val losses: Int,
+    val draws: Int,
+    val totalGames: Int,
+    val winRate: Double,
+)
+
+/**
+ * 득실점 요약
+ */
+data class RunsSummary(
+    val runsScored: Int,
+    val runsAllowed: Int,
+    val avgRunsScored: Double,
+    val avgRunsAllowed: Double,
+    val runDifferential: Int,
+)
+
+/**
+ * 팀 간 교전 경기 응답 DTO
+ */
+data class TeamMatchupGameResponse(
+    val gameId: Long,
+    val date: LocalDate,
+    val homeTeamId: Long,
+    val awayTeamId: Long,
+    val homeScore: Int,
+    val awayScore: Int,
+    val result: String,
+    val venue: String?,
+)
+
+/**
+ * TeamMatchupDto를 TeamMatchupResponse로 변환
+ */
+fun TeamMatchupDto.toResponse(): TeamMatchupResponse {
+    val winRate =
+        if (totalGames > 0) {
+            wins.toDouble() / totalGames
+        } else {
+            0.0
+        }
+
+    return TeamMatchupResponse(
+        teamId = teamId,
+        teamName = teamName,
+        opponentId = opponentId,
+        opponentName = opponentName,
+        record =
+            RecordSummary(
+                wins = wins,
+                losses = losses,
+                draws = draws,
+                totalGames = totalGames,
+                winRate = winRate,
+            ),
+        runs =
+            RunsSummary(
+                runsScored = runsScored,
+                runsAllowed = runsAllowed,
+                avgRunsScored = avgRunsScored,
+                avgRunsAllowed = avgRunsAllowed,
+                runDifferential = runsScored - runsAllowed,
+            ),
+    )
+}
+
+/**
+ * TeamMatchupGameDto를 TeamMatchupGameResponse로 변환
+ */
+fun TeamMatchupGameDto.toResponse(): TeamMatchupGameResponse =
+    TeamMatchupGameResponse(
+        gameId = gameId,
+        date = date,
+        homeTeamId = homeTeamId,
+        awayTeamId = awayTeamId,
+        homeScore = homeScore,
+        awayScore = awayScore,
+        result = result,
+        venue = venue,
+    )
+
+/**
+ * List<TeamMatchupGameDto>를 List<TeamMatchupGameResponse>로 변환
+ */
+fun List<TeamMatchupGameDto>.toResponse(): List<TeamMatchupGameResponse> = map { it.toResponse() }

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/team/TeamRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/team/TeamRequest.kt
@@ -1,0 +1,36 @@
+package com.nextup.api.dto.team
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+/**
+ * 팀 생성 요청 DTO
+ */
+data class CreateTeamRequest(
+    @field:NotBlank(message = "팀 이름은 필수입니다")
+    @field:Size(max = 100, message = "팀 이름은 100자 이하여야 합니다")
+    val name: String,
+    @field:NotBlank(message = "도시는 필수입니다")
+    @field:Size(max = 100, message = "도시는 100자 이하여야 합니다")
+    val city: String,
+    val leagueId: Long? = null,
+    @field:Size(max = 20, message = "약어는 20자 이하여야 합니다")
+    val abbreviation: String? = null,
+    @field:Min(value = 1, message = "등번호는 1 이상이어야 합니다")
+    @field:Max(value = 99, message = "등번호는 99 이하여야 합니다")
+    val uniformNumber: Int = 1,
+)
+
+/**
+ * 팀 수정 요청 DTO
+ */
+data class UpdateTeamRequest(
+    @field:Size(max = 100, message = "팀 이름은 100자 이하여야 합니다")
+    val name: String? = null,
+    @field:Size(max = 100, message = "도시는 100자 이하여야 합니다")
+    val city: String? = null,
+    @field:Size(max = 20, message = "약어는 20자 이하여야 합니다")
+    val abbreviation: String? = null,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/team/TeamResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/team/TeamResponse.kt
@@ -1,0 +1,19 @@
+package com.nextup.api.dto.team
+
+data class TeamSummaryResponse(
+    val teamId: Long,
+    val name: String,
+    val city: String,
+    val abbreviation: String?,
+    val memberCount: Int,
+)
+
+data class TeamDetailResponse(
+    val teamId: Long,
+    val name: String,
+    val city: String,
+    val abbreviation: String?,
+    val leagueName: String?,
+    val foundedYear: Int,
+    val memberCount: Int,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/title/TitleResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/title/TitleResponse.kt
@@ -1,0 +1,91 @@
+package com.nextup.api.dto.title
+
+import com.nextup.core.service.title.dto.TitleCandidateDto
+import com.nextup.core.service.title.dto.TitleDto
+import com.nextup.core.service.title.dto.TitleWinnerDto
+
+/**
+ * 타이틀 목록 응답
+ */
+data class TitleListResponse(
+    val competitionId: Long,
+    val titles: List<TitleResponse>,
+)
+
+/**
+ * 타이틀 응답
+ */
+data class TitleResponse(
+    val category: String,
+    val displayName: String,
+    val winner: TitleWinnerResponse?,
+    val topCandidates: List<TitleCandidateResponse>,
+)
+
+/**
+ * 타이틀 수상자 응답
+ */
+data class TitleWinnerResponse(
+    val playerId: Long,
+    val playerName: String,
+    val teamName: String,
+    val statValue: Double,
+)
+
+/**
+ * 타이틀 후보자 응답
+ */
+data class TitleCandidateResponse(
+    val rank: Int,
+    val playerId: Long,
+    val playerName: String,
+    val teamName: String,
+    val statValue: Double,
+    val isQualified: Boolean,
+)
+
+// ========== Extension Functions (Mappers) ==========
+
+/**
+ * TitleDto를 TitleResponse로 변환합니다.
+ */
+fun TitleDto.toResponse(): TitleResponse =
+    TitleResponse(
+        category = this.category.name,
+        displayName = this.displayName,
+        winner = this.winner?.toResponse(),
+        topCandidates = this.topCandidates.map { it.toResponse() },
+    )
+
+/**
+ * TitleWinnerDto를 TitleWinnerResponse로 변환합니다.
+ */
+fun TitleWinnerDto.toResponse(): TitleWinnerResponse =
+    TitleWinnerResponse(
+        playerId = this.playerId,
+        playerName = this.playerName,
+        teamName = this.teamName,
+        statValue = this.statValue,
+    )
+
+/**
+ * TitleCandidateDto를 TitleCandidateResponse로 변환합니다.
+ */
+fun TitleCandidateDto.toResponse(): TitleCandidateResponse =
+    TitleCandidateResponse(
+        rank = this.rank,
+        playerId = this.playerId,
+        playerName = this.playerName,
+        teamName = this.teamName,
+        statValue = this.statValue,
+        isQualified = this.isQualified,
+    )
+
+/**
+ * List<TitleDto>를 TitleListResponse로 변환합니다.
+ */
+fun List<TitleDto>.toListResponse(competitionId: Long): TitleListResponse =
+    TitleListResponse(
+        competitionId = competitionId,
+        titles = this.map { it.toResponse() },
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
@@ -8,7 +8,9 @@ import com.nextup.common.exception.NotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -46,6 +48,26 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadableException(
+        ex: HttpMessageNotReadableException,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("HttpMessageNotReadableException: {}", ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("INVALID_REQUEST", "요청 본문을 읽을 수 없습니다"))
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    fun handleMissingServletRequestParameterException(
+        ex: MissingServletRequestParameterException,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("MissingServletRequestParameterException: {}", ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("MISSING_PARAMETER", ex.message))
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/certificate/CertificateMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/certificate/CertificateMapper.kt
@@ -1,0 +1,97 @@
+package com.nextup.api.mapper.certificate
+
+import com.nextup.api.dto.certificate.*
+import com.nextup.core.dto.certificate.*
+
+/**
+ * CertificateDto를 CertificateResponse로 변환합니다.
+ */
+fun CertificateDto.toResponse(): CertificateResponse =
+    CertificateResponse(
+        id = this.id,
+        issueNumber = this.issueNumber,
+        playerId = this.playerId,
+        playerName = this.playerName,
+        issuedAt = this.issuedAt,
+        expiresAt = this.expiresAt,
+        status = this.status,
+        playerCareer = this.playerCareer.toResponse(),
+        qrCodeData = this.qrCodeData,
+    )
+
+/**
+ * PlayerCareerDto를 PlayerCareerResponse로 변환합니다.
+ */
+fun PlayerCareerDto.toResponse(): PlayerCareerResponse =
+    PlayerCareerResponse(
+        totalGames = this.totalGames,
+        battingStats = this.battingStats?.toResponse(),
+        pitchingStats = this.pitchingStats?.toResponse(),
+        competitionHistory = this.competitionHistory.map { it.toResponse() },
+    )
+
+/**
+ * CareerBattingStatsDto를 CareerBattingStatsResponse로 변환합니다.
+ */
+fun CareerBattingStatsDto.toResponse(): CareerBattingStatsResponse =
+    CareerBattingStatsResponse(
+        games = this.games,
+        plateAppearances = this.plateAppearances,
+        atBats = this.atBats,
+        hits = this.hits,
+        doubles = this.doubles,
+        triples = this.triples,
+        homeRuns = this.homeRuns,
+        runsBattedIn = this.runsBattedIn,
+        stolenBases = this.stolenBases,
+        battingAverage = this.battingAverage,
+        onBasePercentage = this.onBasePercentage,
+        sluggingPercentage = this.sluggingPercentage,
+    )
+
+/**
+ * CareerPitchingStatsDto를 CareerPitchingStatsResponse로 변환합니다.
+ */
+fun CareerPitchingStatsDto.toResponse(): CareerPitchingStatsResponse =
+    CareerPitchingStatsResponse(
+        games = this.games,
+        wins = this.wins,
+        losses = this.losses,
+        saves = this.saves,
+        holds = this.holds,
+        inningsPitched = this.inningsPitched,
+        strikeouts = this.strikeouts,
+        walks = this.walks,
+        earnedRuns = this.earnedRuns,
+        earnedRunAverage = this.earnedRunAverage,
+        walksAndHitsPerInningPitched = this.walksAndHitsPerInningPitched,
+    )
+
+/**
+ * CompetitionHistoryDto를 CompetitionHistoryResponse로 변환합니다.
+ */
+fun CompetitionHistoryDto.toResponse(): CompetitionHistoryResponse =
+    CompetitionHistoryResponse(
+        year = this.year,
+        competitionName = this.competitionName,
+        teamName = this.teamName,
+        games = this.games,
+    )
+
+/**
+ * CertificateVerificationDto를 CertificateVerificationResponse로 변환합니다.
+ */
+fun CertificateVerificationDto.toResponse(): CertificateVerificationResponse =
+    CertificateVerificationResponse(
+        valid = this.valid,
+        issueNumber = this.issueNumber,
+        playerName = this.playerName,
+        issuedAt = this.issuedAt,
+        expiresAt = this.expiresAt,
+        status = this.status,
+    )
+
+/**
+ * List<CertificateDto>를 List<CertificateResponse>로 변환합니다.
+ */
+fun List<CertificateDto>.toResponse(): List<CertificateResponse> = this.map { it.toResponse() }

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/ScoresheetMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/ScoresheetMapper.kt
@@ -1,0 +1,139 @@
+package com.nextup.api.mapper.game
+
+import com.nextup.api.dto.game.*
+import com.nextup.core.service.game.dto.*
+
+/**
+ * ScoresheetDto -> ScoresheetResponse 변환
+ */
+fun ScoresheetDto.toResponse(): ScoresheetResponse =
+    ScoresheetResponse(
+        gameInfo = gameInfo.toResponse(),
+        teams = teams.toResponse(),
+        inningScores = inningScores.toResponse(),
+        battingRecords = battingRecords.toResponse(),
+        pitchingRecords = pitchingRecords.toResponse(),
+        keyEvents = keyEvents.map { it.toResponse() },
+    )
+
+/**
+ * GameInfoDto -> GameInfoResponse 변환
+ */
+fun GameInfoDto.toResponse(): GameInfoResponse =
+    GameInfoResponse(
+        gameId = gameId,
+        competitionName = competitionName,
+        gameNumber = gameNumber,
+        scheduledAt = scheduledAt,
+        startedAt = startedAt,
+        endedAt = endedAt,
+        location = location,
+        fieldName = fieldName,
+        status = status,
+        currentInning = currentInning,
+        totalInnings = totalInnings,
+    )
+
+/**
+ * TeamsScoresheetDto -> TeamsResponse 변환
+ */
+fun TeamsScoresheetDto.toResponse(): TeamsResponse =
+    TeamsResponse(
+        home = home.toResponse(),
+        away = away.toResponse(),
+    )
+
+/**
+ * TeamScoresheetInfoDto -> TeamScoresheetResponse 변환
+ */
+fun TeamScoresheetInfoDto.toResponse(): TeamScoresheetResponse =
+    TeamScoresheetResponse(
+        teamId = teamId,
+        teamName = teamName,
+        totalScore = totalScore,
+        totalHits = totalHits,
+        totalErrors = totalErrors,
+        result = result,
+    )
+
+/**
+ * InningScoresDto -> InningScoresResponse 변환
+ */
+fun InningScoresDto.toResponse(): InningScoresResponse =
+    InningScoresResponse(
+        innings = innings,
+        homeScores = homeScores,
+        awayScores = awayScores,
+    )
+
+/**
+ * BattingRecordsDto -> BattingRecordsResponse 변환
+ */
+fun BattingRecordsDto.toResponse(): BattingRecordsResponse =
+    BattingRecordsResponse(
+        home = home.map { it.toResponse() },
+        away = away.map { it.toResponse() },
+    )
+
+/**
+ * BatterScoresheetDto -> BatterScoresheetResponse 변환
+ */
+fun BatterScoresheetDto.toResponse(): BatterScoresheetResponse =
+    BatterScoresheetResponse(
+        playerId = playerId,
+        name = name,
+        backNumber = backNumber,
+        position = position,
+        battingOrder = battingOrder,
+        plateAppearances = plateAppearances,
+        atBats = atBats,
+        runs = runs,
+        hits = hits,
+        doubles = doubles,
+        triples = triples,
+        homeRuns = homeRuns,
+        rbis = rbis,
+        walks = walks,
+        strikeouts = strikeouts,
+        stolenBases = stolenBases,
+        avg = avg,
+    )
+
+/**
+ * PitchingRecordsDto -> PitchingRecordsResponse 변환
+ */
+fun PitchingRecordsDto.toResponse(): PitchingRecordsResponse =
+    PitchingRecordsResponse(
+        home = home.map { it.toResponse() },
+        away = away.map { it.toResponse() },
+    )
+
+/**
+ * PitcherScoresheetDto -> PitcherScoresheetResponse 변환
+ */
+fun PitcherScoresheetDto.toResponse(): PitcherScoresheetResponse =
+    PitcherScoresheetResponse(
+        playerId = playerId,
+        name = name,
+        backNumber = backNumber,
+        isStartingPitcher = isStartingPitcher,
+        inningsPitched = inningsPitched,
+        hitsAllowed = hitsAllowed,
+        runsAllowed = runsAllowed,
+        earnedRuns = earnedRuns,
+        walks = walks,
+        strikeouts = strikeouts,
+        homeRunsAllowed = homeRunsAllowed,
+        decision = decision,
+        era = era,
+    )
+
+/**
+ * KeyEventDto -> KeyEventResponse 변환
+ */
+fun KeyEventDto.toResponse(): KeyEventResponse =
+    KeyEventResponse(
+        inning = inning,
+        description = description,
+        timestamp = timestamp,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/LeaderboardMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/LeaderboardMapper.kt
@@ -1,0 +1,32 @@
+package com.nextup.api.mapper.stats
+
+import com.nextup.api.dto.stats.BattingLeaderResponse
+import com.nextup.api.dto.stats.PitchingLeaderResponse
+import com.nextup.core.service.stats.dto.BattingLeaderDto
+import com.nextup.core.service.stats.dto.PitchingLeaderDto
+
+fun BattingLeaderDto.toResponse(): BattingLeaderResponse =
+    BattingLeaderResponse(
+        rank = this.rank,
+        playerId = this.playerId,
+        playerName = this.playerName,
+        teamName = this.teamName,
+        value = this.value,
+        games = this.games,
+        plateAppearances = this.plateAppearances,
+    )
+
+fun PitchingLeaderDto.toResponse(): PitchingLeaderResponse =
+    PitchingLeaderResponse(
+        rank = this.rank,
+        playerId = this.playerId,
+        playerName = this.playerName,
+        teamName = this.teamName,
+        value = this.value,
+        games = this.games,
+        inningsPitched = this.inningsPitched,
+    )
+
+fun List<BattingLeaderDto>.toBattingLeaderResponse(): List<BattingLeaderResponse> = this.map { it.toResponse() }
+
+fun List<PitchingLeaderDto>.toPitchingLeaderResponse(): List<PitchingLeaderResponse> = this.map { it.toResponse() }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/ElectionControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/ElectionControllerTest.kt
@@ -1,0 +1,475 @@
+package com.nextup.api.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.election.CastVoteApiRequest
+import com.nextup.api.dto.election.CreateElectionApiRequest
+import com.nextup.api.dto.election.RegisterCandidateApiRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.CandidateNotFoundException
+import com.nextup.common.exception.DuplicateVoteException
+import com.nextup.common.exception.ElectionNotFoundException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.core.domain.election.ElectionStatus
+import com.nextup.core.domain.election.ElectionType
+import com.nextup.core.service.election.ElectionService
+import com.nextup.core.service.election.dto.CandidateResponse
+import com.nextup.core.service.election.dto.ElectionResponse
+import com.nextup.core.service.election.dto.ElectionResultResponse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class ElectionControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var electionService: ElectionService
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setup() {
+        electionService = mockk()
+        val controller = ElectionController(electionService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).setControllerAdvice(GlobalExceptionHandler()).build()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @Test
+    fun `should create election`() {
+        // given
+        val teamId = 1L
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val request =
+            CreateElectionApiRequest(
+                title = "구단주 선출",
+                description = "2024년 구단주 선출",
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        val response =
+            ElectionResponse(
+                id = 1L,
+                teamId = teamId,
+                title = request.title,
+                description = request.description,
+                electionType = request.electionType,
+                startAt = request.startAt,
+                endAt = request.endAt,
+                status = ElectionStatus.SCHEDULED,
+                isVotingOpen = false,
+                createdAt = Instant.now(),
+            )
+
+        every { electionService.createElection(any()) } returns response
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/teams/$teamId/elections")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.teamId").value(teamId))
+            .andExpect(jsonPath("$.data.title").value(request.title))
+            .andExpect(jsonPath("$.data.electionType").value("OWNER_ELECTION"))
+            .andExpect(jsonPath("$.data.status").value("SCHEDULED"))
+
+        verify(exactly = 1) { electionService.createElection(any()) }
+    }
+
+    @Test
+    fun `should get elections by team`() {
+        // given
+        val teamId = 1L
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val elections =
+            listOf(
+                ElectionResponse(
+                    id = 1L,
+                    teamId = teamId,
+                    title = "구단주 선출",
+                    description = null,
+                    electionType = ElectionType.OWNER_ELECTION,
+                    startAt = startAt,
+                    endAt = endAt,
+                    status = ElectionStatus.SCHEDULED,
+                    isVotingOpen = false,
+                    createdAt = Instant.now(),
+                ),
+            )
+
+        every { electionService.getElectionsByTeam(teamId) } returns elections
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/teams/$teamId/elections"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data[0].id").value(1))
+            .andExpect(jsonPath("$.data[0].teamId").value(teamId))
+
+        verify(exactly = 1) { electionService.getElectionsByTeam(teamId) }
+    }
+
+    @Test
+    fun `should get election by id`() {
+        // given
+        val teamId = 1L
+        val electionId = 1L
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val response =
+            ElectionResponse(
+                id = electionId,
+                teamId = teamId,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+                status = ElectionStatus.SCHEDULED,
+                isVotingOpen = false,
+                createdAt = Instant.now(),
+            )
+
+        every { electionService.getElectionById(electionId) } returns response
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/teams/$teamId/elections/$electionId"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(electionId))
+
+        verify(exactly = 1) { electionService.getElectionById(electionId) }
+    }
+
+    @Test
+    fun `should return 404 when election not found`() {
+        // given
+        val teamId = 1L
+        val electionId = 999L
+
+        every { electionService.getElectionById(electionId) } throws ElectionNotFoundException(electionId)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/teams/$teamId/elections/$electionId"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("ELECTION_NOT_FOUND"))
+
+        verify(exactly = 1) { electionService.getElectionById(electionId) }
+    }
+
+    @Test
+    fun `should start election`() {
+        // given
+        val teamId = 1L
+        val electionId = 1L
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val response =
+            ElectionResponse(
+                id = electionId,
+                teamId = teamId,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+                status = ElectionStatus.IN_PROGRESS,
+                isVotingOpen = false,
+                createdAt = Instant.now(),
+            )
+
+        every { electionService.startElection(electionId) } returns response
+
+        // when & then
+        mockMvc
+            .perform(put("/api/v1/teams/$teamId/elections/$electionId/start"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+
+        verify(exactly = 1) { electionService.startElection(electionId) }
+    }
+
+    @Test
+    fun `should complete election`() {
+        // given
+        val teamId = 1L
+        val electionId = 1L
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val response =
+            ElectionResponse(
+                id = electionId,
+                teamId = teamId,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+                status = ElectionStatus.COMPLETED,
+                isVotingOpen = false,
+                createdAt = Instant.now(),
+            )
+
+        every { electionService.completeElection(electionId) } returns response
+
+        // when & then
+        mockMvc
+            .perform(put("/api/v1/teams/$teamId/elections/$electionId/complete"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.status").value("COMPLETED"))
+
+        verify(exactly = 1) { electionService.completeElection(electionId) }
+    }
+
+    @Test
+    fun `should cancel election`() {
+        // given
+        val teamId = 1L
+        val electionId = 1L
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val response =
+            ElectionResponse(
+                id = electionId,
+                teamId = teamId,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+                status = ElectionStatus.CANCELLED,
+                isVotingOpen = false,
+                createdAt = Instant.now(),
+            )
+
+        every { electionService.cancelElection(electionId) } returns response
+
+        // when & then
+        mockMvc
+            .perform(put("/api/v1/teams/$teamId/elections/$electionId/cancel"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.status").value("CANCELLED"))
+
+        verify(exactly = 1) { electionService.cancelElection(electionId) }
+    }
+
+    @Test
+    fun `should register candidate`() {
+        // given
+        val teamId = 1L
+        val electionId = 1L
+        val request =
+            RegisterCandidateApiRequest(
+                memberId = 100L,
+                memberName = "홍길동",
+                statement = "열심히 하겠습니다",
+            )
+        val response =
+            CandidateResponse(
+                id = 1L,
+                electionId = electionId,
+                memberId = request.memberId,
+                memberName = request.memberName,
+                statement = request.statement,
+                createdAt = Instant.now(),
+            )
+
+        every { electionService.registerCandidate(any()) } returns response
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/teams/$teamId/elections/$electionId/candidates")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.memberId").value(request.memberId))
+            .andExpect(jsonPath("$.data.memberName").value(request.memberName))
+
+        verify(exactly = 1) { electionService.registerCandidate(any()) }
+    }
+
+    @Test
+    fun `should return 400 when registering candidate to non-scheduled election`() {
+        // given
+        val teamId = 1L
+        val electionId = 1L
+        val request =
+            RegisterCandidateApiRequest(
+                memberId = 100L,
+                memberName = "홍길동",
+                statement = null,
+            )
+
+        every { electionService.registerCandidate(any()) } throws
+            InvalidStateException(
+                code = "CANNOT_REGISTER_CANDIDATE",
+                message = "Cannot register candidate: election status is IN_PROGRESS",
+            )
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/teams/$teamId/elections/$electionId/candidates")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("CANNOT_REGISTER_CANDIDATE"))
+
+        verify(exactly = 1) { electionService.registerCandidate(any()) }
+    }
+
+    @Test
+    fun `should cast vote`() {
+        // given
+        val teamId = 1L
+        val electionId = 1L
+        val request =
+            CastVoteApiRequest(
+                voterId = 100L,
+                candidateId = 10L,
+            )
+        val response =
+            CandidateResponse(
+                id = request.candidateId,
+                electionId = electionId,
+                memberId = 200L,
+                memberName = "홍길동",
+                statement = null,
+                createdAt = Instant.now(),
+            )
+
+        every { electionService.vote(any()) } returns response
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/teams/$teamId/elections/$electionId/votes")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(request.candidateId))
+
+        verify(exactly = 1) { electionService.vote(any()) }
+    }
+
+    @Test
+    fun `should return 400 when voting twice`() {
+        // given
+        val teamId = 1L
+        val electionId = 1L
+        val request =
+            CastVoteApiRequest(
+                voterId = 100L,
+                candidateId = 10L,
+            )
+
+        every { electionService.vote(any()) } throws DuplicateVoteException()
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/teams/$teamId/elections/$electionId/votes")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("DUPLICATE_VOTE"))
+
+        verify(exactly = 1) { electionService.vote(any()) }
+    }
+
+    @Test
+    fun `should return 404 when voting for non-existent candidate`() {
+        // given
+        val teamId = 1L
+        val electionId = 1L
+        val candidateId = 999L
+        val request =
+            CastVoteApiRequest(
+                voterId = 100L,
+                candidateId = candidateId,
+            )
+
+        every { electionService.vote(any()) } throws CandidateNotFoundException(candidateId)
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/teams/$teamId/elections/$electionId/votes")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("CANDIDATE_NOT_FOUND"))
+
+        verify(exactly = 1) { electionService.vote(any()) }
+    }
+
+    @Test
+    fun `should get election results`() {
+        // given
+        val teamId = 1L
+        val electionId = 1L
+        val startAt = Instant.now().minus(2, ChronoUnit.DAYS)
+        val endAt = Instant.now().minus(1, ChronoUnit.DAYS)
+        val electionResponse =
+            ElectionResponse(
+                id = electionId,
+                teamId = teamId,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+                status = ElectionStatus.COMPLETED,
+                isVotingOpen = false,
+                createdAt = Instant.now(),
+            )
+        val response =
+            ElectionResultResponse(
+                election = electionResponse,
+                candidates = emptyList(),
+                totalVotes = 0,
+            )
+
+        every { electionService.getResults(electionId) } returns response
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/teams/$teamId/elections/$electionId/results"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.election.id").value(electionId))
+            .andExpect(jsonPath("$.data.totalVotes").value(0))
+
+        verify(exactly = 1) { electionService.getResults(electionId) }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/PitchEventControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/PitchEventControllerTest.kt
@@ -1,0 +1,248 @@
+package com.nextup.api.controller
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.domain.game.PitchEvent
+import com.nextup.core.domain.game.PitchResult
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.service.PitchEventService
+import com.nextup.core.service.PitcherPitchStats
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class PitchEventControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var pitchEventService: PitchEventService
+
+    private lateinit var game: Game
+    private lateinit var pitcher: GamePlayer
+    private lateinit var batter: GamePlayer
+
+    @BeforeEach
+    fun setUp() {
+        pitchEventService = mockk()
+
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(PitchEventController(pitchEventService))
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        // Test fixtures
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league =
+            League(association = association, name = "테스트 리그", foundedYear = 2024, id = 1L)
+        val competition =
+            Competition(
+                league = league,
+                name = "테스트 대회",
+                year = 2024,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2024, 3, 1),
+                id = 1L,
+            )
+
+        game =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.of(2024, 6, 1, 14, 0),
+                status = GameStatus.IN_PROGRESS,
+                currentInning = 1,
+                id = 1L,
+            )
+
+        val homeTeam =
+            Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam =
+            Team(league = league, name = "원정팀", city = "서울", foundedYear = 2020, id = 2L)
+
+        val homeGameTeam =
+            GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME, id = 1L)
+        val awayGameTeam =
+            GameTeam(game = game, team = awayTeam, homeAway = HomeAway.AWAY, id = 2L)
+
+        val pitcherPlayer =
+            Player(
+                name = "투수",
+                birthDate = LocalDate.of(1995, 1, 1),
+                primaryPosition = Position.STARTING_PITCHER,
+                id = 1L,
+            )
+        pitcher =
+            GamePlayer(
+                gameTeam = awayGameTeam,
+                player = pitcherPlayer,
+                position = Position.STARTING_PITCHER,
+                battingOrder = null,
+                id = 1L,
+            )
+
+        val batterPlayer =
+            Player(
+                name = "타자",
+                birthDate = LocalDate.of(1995, 1, 1),
+                primaryPosition = Position.FIRST_BASE,
+                id = 2L,
+            )
+        batter =
+            GamePlayer(
+                gameTeam = homeGameTeam,
+                player = batterPlayer,
+                position = Position.FIRST_BASE,
+                battingOrder = 1,
+                id = 2L,
+            )
+    }
+
+    @Test
+    fun `경기의 투구 이벤트 목록을 조회할 수 있다`() {
+        // given
+        val gameId = 1L
+        val pitchEvents =
+            listOf(
+                createPitchEvent(1, PitchResult.STRIKE),
+                createPitchEvent(2, PitchResult.BALL),
+                createPitchEvent(3, PitchResult.FOUL),
+            )
+
+        every { pitchEventService.getGamePitchEvents(gameId) } returns pitchEvents
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/games/{gameId}/pitch-events", gameId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data.length()").value(3))
+            .andExpect(jsonPath("$.data[0].result").value("STRIKE"))
+            .andExpect(jsonPath("$.data[1].result").value("BALL"))
+            .andExpect(jsonPath("$.data[2].result").value("FOUL"))
+    }
+
+    @Test
+    fun `존재하지 않는 경기의 투구 이벤트를 조회하면 404 에러가 발생한다`() {
+        // given
+        val gameId = 999L
+        every { pitchEventService.getGamePitchEvents(gameId) } throws GameNotFoundException(gameId)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/games/{gameId}/pitch-events", gameId))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("GAME_NOT_FOUND"))
+    }
+
+    @Test
+    fun `경기의 현재 볼카운트를 조회할 수 있다`() {
+        // given
+        val gameId = 1L
+        every { pitchEventService.getCurrentBallCount(gameId) } returns Pair(2, 1)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/games/{gameId}/ball-count", gameId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.balls").value(2))
+            .andExpect(jsonPath("$.data.strikes").value(1))
+            .andExpect(jsonPath("$.data.countDisplay").value("2B-1S"))
+    }
+
+    @Test
+    fun `특정 이닝의 투구 이벤트를 조회할 수 있다`() {
+        // given
+        val gameId = 1L
+        val inning = 3
+        val isTopInning = true
+        val pitchEvents =
+            listOf(
+                createPitchEvent(1, PitchResult.STRIKE),
+                createPitchEvent(2, PitchResult.BALL),
+            )
+
+        every {
+            pitchEventService.getInningPitchEvents(gameId, inning, isTopInning)
+        } returns pitchEvents
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/games/{gameId}/pitch-events/inning/{inning}", gameId, inning)
+                    .param("isTopInning", "true"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data.length()").value(2))
+    }
+
+    @Test
+    fun `투수의 투구 통계를 조회할 수 있다`() {
+        // given
+        val gamePlayerId = 2L
+        val stats =
+            PitcherPitchStats(
+                totalPitches = 100,
+                strikes = 65,
+                balls = 20,
+                fouls = 10,
+                inPlayPitches = 5,
+                strikePercentage = 75.0,
+                avgPitchesPerAtBat = 4.5,
+            )
+
+        every { pitchEventService.calculatePitcherStats(gamePlayerId) } returns stats
+
+        // when & then
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(PitcherStatsController(pitchEventService))
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        mockMvc
+            .perform(get("/api/v1/game-players/{gamePlayerId}/pitch-stats", gamePlayerId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.totalPitches").value(100))
+            .andExpect(jsonPath("$.data.strikes").value(65))
+            .andExpect(jsonPath("$.data.balls").value(20))
+            .andExpect(jsonPath("$.data.strikePercentage").value(75.0))
+            .andExpect(jsonPath("$.data.avgPitchesPerAtBat").value(4.5))
+    }
+
+    private fun createPitchEvent(
+        pitchNumber: Int,
+        result: PitchResult,
+    ): PitchEvent =
+        PitchEvent.create(
+            game = game,
+            pitcher = pitcher,
+            batter = batter,
+            pitchNumber = pitchNumber,
+            result = result,
+            ballCount = 0,
+            strikeCount = 1,
+        )
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/appeal/AppealControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/appeal/AppealControllerTest.kt
@@ -1,0 +1,262 @@
+package com.nextup.api.controller.appeal
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.appeal.CreateAppealApiRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.appeal.Appeal
+import com.nextup.core.domain.appeal.AppealStatus
+import com.nextup.core.domain.appeal.AppealType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.service.appeal.AppealService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+
+@DisplayName("AppealController")
+class AppealControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var appealService: AppealService
+    private lateinit var objectMapper: ObjectMapper
+
+    private val mockGame = mockk<Game>(relaxed = true)
+    private val mockAppeal = mockk<Appeal>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        appealService = mockk()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+        val controller = AppealController(appealService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        every { mockGame.id } returns 1L
+        every { mockAppeal.id } returns 1L
+        every { mockAppeal.game } returns mockGame
+        every { mockAppeal.appealerId } returns 100L
+        every { mockAppeal.appealerName } returns "홍길동"
+        every { mockAppeal.type } returns AppealType.SCORING_ERROR
+        every { mockAppeal.title } returns "득점 오류 정정 요청"
+        every { mockAppeal.description } returns "3회말 득점이 잘못 기록되었습니다"
+        every { mockAppeal.status } returns AppealStatus.PENDING
+        every { mockAppeal.reviewerId } returns null
+        every { mockAppeal.reviewerComment } returns null
+        every { mockAppeal.reviewedAt } returns null
+        every { mockAppeal.createdAt } returns Instant.now()
+    }
+
+    @Test
+    fun `should create appeal successfully`() {
+        // given
+        val request =
+            CreateAppealApiRequest(
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.SCORING_ERROR,
+                title = "득점 오류 정정 요청",
+                description = "3회말 득점이 잘못 기록되었습니다",
+            )
+
+        every { appealService.createAppeal(any()) } returns mockAppeal
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/games/1/appeals")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.gameId").value(1))
+            .andExpect(jsonPath("$.data.appealerId").value(100))
+            .andExpect(jsonPath("$.data.appealerName").value("홍길동"))
+            .andExpect(jsonPath("$.data.type").value("SCORING_ERROR"))
+            .andExpect(jsonPath("$.data.status").value("PENDING"))
+
+        verify(exactly = 1) { appealService.createAppeal(any()) }
+    }
+
+    @Test
+    fun `should fail to create appeal with invalid request`() {
+        // given
+        val invalidRequest =
+            mapOf(
+                "appealerId" to -1,
+                "appealerName" to "",
+                "type" to "SCORING_ERROR",
+                "title" to "",
+                "description" to "",
+            )
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/games/1/appeals")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidRequest)),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+
+        verify(exactly = 0) { appealService.createAppeal(any()) }
+    }
+
+    @Test
+    fun `should fail to create appeal when game not found`() {
+        // given
+        val request =
+            CreateAppealApiRequest(
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.SCORING_ERROR,
+                title = "제목",
+                description = "설명",
+            )
+
+        every { appealService.createAppeal(any()) } throws GameNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/games/999/appeals")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should get my appeals`() {
+        // given
+        every { appealService.getAppealsByAppealer(100L) } returns listOf(mockAppeal)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/appeals").param("appealerId", "100"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].id").value(1))
+            .andExpect(jsonPath("$.data[0].appealerId").value(100))
+
+        verify(exactly = 1) { appealService.getAppealsByAppealer(100L) }
+    }
+
+    @Test
+    fun `should get empty list when no appeals found for appealer`() {
+        // given
+        every { appealService.getAppealsByAppealer(999L) } returns emptyList()
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/appeals").param("appealerId", "999"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data").isEmpty)
+
+        verify(exactly = 1) { appealService.getAppealsByAppealer(999L) }
+    }
+
+    @Test
+    fun `should get game appeals`() {
+        // given
+        every { appealService.getAppealsByGame(1L) } returns listOf(mockAppeal)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/games/1/appeals"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].id").value(1))
+            .andExpect(jsonPath("$.data[0].gameId").value(1))
+
+        verify(exactly = 1) { appealService.getAppealsByGame(1L) }
+    }
+
+    @Test
+    fun `should get empty list when no appeals found for game`() {
+        // given
+        every { appealService.getAppealsByGame(999L) } returns emptyList()
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/games/999/appeals"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data").isEmpty)
+
+        verify(exactly = 1) { appealService.getAppealsByGame(999L) }
+    }
+
+    @Test
+    fun `should handle different appeal types`() {
+        // given
+        val types =
+            listOf(
+                AppealType.SCORING_ERROR,
+                AppealType.RECORD_CORRECTION,
+                AppealType.RULE_VIOLATION,
+                AppealType.OTHER,
+            )
+
+        types.forEach { type ->
+            val request =
+                CreateAppealApiRequest(
+                    appealerId = 100L,
+                    appealerName = "홍길동",
+                    type = type,
+                    title = "제목",
+                    description = "설명",
+                )
+
+            val mockAppealWithType = mockk<Appeal>(relaxed = true)
+            every { mockAppealWithType.id } returns 1L
+            every { mockAppealWithType.game } returns mockGame
+            every { mockAppealWithType.appealerId } returns 100L
+            every { mockAppealWithType.appealerName } returns "홍길동"
+            every { mockAppealWithType.type } returns type
+            every { mockAppealWithType.title } returns "제목"
+            every { mockAppealWithType.description } returns "설명"
+            every { mockAppealWithType.status } returns AppealStatus.PENDING
+            every { mockAppealWithType.reviewerId } returns null
+            every { mockAppealWithType.reviewerComment } returns null
+            every { mockAppealWithType.reviewedAt } returns null
+            every { mockAppealWithType.createdAt } returns Instant.now()
+
+            every { appealService.createAppeal(any()) } returns mockAppealWithType
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/games/1/appeals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.type").value(type.name))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/attendance/AttendanceControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/attendance/AttendanceControllerTest.kt
@@ -1,0 +1,217 @@
+package com.nextup.api.controller.attendance
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.api.dto.attendance.NudgeRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.service.attendance.NudgeResult
+import com.nextup.core.service.attendance.NudgeService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class AttendanceControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var nudgeService: NudgeService
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setup() {
+        nudgeService = mockk()
+        objectMapper = ObjectMapper()
+
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(AttendanceController(nudgeService))
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Test
+    fun `should return nudge result when non-voters exist`() {
+        // given
+        val gameId = 1L
+        val result =
+            NudgeResult(
+                notifiedCount = 3,
+                nonVoterNames = listOf("Player1", "Player2", "Player3"),
+            )
+
+        every { nudgeService.nudgeNonVoters(gameId, null) } returns result
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/games/{gameId}/attendance/nudge", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.notifiedCount").value(3))
+            .andExpect(jsonPath("$.data.nonVoterNames[0]").value("Player1"))
+            .andExpect(jsonPath("$.data.nonVoterNames[1]").value("Player2"))
+            .andExpect(jsonPath("$.data.nonVoterNames[2]").value("Player3"))
+
+        verify(exactly = 1) { nudgeService.nudgeNonVoters(gameId, null) }
+    }
+
+    @Test
+    fun `should return empty result when no non-voters exist`() {
+        // given
+        val gameId = 1L
+        val result =
+            NudgeResult(
+                notifiedCount = 0,
+                nonVoterNames = emptyList(),
+            )
+
+        every { nudgeService.nudgeNonVoters(gameId, null) } returns result
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/games/{gameId}/attendance/nudge", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.notifiedCount").value(0))
+            .andExpect(jsonPath("$.data.nonVoterNames").isEmpty)
+
+        verify(exactly = 1) { nudgeService.nudgeNonVoters(gameId, null) }
+    }
+
+    @Test
+    fun `should send custom message when provided`() {
+        // given
+        val gameId = 1L
+        val customMessage = "Please vote ASAP!"
+        val request = NudgeRequest(message = customMessage)
+        val result =
+            NudgeResult(
+                notifiedCount = 2,
+                nonVoterNames = listOf("Player1", "Player2"),
+            )
+
+        every { nudgeService.nudgeNonVoters(gameId, customMessage) } returns result
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/games/{gameId}/attendance/nudge", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.notifiedCount").value(2))
+
+        verify(exactly = 1) { nudgeService.nudgeNonVoters(gameId, customMessage) }
+    }
+
+    @Test
+    fun `should handle empty request body with default values`() {
+        // given
+        val gameId = 1L
+        val result =
+            NudgeResult(
+                notifiedCount = 1,
+                nonVoterNames = listOf("Player1"),
+            )
+
+        every { nudgeService.nudgeNonVoters(gameId, null) } returns result
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/games/{gameId}/attendance/nudge", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.notifiedCount").value(1))
+            .andExpect(jsonPath("$.data.nonVoterNames[0]").value("Player1"))
+
+        verify(exactly = 1) { nudgeService.nudgeNonVoters(gameId, null) }
+    }
+
+    @Test
+    fun `should return 404 when game does not exist`() {
+        // given
+        val gameId = 999L
+
+        every { nudgeService.nudgeNonVoters(gameId, null) } throws GameNotFoundException(gameId)
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/games/{gameId}/attendance/nudge", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("GAME_NOT_FOUND"))
+            .andExpect(jsonPath("$.error.message").value("Game not found: $gameId"))
+
+        verify(exactly = 1) { nudgeService.nudgeNonVoters(gameId, null) }
+    }
+
+    @Test
+    fun `should handle request without body`() {
+        // given
+        val gameId = 1L
+        val result =
+            NudgeResult(
+                notifiedCount = 1,
+                nonVoterNames = listOf("Player1"),
+            )
+
+        every { nudgeService.nudgeNonVoters(gameId, null) } returns result
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/games/{gameId}/attendance/nudge", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+
+        verify(exactly = 1) { nudgeService.nudgeNonVoters(gameId, null) }
+    }
+
+    @Test
+    fun `should handle multiple non-voters with various names`() {
+        // given
+        val gameId = 1L
+        val result =
+            NudgeResult(
+                notifiedCount = 5,
+                nonVoterNames = listOf("김철수", "이영희", "박민수", "최지원", "정다은"),
+            )
+
+        every { nudgeService.nudgeNonVoters(gameId, null) } returns result
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/games/{gameId}/attendance/nudge", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.notifiedCount").value(5))
+            .andExpect(jsonPath("$.data.nonVoterNames.length()").value(5))
+            .andExpect(jsonPath("$.data.nonVoterNames[0]").value("김철수"))
+            .andExpect(jsonPath("$.data.nonVoterNames[4]").value("정다은"))
+
+        verify(exactly = 1) { nudgeService.nudgeNonVoters(gameId, null) }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/attendance/TeamActivityControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/attendance/TeamActivityControllerTest.kt
@@ -1,0 +1,171 @@
+package com.nextup.api.controller.attendance
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.nextup.api.dto.attendance.UpdateActivityScoreRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.attendance.ActivityScore
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.user.User
+import com.nextup.core.service.attendance.ActivityService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+
+@DisplayName("TeamActivityController")
+class TeamActivityControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var activityService: ActivityService
+    private lateinit var controller: TeamActivityController
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var team: Team
+    private lateinit var member: TeamMember
+    private lateinit var activityScore: ActivityScore
+
+    @BeforeEach
+    fun setUp() {
+        activityService = mockk()
+        controller = TeamActivityController(activityService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        objectMapper = ObjectMapper().registerKotlinModule()
+
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league =
+            League(association = association, name = "테스트 리그", foundedYear = 2024, id = 1L)
+        team = Team(league = league, name = "테스트 팀", city = "서울", foundedYear = 2024, id = 1L)
+        val user = User.createLocalUser(email = "test@test.com", encodedPassword = "password123", nickname = "테스트")
+        val player = Player(name = "홍길동", primaryPosition = Position.STARTING_PITCHER, id = 1L)
+        member = TeamMember.create(team = team, user = user, player = player, uniformNumber = 10)
+        activityScore = ActivityScore.create(team = team, member = member)
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/members/{memberId}/activity")
+    inner class GetActivity {
+        @Test
+        fun `팀원의 활동 점수를 조회할 수 있다`() {
+            // given
+            every { activityService.getActivityScore(1L, 1L) } returns activityScore
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/1/members/1/activity"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.teamId").value(team.id))
+                .andExpect(jsonPath("$.data.memberId").value(member.id))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/members/activity")
+    inner class ListActivities {
+        @Test
+        fun `팀의 모든 활동 점수를 조회할 수 있다`() {
+            // given
+            every { activityService.listActivityScores(1L) } returns listOf(activityScore)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/1/members/activity"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(1))
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/teams/{teamId}/members/{memberId}/activity/game-participation")
+    inner class UpdateGameParticipation {
+        @Test
+        fun `경기 참여율을 업데이트할 수 있다`() {
+            // given
+            val request = UpdateActivityScoreRequest(BigDecimal("85.50"))
+            activityScore.updateGameParticipationRate(BigDecimal("85.50"))
+            every {
+                activityService.updateGameParticipationRate(1L, 1L, BigDecimal("85.50"))
+            } returns activityScore
+
+            // when & then
+            mockMvc
+                .perform(
+                    put("/api/v1/teams/1/members/1/activity/game-participation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.gameParticipationRate").value(85.50))
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/teams/{teamId}/members/{memberId}/activity/practice-attendance")
+    inner class UpdatePracticeAttendance {
+        @Test
+        fun `연습 참석률을 업데이트할 수 있다`() {
+            // given
+            val request = UpdateActivityScoreRequest(BigDecimal("90.00"))
+            activityScore.updatePracticeAttendanceRate(BigDecimal("90.00"))
+            every {
+                activityService.updatePracticeAttendanceRate(1L, 1L, BigDecimal("90.00"))
+            } returns activityScore
+
+            // when & then
+            mockMvc
+                .perform(
+                    put("/api/v1/teams/1/members/1/activity/practice-attendance")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.practiceAttendanceRate").value(90.00))
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/teams/{teamId}/members/{memberId}/activity/contribution")
+    inner class UpdateContribution {
+        @Test
+        fun `기여도 점수를 업데이트할 수 있다`() {
+            // given
+            val request = UpdateActivityScoreRequest(BigDecimal("75.00"))
+            activityScore.updateContributionScore(BigDecimal("75.00"))
+            every {
+                activityService.updateContributionScore(1L, 1L, BigDecimal("75.00"))
+            } returns activityScore
+
+            // when & then
+            mockMvc
+                .perform(
+                    put("/api/v1/teams/1/members/1/activity/contribution")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.contributionScore").value(75.00))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/attendance/TeamAttendancePollControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/attendance/TeamAttendancePollControllerTest.kt
@@ -1,0 +1,235 @@
+package com.nextup.api.controller.attendance
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.nextup.api.dto.attendance.CreatePollRequest
+import com.nextup.api.dto.attendance.SubmitVoteRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.attendance.AttendancePoll
+import com.nextup.core.domain.attendance.AttendanceVote
+import com.nextup.core.domain.attendance.PollStatus
+import com.nextup.core.domain.attendance.VoteType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.service.attendance.AttendanceService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDateTime
+
+@DisplayName("TeamAttendancePollController")
+class TeamAttendancePollControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var attendanceService: AttendanceService
+    private lateinit var controller: TeamAttendancePollController
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var team: Team
+    private lateinit var player: Player
+    private lateinit var poll: AttendancePoll
+
+    @BeforeEach
+    fun setUp() {
+        attendanceService = mockk()
+        controller = TeamAttendancePollController(attendanceService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        objectMapper =
+            ObjectMapper()
+                .registerKotlinModule()
+                .registerModule(JavaTimeModule())
+
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league =
+            League(association = association, name = "테스트 리그", foundedYear = 2024, id = 1L)
+        team = Team(league = league, name = "테스트 팀", city = "서울", foundedYear = 2024, id = 1L)
+        player = Player(name = "홍길동", primaryPosition = Position.STARTING_PITCHER, id = 1L)
+        poll =
+            AttendancePoll.create(
+                team = team,
+                title = "이번 주 일요일 경기",
+                eventDate = LocalDateTime.now().plusDays(7),
+                deadline = LocalDateTime.now().plusDays(5),
+            )
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/teams/{teamId}/attendance-polls")
+    inner class CreatePoll {
+        @Test
+        fun `출석 투표를 생성할 수 있다`() {
+            // given
+            val eventDate = LocalDateTime.now().plusDays(7)
+            val deadline = LocalDateTime.now().plusDays(5)
+            val request = CreatePollRequest("이번 주 일요일 경기", eventDate, deadline)
+            every { attendanceService.createPoll(1L, any(), any(), any()) } returns poll
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/teams/1/attendance-polls")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.title").value("이번 주 일요일 경기"))
+                .andExpect(jsonPath("$.data.status").value("OPEN"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/attendance-polls")
+    inner class ListPolls {
+        @Test
+        fun `팀의 투표 목록을 조회할 수 있다`() {
+            // given
+            every { attendanceService.listPolls(1L, null) } returns listOf(poll)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/1/attendance-polls"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].title").value("이번 주 일요일 경기"))
+        }
+
+        @Test
+        fun `상태별로 투표 목록을 조회할 수 있다`() {
+            // given
+            every { attendanceService.listPolls(1L, PollStatus.OPEN) } returns listOf(poll)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/1/attendance-polls?status=OPEN"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].status").value("OPEN"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/attendance-polls/{pollId}")
+    inner class GetPoll {
+        @Test
+        fun `투표를 조회할 수 있다`() {
+            // given
+            every { attendanceService.getPoll(1L) } returns poll
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/1/attendance-polls/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.title").value("이번 주 일요일 경기"))
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/teams/{teamId}/attendance-polls/{pollId}/vote")
+    inner class SubmitVote {
+        @Test
+        fun `투표에 응답할 수 있다`() {
+            // given
+            val request = SubmitVoteRequest(playerId = 1L, voteType = VoteType.ATTEND)
+            val vote =
+                AttendanceVote.create(poll = poll, player = player, voteType = VoteType.ATTEND)
+            every { attendanceService.submitVote(1L, 1L, VoteType.ATTEND) } returns vote
+
+            // when & then
+            mockMvc
+                .perform(
+                    put("/api/v1/teams/1/attendance-polls/1/vote")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.voteType").value("ATTEND"))
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/teams/{teamId}/attendance-polls/{pollId}/close")
+    inner class ClosePoll {
+        @Test
+        fun `투표를 마감할 수 있다`() {
+            // given
+            poll.close()
+            every { attendanceService.closePoll(1L) } returns poll
+
+            // when & then
+            mockMvc
+                .perform(put("/api/v1/teams/1/attendance-polls/1/close"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("CLOSED"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/attendance-polls/{pollId}/votes")
+    inner class ListVotes {
+        @Test
+        fun `투표 응답 목록을 조회할 수 있다`() {
+            // given
+            val vote =
+                AttendanceVote.create(poll = poll, player = player, voteType = VoteType.ATTEND)
+            every { attendanceService.listVotes(1L) } returns listOf(vote)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/1/attendance-polls/1/votes"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].voteType").value("ATTEND"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/attendance-polls/{pollId}/statistics")
+    inner class GetStatistics {
+        @Test
+        fun `투표 통계를 조회할 수 있다`() {
+            // given
+            val vote1 =
+                AttendanceVote.create(poll = poll, player = player, voteType = VoteType.ATTEND)
+            val vote2 =
+                AttendanceVote.create(poll = poll, player = player, voteType = VoteType.ATTEND)
+            val vote3 =
+                AttendanceVote.create(poll = poll, player = player, voteType = VoteType.ABSENT)
+            every { attendanceService.listVotes(1L) } returns listOf(vote1, vote2, vote3)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/1/attendance-polls/1/statistics"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.totalVotes").value(3))
+                .andExpect(jsonPath("$.data.attendCount").value(2))
+                .andExpect(jsonPath("$.data.absentCount").value(1))
+                .andExpect(jsonPath("$.data.undecidedCount").value(0))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/bracket/BracketControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/bracket/BracketControllerTest.kt
@@ -1,0 +1,168 @@
+package com.nextup.api.controller.bracket
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.BracketEntry
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.service.bracket.BracketGeneratorService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+
+class BracketControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var bracketGeneratorService: BracketGeneratorService
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var competition: Competition
+    private lateinit var team1: Team
+    private lateinit var team2: Team
+
+    @BeforeEach
+    fun setup() {
+        bracketGeneratorService = mockk()
+        objectMapper = ObjectMapper().registerModule(JavaTimeModule())
+
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(BracketController(bracketGeneratorService))
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        // Test data
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계 토너먼트",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.TOURNAMENT,
+                startDate = LocalDate.of(2025, 3, 1),
+                id = 1L,
+            )
+        team1 = Team(league = league, name = "팀A", city = "서울", foundedYear = 2020, id = 1L)
+        team2 = Team(league = league, name = "팀B", city = "서울", foundedYear = 2020, id = 2L)
+    }
+
+    @Test
+    fun `should return bracket when competition exists`() {
+        // given
+        val competitionId = 1L
+        val bracketEntries =
+            listOf(
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = 1,
+                    team1 = team1,
+                    team2 = team2,
+                    bracketType = "WINNERS",
+                    seed1 = 1,
+                    seed2 = 2,
+                    id = 1L,
+                ),
+            )
+
+        every { bracketGeneratorService.getBracket(competitionId) } returns bracketEntries
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/competitions/{competitionId}/bracket", competitionId)
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.competitionId").value(competitionId))
+            .andExpect(jsonPath("$.data.entries").isArray)
+            .andExpect(jsonPath("$.data.entries[0].id").value(1))
+            .andExpect(jsonPath("$.data.entries[0].roundNumber").value(1))
+            .andExpect(jsonPath("$.data.entries[0].matchNumber").value(1))
+            .andExpect(jsonPath("$.data.entries[0].team1.id").value(1))
+            .andExpect(jsonPath("$.data.entries[0].team1.name").value("팀A"))
+            .andExpect(jsonPath("$.data.entries[0].team2.id").value(2))
+            .andExpect(jsonPath("$.data.entries[0].team2.name").value("팀B"))
+            .andExpect(jsonPath("$.data.entries[0].bracketType").value("WINNERS"))
+    }
+
+    @Test
+    fun `should return empty bracket when no entries exist`() {
+        // given
+        val competitionId = 1L
+        every { bracketGeneratorService.getBracket(competitionId) } returns emptyList()
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/competitions/{competitionId}/bracket", competitionId)
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.competitionId").value(competitionId))
+            .andExpect(jsonPath("$.data.entries").isEmpty)
+    }
+
+    @Test
+    fun `should return 404 when competition not found`() {
+        // given
+        val competitionId = 999L
+        every { bracketGeneratorService.getBracket(competitionId) } throws CompetitionNotFoundException(competitionId)
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/competitions/{competitionId}/bracket", competitionId)
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("COMPETITION_NOT_FOUND"))
+    }
+
+    @Test
+    fun `should return bracket with bye match`() {
+        // given
+        val competitionId = 1L
+        val bracketEntries =
+            listOf(
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = 1,
+                    team1 = team1,
+                    team2 = null,
+                    bracketType = "WINNERS",
+                    seed1 = 1,
+                    seed2 = 2,
+                    id = 1L,
+                ),
+            )
+
+        every { bracketGeneratorService.getBracket(competitionId) } returns bracketEntries
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/competitions/{competitionId}/bracket", competitionId)
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.entries[0].team1.id").value(1))
+            .andExpect(jsonPath("$.data.entries[0].team2").isEmpty)
+            .andExpect(jsonPath("$.data.entries[0].isBye").value(true))
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/certificate/CertificateControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/certificate/CertificateControllerTest.kt
@@ -1,0 +1,220 @@
+package com.nextup.api.controller.certificate
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.api.dto.certificate.IssueCertificateRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.CertificateNotFoundByIssueNumberException
+import com.nextup.common.exception.CertificateNotFoundException
+import com.nextup.core.domain.certificate.CertificateStatus
+import com.nextup.core.dto.certificate.*
+import com.nextup.core.service.certificate.CertificateService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+
+class CertificateControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var certificateService: CertificateService
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        certificateService = mockk()
+        objectMapper = ObjectMapper()
+
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(CertificateController(certificateService))
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Test
+    fun `should issue certificate for player`() {
+        // given
+        val playerId = 1L
+        val request = IssueCertificateRequest(validityDays = 365)
+        val certificateDto = createCertificateDto(playerId)
+
+        every { certificateService.issueCertificate(playerId, 365) } returns certificateDto
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/players/{playerId}/certificate", playerId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.playerId").value(playerId))
+            .andExpect(jsonPath("$.data.playerName").value("홍길동"))
+            .andExpect(jsonPath("$.data.status").value("VALID"))
+
+        verify { certificateService.issueCertificate(playerId, 365) }
+    }
+
+    @Test
+    fun `should issue certificate with default validity days`() {
+        // given
+        val playerId = 1L
+        val certificateDto = createCertificateDto(playerId)
+
+        every { certificateService.issueCertificate(playerId, 365) } returns certificateDto
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/players/{playerId}/certificate", playerId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"),
+            )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+
+        verify { certificateService.issueCertificate(playerId, 365) }
+    }
+
+    @Test
+    fun `should get certificate by id`() {
+        // given
+        val certificateId = 1L
+        val certificateDto = createCertificateDto(1L)
+
+        every { certificateService.getCertificate(certificateId) } returns certificateDto
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/certificates/{certificateId}", certificateId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(certificateId))
+            .andExpect(jsonPath("$.data.playerName").value("홍길동"))
+
+        verify { certificateService.getCertificate(certificateId) }
+    }
+
+    @Test
+    fun `should return 404 when certificate not found`() {
+        // given
+        val certificateId = 999L
+
+        every { certificateService.getCertificate(certificateId) } throws
+            CertificateNotFoundException(certificateId)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/certificates/{certificateId}", certificateId))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("CERTIFICATE_NOT_FOUND"))
+    }
+
+    @Test
+    fun `should verify certificate by issue number`() {
+        // given
+        val issueNumber = "test-uuid-123"
+        val verificationDto =
+            CertificateVerificationDto(
+                valid = true,
+                issueNumber = issueNumber,
+                playerName = "홍길동",
+                issuedAt = Instant.now(),
+                expiresAt = Instant.now().plusSeconds(365 * 24 * 60 * 60),
+                status = CertificateStatus.VALID,
+            )
+
+        every { certificateService.verifyCertificate(issueNumber) } returns verificationDto
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/certificates/{issueNumber}/verify", issueNumber))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.valid").value(true))
+            .andExpect(jsonPath("$.data.issueNumber").value(issueNumber))
+            .andExpect(jsonPath("$.data.playerName").value("홍길동"))
+            .andExpect(jsonPath("$.data.status").value("VALID"))
+
+        verify { certificateService.verifyCertificate(issueNumber) }
+    }
+
+    @Test
+    fun `should return 404 when verifying non-existent certificate`() {
+        // given
+        val issueNumber = "non-existent-uuid"
+
+        every { certificateService.verifyCertificate(issueNumber) } throws
+            CertificateNotFoundByIssueNumberException(issueNumber)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/certificates/{issueNumber}/verify", issueNumber))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("CERTIFICATE_NOT_FOUND"))
+    }
+
+    @Test
+    fun `should get all player certificates`() {
+        // given
+        val playerId = 1L
+        val certificates = listOf(createCertificateDto(playerId), createCertificateDto(playerId))
+
+        every { certificateService.getPlayerCertificates(playerId) } returns certificates
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/players/{playerId}/certificates", playerId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data.length()").value(2))
+            .andExpect(jsonPath("$.data[0].playerId").value(playerId))
+            .andExpect(jsonPath("$.data[1].playerId").value(playerId))
+
+        verify { certificateService.getPlayerCertificates(playerId) }
+    }
+
+    @Test
+    fun `should revoke certificate`() {
+        // given
+        val certificateId = 1L
+
+        every { certificateService.revokeCertificate(certificateId) } returns Unit
+
+        // when & then
+        mockMvc
+            .perform(delete("/api/v1/certificates/{certificateId}", certificateId))
+            .andExpect(status().isNoContent)
+
+        verify { certificateService.revokeCertificate(certificateId) }
+    }
+
+    private fun createCertificateDto(playerId: Long): CertificateDto =
+        CertificateDto(
+            id = 1L,
+            issueNumber = "test-uuid-123",
+            playerId = playerId,
+            playerName = "홍길동",
+            issuedAt = Instant.now(),
+            expiresAt = Instant.now().plusSeconds(365 * 24 * 60 * 60),
+            status = CertificateStatus.VALID,
+            playerCareer =
+                PlayerCareerDto(
+                    totalGames = 10,
+                    battingStats = null,
+                    pitchingStats = null,
+                    competitionHistory = emptyList(),
+                ),
+            qrCodeData = "QR_CODE_DATA",
+        )
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerStandingsTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerStandingsTest.kt
@@ -2,6 +2,11 @@ package com.nextup.api.controller.competition
 
 import com.nextup.api.exception.GlobalExceptionHandler
 import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
 import com.nextup.core.service.competition.CompetitionService
 import com.nextup.core.service.standings.StandingsService
 import com.nextup.core.service.standings.dto.StandingsDto
@@ -18,6 +23,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @DisplayName("CompetitionController - Standings")
@@ -39,6 +45,24 @@ class CompetitionControllerStandingsTest {
                 .build()
     }
 
+    private fun createCompetition(
+        id: Long = 1L,
+        playoffTeams: Int? = null,
+    ): Competition {
+        val association = Association(name = "서울시야구협회", region = "서울")
+        val league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        return Competition(
+            league = league,
+            name = "2025 춘계대회",
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            status = CompetitionStatus.IN_PROGRESS,
+            playoffTeams = playoffTeams,
+        )
+    }
+
     @Nested
     @DisplayName("GET /api/v1/competitions/{id}/standings")
     inner class GetStandings {
@@ -46,6 +70,8 @@ class CompetitionControllerStandingsTest {
         fun `GET competitions id standings 정상 조회`() {
             // given
             val competitionId = 1L
+            val competition = createCompetition(competitionId)
+            every { competitionService.getById(competitionId) } returns competition
             val standingsDto =
                 StandingsDto(
                     competitionId = competitionId,
@@ -127,6 +153,8 @@ class CompetitionControllerStandingsTest {
                 .andExpect(jsonPath("$.data.standings[0].runsScored").value(25))
                 .andExpect(jsonPath("$.data.standings[0].runsAllowed").value(15))
                 .andExpect(jsonPath("$.data.standings[0].runDifferential").value(10))
+                .andExpect(jsonPath("$.data.standings[0].isPlayoffPosition").value(false))
+                .andExpect(jsonPath("$.data.playoffCutoff").isEmpty)
                 // 2위 Lions
                 .andExpect(jsonPath("$.data.standings[1].rank").value(2))
                 .andExpect(jsonPath("$.data.standings[1].teamName").value("Lions"))
@@ -141,6 +169,8 @@ class CompetitionControllerStandingsTest {
         fun `대회가 없으면 404 반환`() {
             // given
             val competitionId = 999L
+            every { competitionService.getById(competitionId) } throws
+                CompetitionNotFoundException(competitionId)
             every { standingsService.getStandings(competitionId) } throws
                 CompetitionNotFoundException(competitionId)
 
@@ -154,6 +184,8 @@ class CompetitionControllerStandingsTest {
         fun `경기가 없는 대회는 빈 순위표 반환`() {
             // given
             val competitionId = 1L
+            val competition = createCompetition(competitionId)
+            every { competitionService.getById(competitionId) } returns competition
             val standingsDto =
                 StandingsDto(
                     competitionId = competitionId,
@@ -179,6 +211,8 @@ class CompetitionControllerStandingsTest {
         fun `무승부가 포함된 순위표 조회`() {
             // given
             val competitionId = 1L
+            val competition = createCompetition(competitionId)
+            every { competitionService.getById(competitionId) } returns competition
             val standingsDto =
                 StandingsDto(
                     competitionId = competitionId,
@@ -222,6 +256,8 @@ class CompetitionControllerStandingsTest {
         fun `동률팀이 있는 순위표 조회`() {
             // given
             val competitionId = 1L
+            val competition = createCompetition(competitionId)
+            every { competitionService.getById(competitionId) } returns competition
             val standingsDto =
                 StandingsDto(
                     competitionId = competitionId,
@@ -274,6 +310,126 @@ class CompetitionControllerStandingsTest {
                 .andExpect(jsonPath("$.data.standings[0].runDifferential").value(2))
                 .andExpect(jsonPath("$.data.standings[1].winningPercentage").value(0.500))
                 .andExpect(jsonPath("$.data.standings[1].runDifferential").value(-2))
+        }
+
+        @Test
+        fun `플레이오프 cutoff 설정 시 isPlayoffPosition이 표시된다`() {
+            // given
+            val competitionId = 1L
+            val competition = createCompetition(competitionId, playoffTeams = 2)
+            every { competitionService.getById(competitionId) } returns competition
+            val standingsDto =
+                StandingsDto(
+                    competitionId = competitionId,
+                    competitionName = "2025 춘계대회",
+                    totalGamesPerTeam = 10,
+                    standings =
+                        listOf(
+                            TeamStandingDto(
+                                rank = 1,
+                                teamId = 1L,
+                                teamName = "Tigers",
+                                gamesPlayed = 5,
+                                remainingGames = 5,
+                                wins = 4,
+                                losses = 1,
+                                draws = 0,
+                                winningPercentage = BigDecimal("0.800"),
+                                gamesBehind = BigDecimal.ZERO,
+                                runsScored = 25,
+                                runsAllowed = 15,
+                                runDifferential = 10,
+                            ),
+                            TeamStandingDto(
+                                rank = 2,
+                                teamId = 2L,
+                                teamName = "Lions",
+                                gamesPlayed = 5,
+                                remainingGames = 5,
+                                wins = 3,
+                                losses = 2,
+                                draws = 0,
+                                winningPercentage = BigDecimal("0.600"),
+                                gamesBehind = BigDecimal("1.0"),
+                                runsScored = 20,
+                                runsAllowed = 18,
+                                runDifferential = 2,
+                            ),
+                            TeamStandingDto(
+                                rank = 3,
+                                teamId = 3L,
+                                teamName = "Bears",
+                                gamesPlayed = 5,
+                                remainingGames = 5,
+                                wins = 1,
+                                losses = 4,
+                                draws = 0,
+                                winningPercentage = BigDecimal("0.200"),
+                                gamesBehind = BigDecimal("3.0"),
+                                runsScored = 12,
+                                runsAllowed = 28,
+                                runDifferential = -16,
+                            ),
+                        ),
+                    lastUpdated = LocalDateTime.of(2025, 3, 15, 10, 30),
+                )
+
+            every { standingsService.getStandings(competitionId) } returns standingsDto
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/competitions/$competitionId/standings"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.playoffCutoff").value(2))
+                // 1위, 2위는 플레이오프 진출
+                .andExpect(jsonPath("$.data.standings[0].isPlayoffPosition").value(true))
+                .andExpect(jsonPath("$.data.standings[1].isPlayoffPosition").value(true))
+                // 3위는 플레이오프 미진출
+                .andExpect(jsonPath("$.data.standings[2].isPlayoffPosition").value(false))
+        }
+
+        @Test
+        fun `플레이오프 cutoff 미설정 시 isPlayoffPosition이 모두 false`() {
+            // given
+            val competitionId = 1L
+            val competition = createCompetition(competitionId, playoffTeams = null)
+            every { competitionService.getById(competitionId) } returns competition
+            val standingsDto =
+                StandingsDto(
+                    competitionId = competitionId,
+                    competitionName = "2025 춘계대회",
+                    totalGamesPerTeam = 10,
+                    standings =
+                        listOf(
+                            TeamStandingDto(
+                                rank = 1,
+                                teamId = 1L,
+                                teamName = "Tigers",
+                                gamesPlayed = 5,
+                                remainingGames = 5,
+                                wins = 4,
+                                losses = 1,
+                                draws = 0,
+                                winningPercentage = BigDecimal("0.800"),
+                                gamesBehind = BigDecimal.ZERO,
+                                runsScored = 25,
+                                runsAllowed = 15,
+                                runDifferential = 10,
+                            ),
+                        ),
+                    lastUpdated = LocalDateTime.of(2025, 3, 15, 10, 30),
+                )
+
+            every { standingsService.getStandings(competitionId) } returns standingsDto
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/competitions/$competitionId/standings"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.playoffCutoff").isEmpty)
+                .andExpect(jsonPath("$.data.standings[0].isPlayoffPosition").value(false))
         }
     }
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/GameScheduleControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/GameScheduleControllerTest.kt
@@ -1,0 +1,240 @@
+package com.nextup.api.controller.game
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.service.game.GameScheduleService
+import com.nextup.core.service.game.dto.GameDetailDto
+import com.nextup.core.service.game.dto.GameSummaryDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDateTime
+
+@DisplayName("GameScheduleController 테스트")
+class GameScheduleControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var gameScheduleService: GameScheduleService
+
+    @BeforeEach
+    fun setUp() {
+        gameScheduleService = mockk()
+
+        val controller = GameScheduleController(gameScheduleService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    private fun createGameSummaryDto(
+        gameId: Long = 1L,
+        status: GameStatus = GameStatus.SCHEDULED,
+        homeScore: Int = 0,
+        awayScore: Int = 0,
+    ): GameSummaryDto =
+        GameSummaryDto(
+            gameId = gameId,
+            competitionId = 10L,
+            competitionName = "2025 춘계대회",
+            homeTeamId = 100L,
+            homeTeamName = "홈팀",
+            awayTeamId = 200L,
+            awayTeamName = "원정팀",
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            status = status,
+            homeScore = homeScore,
+            awayScore = awayScore,
+            location = "잠실야구장",
+            fieldName = "1구장",
+        )
+
+    @Nested
+    @DisplayName("GET /api/v1/games")
+    inner class GetGames {
+        @Test
+        fun `경기 목록을 정상적으로 조회한다`() {
+            // given
+            val games =
+                listOf(
+                    createGameSummaryDto(gameId = 1L),
+                    createGameSummaryDto(gameId = 2L, status = GameStatus.IN_PROGRESS, homeScore = 3, awayScore = 1),
+                )
+            every {
+                gameScheduleService.getGames(
+                    date = null,
+                    teamId = null,
+                    competitionId = null,
+                    page = 0,
+                    size = 20,
+                )
+            } returns games
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/games"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].gameId").value(1))
+                .andExpect(jsonPath("$.data[0].homeTeam.teamName").value("홈팀"))
+                .andExpect(jsonPath("$.data[0].awayTeam.teamName").value("원정팀"))
+                .andExpect(jsonPath("$.data[0].status").value("SCHEDULED"))
+                .andExpect(jsonPath("$.data[1].homeTeam.score").value(3))
+                .andExpect(jsonPath("$.data[1].awayTeam.score").value(1))
+        }
+
+        @Test
+        fun `빈 경기 목록을 반환한다`() {
+            // given
+            every {
+                gameScheduleService.getGames(
+                    date = null,
+                    teamId = null,
+                    competitionId = null,
+                    page = 0,
+                    size = 20,
+                )
+            } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/games"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(0))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/games/{gameId}")
+    inner class GetGameDetail {
+        @Test
+        fun `경기 상세 정보를 정상적으로 조회한다`() {
+            // given
+            val detail =
+                GameDetailDto(
+                    gameId = 1L,
+                    competitionId = 10L,
+                    competitionName = "2025 춘계대회",
+                    homeTeamId = 100L,
+                    homeTeamName = "홈팀",
+                    awayTeamId = 200L,
+                    awayTeamName = "원정팀",
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                    status = GameStatus.FINISHED,
+                    homeScore = 5,
+                    awayScore = 3,
+                    location = "잠실야구장",
+                    fieldName = "1구장",
+                    gameNumber = 1,
+                    currentInning = "9회말",
+                    totalInnings = 9,
+                    startedAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                    endedAt = LocalDateTime.of(2025, 4, 15, 16, 30),
+                    note = null,
+                    forfeitReason = null,
+                )
+            every { gameScheduleService.getGameDetail(1L) } returns detail
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/games/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.gameId").value(1))
+                .andExpect(jsonPath("$.data.homeTeam.teamName").value("홈팀"))
+                .andExpect(jsonPath("$.data.homeTeam.score").value(5))
+                .andExpect(jsonPath("$.data.awayTeam.score").value(3))
+                .andExpect(jsonPath("$.data.status").value("FINISHED"))
+                .andExpect(jsonPath("$.data.statusDisplayName").value("종료"))
+                .andExpect(jsonPath("$.data.currentInning").value("9회말"))
+                .andExpect(jsonPath("$.data.totalInnings").value(9))
+                .andExpect(jsonPath("$.data.gameNumber").value(1))
+        }
+
+        @Test
+        fun `존재하지 않는 경기 조회 시 404를 반환한다`() {
+            // given
+            every { gameScheduleService.getGameDetail(999L) } throws GameNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/games/999"))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("GAME_NOT_FOUND"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/games")
+    inner class GetGamesByTeam {
+        @Test
+        fun `팀별 경기 일정을 정상적으로 조회한다`() {
+            // given
+            val games =
+                listOf(
+                    createGameSummaryDto(gameId = 1L),
+                    createGameSummaryDto(gameId = 2L),
+                )
+            every { gameScheduleService.getGamesByTeam(100L) } returns games
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/100/games"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/games/upcoming")
+    inner class GetUpcomingGames {
+        @Test
+        fun `다가오는 경기를 정상적으로 조회한다`() {
+            // given
+            val games =
+                listOf(
+                    createGameSummaryDto(gameId = 3L),
+                )
+            every { gameScheduleService.getUpcomingGamesByTeam(100L, 5) } returns games
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/100/games/upcoming"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].gameId").value(3))
+        }
+
+        @Test
+        fun `다가오는 경기가 없으면 빈 리스트를 반환한다`() {
+            // given
+            every { gameScheduleService.getUpcomingGamesByTeam(100L, 5) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/100/games/upcoming"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(0))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/ScoresheetControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/ScoresheetControllerTest.kt
@@ -1,0 +1,248 @@
+package com.nextup.api.controller.game
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.port.PdfGeneratorPort
+import com.nextup.core.service.game.ScoresheetService
+import com.nextup.core.service.game.dto.*
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDateTime
+
+class ScoresheetControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var scoresheetService: ScoresheetService
+    private lateinit var pdfGenerator: PdfGeneratorPort
+
+    @BeforeEach
+    fun setUp() {
+        scoresheetService = mockk()
+        pdfGenerator = mockk()
+
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(ScoresheetController(scoresheetService, pdfGenerator))
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Test
+    fun `should return scoresheet data`() {
+        // given
+        val scoresheetDto =
+            ScoresheetDto(
+                gameInfo =
+                    GameInfoDto(
+                        gameId = 100L,
+                        competitionName = "2024 시즌",
+                        gameNumber = 1,
+                        scheduledAt = LocalDateTime.of(2024, 3, 15, 14, 0),
+                        startedAt = LocalDateTime.of(2024, 3, 15, 14, 10),
+                        endedAt = LocalDateTime.of(2024, 3, 15, 17, 0),
+                        location = "서울",
+                        fieldName = "잠실구장",
+                        status = "종료",
+                        currentInning = "9회말",
+                        totalInnings = 9,
+                    ),
+                teams =
+                    TeamsScoresheetDto(
+                        home =
+                            TeamScoresheetInfoDto(
+                                teamId = 1L,
+                                teamName = "홈팀",
+                                totalScore = 5,
+                                totalHits = 10,
+                                totalErrors = 1,
+                                result = "승리",
+                            ),
+                        away =
+                            TeamScoresheetInfoDto(
+                                teamId = 2L,
+                                teamName = "원정팀",
+                                totalScore = 3,
+                                totalHits = 8,
+                                totalErrors = 2,
+                                result = "패배",
+                            ),
+                    ),
+                inningScores =
+                    InningScoresDto(
+                        innings = 9,
+                        homeScores = listOf(0, 2, 0, 1, 0, 0, 2, 0, 0),
+                        awayScores = listOf(1, 0, 2, 0, 0, 0, 0, 0, 0),
+                    ),
+                battingRecords =
+                    BattingRecordsDto(
+                        home =
+                            listOf(
+                                BatterScoresheetDto(
+                                    playerId = 1L,
+                                    name = "홈타자1",
+                                    backNumber = 10,
+                                    position = "1B",
+                                    battingOrder = 1,
+                                    plateAppearances = 4,
+                                    atBats = 3,
+                                    runs = 2,
+                                    hits = 2,
+                                    doubles = 1,
+                                    triples = 0,
+                                    homeRuns = 0,
+                                    rbis = 1,
+                                    walks = 1,
+                                    strikeouts = 1,
+                                    stolenBases = 0,
+                                    avg = "0.667",
+                                ),
+                            ),
+                        away = emptyList(),
+                    ),
+                pitchingRecords =
+                    PitchingRecordsDto(
+                        home =
+                            listOf(
+                                PitcherScoresheetDto(
+                                    playerId = 10L,
+                                    name = "홈투수1",
+                                    backNumber = 1,
+                                    isStartingPitcher = true,
+                                    inningsPitched = "7.0",
+                                    hitsAllowed = 6,
+                                    runsAllowed = 3,
+                                    earnedRuns = 2,
+                                    walks = 2,
+                                    strikeouts = 8,
+                                    homeRunsAllowed = 1,
+                                    decision = "W",
+                                    era = "2.57",
+                                ),
+                            ),
+                        away = emptyList(),
+                    ),
+                keyEvents =
+                    listOf(
+                        KeyEventDto(
+                            inning = "1회초",
+                            description = "원정팀 선제 득점",
+                            timestamp = "14:15:30",
+                        ),
+                    ),
+            )
+
+        every { scoresheetService.getScoresheet(100L) } returns scoresheetDto
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/games/100/scoresheet"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.gameInfo.gameId").value(100))
+            .andExpect(jsonPath("$.data.gameInfo.competitionName").value("2024 시즌"))
+            .andExpect(jsonPath("$.data.teams.home.teamName").value("홈팀"))
+            .andExpect(jsonPath("$.data.teams.away.teamName").value("원정팀"))
+            .andExpect(jsonPath("$.data.teams.home.totalScore").value(5))
+            .andExpect(jsonPath("$.data.teams.away.totalScore").value(3))
+            .andExpect(jsonPath("$.data.inningScores.innings").value(9))
+            .andExpect(jsonPath("$.data.battingRecords.home[0].name").value("홈타자1"))
+            .andExpect(jsonPath("$.data.pitchingRecords.home[0].name").value("홈투수1"))
+            .andExpect(jsonPath("$.data.keyEvents[0].description").value("원정팀 선제 득점"))
+    }
+
+    @Test
+    fun `should return 404 when game not found`() {
+        // given
+        every { scoresheetService.getScoresheet(999L) } throws GameNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/games/999/scoresheet"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("GAME_NOT_FOUND"))
+    }
+
+    @Test
+    fun `should download scoresheet as PDF`() {
+        // given
+        val scoresheetDto =
+            ScoresheetDto(
+                gameInfo =
+                    GameInfoDto(
+                        gameId = 100L,
+                        competitionName = "2024 시즌",
+                        gameNumber = 1,
+                        scheduledAt = LocalDateTime.of(2024, 3, 15, 14, 0),
+                        startedAt = null,
+                        endedAt = null,
+                        location = null,
+                        fieldName = null,
+                        status = "예정",
+                        currentInning = "경기 전",
+                        totalInnings = 9,
+                    ),
+                teams =
+                    TeamsScoresheetDto(
+                        home =
+                            TeamScoresheetInfoDto(
+                                teamId = 1L,
+                                teamName = "홈팀",
+                                totalScore = 0,
+                                totalHits = 0,
+                                totalErrors = 0,
+                                result = "미정",
+                            ),
+                        away =
+                            TeamScoresheetInfoDto(
+                                teamId = 2L,
+                                teamName = "원정팀",
+                                totalScore = 0,
+                                totalHits = 0,
+                                totalErrors = 0,
+                                result = "미정",
+                            ),
+                    ),
+                inningScores = InningScoresDto(9, emptyList(), emptyList()),
+                battingRecords = BattingRecordsDto(emptyList(), emptyList()),
+                pitchingRecords = PitchingRecordsDto(emptyList(), emptyList()),
+                keyEvents = emptyList(),
+            )
+
+        val pdfBytes = "PDF Content".toByteArray()
+
+        every { scoresheetService.getScoresheet(100L) } returns scoresheetDto
+        every { pdfGenerator.generateScoresheetPdf(scoresheetDto) } returns pdfBytes
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/games/100/scoresheet/pdf"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_PDF))
+            .andExpect(
+                header().string(
+                    "Content-Disposition",
+                    "form-data; name=\"attachment\"; filename=\"scoresheet_game_100.pdf\""
+                )
+            )
+            .andExpect(content().bytes(pdfBytes))
+    }
+
+    @Test
+    fun `should return 404 when downloading PDF for non-existent game`() {
+        // given
+        every { scoresheetService.getScoresheet(999L) } throws GameNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/games/999/scoresheet/pdf"))
+            .andExpect(status().isNotFound)
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/match/MatchRequestControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/match/MatchRequestControllerTest.kt
@@ -1,0 +1,356 @@
+package com.nextup.api.controller.match
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.match.CreateMatchRequestApiRequest
+import com.nextup.api.dto.match.RespondToMatchRequestApiRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.MatchRequestNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.match.MatchRequest
+import com.nextup.core.domain.match.MatchRequestStatus
+import com.nextup.core.domain.match.MatchResponse
+import com.nextup.core.domain.match.MatchResponseStatus
+import com.nextup.core.domain.match.SkillLevel
+import com.nextup.core.domain.team.Team
+import com.nextup.core.service.match.MatchingService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+import java.time.LocalDate
+
+@DisplayName("MatchRequestController")
+class MatchRequestControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var matchingService: MatchingService
+    private lateinit var objectMapper: ObjectMapper
+
+    private val mockTeam = mockk<Team>(relaxed = true)
+    private val mockRespondTeam = mockk<Team>(relaxed = true)
+    private val mockMatchRequest = mockk<MatchRequest>(relaxed = true)
+    private val mockMatchResponse = mockk<MatchResponse>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        matchingService = mockk()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+        val controller = MatchRequestController(matchingService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        every { mockTeam.id } returns 1L
+        every { mockTeam.name } returns "테스트 팀"
+        every { mockRespondTeam.id } returns 2L
+        every { mockRespondTeam.name } returns "응답 팀"
+
+        every { mockMatchRequest.id } returns 1L
+        every { mockMatchRequest.team } returns mockTeam
+        every { mockMatchRequest.preferredDate } returns LocalDate.now().plusDays(7)
+        every { mockMatchRequest.preferredTime } returns "14:00-17:00"
+        every { mockMatchRequest.preferredLocation } returns "서울 야구장"
+        every { mockMatchRequest.message } returns "연습 경기 희망합니다"
+        every { mockMatchRequest.skillLevel } returns SkillLevel.INTERMEDIATE
+        every { mockMatchRequest.status } returns MatchRequestStatus.OPEN
+        every { mockMatchRequest.createdAt } returns Instant.now()
+
+        every { mockMatchResponse.id } returns 1L
+        every { mockMatchResponse.matchRequest } returns mockMatchRequest
+        every { mockMatchResponse.respondTeam } returns mockRespondTeam
+        every { mockMatchResponse.message } returns "함께 경기하고 싶습니다"
+        every { mockMatchResponse.status } returns MatchResponseStatus.PENDING
+        every { mockMatchResponse.createdAt } returns Instant.now()
+    }
+
+    @Test
+    fun `should create match request successfully`() {
+        // given
+        val request =
+            CreateMatchRequestApiRequest(
+                teamId = 1L,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = "14:00-17:00",
+                preferredLocation = "서울 야구장",
+                message = "연습 경기 희망합니다",
+                skillLevel = SkillLevel.INTERMEDIATE,
+            )
+
+        every { matchingService.createRequest(any()) } returns mockMatchRequest
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/match-requests")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.teamId").value(1))
+            .andExpect(jsonPath("$.data.teamName").value("테스트 팀"))
+            .andExpect(jsonPath("$.data.skillLevel").value("INTERMEDIATE"))
+            .andExpect(jsonPath("$.data.status").value("OPEN"))
+
+        verify(exactly = 1) { matchingService.createRequest(any()) }
+    }
+
+    @Test
+    fun `should fail to create match request with invalid data`() {
+        // given
+        val invalidRequest =
+            mapOf(
+                "teamId" to null,
+                "preferredDate" to null,
+                "skillLevel" to null,
+            )
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/match-requests")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidRequest)),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+
+        verify(exactly = 0) { matchingService.createRequest(any()) }
+    }
+
+    @Test
+    fun `should fail to create match request when team not found`() {
+        // given
+        val request =
+            CreateMatchRequestApiRequest(
+                teamId = 999L,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+
+        every { matchingService.createRequest(any()) } throws TeamNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/match-requests")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should get open match requests`() {
+        // given
+        every { matchingService.getOpenRequests() } returns listOf(mockMatchRequest)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/match-requests"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].id").value(1))
+            .andExpect(jsonPath("$.data[0].status").value("OPEN"))
+
+        verify(exactly = 1) { matchingService.getOpenRequests() }
+    }
+
+    @Test
+    fun `should get empty list when no open requests`() {
+        // given
+        every { matchingService.getOpenRequests() } returns emptyList()
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/match-requests"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data").isEmpty)
+
+        verify(exactly = 1) { matchingService.getOpenRequests() }
+    }
+
+    @Test
+    fun `should get match request detail with responses`() {
+        // given
+        every { matchingService.getRequestById(1L) } returns mockMatchRequest
+        every { matchingService.getResponsesByRequest(1L) } returns listOf(mockMatchResponse)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/match-requests/1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.responses").isArray)
+            .andExpect(jsonPath("$.data.responses[0].id").value(1))
+            .andExpect(jsonPath("$.data.responses[0].respondTeamName").value("응답 팀"))
+
+        verify(exactly = 1) { matchingService.getRequestById(1L) }
+        verify(exactly = 1) { matchingService.getResponsesByRequest(1L) }
+    }
+
+    @Test
+    fun `should fail to get match request detail when not found`() {
+        // given
+        every { matchingService.getRequestById(999L) } throws MatchRequestNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/match-requests/999"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should respond to match request successfully`() {
+        // given
+        val request =
+            RespondToMatchRequestApiRequest(
+                respondTeamId = 2L,
+                message = "함께 경기하고 싶습니다",
+            )
+
+        every { matchingService.respondToRequest(any()) } returns mockMatchResponse
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/match-requests/1/respond")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.respondTeamId").value(2))
+            .andExpect(jsonPath("$.data.status").value("PENDING"))
+
+        verify(exactly = 1) { matchingService.respondToRequest(any()) }
+    }
+
+    @Test
+    fun `should fail to respond with invalid data`() {
+        // given - send invalid JSON that cannot be deserialized
+        val invalidJson = """{"respondTeamId": "not-a-number"}"""
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/match-requests/1/respond")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidJson),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+
+        verify(exactly = 0) { matchingService.respondToRequest(any()) }
+    }
+
+    @Test
+    fun `should accept match response successfully`() {
+        // given
+        every { matchingService.acceptResponse(1L, 1L) } returns mockMatchRequest
+
+        // when & then
+        mockMvc
+            .perform(put("/api/v1/match-requests/1/accept/1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+
+        verify(exactly = 1) { matchingService.acceptResponse(1L, 1L) }
+    }
+
+    @Test
+    fun `should cancel match request successfully`() {
+        // given
+        every { mockMatchRequest.status } returns MatchRequestStatus.CANCELLED
+        every { matchingService.cancelRequest(1L) } returns mockMatchRequest
+
+        // when & then
+        mockMvc
+            .perform(delete("/api/v1/match-requests/1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.status").value("CANCELLED"))
+
+        verify(exactly = 1) { matchingService.cancelRequest(1L) }
+    }
+
+    @Test
+    fun `should fail to cancel when request not found`() {
+        // given
+        every { matchingService.cancelRequest(999L) } throws MatchRequestNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(delete("/api/v1/match-requests/999"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should handle all skill levels`() {
+        // given
+        val skillLevels = listOf(SkillLevel.BEGINNER, SkillLevel.INTERMEDIATE, SkillLevel.ADVANCED, SkillLevel.ANY)
+
+        skillLevels.forEach { skillLevel ->
+            val request =
+                CreateMatchRequestApiRequest(
+                    teamId = 1L,
+                    preferredDate = LocalDate.now().plusDays(7),
+                    preferredTime = null,
+                    preferredLocation = null,
+                    message = null,
+                    skillLevel = skillLevel,
+                )
+
+            val mockRequestWithSkill = mockk<MatchRequest>(relaxed = true)
+            every { mockRequestWithSkill.id } returns 1L
+            every { mockRequestWithSkill.team } returns mockTeam
+            every { mockRequestWithSkill.preferredDate } returns LocalDate.now().plusDays(7)
+            every { mockRequestWithSkill.preferredTime } returns null
+            every { mockRequestWithSkill.preferredLocation } returns null
+            every { mockRequestWithSkill.message } returns null
+            every { mockRequestWithSkill.skillLevel } returns skillLevel
+            every { mockRequestWithSkill.status } returns MatchRequestStatus.OPEN
+            every { mockRequestWithSkill.createdAt } returns Instant.now()
+
+            every { matchingService.createRequest(any()) } returns mockRequestWithSkill
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/match-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.skillLevel").value(skillLevel.name))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/notification/NotificationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/notification/NotificationControllerTest.kt
@@ -1,0 +1,388 @@
+package com.nextup.api.controller.notification
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.notification.RegisterDeviceApiRequest
+import com.nextup.api.dto.notification.UpdatePreferenceApiRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.DeviceTokenNotFoundException
+import com.nextup.common.exception.NotificationNotFoundException
+import com.nextup.core.domain.notification.*
+import com.nextup.core.service.notification.NotificationService
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+
+@DisplayName("NotificationController")
+class NotificationControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var notificationService: NotificationService
+    private lateinit var objectMapper: ObjectMapper
+
+    private val mockNotification = mockk<Notification>(relaxed = true)
+    private val mockDeviceToken = mockk<DeviceToken>(relaxed = true)
+    private val mockPreference = mockk<NotificationPreference>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        notificationService = mockk()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+        val controller = NotificationController(notificationService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .setCustomArgumentResolvers(PageableHandlerMethodArgumentResolver())
+                .build()
+
+        every { mockNotification.id } returns 1L
+        every { mockNotification.userId } returns 100L
+        every { mockNotification.type } returns NotificationType.GAME_START
+        every { mockNotification.title } returns "경기 시작"
+        every { mockNotification.body } returns "30분 후 경기가 시작됩니다"
+        every { mockNotification.data } returns """{"gameId": 123}"""
+        every { mockNotification.readAt } returns null
+        every { mockNotification.sentAt } returns null
+        every { mockNotification.createdAt } returns Instant.now()
+
+        every { mockDeviceToken.id } returns 1L
+        every { mockDeviceToken.userId } returns 100L
+        every { mockDeviceToken.token } returns "fcm-token-12345"
+        every { mockDeviceToken.platform } returns DevicePlatform.IOS
+        every { mockDeviceToken.createdAt } returns Instant.now()
+
+        every { mockPreference.id } returns 1L
+        every { mockPreference.userId } returns 100L
+        every { mockPreference.type } returns NotificationType.GAME_START
+        every { mockPreference.enabled } returns true
+        every { mockPreference.createdAt } returns Instant.now()
+    }
+
+    @Test
+    fun `should register device successfully`() {
+        // given
+        val request =
+            RegisterDeviceApiRequest(
+                token = "fcm-token-12345",
+                platform = DevicePlatform.IOS,
+            )
+
+        every { notificationService.registerDevice(any()) } returns mockDeviceToken
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/devices")
+                    .param("userId", "100")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.userId").value(100))
+            .andExpect(jsonPath("$.data.token").value("fcm-token-12345"))
+            .andExpect(jsonPath("$.data.platform").value("IOS"))
+
+        verify(exactly = 1) { notificationService.registerDevice(any()) }
+    }
+
+    @Test
+    fun `should fail to register device with invalid request`() {
+        // given
+        val invalidRequest =
+            mapOf(
+                "token" to "",
+                "platform" to "INVALID",
+            )
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/devices")
+                    .param("userId", "100")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidRequest)),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+
+        verify(exactly = 0) { notificationService.registerDevice(any()) }
+    }
+
+    @Test
+    fun `should remove device successfully`() {
+        // given
+        justRun { notificationService.removeDevice(1L) }
+
+        // when & then
+        mockMvc
+            .perform(delete("/api/v1/devices/1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+
+        verify(exactly = 1) { notificationService.removeDevice(1L) }
+    }
+
+    @Test
+    fun `should fail to remove device when not found`() {
+        // given
+        every { notificationService.removeDevice(999L) } throws DeviceTokenNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(delete("/api/v1/devices/999"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should get notifications successfully`() {
+        // given
+        val pageable = PageRequest.of(0, 20)
+        val page = PageImpl(listOf(mockNotification), pageable, 1)
+
+        every { notificationService.getUserNotifications(100L, any()) } returns page
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/notifications")
+                    .param("userId", "100")
+                    .param("page", "0")
+                    .param("size", "20"),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].id").value(1))
+            .andExpect(jsonPath("$.data[0].userId").value(100))
+            .andExpect(jsonPath("$.data[0].type").value("GAME_START"))
+            .andExpect(jsonPath("$.data[0].title").value("경기 시작"))
+
+        verify(exactly = 1) { notificationService.getUserNotifications(100L, any()) }
+    }
+
+    @Test
+    fun `should get empty list when no notifications found`() {
+        // given
+        val pageable = PageRequest.of(0, 20)
+        val page = PageImpl<Notification>(emptyList(), pageable, 0)
+
+        every { notificationService.getUserNotifications(999L, any()) } returns page
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/notifications")
+                    .param("userId", "999")
+                    .param("page", "0")
+                    .param("size", "20"),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data").isEmpty)
+
+        verify(exactly = 1) { notificationService.getUserNotifications(999L, any()) }
+    }
+
+    @Test
+    fun `should mark notification as read successfully`() {
+        // given
+        every { notificationService.markAsRead(1L) } returns mockNotification
+
+        // when & then
+        mockMvc
+            .perform(put("/api/v1/notifications/1/read"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+
+        verify(exactly = 1) { notificationService.markAsRead(1L) }
+    }
+
+    @Test
+    fun `should fail to mark notification as read when not found`() {
+        // given
+        every { notificationService.markAsRead(999L) } throws NotificationNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(put("/api/v1/notifications/999/read"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should update preference successfully`() {
+        // given
+        val request =
+            UpdatePreferenceApiRequest(
+                type = NotificationType.GAME_START,
+                enabled = false,
+            )
+
+        every { notificationService.updatePreference(any()) } returns mockPreference
+
+        // when & then
+        mockMvc
+            .perform(
+                put("/api/v1/notifications/preferences")
+                    .param("userId", "100")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.userId").value(100))
+            .andExpect(jsonPath("$.data.type").value("GAME_START"))
+
+        verify(exactly = 1) { notificationService.updatePreference(any()) }
+    }
+
+    @Test
+    fun `should fail to update preference with invalid request`() {
+        // given
+        val invalidRequest =
+            mapOf(
+                "type" to "INVALID",
+                "enabled" to "not-a-boolean",
+            )
+
+        // when & then
+        mockMvc
+            .perform(
+                put("/api/v1/notifications/preferences")
+                    .param("userId", "100")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidRequest)),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+
+        verify(exactly = 0) { notificationService.updatePreference(any()) }
+    }
+
+    @Test
+    fun `should get preferences successfully`() {
+        // given
+        every { notificationService.getUserPreferences(100L) } returns listOf(mockPreference)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/notifications/preferences").param("userId", "100"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].id").value(1))
+            .andExpect(jsonPath("$.data[0].userId").value(100))
+            .andExpect(jsonPath("$.data[0].type").value("GAME_START"))
+            .andExpect(jsonPath("$.data[0].enabled").value(true))
+
+        verify(exactly = 1) { notificationService.getUserPreferences(100L) }
+    }
+
+    @Test
+    fun `should get empty list when no preferences found`() {
+        // given
+        every { notificationService.getUserPreferences(999L) } returns emptyList()
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/notifications/preferences").param("userId", "999"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data").isEmpty)
+
+        verify(exactly = 1) { notificationService.getUserPreferences(999L) }
+    }
+
+    @Test
+    fun `should handle different notification types`() {
+        // given
+        val types =
+            listOf(
+                NotificationType.GAME_START,
+                NotificationType.TEAM_NOTICE,
+                NotificationType.ATTENDANCE_NUDGE,
+                NotificationType.RECORD_ALERT,
+            )
+
+        types.forEach { type ->
+            val mockPref = mockk<NotificationPreference>(relaxed = true)
+            every { mockPref.id } returns 1L
+            every { mockPref.userId } returns 100L
+            every { mockPref.type } returns type
+            every { mockPref.enabled } returns true
+            every { mockPref.createdAt } returns Instant.now()
+
+            every { notificationService.getUserPreferences(100L) } returns listOf(mockPref)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/notifications/preferences").param("userId", "100"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].type").value(type.name))
+        }
+    }
+
+    @Test
+    fun `should handle different device platforms`() {
+        // given
+        val platforms =
+            listOf(
+                DevicePlatform.IOS,
+                DevicePlatform.ANDROID,
+                DevicePlatform.WEB,
+            )
+
+        platforms.forEach { platform ->
+            val request =
+                RegisterDeviceApiRequest(
+                    token = "token-for-$platform",
+                    platform = platform,
+                )
+
+            val mockDevice = mockk<DeviceToken>(relaxed = true)
+            every { mockDevice.id } returns 1L
+            every { mockDevice.userId } returns 100L
+            every { mockDevice.token } returns "token-for-$platform"
+            every { mockDevice.platform } returns platform
+            every { mockDevice.createdAt } returns Instant.now()
+
+            every { notificationService.registerDevice(any()) } returns mockDevice
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/devices")
+                        .param("userId", "100")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.platform").value(platform.name))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/recruitment/RecruitmentControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/recruitment/RecruitmentControllerTest.kt
@@ -1,0 +1,278 @@
+package com.nextup.api.controller.recruitment
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.recruitment.CreateRecruitmentApiRequest
+import com.nextup.api.dto.recruitment.UpdateRecruitmentApiRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.RecruitmentNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.recruitment.RecruitmentStatus
+import com.nextup.core.domain.recruitment.TeamRecruitment
+import com.nextup.core.domain.team.Team
+import com.nextup.core.service.recruitment.TeamRecruitmentService
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+import java.time.LocalDate
+
+@DisplayName("RecruitmentController")
+class RecruitmentControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var recruitmentService: TeamRecruitmentService
+    private lateinit var objectMapper: ObjectMapper
+
+    private val mockTeam = mockk<Team>(relaxed = true)
+    private val mockRecruitment = mockk<TeamRecruitment>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        recruitmentService = mockk()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+        val controller = RecruitmentController(recruitmentService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        every { mockTeam.id } returns 1L
+        every { mockTeam.name } returns "테스트 팀"
+
+        every { mockRecruitment.id } returns 1L
+        every { mockRecruitment.team } returns mockTeam
+        every { mockRecruitment.title } returns "투수 모집"
+        every { mockRecruitment.description } returns "경험 많은 투수를 모집합니다"
+        every { mockRecruitment.positionsNeeded } returns "투수,포수"
+        every { mockRecruitment.ageRange } returns "20-35"
+        every { mockRecruitment.skillLevel } returns "중급"
+        every { mockRecruitment.location } returns "서울"
+        every { mockRecruitment.deadline } returns LocalDate.now().plusDays(30)
+        every { mockRecruitment.status } returns RecruitmentStatus.OPEN
+        every { mockRecruitment.createdAt } returns Instant.now()
+        every { mockRecruitment.updatedAt } returns Instant.now()
+    }
+
+    @Test
+    fun `should get all open recruitments`() {
+        // given
+        every { recruitmentService.getAllOpen() } returns listOf(mockRecruitment)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/recruitments"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].title").value("투수 모집"))
+            .andExpect(jsonPath("$.data[0].status").value("OPEN"))
+
+        verify(exactly = 1) { recruitmentService.getAllOpen() }
+    }
+
+    @Test
+    fun `should get empty list when no open recruitments`() {
+        // given
+        every { recruitmentService.getAllOpen() } returns emptyList()
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/recruitments"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data").isEmpty)
+
+        verify(exactly = 1) { recruitmentService.getAllOpen() }
+    }
+
+    @Test
+    fun `should get recruitment by id`() {
+        // given
+        every { recruitmentService.getById(1L) } returns mockRecruitment
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/recruitments/1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.title").value("투수 모집"))
+            .andExpect(jsonPath("$.data.teamName").value("테스트 팀"))
+
+        verify(exactly = 1) { recruitmentService.getById(1L) }
+    }
+
+    @Test
+    fun `should return 404 when recruitment not found`() {
+        // given
+        every { recruitmentService.getById(999L) } throws RecruitmentNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/recruitments/999"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should create recruitment`() {
+        // given
+        val request =
+            CreateRecruitmentApiRequest(
+                title = "투수 모집",
+                description = "경험 많은 투수를 모집합니다",
+                positionsNeeded = "투수,포수",
+                ageRange = "20-35",
+                skillLevel = "중급",
+                location = "서울",
+                deadline = LocalDate.now().plusDays(30),
+            )
+
+        every { recruitmentService.createRecruitment(any()) } returns mockRecruitment
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/teams/1/recruitments")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.title").value("투수 모집"))
+            .andExpect(jsonPath("$.data.status").value("OPEN"))
+
+        verify(exactly = 1) { recruitmentService.createRecruitment(any()) }
+    }
+
+    @Test
+    fun `should return 400 when creating recruitment with invalid data`() {
+        // given
+        val invalidRequest =
+            mapOf(
+                "title" to "",
+                "description" to "설명",
+                "positionsNeeded" to "투수",
+                "deadline" to LocalDate.now().plusDays(30).toString(),
+            )
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/teams/1/recruitments")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidRequest)),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+
+        verify(exactly = 0) { recruitmentService.createRecruitment(any()) }
+    }
+
+    @Test
+    fun `should return 404 when creating recruitment with non-existent team`() {
+        // given
+        val request =
+            CreateRecruitmentApiRequest(
+                title = "투수 모집",
+                description = "설명",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = LocalDate.now().plusDays(30),
+            )
+
+        every { recruitmentService.createRecruitment(any()) } throws TeamNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/teams/999/recruitments")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should update recruitment`() {
+        // given
+        val request =
+            UpdateRecruitmentApiRequest(
+                title = "새 제목",
+                description = "새 설명",
+                positionsNeeded = "투수,포수,내야수",
+                deadline = LocalDate.now().plusDays(60),
+            )
+
+        val updatedRecruitment = mockk<TeamRecruitment>(relaxed = true)
+        every { updatedRecruitment.id } returns 1L
+        every { updatedRecruitment.team } returns mockTeam
+        every { updatedRecruitment.title } returns "새 제목"
+        every { updatedRecruitment.description } returns "새 설명"
+        every { updatedRecruitment.positionsNeeded } returns "투수,포수,내야수"
+        every { updatedRecruitment.ageRange } returns null
+        every { updatedRecruitment.skillLevel } returns null
+        every { updatedRecruitment.location } returns null
+        every { updatedRecruitment.deadline } returns LocalDate.now().plusDays(60)
+        every { updatedRecruitment.status } returns RecruitmentStatus.OPEN
+        every { updatedRecruitment.createdAt } returns Instant.now()
+        every { updatedRecruitment.updatedAt } returns Instant.now()
+
+        every { recruitmentService.updateRecruitment(any(), any()) } returns updatedRecruitment
+
+        // when & then
+        mockMvc
+            .perform(
+                put("/api/v1/teams/1/recruitments/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.title").value("새 제목"))
+
+        verify(exactly = 1) { recruitmentService.updateRecruitment(any(), any()) }
+    }
+
+    @Test
+    fun `should delete recruitment`() {
+        // given
+        justRun { recruitmentService.deleteRecruitment(1L) }
+
+        // when & then
+        mockMvc
+            .perform(delete("/api/v1/teams/1/recruitments/1"))
+            .andExpect(status().isNoContent)
+            .andExpect(jsonPath("$.success").value(true))
+
+        verify(exactly = 1) { recruitmentService.deleteRecruitment(1L) }
+    }
+
+    @Test
+    fun `should return 404 when deleting non-existent recruitment`() {
+        // given
+        every { recruitmentService.deleteRecruitment(999L) } throws RecruitmentNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(delete("/api/v1/teams/1/recruitments/999"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/report/CompetitionReportControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/report/CompetitionReportControllerTest.kt
@@ -1,0 +1,173 @@
+package com.nextup.api.controller.report
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.service.report.CompetitionReportService
+import com.nextup.core.service.report.dto.CompetitionReportDto
+import com.nextup.core.service.report.dto.CompetitionSummaryDto
+import com.nextup.core.service.report.dto.HighScoringGameDto
+import com.nextup.core.service.report.dto.WinStreakDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+
+class CompetitionReportControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var reportService: CompetitionReportService
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        reportService = mockk()
+        val controller = CompetitionReportController(reportService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @Test
+    fun `should return full report successfully`() {
+        // given
+        val competitionId = 1L
+        val summary =
+            CompetitionSummaryDto(
+                competitionId = competitionId,
+                totalGames = 10,
+                completedGames = 8,
+                totalRuns = 80,
+                averageRunsPerGame = 10.0,
+                totalHits = 120,
+                totalHomeRuns = 15,
+                totalStrikeouts = 100,
+                highestScoringGame =
+                    HighScoringGameDto(
+                        gameId = 5L,
+                        homeTeamName = "팀A",
+                        awayTeamName = "팀B",
+                        totalRuns = 20,
+                        date = LocalDate.of(2024, 3, 15),
+                    ),
+                longestWinStreak =
+                    WinStreakDto(
+                        teamName = "팀A",
+                        streakLength = 5,
+                    ),
+            )
+
+        val report =
+            CompetitionReportDto(
+                competitionId = competitionId,
+                competitionName = "2024 춘계대회",
+                season = 1,
+                standings = emptyList(),
+                summary = summary,
+            )
+
+        every { reportService.getReport(competitionId) } returns report
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/competitions/{competitionId}/report", competitionId)
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.competitionId").value(competitionId))
+            .andExpect(jsonPath("$.data.competitionName").value("2024 춘계대회"))
+            .andExpect(jsonPath("$.data.season").value(1))
+            .andExpect(jsonPath("$.data.summary.totalGames").value(10))
+            .andExpect(jsonPath("$.data.summary.completedGames").value(8))
+            .andExpect(jsonPath("$.data.summary.totalRuns").value(80))
+            .andExpect(jsonPath("$.data.summary.averageRunsPerGame").value(10.0))
+            .andExpect(jsonPath("$.data.summary.totalHits").value(120))
+            .andExpect(jsonPath("$.data.summary.totalHomeRuns").value(15))
+            .andExpect(jsonPath("$.data.summary.totalStrikeouts").value(100))
+            .andExpect(jsonPath("$.data.summary.highestScoringGame.gameId").value(5))
+            .andExpect(jsonPath("$.data.summary.highestScoringGame.homeTeamName").value("팀A"))
+            .andExpect(jsonPath("$.data.summary.highestScoringGame.awayTeamName").value("팀B"))
+            .andExpect(jsonPath("$.data.summary.highestScoringGame.totalRuns").value(20))
+            .andExpect(jsonPath("$.data.summary.longestWinStreak.teamName").value("팀A"))
+            .andExpect(jsonPath("$.data.summary.longestWinStreak.streakLength").value(5))
+    }
+
+    @Test
+    fun `should return summary only successfully`() {
+        // given
+        val competitionId = 1L
+        val summary =
+            CompetitionSummaryDto(
+                competitionId = competitionId,
+                totalGames = 10,
+                completedGames = 8,
+                totalRuns = 80,
+                averageRunsPerGame = 10.0,
+                totalHits = 120,
+                totalHomeRuns = 15,
+                totalStrikeouts = 100,
+                highestScoringGame = null,
+                longestWinStreak = null,
+            )
+
+        every { reportService.getReportSummary(competitionId) } returns summary
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/competitions/{competitionId}/report/summary", competitionId)
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.competitionId").value(competitionId))
+            .andExpect(jsonPath("$.data.totalGames").value(10))
+            .andExpect(jsonPath("$.data.completedGames").value(8))
+            .andExpect(jsonPath("$.data.totalRuns").value(80))
+            .andExpect(jsonPath("$.data.highestScoringGame").isEmpty)
+            .andExpect(jsonPath("$.data.longestWinStreak").isEmpty)
+    }
+
+    @Test
+    fun `should return 404 when competition not found`() {
+        // given
+        val competitionId = 999L
+        every { reportService.getReport(competitionId) } throws CompetitionNotFoundException(competitionId)
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/competitions/{competitionId}/report", competitionId)
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("COMPETITION_NOT_FOUND"))
+    }
+
+    @Test
+    fun `should return 404 when competition not found for summary`() {
+        // given
+        val competitionId = 999L
+        every { reportService.getReportSummary(competitionId) } throws CompetitionNotFoundException(competitionId)
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/competitions/{competitionId}/report/summary", competitionId)
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("COMPETITION_NOT_FOUND"))
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingControllerTest.kt
@@ -1,0 +1,169 @@
+package com.nextup.api.controller.stadium
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.domain.stadium.Stadium
+import com.nextup.core.domain.stadium.StadiumBooking
+import com.nextup.core.domain.stadium.StadiumSlot
+import com.nextup.core.service.stadium.StadiumService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+import java.time.LocalTime
+
+@DisplayName("BookingController")
+class BookingControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var stadiumService: StadiumService
+    private lateinit var controller: BookingController
+
+    @BeforeEach
+    fun setUp() {
+        stadiumService = mockk()
+        controller = BookingController(stadiumService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).setControllerAdvice(GlobalExceptionHandler()).build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/bookings/team/{teamId}")
+    inner class GetTeamBookings {
+        @Test
+        fun `should return all team bookings`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장")
+            val slot = createSlot(1L, stadium)
+            val bookings =
+                listOf(
+                    createBooking(1L, slot, 100L, 200L),
+                    createBooking(2L, slot, 100L, 200L),
+                )
+            every { stadiumService.getTeamBookings(100L, null) } returns bookings
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/bookings/team/100"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+        }
+
+        @Test
+        fun `should filter by status when provided`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장")
+            val slot = createSlot(1L, stadium)
+            val bookings = listOf(createBooking(1L, slot, 100L, 200L))
+            every { stadiumService.getTeamBookings(100L, BookingStatus.CONFIRMED) } returns bookings
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/bookings/team/100")
+                        .param("status", "CONFIRMED"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(1))
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/bookings/{id}")
+    inner class CancelBooking {
+        @Test
+        fun `should cancel booking successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장")
+            val slot = createSlot(1L, stadium)
+            val booking = createBooking(1L, slot, 100L, 200L)
+            booking.cancel()
+            every { stadiumService.cancelBooking(1L) } returns booking
+
+            // when & then
+            mockMvc
+                .perform(delete("/api/v1/bookings/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"))
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/bookings/{id}/complete")
+    inner class CompleteBooking {
+        @Test
+        fun `should complete booking successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장")
+            val slot = createSlot(1L, stadium)
+            val booking = createBooking(1L, slot, 100L, 200L)
+            booking.complete()
+            every { stadiumService.completeBooking(1L) } returns booking
+
+            // when & then
+            mockMvc
+                .perform(put("/api/v1/bookings/1/complete"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"))
+        }
+    }
+
+    private fun createStadium(
+        id: Long,
+        name: String,
+    ): Stadium {
+        val stadium =
+            Stadium.create(
+                name = name,
+                address = "서울특별시",
+                latitude = 37.5121,
+                longitude = 127.0717,
+            )
+        val idField = Stadium::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(stadium, id)
+        return stadium
+    }
+
+    private fun createSlot(
+        id: Long,
+        stadium: Stadium,
+    ): StadiumSlot {
+        val slot =
+            StadiumSlot.create(
+                stadium = stadium,
+                date = LocalDate.of(2024, 12, 25),
+                startTime = LocalTime.of(10, 0),
+                endTime = LocalTime.of(12, 0),
+            )
+        val idField = StadiumSlot::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(slot, id)
+        return slot
+    }
+
+    private fun createBooking(
+        id: Long,
+        slot: StadiumSlot,
+        teamId: Long,
+        bookedBy: Long,
+    ): StadiumBooking {
+        val booking = StadiumBooking.create(slot = slot, teamId = teamId, bookedBy = bookedBy)
+        val idField = StadiumBooking::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(booking, id)
+        return booking
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/StadiumControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/StadiumControllerTest.kt
@@ -1,0 +1,206 @@
+package com.nextup.api.controller.stadium
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.core.domain.stadium.Stadium
+import com.nextup.core.domain.stadium.StadiumBooking
+import com.nextup.core.domain.stadium.StadiumSlot
+import com.nextup.core.service.stadium.StadiumService
+import com.nextup.core.service.stadium.dto.BookSlotRequest
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+import java.time.LocalTime
+
+@DisplayName("StadiumController")
+class StadiumControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var stadiumService: StadiumService
+    private lateinit var controller: StadiumController
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        stadiumService = mockk()
+        controller = StadiumController(stadiumService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).setControllerAdvice(GlobalExceptionHandler()).build()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/stadiums/search")
+    inner class SearchStadiums {
+        @Test
+        fun `should search nearby stadiums`() {
+            // given
+            val stadiums =
+                listOf(
+                    createStadium(1L, "잠실 야구장", 37.5121, 127.0717),
+                    createStadium(2L, "고척 야구장", 37.4981, 126.8671),
+                )
+            every { stadiumService.searchStadiums(37.5, 127.0, 10.0) } returns stadiums
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/search")
+                        .param("latitude", "37.5")
+                        .param("longitude", "127.0")
+                        .param("radiusKm", "10.0"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].name").value("잠실 야구장"))
+        }
+
+        @Test
+        fun `should use default radius when not provided`() {
+            // given
+            val stadiums = listOf(createStadium(1L, "잠실 야구장", 37.5121, 127.0717))
+            every { stadiumService.searchStadiums(37.5, 127.0, 10.0) } returns stadiums
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/search")
+                        .param("latitude", "37.5")
+                        .param("longitude", "127.0"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/stadiums/{id}")
+    inner class GetStadium {
+        @Test
+        fun `should return stadium when found`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            every { stadiumService.getById(1L) } returns stadium
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/stadiums/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("잠실 야구장"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/stadiums/{id}/slots")
+    inner class GetAvailableSlots {
+        @Test
+        fun `should return available slots for a date`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val slots =
+                listOf(
+                    createSlot(1L, stadium, LocalDate.of(2024, 12, 25)),
+                    createSlot(2L, stadium, LocalDate.of(2024, 12, 25)),
+                )
+            every { stadiumService.getAvailableSlots(1L, LocalDate.of(2024, 12, 25)) } returns slots
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/1/slots")
+                        .param("date", "2024-12-25"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/stadiums/book")
+    inner class BookSlot {
+        @Test
+        fun `should book slot successfully`() {
+            // given
+            val request = BookSlotRequest(slotId = 1L, teamId = 100L, bookedBy = 200L)
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val slot = createSlot(1L, stadium, LocalDate.of(2024, 12, 25))
+            val booking = createBooking(1L, slot, 100L, 200L)
+            every { stadiumService.bookSlot(request) } returns booking
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/stadiums/book")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.teamId").value(100))
+                .andExpect(jsonPath("$.data.bookedBy").value(200))
+        }
+    }
+
+    private fun createStadium(
+        id: Long,
+        name: String,
+        latitude: Double,
+        longitude: Double,
+    ): Stadium {
+        val stadium =
+            Stadium.create(
+                name = name,
+                address = "서울특별시",
+                latitude = latitude,
+                longitude = longitude,
+            )
+        val idField = Stadium::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(stadium, id)
+        return stadium
+    }
+
+    private fun createSlot(
+        id: Long,
+        stadium: Stadium,
+        date: LocalDate,
+    ): StadiumSlot {
+        val slot =
+            StadiumSlot.create(
+                stadium = stadium,
+                date = date,
+                startTime = LocalTime.of(10, 0),
+                endTime = LocalTime.of(12, 0),
+            )
+        val idField = StadiumSlot::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(slot, id)
+        return slot
+    }
+
+    private fun createBooking(
+        id: Long,
+        slot: StadiumSlot,
+        teamId: Long,
+        bookedBy: Long,
+    ): StadiumBooking {
+        val booking = StadiumBooking.create(slot = slot, teamId = teamId, bookedBy = bookedBy)
+        val idField = StadiumBooking::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(booking, id)
+        return booking
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/LeaderboardControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/LeaderboardControllerTest.kt
@@ -1,0 +1,268 @@
+package com.nextup.api.controller.stats
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.service.stats.IndividualRankingService
+import com.nextup.core.service.stats.dto.BattingCategory
+import com.nextup.core.service.stats.dto.BattingLeaderDto
+import com.nextup.core.service.stats.dto.PitchingCategory
+import com.nextup.core.service.stats.dto.PitchingLeaderDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("LeaderboardController 테스트")
+class LeaderboardControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var individualRankingService: IndividualRankingService
+
+    private val competitionId = 1L
+
+    @BeforeEach
+    fun setUp() {
+        individualRankingService = mockk()
+        val controller = LeaderboardController(individualRankingService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/competitions/{competitionId}/leaderboard/batting")
+    inner class GetBattingLeaders {
+        @Test
+        fun `should return batting leaders successfully`() {
+            // given
+            val leaders =
+                listOf(
+                    BattingLeaderDto(
+                        rank = 1,
+                        playerId = 10L,
+                        playerName = "홍길동",
+                        teamName = "타이거즈",
+                        value = 0.350,
+                        games = 15,
+                        plateAppearances = 50,
+                    ),
+                    BattingLeaderDto(
+                        rank = 2,
+                        playerId = 20L,
+                        playerName = "김철수",
+                        teamName = "이글스",
+                        value = 0.320,
+                        games = 14,
+                        plateAppearances = 48,
+                    ),
+                )
+            every {
+                individualRankingService.getBattingLeaders(competitionId, BattingCategory.BATTING_AVG, 10)
+            } returns leaders
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/$competitionId/leaderboard/batting")
+                        .param("category", "BATTING_AVG"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].rank").value(1))
+                .andExpect(jsonPath("$.data[0].playerName").value("홍길동"))
+                .andExpect(jsonPath("$.data[0].teamName").value("타이거즈"))
+                .andExpect(jsonPath("$.data[0].value").value(0.350))
+                .andExpect(jsonPath("$.data[1].rank").value(2))
+                .andExpect(jsonPath("$.data[1].playerName").value("김철수"))
+        }
+
+        @Test
+        fun `should return home run leaders`() {
+            // given
+            val leaders =
+                listOf(
+                    BattingLeaderDto(
+                        rank = 1,
+                        playerId = 10L,
+                        playerName = "홍길동",
+                        teamName = "타이거즈",
+                        value = 5.0,
+                        games = 15,
+                        plateAppearances = 50,
+                    ),
+                )
+            every {
+                individualRankingService.getBattingLeaders(competitionId, BattingCategory.HOME_RUNS, 10)
+            } returns leaders
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/$competitionId/leaderboard/batting")
+                        .param("category", "HOME_RUNS"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].value").value(5.0))
+        }
+
+        @Test
+        fun `should return empty list when no stats exist`() {
+            // given
+            every {
+                individualRankingService.getBattingLeaders(competitionId, BattingCategory.BATTING_AVG, 10)
+            } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/$competitionId/leaderboard/batting")
+                        .param("category", "BATTING_AVG"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+
+        @Test
+        fun `should return 404 when competition not found`() {
+            // given
+            every {
+                individualRankingService.getBattingLeaders(999L, BattingCategory.BATTING_AVG, 10)
+            } throws CompetitionNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/999/leaderboard/batting")
+                        .param("category", "BATTING_AVG"),
+                )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("COMPETITION_NOT_FOUND"))
+        }
+
+        @Test
+        fun `should support custom limit parameter`() {
+            // given
+            every {
+                individualRankingService.getBattingLeaders(competitionId, BattingCategory.RBI, 5)
+            } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/$competitionId/leaderboard/batting")
+                        .param("category", "RBI")
+                        .param("limit", "5"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/competitions/{competitionId}/leaderboard/pitching")
+    inner class GetPitchingLeaders {
+        @Test
+        fun `should return pitching leaders successfully`() {
+            // given
+            val leaders =
+                listOf(
+                    PitchingLeaderDto(
+                        rank = 1,
+                        playerId = 30L,
+                        playerName = "박지성",
+                        teamName = "라이온즈",
+                        value = 2.50,
+                        games = 12,
+                        inningsPitched = 36.0,
+                    ),
+                    PitchingLeaderDto(
+                        rank = 2,
+                        playerId = 40L,
+                        playerName = "이승엽",
+                        teamName = "베어스",
+                        value = 3.10,
+                        games = 10,
+                        inningsPitched = 30.0,
+                    ),
+                )
+            every {
+                individualRankingService.getPitchingLeaders(competitionId, PitchingCategory.ERA, 10)
+            } returns leaders
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/$competitionId/leaderboard/pitching")
+                        .param("category", "ERA"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].rank").value(1))
+                .andExpect(jsonPath("$.data[0].playerName").value("박지성"))
+                .andExpect(jsonPath("$.data[0].value").value(2.50))
+                .andExpect(jsonPath("$.data[0].inningsPitched").value(36.0))
+        }
+
+        @Test
+        fun `should return wins leaders`() {
+            // given
+            val leaders =
+                listOf(
+                    PitchingLeaderDto(
+                        rank = 1,
+                        playerId = 30L,
+                        playerName = "박지성",
+                        teamName = "라이온즈",
+                        value = 8.0,
+                        games = 15,
+                        inningsPitched = 50.0,
+                    ),
+                )
+            every {
+                individualRankingService.getPitchingLeaders(competitionId, PitchingCategory.WINS, 10)
+            } returns leaders
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/$competitionId/leaderboard/pitching")
+                        .param("category", "WINS"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.data[0].value").value(8.0))
+        }
+
+        @Test
+        fun `should return 404 when competition not found for pitching`() {
+            // given
+            every {
+                individualRankingService.getPitchingLeaders(999L, PitchingCategory.ERA, 10)
+            } throws CompetitionNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/999/leaderboard/pitching")
+                        .param("category", "ERA"),
+                )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamControllerTest.kt
@@ -1,0 +1,308 @@
+package com.nextup.api.controller.team
+
+import com.nextup.api.dto.team.CreateTeamRequest
+import com.nextup.api.dto.team.UpdateTeamRequest
+import com.nextup.common.exception.InsufficientTeamRoleException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.port.repository.LeagueRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.team.TeamMembershipService
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("TeamController")
+class TeamControllerTest {
+    private lateinit var teamMembershipService: TeamMembershipService
+    private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var leagueRepository: LeagueRepositoryPort
+    private lateinit var controller: TeamController
+
+    private val league =
+        mockk<League> {
+            every { id } returns 1L
+            every { name } returns "1부 리그"
+        }
+    private val team =
+        mockk<Team> {
+            every { id } returns 10L
+            every { name } returns "타이거즈"
+            every { city } returns "서울"
+            every { abbreviation } returns "TGR"
+            every { this@mockk.league } returns this@TeamControllerTest.league
+            every { foundedYear } returns 2026
+            every { isActive } returns true
+        }
+
+    @BeforeEach
+    fun setUp() {
+        teamMembershipService = mockk()
+        teamRepository = mockk()
+        leagueRepository = mockk()
+        controller = TeamController(teamMembershipService, teamRepository, leagueRepository)
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/teams")
+    inner class CreateTeam {
+        @Test
+        fun `should create team and register owner`() {
+            // given
+            val request =
+                CreateTeamRequest(
+                    name = "타이거즈",
+                    city = "서울",
+                    leagueId = 1L,
+                    abbreviation = "TGR",
+                    uniformNumber = 1,
+                )
+            every { leagueRepository.findByIdOrNull(1L) } returns league
+            every {
+                teamMembershipService.createTeamWithOwner(
+                    userId = 100L,
+                    team = any(),
+                    uniformNumber = 1,
+                )
+            } returns team
+            every { teamMembershipService.getTeamMemberCount(10L) } returns 1
+
+            // when
+            val response = controller.createTeam(request, 100L)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.teamId).isEqualTo(10L)
+            assertThat(response.data?.name).isEqualTo("타이거즈")
+            assertThat(response.data?.city).isEqualTo("서울")
+            assertThat(response.data?.leagueName).isEqualTo("1부 리그")
+            assertThat(response.data?.memberCount).isEqualTo(1)
+        }
+
+        @Test
+        fun `should throw when league not found`() {
+            // given
+            val request =
+                CreateTeamRequest(
+                    name = "타이거즈",
+                    city = "서울",
+                    leagueId = 999L,
+                )
+            every { leagueRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                controller.createTeam(request, 100L)
+            }
+        }
+
+        @Test
+        fun `should throw when leagueId is null`() {
+            // given
+            val request =
+                CreateTeamRequest(
+                    name = "타이거즈",
+                    city = "서울",
+                    leagueId = null,
+                )
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                controller.createTeam(request, 100L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/teams/{teamId}")
+    inner class UpdateTeam {
+        @Test
+        fun `should update team when owner`() {
+            // given
+            val request = UpdateTeamRequest(name = "뉴타이거즈")
+            val ownerMember =
+                mockk<TeamMember> {
+                    every { isOwner() } returns true
+                    every { role } returns TeamMemberRole.OWNER
+                }
+            every { teamMembershipService.getMember(10L, 100L) } returns ownerMember
+            every { teamRepository.findByIdWithLeague(10L) } returns team
+            every { team.updateBasicInfo(name = "뉴타이거즈", city = null, abbreviation = null) } returns Unit
+            every { teamRepository.save(team) } returns team
+            every { teamMembershipService.getTeamMemberCount(10L) } returns 5
+
+            // when
+            val response = controller.updateTeam(10L, request, 100L)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.teamId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should throw when not owner`() {
+            // given
+            val request = UpdateTeamRequest(name = "뉴타이거즈")
+            val memberMock =
+                mockk<TeamMember> {
+                    every { isOwner() } returns false
+                    every { role } returns TeamMemberRole.MEMBER
+                }
+            every { teamMembershipService.getMember(10L, 100L) } returns memberMock
+
+            // when & then
+            assertThrows<InsufficientTeamRoleException> {
+                controller.updateTeam(10L, request, 100L)
+            }
+        }
+
+        @Test
+        fun `should throw when not a member`() {
+            // given
+            val request = UpdateTeamRequest(name = "뉴타이거즈")
+            every { teamMembershipService.getMember(10L, 100L) } returns null
+
+            // when & then
+            assertThrows<InsufficientTeamRoleException> {
+                controller.updateTeam(10L, request, 100L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}")
+    inner class GetTeam {
+        @Test
+        fun `should return team detail`() {
+            // given
+            every { teamRepository.findByIdWithLeague(10L) } returns team
+            every { teamMembershipService.getTeamMemberCount(10L) } returns 15
+
+            // when
+            val response = controller.getTeam(10L)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.teamId).isEqualTo(10L)
+            assertThat(response.data?.name).isEqualTo("타이거즈")
+            assertThat(response.data?.memberCount).isEqualTo(15)
+        }
+
+        @Test
+        fun `should throw when team not found`() {
+            // given
+            every { teamRepository.findByIdWithLeague(999L) } returns null
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                controller.getTeam(999L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams")
+    inner class GetTeams {
+        @Test
+        fun `should return all active teams`() {
+            // given
+            val team2 =
+                mockk<Team> {
+                    every { id } returns 20L
+                    every { name } returns "이글스"
+                    every { city } returns "부산"
+                    every { abbreviation } returns "EGL"
+                    every { isActive } returns true
+                }
+            every { teamRepository.findActiveTeams() } returns listOf(team, team2)
+            every { teamMembershipService.getTeamMemberCount(10L) } returns 15
+            every { teamMembershipService.getTeamMemberCount(20L) } returns 12
+
+            // when
+            val response = controller.getTeams(null, null)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data).hasSize(2)
+        }
+
+        @Test
+        fun `should filter by name`() {
+            // given
+            every { teamRepository.findActiveTeams() } returns listOf(team)
+            every { teamMembershipService.getTeamMemberCount(10L) } returns 15
+
+            // when
+            val response = controller.getTeams(name = "타이거", city = null)
+
+            // then
+            assertThat(response.data).hasSize(1)
+            assertThat(response.data?.first()?.name).isEqualTo("타이거즈")
+        }
+
+        @Test
+        fun `should filter by city`() {
+            // given
+            every { teamRepository.findActiveTeams() } returns listOf(team)
+            every { teamMembershipService.getTeamMemberCount(10L) } returns 15
+
+            // when
+            val response = controller.getTeams(name = null, city = "서울")
+
+            // then
+            assertThat(response.data).hasSize(1)
+        }
+
+        @Test
+        fun `should return empty when no match`() {
+            // given
+            every { teamRepository.findActiveTeams() } returns listOf(team)
+
+            // when
+            val response = controller.getTeams(name = "없는팀", city = null)
+
+            // then
+            assertThat(response.data).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/teams/{teamId}")
+    inner class DeleteTeam {
+        @Test
+        fun `should delete team when owner and single member`() {
+            // given
+            justRun { teamMembershipService.deleteTeam(10L, 100L) }
+
+            // when
+            val response = controller.deleteTeam(10L, 100L)
+
+            // then
+            assertThat(response.success).isTrue()
+            verify { teamMembershipService.deleteTeam(10L, 100L) }
+        }
+
+        @Test
+        fun `should throw when team not found on delete`() {
+            // given
+            every {
+                teamMembershipService.deleteTeam(999L, 100L)
+            } throws TeamNotFoundException(999L)
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                controller.deleteTeam(999L, 100L)
+            }
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamControllerTest.kt
@@ -3,6 +3,8 @@ package com.nextup.api.controller.team
 import com.nextup.api.dto.team.CreateTeamRequest
 import com.nextup.api.dto.team.UpdateTeamRequest
 import com.nextup.common.exception.InsufficientTeamRoleException
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.common.exception.LeagueNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.team.Team
@@ -101,7 +103,7 @@ class TeamControllerTest {
             every { leagueRepository.findByIdOrNull(999L) } returns null
 
             // when & then
-            assertThrows<IllegalArgumentException> {
+            assertThrows<LeagueNotFoundException> {
                 controller.createTeam(request, 100L)
             }
         }
@@ -117,7 +119,7 @@ class TeamControllerTest {
                 )
 
             // when & then
-            assertThrows<IllegalArgumentException> {
+            assertThrows<InvalidInputException> {
                 controller.createTeam(request, 100L)
             }
         }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamMatchupControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamMatchupControllerTest.kt
@@ -1,0 +1,299 @@
+package com.nextup.api.controller.team
+
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.service.team.TeamMatchupService
+import com.nextup.core.service.team.dto.TeamMatchupDto
+import com.nextup.core.service.team.dto.TeamMatchupGameDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class TeamMatchupControllerTest {
+    private val teamMatchupService: TeamMatchupService = mockk()
+    private val controller = TeamMatchupController(teamMatchupService)
+
+    @Test
+    fun `should return team matchup successfully`() {
+        // given
+        val teamId = 1L
+        val opponentId = 2L
+        val competitionId = 10L
+
+        val matchupDto =
+            TeamMatchupDto(
+                teamId = teamId,
+                teamName = "서울 타이거즈",
+                opponentId = opponentId,
+                opponentName = "부산 라이온즈",
+                wins = 5,
+                losses = 3,
+                draws = 1,
+                totalGames = 9,
+                runsScored = 45,
+                runsAllowed = 30,
+                avgRunsScored = 5.0,
+                avgRunsAllowed = 3.33,
+            )
+
+        every {
+            teamMatchupService.getTeamMatchup(teamId, opponentId, competitionId)
+        } returns matchupDto
+
+        // when
+        val response = controller.getTeamMatchup(teamId, opponentId, competitionId)
+
+        // then
+        assertThat(response.success).isTrue()
+        assertThat(response.data).isNotNull
+        assertThat(response.data?.teamId).isEqualTo(teamId)
+        assertThat(response.data?.opponentId).isEqualTo(opponentId)
+        assertThat(response.data?.record?.wins).isEqualTo(5)
+        assertThat(response.data?.record?.losses).isEqualTo(3)
+        assertThat(response.data?.record?.draws).isEqualTo(1)
+        assertThat(response.data?.record?.totalGames).isEqualTo(9)
+        assertThat(response.data?.record?.winRate).isEqualTo(5.0 / 9.0)
+        assertThat(response.data?.runs?.runsScored).isEqualTo(45)
+        assertThat(response.data?.runs?.runsAllowed).isEqualTo(30)
+        assertThat(response.data?.runs?.runDifferential).isEqualTo(15)
+
+        verify(exactly = 1) {
+            teamMatchupService.getTeamMatchup(teamId, opponentId, competitionId)
+        }
+    }
+
+    @Test
+    fun `should return team matchup without competition filter`() {
+        // given
+        val teamId = 1L
+        val opponentId = 2L
+
+        val matchupDto =
+            TeamMatchupDto(
+                teamId = teamId,
+                teamName = "서울 타이거즈",
+                opponentId = opponentId,
+                opponentName = "부산 라이온즈",
+                wins = 10,
+                losses = 5,
+                draws = 2,
+                totalGames = 17,
+                runsScored = 85,
+                runsAllowed = 60,
+                avgRunsScored = 5.0,
+                avgRunsAllowed = 3.53,
+            )
+
+        every {
+            teamMatchupService.getTeamMatchup(teamId, opponentId, null)
+        } returns matchupDto
+
+        // when
+        val response = controller.getTeamMatchup(teamId, opponentId, null)
+
+        // then
+        assertThat(response.success).isTrue()
+        assertThat(response.data).isNotNull
+        assertThat(response.data?.record?.totalGames).isEqualTo(17)
+
+        verify(exactly = 1) {
+            teamMatchupService.getTeamMatchup(teamId, opponentId, null)
+        }
+    }
+
+    @Test
+    fun `should throw TeamNotFoundException when team does not exist`() {
+        // given
+        val teamId = 999L
+        val opponentId = 2L
+
+        every {
+            teamMatchupService.getTeamMatchup(teamId, opponentId, null)
+        } throws TeamNotFoundException(teamId)
+
+        // when & then
+        assertThrows<TeamNotFoundException> {
+            controller.getTeamMatchup(teamId, opponentId, null)
+        }
+    }
+
+    @Test
+    fun `should return recent games successfully`() {
+        // given
+        val teamId = 1L
+        val opponentId = 2L
+        val limit = 5
+
+        val games =
+            listOf(
+                TeamMatchupGameDto(
+                    gameId = 1L,
+                    date = LocalDate.of(2024, 1, 15),
+                    homeTeamId = teamId,
+                    awayTeamId = opponentId,
+                    homeScore = 5,
+                    awayScore = 3,
+                    result = "WIN",
+                    venue = "서울 야구장",
+                ),
+                TeamMatchupGameDto(
+                    gameId = 2L,
+                    date = LocalDate.of(2024, 1, 10),
+                    homeTeamId = opponentId,
+                    awayTeamId = teamId,
+                    homeScore = 4,
+                    awayScore = 2,
+                    result = "LOSS",
+                    venue = "부산 야구장",
+                ),
+            )
+
+        every {
+            teamMatchupService.getRecentGames(teamId, opponentId, limit)
+        } returns games
+
+        // when
+        val response = controller.getRecentGames(teamId, opponentId, limit)
+
+        // then
+        assertThat(response.success).isTrue()
+        assertThat(response.data).isNotNull
+        assertThat(response.data).hasSize(2)
+        assertThat(response.data?.get(0)?.gameId).isEqualTo(1L)
+        assertThat(response.data?.get(0)?.result).isEqualTo("WIN")
+        assertThat(response.data?.get(1)?.gameId).isEqualTo(2L)
+        assertThat(response.data?.get(1)?.result).isEqualTo("LOSS")
+
+        verify(exactly = 1) {
+            teamMatchupService.getRecentGames(teamId, opponentId, limit)
+        }
+    }
+
+    @Test
+    fun `should use default limit when not specified`() {
+        // given
+        val teamId = 1L
+        val opponentId = 2L
+        val defaultLimit = 10
+
+        every {
+            teamMatchupService.getRecentGames(teamId, opponentId, defaultLimit)
+        } returns emptyList()
+
+        // when
+        val response = controller.getRecentGames(teamId, opponentId, defaultLimit)
+
+        // then
+        assertThat(response.success).isTrue()
+        assertThat(response.data).isNotNull
+        assertThat(response.data).isEmpty()
+
+        verify(exactly = 1) {
+            teamMatchupService.getRecentGames(teamId, opponentId, defaultLimit)
+        }
+    }
+
+    @Test
+    fun `should cap limit to maximum of 50`() {
+        // given
+        val teamId = 1L
+        val opponentId = 2L
+        val requestedLimit = 100
+        val expectedLimit = 50
+
+        every {
+            teamMatchupService.getRecentGames(teamId, opponentId, expectedLimit)
+        } returns emptyList()
+
+        // when
+        val response = controller.getRecentGames(teamId, opponentId, requestedLimit)
+
+        // then
+        assertThat(response.success).isTrue()
+
+        verify(exactly = 1) {
+            teamMatchupService.getRecentGames(teamId, opponentId, expectedLimit)
+        }
+    }
+
+    @Test
+    fun `should enforce minimum limit of 1`() {
+        // given
+        val teamId = 1L
+        val opponentId = 2L
+        val requestedLimit = 0
+        val expectedLimit = 1
+
+        every {
+            teamMatchupService.getRecentGames(teamId, opponentId, expectedLimit)
+        } returns emptyList()
+
+        // when
+        val response = controller.getRecentGames(teamId, opponentId, requestedLimit)
+
+        // then
+        assertThat(response.success).isTrue()
+
+        verify(exactly = 1) {
+            teamMatchupService.getRecentGames(teamId, opponentId, expectedLimit)
+        }
+    }
+
+    @Test
+    fun `should return empty list when no games found`() {
+        // given
+        val teamId = 1L
+        val opponentId = 2L
+        val limit = 10
+
+        every {
+            teamMatchupService.getRecentGames(teamId, opponentId, limit)
+        } returns emptyList()
+
+        // when
+        val response = controller.getRecentGames(teamId, opponentId, limit)
+
+        // then
+        assertThat(response.success).isTrue()
+        assertThat(response.data).isNotNull
+        assertThat(response.data).isEmpty()
+    }
+
+    @Test
+    fun `should calculate win rate correctly for zero games`() {
+        // given
+        val teamId = 1L
+        val opponentId = 2L
+
+        val matchupDto =
+            TeamMatchupDto(
+                teamId = teamId,
+                teamName = "서울 타이거즈",
+                opponentId = opponentId,
+                opponentName = "부산 라이온즈",
+                wins = 0,
+                losses = 0,
+                draws = 0,
+                totalGames = 0,
+                runsScored = 0,
+                runsAllowed = 0,
+                avgRunsScored = 0.0,
+                avgRunsAllowed = 0.0,
+            )
+
+        every {
+            teamMatchupService.getTeamMatchup(teamId, opponentId, null)
+        } returns matchupDto
+
+        // when
+        val response = controller.getTeamMatchup(teamId, opponentId, null)
+
+        // then
+        assertThat(response.success).isTrue()
+        assertThat(response.data?.record?.winRate).isEqualTo(0.0)
+        assertThat(response.data?.runs?.runDifferential).isEqualTo(0)
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/title/TitleControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/title/TitleControllerTest.kt
@@ -1,0 +1,258 @@
+package com.nextup.api.controller.title
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.service.title.TitleCategory
+import com.nextup.core.service.title.TitleService
+import com.nextup.core.service.title.dto.TitleCandidateDto
+import com.nextup.core.service.title.dto.TitleDto
+import com.nextup.core.service.title.dto.TitleWinnerDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("TitleController")
+class TitleControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var titleService: TitleService
+
+    @BeforeEach
+    fun setUp() {
+        titleService = mockk()
+        val controller = TitleController(titleService)
+        mockMvc =
+            MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/competitions/{competitionId}/titles")
+    inner class GetTitles {
+        @Test
+        fun `대회의 모든 타이틀을 조회한다`() {
+            // given
+            val competitionId = 1L
+            val battingAvgTitle =
+                TitleDto(
+                    category = TitleCategory.BATTING_AVG,
+                    displayName = "타격왕",
+                    winner =
+                        TitleWinnerDto(
+                            playerId = 1L,
+                            playerName = "김타격",
+                            teamName = "Tigers",
+                            statValue = 0.350,
+                        ),
+                    topCandidates =
+                        listOf(
+                            TitleCandidateDto(
+                                rank = 1,
+                                playerId = 1L,
+                                playerName = "김타격",
+                                teamName = "Tigers",
+                                statValue = 0.350,
+                                isQualified = true,
+                            ),
+                        ),
+                )
+
+            val homeRunsTitle =
+                TitleDto(
+                    category = TitleCategory.HOME_RUNS,
+                    displayName = "홈런왕",
+                    winner =
+                        TitleWinnerDto(
+                            playerId = 2L,
+                            playerName = "박홈런",
+                            teamName = "Lions",
+                            statValue = 15.0,
+                        ),
+                    topCandidates =
+                        listOf(
+                            TitleCandidateDto(
+                                rank = 1,
+                                playerId = 2L,
+                                playerName = "박홈런",
+                                teamName = "Lions",
+                                statValue = 15.0,
+                                isQualified = true,
+                            ),
+                        ),
+                )
+
+            every { titleService.getTitles(competitionId) } returns listOf(battingAvgTitle, homeRunsTitle)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/competitions/{competitionId}/titles", competitionId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.competitionId").value(competitionId))
+                .andExpect(jsonPath("$.data.titles").isArray)
+                .andExpect(jsonPath("$.data.titles.length()").value(2))
+                .andExpect(jsonPath("$.data.titles[0].category").value("BATTING_AVG"))
+                .andExpect(jsonPath("$.data.titles[0].displayName").value("타격왕"))
+                .andExpect(jsonPath("$.data.titles[0].winner.playerId").value(1))
+                .andExpect(jsonPath("$.data.titles[0].winner.playerName").value("김타격"))
+                .andExpect(jsonPath("$.data.titles[0].winner.statValue").value(0.350))
+                .andExpect(jsonPath("$.data.titles[1].category").value("HOME_RUNS"))
+                .andExpect(jsonPath("$.data.titles[1].displayName").value("홈런왕"))
+        }
+
+        @Test
+        fun `대회가 존재하지 않으면 404 응답`() {
+            // given
+            val competitionId = 999L
+            every { titleService.getTitles(competitionId) } throws CompetitionNotFoundException(competitionId)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/competitions/{competitionId}/titles", competitionId))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("COMPETITION_NOT_FOUND"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/competitions/{competitionId}/titles/{category}")
+    inner class GetTitleByCategory {
+        @Test
+        fun `특정 카테고리의 타이틀을 조회한다`() {
+            // given
+            val competitionId = 1L
+            val category = "BATTING_AVG"
+            val title =
+                TitleDto(
+                    category = TitleCategory.BATTING_AVG,
+                    displayName = "타격왕",
+                    winner =
+                        TitleWinnerDto(
+                            playerId = 1L,
+                            playerName = "김타격",
+                            teamName = "Tigers",
+                            statValue = 0.350,
+                        ),
+                    topCandidates =
+                        listOf(
+                            TitleCandidateDto(
+                                rank = 1,
+                                playerId = 1L,
+                                playerName = "김타격",
+                                teamName = "Tigers",
+                                statValue = 0.350,
+                                isQualified = true,
+                            ),
+                            TitleCandidateDto(
+                                rank = 2,
+                                playerId = 2L,
+                                playerName = "박안타",
+                                teamName = "Lions",
+                                statValue = 0.320,
+                                isQualified = true,
+                            ),
+                        ),
+                )
+
+            every { titleService.getTitleByCategory(competitionId, TitleCategory.BATTING_AVG) } returns title
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/competitions/{competitionId}/titles/{category}", competitionId, category))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.category").value("BATTING_AVG"))
+                .andExpect(jsonPath("$.data.displayName").value("타격왕"))
+                .andExpect(jsonPath("$.data.winner.playerId").value(1))
+                .andExpect(jsonPath("$.data.winner.playerName").value("김타격"))
+                .andExpect(jsonPath("$.data.winner.teamName").value("Tigers"))
+                .andExpect(jsonPath("$.data.winner.statValue").value(0.350))
+                .andExpect(jsonPath("$.data.topCandidates").isArray)
+                .andExpect(jsonPath("$.data.topCandidates.length()").value(2))
+                .andExpect(jsonPath("$.data.topCandidates[0].rank").value(1))
+                .andExpect(jsonPath("$.data.topCandidates[0].isQualified").value(true))
+                .andExpect(jsonPath("$.data.topCandidates[1].rank").value(2))
+        }
+
+        @Test
+        fun `우승자가 없는 경우 winner는 null`() {
+            // given
+            val competitionId = 1L
+            val category = "BATTING_AVG"
+            val title =
+                TitleDto(
+                    category = TitleCategory.BATTING_AVG,
+                    displayName = "타격왕",
+                    winner = null, // 규정 타석 충족자 없음
+                    topCandidates =
+                        listOf(
+                            TitleCandidateDto(
+                                rank = 1,
+                                playerId = 1L,
+                                playerName = "김타격",
+                                teamName = "Tigers",
+                                statValue = 0.350,
+                                isQualified = false, // 규정 미충족
+                            ),
+                        ),
+                )
+
+            every { titleService.getTitleByCategory(competitionId, TitleCategory.BATTING_AVG) } returns title
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/competitions/{competitionId}/titles/{category}", competitionId, category))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.category").value("BATTING_AVG"))
+                .andExpect(jsonPath("$.data.winner").doesNotExist())
+                .andExpect(jsonPath("$.data.topCandidates.length()").value(1))
+                .andExpect(jsonPath("$.data.topCandidates[0].isQualified").value(false))
+        }
+
+        @Test
+        fun `잘못된 카테고리 입력 시 400 응답`() {
+            // given
+            val competitionId = 1L
+            val invalidCategory = "INVALID_CATEGORY"
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/competitions/{competitionId}/titles/{category}", competitionId, invalidCategory))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+
+        @Test
+        fun `소문자 카테고리도 정상 처리`() {
+            // given
+            val competitionId = 1L
+            val category = "batting_avg"
+            val title =
+                TitleDto(
+                    category = TitleCategory.BATTING_AVG,
+                    displayName = "타격왕",
+                    winner = null,
+                    topCandidates = emptyList(),
+                )
+
+            every { titleService.getTitleByCategory(competitionId, TitleCategory.BATTING_AVG) } returns title
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/competitions/{competitionId}/titles/{category}", competitionId, category))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.category").value("BATTING_AVG"))
+        }
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/appeal/AppealAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/appeal/AppealAdminController.kt
@@ -1,0 +1,87 @@
+package com.nextup.backoffice.controller.appeal
+
+import com.nextup.backoffice.dto.appeal.AppealAdminResponse
+import com.nextup.backoffice.dto.appeal.ApproveAppealAdminRequest
+import com.nextup.backoffice.dto.appeal.RejectAppealAdminRequest
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.core.domain.appeal.AppealStatus
+import com.nextup.core.service.appeal.AppealService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 이의 제기 관리 API Controller (관리자용)
+ *
+ * 전체 권한: 조회, 승인, 반려
+ */
+@RestController
+@RequestMapping("/api/backoffice/appeals")
+class AppealAdminController(
+    private val appealService: AppealService,
+) {
+    /**
+     * 전체 이의 제기 목록을 조회합니다.
+     */
+    @GetMapping
+    fun getAllAppeals(
+        @RequestParam(required = false) status: AppealStatus?,
+    ): ApiResponse<List<AppealAdminResponse>> {
+        val appeals =
+            if (status != null) {
+                appealService.getAppealsByStatus(status)
+            } else {
+                appealService.getAllAppeals()
+            }
+
+        return ApiResponse.success(
+            appeals.map { AppealAdminResponse.from(it) },
+        )
+    }
+
+    /**
+     * 이의 제기 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getAppeal(
+        @PathVariable id: Long,
+    ): ApiResponse<AppealAdminResponse> {
+        val appeal = appealService.getById(id)
+        return ApiResponse.success(AppealAdminResponse.from(appeal))
+    }
+
+    /**
+     * 이의 제기를 승인합니다.
+     */
+    @PutMapping("/{id}/approve")
+    fun approveAppeal(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: ApproveAppealAdminRequest,
+    ): ApiResponse<AppealAdminResponse> {
+        val appeal =
+            appealService.approveAppeal(
+                appealId = id,
+                reviewerId = request.reviewerId,
+                comment = request.comment,
+            )
+
+        return ApiResponse.success(AppealAdminResponse.from(appeal))
+    }
+
+    /**
+     * 이의 제기를 반려합니다.
+     */
+    @PutMapping("/{id}/reject")
+    fun rejectAppeal(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: RejectAppealAdminRequest,
+    ): ApiResponse<AppealAdminResponse> {
+        val appeal =
+            appealService.rejectAppeal(
+                appealId = id,
+                reviewerId = request.reviewerId,
+                comment = request.comment,
+            )
+
+        return ApiResponse.success(AppealAdminResponse.from(appeal))
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/bracket/BracketManagementController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/bracket/BracketManagementController.kt
@@ -1,0 +1,46 @@
+package com.nextup.backoffice.controller.bracket
+
+import com.nextup.backoffice.dto.bracket.AdvanceWinnerRequest
+import com.nextup.backoffice.dto.bracket.BracketEntryResponse
+import com.nextup.backoffice.dto.bracket.GenerateBracketRequest
+import com.nextup.backoffice.dto.bracket.toResponse
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.core.domain.competition.TournamentType
+import com.nextup.core.service.bracket.BracketGeneratorService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/backoffice/v1/competitions/{competitionId}/bracket")
+class BracketManagementController(
+    private val bracketGeneratorService: BracketGeneratorService,
+) {
+    @PostMapping("/generate")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun generateBracket(
+        @PathVariable competitionId: Long,
+        @RequestBody @Valid request: GenerateBracketRequest,
+    ): ApiResponse<List<BracketEntryResponse>> {
+        val entries =
+            when (request.tournamentType) {
+                TournamentType.SINGLE_ELIMINATION ->
+                    bracketGeneratorService.generateSingleElimination(competitionId, request.seededTeamIds)
+
+                TournamentType.DOUBLE_ELIMINATION ->
+                    bracketGeneratorService.generateDoubleElimination(competitionId, request.seededTeamIds)
+            }
+
+        return ApiResponse.success(entries.toResponse())
+    }
+
+    @PutMapping("/{entryId}/advance")
+    fun advanceWinner(
+        @PathVariable competitionId: Long,
+        @PathVariable entryId: Long,
+        @RequestBody @Valid request: AdvanceWinnerRequest,
+    ): ApiResponse<BracketEntryResponse> {
+        val entry = bracketGeneratorService.advanceWinner(entryId, request.winnerTeamId)
+        return ApiResponse.success(entry.toResponse())
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/discipline/DisciplineAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/discipline/DisciplineAdminController.kt
@@ -1,0 +1,152 @@
+package com.nextup.backoffice.controller.discipline
+
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.backoffice.dto.discipline.DisciplineAdminResponse
+import com.nextup.backoffice.dto.discipline.IssueDisciplineRequest
+import com.nextup.core.domain.discipline.DisciplineStatus
+import com.nextup.core.domain.discipline.DisciplineType
+import com.nextup.core.service.discipline.DisciplineService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 징계 관리 API Controller (관리자용)
+ *
+ * 전체 권한: 생성, 조회, 취소
+ */
+@RestController
+@RequestMapping("/api/backoffice/disciplines")
+class DisciplineAdminController(
+    private val disciplineService: DisciplineService,
+) {
+    /**
+     * 모든 징계 목록을 조회합니다.
+     */
+    @GetMapping
+    fun getAllDisciplines(
+        @RequestParam(required = false) playerId: Long?,
+        @RequestParam(required = false) competitionId: Long?,
+        @RequestParam(required = false) status: DisciplineStatus?,
+    ): ApiResponse<List<DisciplineAdminResponse>> {
+        val disciplines =
+            when {
+                playerId != null && competitionId != null ->
+                    disciplineService.getDisciplinesByPlayerAndCompetition(playerId, competitionId)
+
+                playerId != null -> disciplineService.getDisciplinesByPlayer(playerId)
+                competitionId != null -> disciplineService.getDisciplinesByCompetition(competitionId)
+                status != null -> disciplineService.getDisciplinesByStatus(status)
+                else -> disciplineService.getAll()
+            }
+
+        return ApiResponse.success(
+            disciplines.map { DisciplineAdminResponse.from(it) }
+        )
+    }
+
+    /**
+     * 징계 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getDiscipline(
+        @PathVariable id: Long,
+    ): ApiResponse<DisciplineAdminResponse> {
+        val discipline = disciplineService.getById(id)
+        return ApiResponse.success(DisciplineAdminResponse.from(discipline))
+    }
+
+    /**
+     * 선수의 활성 징계를 조회합니다.
+     */
+    @GetMapping("/active")
+    fun getActiveDisciplines(
+        @RequestParam playerId: Long,
+        @RequestParam competitionId: Long,
+    ): ApiResponse<List<DisciplineAdminResponse>> {
+        val disciplines =
+            disciplineService.getActiveDisciplines(playerId, competitionId)
+
+        return ApiResponse.success(
+            disciplines.map { DisciplineAdminResponse.from(it) }
+        )
+    }
+
+    /**
+     * 선수가 출장 가능한지 확인합니다.
+     */
+    @GetMapping("/eligibility")
+    fun checkPlayerEligibility(
+        @RequestParam playerId: Long,
+        @RequestParam competitionId: Long,
+    ): ApiResponse<Map<String, Boolean>> {
+        val canPlay = disciplineService.canPlayerPlay(playerId, competitionId)
+        return ApiResponse.success(mapOf("canPlay" to canPlay))
+    }
+
+    /**
+     * 징계를 발급합니다.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun issueDiscipline(
+        @Valid @RequestBody request: IssueDisciplineRequest,
+    ): ApiResponse<DisciplineAdminResponse> {
+        val discipline =
+            when (request.type) {
+                DisciplineType.WARNING ->
+                    disciplineService.issueWarning(
+                        playerId = request.playerId,
+                        competitionId = request.competitionId,
+                        reason = request.reason,
+                        issuedBy = request.issuedBy,
+                        expiresAt = request.expiresAt,
+                    )
+
+                DisciplineType.SUSPENSION -> {
+                    require(request.suspensionGames != null && request.suspensionGames > 0) {
+                        "출장 정지 경기 수는 1 이상이어야 합니다"
+                    }
+                    disciplineService.issueSuspension(
+                        playerId = request.playerId,
+                        competitionId = request.competitionId,
+                        reason = request.reason,
+                        suspensionGames = request.suspensionGames,
+                        issuedBy = request.issuedBy,
+                    )
+                }
+
+                DisciplineType.BAN ->
+                    disciplineService.issueBan(
+                        playerId = request.playerId,
+                        competitionId = request.competitionId,
+                        reason = request.reason,
+                        issuedBy = request.issuedBy,
+                    )
+            }
+
+        return ApiResponse.success(DisciplineAdminResponse.from(discipline))
+    }
+
+    /**
+     * 징계를 취소합니다.
+     */
+    @PutMapping("/{id}/cancel")
+    fun cancelDiscipline(
+        @PathVariable id: Long,
+    ): ApiResponse<DisciplineAdminResponse> {
+        val discipline = disciplineService.cancelDiscipline(id)
+        return ApiResponse.success(DisciplineAdminResponse.from(discipline))
+    }
+
+    /**
+     * 출장 정지 징계의 경기를 소화합니다.
+     */
+    @PutMapping("/{id}/increment-served")
+    fun incrementServedGames(
+        @PathVariable id: Long,
+    ): ApiResponse<DisciplineAdminResponse> {
+        val discipline = disciplineService.incrementServedGames(id)
+        return ApiResponse.success(DisciplineAdminResponse.from(discipline))
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminController.kt
@@ -2,8 +2,11 @@ package com.nextup.backoffice.controller.schedule
 
 import com.nextup.backoffice.dto.common.ApiResponse
 import com.nextup.backoffice.dto.schedule.CreateScheduleRequest
+import com.nextup.backoffice.dto.schedule.PostponeBulkRequest
+import com.nextup.backoffice.dto.schedule.RescheduleRequest
 import com.nextup.backoffice.dto.schedule.ScheduleAdminResponse
 import com.nextup.backoffice.dto.schedule.ScheduleConflictResponse
+import com.nextup.backoffice.dto.schedule.ScheduleGenerateRequest
 import com.nextup.backoffice.dto.schedule.UpdateScheduleRequest
 import com.nextup.core.service.schedule.LeagueScheduleService
 import jakarta.validation.Valid
@@ -115,5 +118,58 @@ class ScheduleAdminController(
                 venue = request.venue,
             )
         return ApiResponse.success(conflicts.map { ScheduleConflictResponse.from(it) })
+    }
+
+    /**
+     * 라운드 로빈 방식으로 대진표를 자동 생성합니다.
+     */
+    @PostMapping("/generate")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun generateSchedule(
+        @PathVariable competitionId: Long,
+        @Valid @RequestBody request: ScheduleGenerateRequest,
+    ): ApiResponse<List<ScheduleAdminResponse>> {
+        val schedules =
+            scheduleService.generateRoundRobinSchedule(
+                competitionId = competitionId,
+                teamIds = request.teamIds,
+                doubleRoundRobin = request.doubleRoundRobin,
+            )
+        return ApiResponse.success(schedules.map { ScheduleAdminResponse.from(it) })
+    }
+
+    /**
+     * 특정 날짜의 경기를 일괄 연기합니다. (우천 순연)
+     */
+    @PostMapping("/postpone-bulk")
+    fun postponeGamesBulk(
+        @PathVariable competitionId: Long,
+        @Valid @RequestBody request: PostponeBulkRequest,
+    ): ApiResponse<List<ScheduleAdminResponse>> {
+        val schedules =
+            scheduleService.postponeGamesBulk(
+                competitionId = competitionId,
+                date = request.date,
+                reason = request.reason,
+            )
+        return ApiResponse.success(schedules.map { ScheduleAdminResponse.from(it) })
+    }
+
+    /**
+     * 연기된 경기의 일정을 재조정합니다.
+     */
+    @PutMapping("/{id}/reschedule")
+    fun rescheduleGame(
+        @PathVariable competitionId: Long,
+        @PathVariable id: Long,
+        @Valid @RequestBody request: RescheduleRequest,
+    ): ApiResponse<ScheduleAdminResponse> {
+        val schedule =
+            scheduleService.rescheduleGame(
+                scheduleId = id,
+                newDate = request.newDate,
+                newVenue = request.newVenue,
+            )
+        return ApiResponse.success(ScheduleAdminResponse.from(schedule))
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminController.kt
@@ -1,0 +1,94 @@
+package com.nextup.backoffice.controller.schedule
+
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.backoffice.dto.schedule.CreateScheduleRequest
+import com.nextup.backoffice.dto.schedule.ScheduleAdminResponse
+import com.nextup.backoffice.dto.schedule.UpdateScheduleRequest
+import com.nextup.core.service.schedule.LeagueScheduleService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 대진표 관리 API Controller (관리자용)
+ *
+ * 전체 권한: 생성, 조회, 수정, 삭제
+ */
+@RestController
+@RequestMapping("/api/backoffice/competitions/{competitionId}/schedule")
+class ScheduleAdminController(
+    private val scheduleService: LeagueScheduleService,
+) {
+    /**
+     * 대회의 전체 대진표를 조회합니다.
+     */
+    @GetMapping
+    fun getSchedules(
+        @PathVariable competitionId: Long,
+    ): ApiResponse<List<ScheduleAdminResponse>> {
+        val schedules = scheduleService.getSchedulesByCompetition(competitionId)
+        return ApiResponse.success(schedules.map { ScheduleAdminResponse.from(it) })
+    }
+
+    /**
+     * 대진표를 생성합니다.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createSchedule(
+        @PathVariable competitionId: Long,
+        @Valid @RequestBody request: CreateScheduleRequest,
+    ): ApiResponse<ScheduleAdminResponse> {
+        val schedule =
+            scheduleService.createSchedule(
+                competitionId = competitionId,
+                round = request.round,
+                matchNumber = request.matchNumber,
+                homeTeamId = request.homeTeamId,
+                awayTeamId = request.awayTeamId,
+                scheduledDate = request.scheduledDate,
+                scheduledTime = request.scheduledTime,
+                venue = request.venue,
+            )
+        return ApiResponse.success(ScheduleAdminResponse.from(schedule))
+    }
+
+    /**
+     * 대진표를 수정합니다.
+     */
+    @PutMapping("/{id}")
+    fun updateSchedule(
+        @PathVariable competitionId: Long,
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateScheduleRequest,
+    ): ApiResponse<ScheduleAdminResponse> {
+        val schedule =
+            scheduleService.updateSchedule(
+                scheduleId = id,
+                scheduledDate = request.scheduledDate,
+                scheduledTime = request.scheduledTime,
+                venue = request.venue,
+            )
+        return ApiResponse.success(ScheduleAdminResponse.from(schedule))
+    }
+
+    /**
+     * 대진표를 삭제합니다.
+     */
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteSchedule(
+        @PathVariable competitionId: Long,
+        @PathVariable id: Long,
+    ) {
+        scheduleService.deleteSchedule(id)
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminController.kt
@@ -3,6 +3,7 @@ package com.nextup.backoffice.controller.schedule
 import com.nextup.backoffice.dto.common.ApiResponse
 import com.nextup.backoffice.dto.schedule.CreateScheduleRequest
 import com.nextup.backoffice.dto.schedule.ScheduleAdminResponse
+import com.nextup.backoffice.dto.schedule.ScheduleConflictResponse
 import com.nextup.backoffice.dto.schedule.UpdateScheduleRequest
 import com.nextup.core.service.schedule.LeagueScheduleService
 import jakarta.validation.Valid
@@ -90,5 +91,29 @@ class ScheduleAdminController(
         @PathVariable id: Long,
     ) {
         scheduleService.deleteSchedule(id)
+    }
+
+    /**
+     * 대진표를 검증합니다. (Dry-run)
+     *
+     * 실제로 생성하지 않고 충돌만 확인합니다.
+     */
+    @PostMapping("/validate")
+    fun validateSchedule(
+        @PathVariable competitionId: Long,
+        @Valid @RequestBody request: CreateScheduleRequest,
+    ): ApiResponse<List<ScheduleConflictResponse>> {
+        val conflicts =
+            scheduleService.validateSchedule(
+                competitionId = competitionId,
+                round = request.round,
+                matchNumber = request.matchNumber,
+                homeTeamId = request.homeTeamId,
+                awayTeamId = request.awayTeamId,
+                scheduledDate = request.scheduledDate,
+                scheduledTime = request.scheduledTime,
+                venue = request.venue,
+            )
+        return ApiResponse.success(conflicts.map { ScheduleConflictResponse.from(it) })
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/stadium/StadiumAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/stadium/StadiumAdminController.kt
@@ -1,0 +1,108 @@
+package com.nextup.backoffice.controller.stadium
+
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.backoffice.dto.stadium.CreateSlotRequest
+import com.nextup.backoffice.dto.stadium.CreateStadiumRequest
+import com.nextup.backoffice.dto.stadium.StadiumResponse
+import com.nextup.backoffice.dto.stadium.StadiumSlotResponse
+import com.nextup.backoffice.dto.stadium.UpdateStadiumRequest
+import com.nextup.core.service.stadium.StadiumAdminService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 구장 관리 API Controller (백오피스용)
+ */
+@RestController
+@RequestMapping("/api/backoffice/stadiums")
+class StadiumAdminController(
+    private val stadiumAdminService: StadiumAdminService,
+) {
+    /**
+     * 구장을 생성합니다.
+     */
+    @PostMapping
+    fun createStadium(
+        @RequestBody @Valid request: CreateStadiumRequest,
+    ): ApiResponse<StadiumResponse> {
+        val stadium =
+            stadiumAdminService.createStadium(
+                com.nextup.core.service.stadium.dto.CreateStadiumRequest(
+                    name = request.name,
+                    address = request.address,
+                    latitude = request.latitude,
+                    longitude = request.longitude,
+                    capacity = request.capacity,
+                    facilities = request.facilities,
+                    contactInfo = request.contactInfo,
+                    imageUrls = request.imageUrls,
+                ),
+            )
+        return ApiResponse.success(StadiumResponse.from(stadium))
+    }
+
+    /**
+     * 구장 정보를 수정합니다.
+     */
+    @PutMapping("/{id}")
+    fun updateStadium(
+        @PathVariable id: Long,
+        @RequestBody @Valid request: UpdateStadiumRequest,
+    ): ApiResponse<StadiumResponse> {
+        val stadium =
+            stadiumAdminService.updateStadium(
+                id = id,
+                address = request.address,
+                latitude = request.latitude,
+                longitude = request.longitude,
+                capacity = request.capacity,
+                facilities = request.facilities,
+                contactInfo = request.contactInfo,
+                imageUrls = request.imageUrls,
+            )
+        return ApiResponse.success(StadiumResponse.from(stadium))
+    }
+
+    /**
+     * 구장 슬롯을 생성합니다.
+     */
+    @PostMapping("/slots")
+    fun createSlots(
+        @RequestBody @Valid requests: List<CreateSlotRequest>,
+    ): ApiResponse<List<StadiumSlotResponse>> {
+        val coreRequests =
+            requests.map {
+                com.nextup.core.service.stadium.dto.CreateSlotRequest(
+                    stadiumId = it.stadiumId,
+                    date = it.date,
+                    startTime = it.startTime,
+                    endTime = it.endTime,
+                    price = it.price,
+                )
+            }
+        val slots = stadiumAdminService.createSlots(coreRequests)
+        return ApiResponse.success(slots.map { StadiumSlotResponse.from(it) })
+    }
+
+    /**
+     * 구장을 비활성화합니다.
+     */
+    @PutMapping("/{id}/deactivate")
+    fun deactivateStadium(
+        @PathVariable id: Long,
+    ): ApiResponse<StadiumResponse> {
+        val stadium = stadiumAdminService.deactivateStadium(id)
+        return ApiResponse.success(StadiumResponse.from(stadium))
+    }
+
+    /**
+     * 구장을 활성화합니다.
+     */
+    @PutMapping("/{id}/activate")
+    fun activateStadium(
+        @PathVariable id: Long,
+    ): ApiResponse<StadiumResponse> {
+        val stadium = stadiumAdminService.activateStadium(id)
+        return ApiResponse.success(StadiumResponse.from(stadium))
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminController.kt
@@ -2,6 +2,7 @@ package com.nextup.backoffice.controller.team
 
 import com.nextup.backoffice.dto.common.ApiResponse
 import com.nextup.backoffice.dto.team.*
+import com.nextup.common.exception.TeamMemberNotFoundException
 import com.nextup.core.domain.team.TeamMemberStatus
 import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.team.TeamMembershipService
@@ -61,7 +62,7 @@ class TeamMemberAdminController(
     ): ApiResponse<TeamMemberAdminResponse> {
         val member =
             teamMemberRepository.findByIdOrNull(memberId)
-                ?: throw IllegalStateException("Member not found: $memberId")
+                ?: throw TeamMemberNotFoundException(memberId)
 
         // 상태 변경 (관리자 권한으로 직접 변경)
         when (request.status) {

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminController.kt
@@ -77,7 +77,10 @@ class TeamMemberAdminController(
                 member.memo = request.reason
             }
             else -> {
-                throw IllegalArgumentException("Cannot change to status: ${request.status}")
+                throw com.nextup.common.exception.InvalidInputException(
+                    "INVALID_STATUS",
+                    "Cannot change to status: ${request.status}",
+                )
             }
         }
 

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/appeal/AppealAdminRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/appeal/AppealAdminRequest.kt
@@ -1,0 +1,26 @@
+package com.nextup.backoffice.dto.appeal
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+
+/**
+ * 이의 제기 승인 요청 DTO (관리자용)
+ */
+data class ApproveAppealAdminRequest(
+    @field:NotNull(message = "검토자 ID는 필수입니다")
+    @field:Positive(message = "검토자 ID는 양수여야 합니다")
+    val reviewerId: Long,
+    val comment: String? = null,
+)
+
+/**
+ * 이의 제기 반려 요청 DTO (관리자용)
+ */
+data class RejectAppealAdminRequest(
+    @field:NotNull(message = "검토자 ID는 필수입니다")
+    @field:Positive(message = "검토자 ID는 양수여야 합니다")
+    val reviewerId: Long,
+    @field:NotBlank(message = "반려 사유는 필수입니다")
+    val comment: String,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/appeal/AppealAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/appeal/AppealAdminResponse.kt
@@ -1,0 +1,47 @@
+package com.nextup.backoffice.dto.appeal
+
+import com.nextup.core.domain.appeal.Appeal
+import com.nextup.core.domain.appeal.AppealStatus
+import com.nextup.core.domain.appeal.AppealType
+import java.time.Instant
+import java.time.LocalDateTime
+
+/**
+ * 이의 제기 관리자 응답 DTO
+ *
+ * backoffice 모듈에 독립적으로 존재
+ */
+data class AppealAdminResponse(
+    val id: Long,
+    val gameId: Long,
+    val appealerId: Long,
+    val appealerName: String,
+    val type: AppealType,
+    val title: String,
+    val description: String,
+    val status: AppealStatus,
+    val reviewerId: Long?,
+    val reviewerComment: String?,
+    val reviewedAt: LocalDateTime?,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(appeal: Appeal): AppealAdminResponse =
+            AppealAdminResponse(
+                id = appeal.id,
+                gameId = appeal.game.id,
+                appealerId = appeal.appealerId,
+                appealerName = appeal.appealerName,
+                type = appeal.type,
+                title = appeal.title,
+                description = appeal.description,
+                status = appeal.status,
+                reviewerId = appeal.reviewerId,
+                reviewerComment = appeal.reviewerComment,
+                reviewedAt = appeal.reviewedAt,
+                createdAt = appeal.createdAt,
+                updatedAt = appeal.updatedAt,
+            )
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/bracket/AdvanceWinnerRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/bracket/AdvanceWinnerRequest.kt
@@ -1,0 +1,8 @@
+package com.nextup.backoffice.dto.bracket
+
+import jakarta.validation.constraints.NotNull
+
+data class AdvanceWinnerRequest(
+    @field:NotNull(message = "승자 팀 ID는 필수입니다")
+    val winnerTeamId: Long,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/bracket/BracketEntryResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/bracket/BracketEntryResponse.kt
@@ -1,0 +1,22 @@
+package com.nextup.backoffice.dto.bracket
+
+data class BracketEntryResponse(
+    val id: Long,
+    val competitionId: Long,
+    val roundNumber: Int,
+    val matchNumber: Int,
+    val team1: TeamBriefResponse?,
+    val team2: TeamBriefResponse?,
+    val winner: TeamBriefResponse?,
+    val bracketType: String,
+    val seed1: Int?,
+    val seed2: Int?,
+    val isBye: Boolean,
+    val isCompleted: Boolean,
+)
+
+data class TeamBriefResponse(
+    val id: Long,
+    val name: String,
+    val city: String,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/bracket/BracketMapper.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/bracket/BracketMapper.kt
@@ -1,0 +1,29 @@
+package com.nextup.backoffice.dto.bracket
+
+import com.nextup.core.domain.competition.BracketEntry
+import com.nextup.core.domain.team.Team
+
+fun BracketEntry.toResponse(): BracketEntryResponse =
+    BracketEntryResponse(
+        id = this.id,
+        competitionId = this.competition.id,
+        roundNumber = this.roundNumber,
+        matchNumber = this.matchNumber,
+        team1 = this.team1?.toBriefResponse(),
+        team2 = this.team2?.toBriefResponse(),
+        winner = this.winner?.toBriefResponse(),
+        bracketType = this.bracketType,
+        seed1 = this.seed1,
+        seed2 = this.seed2,
+        isBye = this.isBye(),
+        isCompleted = this.isCompleted(),
+    )
+
+fun Team.toBriefResponse(): TeamBriefResponse =
+    TeamBriefResponse(
+        id = this.id,
+        name = this.name,
+        city = this.city,
+    )
+
+fun List<BracketEntry>.toResponse(): List<BracketEntryResponse> = this.map { it.toResponse() }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/bracket/GenerateBracketRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/bracket/GenerateBracketRequest.kt
@@ -1,0 +1,12 @@
+package com.nextup.backoffice.dto.bracket
+
+import com.nextup.core.domain.competition.TournamentType
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+
+data class GenerateBracketRequest(
+    @field:NotNull(message = "토너먼트 타입은 필수입니다")
+    val tournamentType: TournamentType,
+    @field:NotEmpty(message = "팀 목록은 비어있을 수 없습니다")
+    val seededTeamIds: List<Long>,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/discipline/DisciplineAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/discipline/DisciplineAdminResponse.kt
@@ -1,0 +1,53 @@
+package com.nextup.backoffice.dto.discipline
+
+import com.nextup.core.domain.discipline.Discipline
+import com.nextup.core.domain.discipline.DisciplineStatus
+import com.nextup.core.domain.discipline.DisciplineType
+import java.time.Instant
+import java.time.LocalDateTime
+
+/**
+ * 징계 관리자 응답 DTO
+ *
+ * backoffice 모듈에 독립적으로 존재
+ */
+data class DisciplineAdminResponse(
+    val id: Long,
+    val playerId: Long,
+    val playerName: String,
+    val competitionId: Long,
+    val competitionName: String,
+    val type: DisciplineType,
+    val reason: String,
+    val suspensionGames: Int?,
+    val servedGames: Int,
+    val issuedAt: LocalDateTime,
+    val expiresAt: LocalDateTime?,
+    val issuedBy: String,
+    val status: DisciplineStatus,
+    val isEffective: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(discipline: Discipline): DisciplineAdminResponse =
+            DisciplineAdminResponse(
+                id = discipline.id,
+                playerId = discipline.player.id,
+                playerName = discipline.player.name,
+                competitionId = discipline.competition.id,
+                competitionName = discipline.competition.name,
+                type = discipline.type,
+                reason = discipline.reason,
+                suspensionGames = discipline.suspensionGames,
+                servedGames = discipline.servedGames,
+                issuedAt = discipline.issuedAt,
+                expiresAt = discipline.expiresAt,
+                issuedBy = discipline.issuedBy,
+                status = discipline.status,
+                isEffective = discipline.isEffective(),
+                createdAt = discipline.createdAt,
+                updatedAt = discipline.updatedAt,
+            )
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/discipline/IssueDisciplineRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/discipline/IssueDisciplineRequest.kt
@@ -1,0 +1,30 @@
+package com.nextup.backoffice.dto.discipline
+
+import com.nextup.core.domain.discipline.DisciplineType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
+
+/**
+ * 징계 발급 요청 DTO (관리자용)
+ */
+data class IssueDisciplineRequest(
+    @field:NotNull(message = "선수 ID는 필수입니다")
+    @field:Positive(message = "선수 ID는 양수여야 합니다")
+    val playerId: Long,
+    @field:NotNull(message = "대회 ID는 필수입니다")
+    @field:Positive(message = "대회 ID는 양수여야 합니다")
+    val competitionId: Long,
+    @field:NotNull(message = "징계 유형은 필수입니다")
+    val type: DisciplineType,
+    @field:NotBlank(message = "징계 사유는 필수입니다")
+    @field:Size(max = 1000, message = "징계 사유는 1000자를 초과할 수 없습니다")
+    val reason: String,
+    val suspensionGames: Int? = null,
+    val expiresAt: LocalDateTime? = null,
+    @field:NotBlank(message = "발급자는 필수입니다")
+    @field:Size(max = 255, message = "발급자는 255자를 초과할 수 없습니다")
+    val issuedBy: String,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/PostponeBulkRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/PostponeBulkRequest.kt
@@ -1,0 +1,12 @@
+package com.nextup.backoffice.dto.schedule
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class PostponeBulkRequest(
+    @field:NotNull(message = "연기 날짜는 필수입니다")
+    val date: LocalDate,
+    @field:NotBlank(message = "연기 사유는 필수입니다")
+    val reason: String,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/RescheduleRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/RescheduleRequest.kt
@@ -1,0 +1,10 @@
+package com.nextup.backoffice.dto.schedule
+
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class RescheduleRequest(
+    @field:NotNull(message = "새로운 날짜는 필수입니다")
+    val newDate: LocalDate,
+    val newVenue: String? = null,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/ScheduleAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/ScheduleAdminResponse.kt
@@ -1,0 +1,51 @@
+package com.nextup.backoffice.dto.schedule
+
+import com.nextup.core.domain.schedule.LeagueSchedule
+import com.nextup.core.domain.schedule.ScheduleStatus
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 대진표 관리자 응답 DTO
+ *
+ * backoffice 모듈에 독립적으로 존재
+ */
+data class ScheduleAdminResponse(
+    val id: Long,
+    val competitionId: Long,
+    val round: Int,
+    val matchNumber: Int,
+    val homeTeamId: Long,
+    val homeTeamName: String,
+    val awayTeamId: Long,
+    val awayTeamName: String,
+    val scheduledDate: LocalDate,
+    val scheduledTime: LocalTime?,
+    val venue: String?,
+    val status: ScheduleStatus,
+    val gameId: Long?,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(schedule: LeagueSchedule): ScheduleAdminResponse =
+            ScheduleAdminResponse(
+                id = schedule.id,
+                competitionId = schedule.competition.id,
+                round = schedule.round,
+                matchNumber = schedule.matchNumber,
+                homeTeamId = schedule.homeTeam.id,
+                homeTeamName = schedule.homeTeam.name,
+                awayTeamId = schedule.awayTeam.id,
+                awayTeamName = schedule.awayTeam.name,
+                scheduledDate = schedule.scheduledDate,
+                scheduledTime = schedule.scheduledTime,
+                venue = schedule.venue,
+                status = schedule.status,
+                gameId = schedule.game?.id,
+                createdAt = schedule.createdAt,
+                updatedAt = schedule.updatedAt,
+            )
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/ScheduleAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/ScheduleAdminResponse.kt
@@ -25,6 +25,8 @@ data class ScheduleAdminResponse(
     val venue: String?,
     val status: ScheduleStatus,
     val gameId: Long?,
+    val postponedReason: String?,
+    val originalDate: LocalDate?,
     val createdAt: Instant,
     val updatedAt: Instant,
 ) {
@@ -44,6 +46,8 @@ data class ScheduleAdminResponse(
                 venue = schedule.venue,
                 status = schedule.status,
                 gameId = schedule.game?.id,
+                postponedReason = schedule.postponedReason,
+                originalDate = schedule.originalDate,
                 createdAt = schedule.createdAt,
                 updatedAt = schedule.updatedAt,
             )

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/ScheduleConflictResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/ScheduleConflictResponse.kt
@@ -1,0 +1,22 @@
+package com.nextup.backoffice.dto.schedule
+
+import com.nextup.core.domain.schedule.ConflictType
+import com.nextup.core.domain.schedule.ScheduleConflict
+
+/**
+ * 대진표 충돌 응답 DTO
+ */
+data class ScheduleConflictResponse(
+    val type: ConflictType,
+    val conflictingScheduleId: Long,
+    val description: String,
+) {
+    companion object {
+        fun from(conflict: ScheduleConflict): ScheduleConflictResponse =
+            ScheduleConflictResponse(
+                type = conflict.type,
+                conflictingScheduleId = conflict.conflictingScheduleId,
+                description = conflict.description,
+            )
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/ScheduleGenerateRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/ScheduleGenerateRequest.kt
@@ -1,0 +1,16 @@
+package com.nextup.backoffice.dto.schedule
+
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Positive
+
+/**
+ * 대진표 자동 생성 요청 DTO (관리자용)
+ */
+data class ScheduleGenerateRequest(
+    @field:NotEmpty(message = "참가 팀 목록은 비어있을 수 없습니다")
+    val teamIds: List<
+        @Positive(message = "팀 ID는 양수여야 합니다")
+        Long,
+    >,
+    val doubleRoundRobin: Boolean = false,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/ScheduleRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/ScheduleRequest.kt
@@ -1,0 +1,40 @@
+package com.nextup.backoffice.dto.schedule
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 대진표 생성 요청 DTO (관리자용)
+ */
+data class CreateScheduleRequest(
+    @field:NotNull(message = "라운드는 필수입니다")
+    @field:Positive(message = "라운드는 1 이상이어야 합니다")
+    val round: Int,
+    @field:NotNull(message = "경기 번호는 필수입니다")
+    @field:Positive(message = "경기 번호는 1 이상이어야 합니다")
+    val matchNumber: Int,
+    @field:NotNull(message = "홈팀 ID는 필수입니다")
+    @field:Positive(message = "홈팀 ID는 양수여야 합니다")
+    val homeTeamId: Long,
+    @field:NotNull(message = "원정팀 ID는 필수입니다")
+    @field:Positive(message = "원정팀 ID는 양수여야 합니다")
+    val awayTeamId: Long,
+    @field:NotNull(message = "경기 날짜는 필수입니다")
+    val scheduledDate: LocalDate,
+    val scheduledTime: LocalTime? = null,
+    @field:Size(max = 255, message = "경기장은 255자를 초과할 수 없습니다")
+    val venue: String? = null,
+)
+
+/**
+ * 대진표 수정 요청 DTO (관리자용)
+ */
+data class UpdateScheduleRequest(
+    val scheduledDate: LocalDate? = null,
+    val scheduledTime: LocalTime? = null,
+    @field:Size(max = 255, message = "경기장은 255자를 초과할 수 없습니다")
+    val venue: String? = null,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/stadium/CreateSlotRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/stadium/CreateSlotRequest.kt
@@ -1,0 +1,24 @@
+package com.nextup.backoffice.dto.stadium
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 구장 슬롯 생성 요청 DTO (백오피스용)
+ */
+data class CreateSlotRequest(
+    @field:NotNull(message = "Stadium ID is required")
+    @field:Positive(message = "Stadium ID must be positive")
+    val stadiumId: Long,
+    @field:NotNull(message = "Date is required")
+    val date: LocalDate,
+    @field:NotNull(message = "Start time is required")
+    val startTime: LocalTime,
+    @field:NotNull(message = "End time is required")
+    val endTime: LocalTime,
+    @field:Positive(message = "Price must be positive")
+    val price: BigDecimal? = null,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/stadium/CreateStadiumRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/stadium/CreateStadiumRequest.kt
@@ -1,0 +1,27 @@
+package com.nextup.backoffice.dto.stadium
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
+
+/**
+ * 구장 생성 요청 DTO (백오피스용)
+ */
+data class CreateStadiumRequest(
+    @field:NotBlank(message = "Stadium name is required")
+    val name: String,
+    @field:NotBlank(message = "Address is required")
+    val address: String,
+    @field:Min(value = -90, message = "Latitude must be between -90 and 90")
+    @field:Max(value = 90, message = "Latitude must be between -90 and 90")
+    val latitude: Double,
+    @field:Min(value = -180, message = "Longitude must be between -180 and 180")
+    @field:Max(value = 180, message = "Longitude must be between -180 and 180")
+    val longitude: Double,
+    @field:Positive(message = "Capacity must be positive")
+    val capacity: Int? = null,
+    val facilities: String? = null,
+    val contactInfo: String? = null,
+    val imageUrls: String? = null,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/stadium/StadiumResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/stadium/StadiumResponse.kt
@@ -1,0 +1,40 @@
+package com.nextup.backoffice.dto.stadium
+
+import com.nextup.core.domain.stadium.Stadium
+import java.time.Instant
+
+/**
+ * 구장 응답 DTO (백오피스용)
+ */
+data class StadiumResponse(
+    val id: Long,
+    val name: String,
+    val address: String,
+    val latitude: Double,
+    val longitude: Double,
+    val capacity: Int?,
+    val facilities: String?,
+    val contactInfo: String?,
+    val imageUrls: String?,
+    val isActive: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(stadium: Stadium): StadiumResponse =
+            StadiumResponse(
+                id = stadium.id,
+                name = stadium.name,
+                address = stadium.address,
+                latitude = stadium.latitude,
+                longitude = stadium.longitude,
+                capacity = stadium.capacity,
+                facilities = stadium.facilities,
+                contactInfo = stadium.contactInfo,
+                imageUrls = stadium.imageUrls,
+                isActive = stadium.isActive,
+                createdAt = stadium.createdAt,
+                updatedAt = stadium.updatedAt,
+            )
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/stadium/StadiumSlotResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/stadium/StadiumSlotResponse.kt
@@ -1,0 +1,40 @@
+package com.nextup.backoffice.dto.stadium
+
+import com.nextup.core.domain.stadium.SlotStatus
+import com.nextup.core.domain.stadium.StadiumSlot
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 구장 슬롯 응답 DTO (백오피스용)
+ */
+data class StadiumSlotResponse(
+    val id: Long,
+    val stadiumId: Long,
+    val stadiumName: String,
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val price: BigDecimal?,
+    val status: SlotStatus,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(slot: StadiumSlot): StadiumSlotResponse =
+            StadiumSlotResponse(
+                id = slot.id,
+                stadiumId = slot.stadium.id,
+                stadiumName = slot.stadium.name,
+                date = slot.date,
+                startTime = slot.startTime,
+                endTime = slot.endTime,
+                price = slot.price,
+                status = slot.status,
+                createdAt = slot.createdAt,
+                updatedAt = slot.updatedAt,
+            )
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/stadium/UpdateStadiumRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/stadium/UpdateStadiumRequest.kt
@@ -1,0 +1,23 @@
+package com.nextup.backoffice.dto.stadium
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Positive
+
+/**
+ * 구장 수정 요청 DTO (백오피스용)
+ */
+data class UpdateStadiumRequest(
+    val address: String? = null,
+    @field:Min(value = -90, message = "Latitude must be between -90 and 90")
+    @field:Max(value = 90, message = "Latitude must be between -90 and 90")
+    val latitude: Double? = null,
+    @field:Min(value = -180, message = "Longitude must be between -180 and 180")
+    @field:Max(value = 180, message = "Longitude must be between -180 and 180")
+    val longitude: Double? = null,
+    @field:Positive(message = "Capacity must be positive")
+    val capacity: Int? = null,
+    val facilities: String? = null,
+    val contactInfo: String? = null,
+    val imageUrls: String? = null,
+)

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/exception/GlobalExceptionHandler.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,70 @@
+package com.nextup.backoffice.exception
+
+import com.nextup.backoffice.dto.common.ApiResponse
+import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.NotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(NotFoundException::class)
+    fun handleNotFoundException(ex: NotFoundException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("NotFoundException: code={}, message={}", ex.code, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    @ExceptionHandler(BusinessException::class)
+    fun handleBusinessException(ex: BusinessException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("BusinessException: code={}, message={}", ex.code, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadableException(
+        ex: HttpMessageNotReadableException,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("HttpMessageNotReadableException: {}", ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("INVALID_REQUEST", "요청 본문을 읽을 수 없습니다"))
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
+        val errors =
+            ex.bindingResult.fieldErrors
+                .joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
+        log.warn("ValidationException: {}", errors)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("VALIDATION_ERROR", errors))
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(ex: IllegalArgumentException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("IllegalArgumentException: {}", ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("INVALID_ARGUMENT", ex.message ?: "Invalid argument"))
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(ex: Exception): ResponseEntity<ApiResponse<Nothing>> {
+        log.error("UnexpectedException: {}", ex.message, ex)
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.error("INTERNAL_ERROR", "An unexpected error occurred"))
+    }
+}

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/appeal/AppealAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/appeal/AppealAdminControllerTest.kt
@@ -1,0 +1,280 @@
+package com.nextup.backoffice.controller.appeal
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.backoffice.dto.appeal.ApproveAppealAdminRequest
+import com.nextup.backoffice.dto.appeal.RejectAppealAdminRequest
+import com.nextup.core.domain.appeal.Appeal
+import com.nextup.core.domain.appeal.AppealStatus
+import com.nextup.core.domain.appeal.AppealType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.service.appeal.AppealService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+import java.time.LocalDateTime
+
+@DisplayName("AppealAdminController")
+class AppealAdminControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var appealService: AppealService
+    private lateinit var objectMapper: ObjectMapper
+
+    private val mockGame = mockk<Game>(relaxed = true)
+    private val mockAppeal = mockk<Appeal>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        appealService = mockk()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+        val controller = AppealAdminController(appealService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .build()
+
+        every { mockGame.id } returns 1L
+        every { mockAppeal.id } returns 1L
+        every { mockAppeal.game } returns mockGame
+        every { mockAppeal.appealerId } returns 100L
+        every { mockAppeal.appealerName } returns "홍길동"
+        every { mockAppeal.type } returns AppealType.SCORING_ERROR
+        every { mockAppeal.title } returns "득점 오류 정정 요청"
+        every { mockAppeal.description } returns "3회말 득점이 잘못 기록되었습니다"
+        every { mockAppeal.status } returns AppealStatus.PENDING
+        every { mockAppeal.reviewerId } returns null
+        every { mockAppeal.reviewerComment } returns null
+        every { mockAppeal.reviewedAt } returns null
+        every { mockAppeal.createdAt } returns Instant.now()
+        every { mockAppeal.updatedAt } returns Instant.now()
+    }
+
+    @Test
+    fun `should get all appeals`() {
+        // given
+        every { appealService.getAllAppeals() } returns listOf(mockAppeal)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/backoffice/appeals"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].id").value(1))
+            .andExpect(jsonPath("$.data[0].status").value("PENDING"))
+
+        verify(exactly = 1) { appealService.getAllAppeals() }
+    }
+
+    @Test
+    fun `should get appeals by status`() {
+        // given
+        every { appealService.getAppealsByStatus(AppealStatus.PENDING) } returns listOf(mockAppeal)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/backoffice/appeals").param("status", "PENDING"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].status").value("PENDING"))
+
+        verify(exactly = 1) { appealService.getAppealsByStatus(AppealStatus.PENDING) }
+        verify(exactly = 0) { appealService.getAllAppeals() }
+    }
+
+    @Test
+    fun `should get empty list when no appeals found`() {
+        // given
+        every { appealService.getAllAppeals() } returns emptyList()
+
+        // when & then
+        mockMvc
+            .perform(get("/api/backoffice/appeals"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data").isEmpty)
+    }
+
+    @Test
+    fun `should get appeal by id`() {
+        // given
+        every { appealService.getById(1L) } returns mockAppeal
+
+        // when & then
+        mockMvc
+            .perform(get("/api/backoffice/appeals/1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.appealerId").value(100))
+            .andExpect(jsonPath("$.data.status").value("PENDING"))
+
+        verify(exactly = 1) { appealService.getById(1L) }
+    }
+
+    @Test
+    fun `should approve appeal successfully`() {
+        // given
+        val request = ApproveAppealAdminRequest(reviewerId = 200L, comment = "검토 완료")
+
+        val approvedAppeal = mockk<Appeal>(relaxed = true)
+        every { approvedAppeal.id } returns 1L
+        every { approvedAppeal.game } returns mockGame
+        every { approvedAppeal.appealerId } returns 100L
+        every { approvedAppeal.appealerName } returns "홍길동"
+        every { approvedAppeal.type } returns AppealType.SCORING_ERROR
+        every { approvedAppeal.title } returns "득점 오류 정정 요청"
+        every { approvedAppeal.description } returns "설명"
+        every { approvedAppeal.status } returns AppealStatus.APPROVED
+        every { approvedAppeal.reviewerId } returns 200L
+        every { approvedAppeal.reviewerComment } returns "검토 완료"
+        every { approvedAppeal.reviewedAt } returns LocalDateTime.now()
+        every { approvedAppeal.createdAt } returns Instant.now()
+        every { approvedAppeal.updatedAt } returns Instant.now()
+
+        every {
+            appealService.approveAppeal(
+                appealId = 1L,
+                reviewerId = 200L,
+                comment = "검토 완료",
+            )
+        } returns approvedAppeal
+
+        // when & then
+        mockMvc
+            .perform(
+                put("/api/backoffice/appeals/1/approve")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.status").value("APPROVED"))
+            .andExpect(jsonPath("$.data.reviewerId").value(200))
+            .andExpect(jsonPath("$.data.reviewerComment").value("검토 완료"))
+
+        verify(exactly = 1) {
+            appealService.approveAppeal(
+                appealId = 1L,
+                reviewerId = 200L,
+                comment = "검토 완료",
+            )
+        }
+    }
+
+    @Test
+    fun `should approve appeal without comment`() {
+        // given
+        val request = ApproveAppealAdminRequest(reviewerId = 200L, comment = null)
+
+        val approvedAppeal = mockk<Appeal>(relaxed = true)
+        every { approvedAppeal.id } returns 1L
+        every { approvedAppeal.game } returns mockGame
+        every { approvedAppeal.appealerId } returns 100L
+        every { approvedAppeal.appealerName } returns "홍길동"
+        every { approvedAppeal.type } returns AppealType.SCORING_ERROR
+        every { approvedAppeal.title } returns "제목"
+        every { approvedAppeal.description } returns "설명"
+        every { approvedAppeal.status } returns AppealStatus.APPROVED
+        every { approvedAppeal.reviewerId } returns 200L
+        every { approvedAppeal.reviewerComment } returns null
+        every { approvedAppeal.reviewedAt } returns LocalDateTime.now()
+        every { approvedAppeal.createdAt } returns Instant.now()
+        every { approvedAppeal.updatedAt } returns Instant.now()
+
+        every { appealService.approveAppeal(1L, 200L, null) } returns approvedAppeal
+
+        // when & then
+        mockMvc
+            .perform(
+                put("/api/backoffice/appeals/1/approve")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.status").value("APPROVED"))
+            .andExpect(jsonPath("$.data.reviewerComment").isEmpty)
+    }
+
+    @Test
+    fun `should reject appeal successfully`() {
+        // given
+        val request = RejectAppealAdminRequest(reviewerId = 200L, comment = "증거 불충분")
+
+        val rejectedAppeal = mockk<Appeal>(relaxed = true)
+        every { rejectedAppeal.id } returns 1L
+        every { rejectedAppeal.game } returns mockGame
+        every { rejectedAppeal.appealerId } returns 100L
+        every { rejectedAppeal.appealerName } returns "홍길동"
+        every { rejectedAppeal.type } returns AppealType.SCORING_ERROR
+        every { rejectedAppeal.title } returns "제목"
+        every { rejectedAppeal.description } returns "설명"
+        every { rejectedAppeal.status } returns AppealStatus.REJECTED
+        every { rejectedAppeal.reviewerId } returns 200L
+        every { rejectedAppeal.reviewerComment } returns "증거 불충분"
+        every { rejectedAppeal.reviewedAt } returns LocalDateTime.now()
+        every { rejectedAppeal.createdAt } returns Instant.now()
+        every { rejectedAppeal.updatedAt } returns Instant.now()
+
+        every { appealService.rejectAppeal(1L, 200L, "증거 불충분") } returns rejectedAppeal
+
+        // when & then
+        mockMvc
+            .perform(
+                put("/api/backoffice/appeals/1/reject")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(1))
+            .andExpect(jsonPath("$.data.status").value("REJECTED"))
+            .andExpect(jsonPath("$.data.reviewerId").value(200))
+            .andExpect(jsonPath("$.data.reviewerComment").value("증거 불충분"))
+
+        verify(exactly = 1) { appealService.rejectAppeal(1L, 200L, "증거 불충분") }
+    }
+
+    @Test
+    fun `should handle different appeal statuses`() {
+        // given
+        val pendingAppeal = mockk<Appeal>(relaxed = true)
+        val approvedAppeal = mockk<Appeal>(relaxed = true)
+        val rejectedAppeal = mockk<Appeal>(relaxed = true)
+
+        every { pendingAppeal.status } returns AppealStatus.PENDING
+        every { approvedAppeal.status } returns AppealStatus.APPROVED
+        every { rejectedAppeal.status } returns AppealStatus.REJECTED
+
+        every { appealService.getAppealsByStatus(AppealStatus.PENDING) } returns listOf(pendingAppeal)
+        every { appealService.getAppealsByStatus(AppealStatus.APPROVED) } returns listOf(approvedAppeal)
+        every { appealService.getAppealsByStatus(AppealStatus.REJECTED) } returns listOf(rejectedAppeal)
+
+        // when & then
+        listOf(AppealStatus.PENDING, AppealStatus.APPROVED, AppealStatus.REJECTED).forEach { status ->
+            mockMvc
+                .perform(get("/api/backoffice/appeals").param("status", status.name))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+
+            verify { appealService.getAppealsByStatus(status) }
+        }
+    }
+}

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/bracket/BracketManagementControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/bracket/BracketManagementControllerTest.kt
@@ -1,0 +1,330 @@
+package com.nextup.backoffice.controller.bracket
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.nextup.backoffice.exception.GlobalExceptionHandler
+import com.nextup.common.exception.BracketEntryNotFoundException
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.BracketEntry
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.service.bracket.BracketGeneratorService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+
+@DisplayName("BracketManagementController")
+class BracketManagementControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var bracketGeneratorService: BracketGeneratorService
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var competition: Competition
+    private lateinit var team1: Team
+    private lateinit var team2: Team
+
+    @BeforeEach
+    fun setup() {
+        bracketGeneratorService = mockk()
+        objectMapper = ObjectMapper().registerModule(JavaTimeModule())
+
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(BracketManagementController(bracketGeneratorService))
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        // Test data
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계 토너먼트",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.TOURNAMENT,
+                startDate = LocalDate.of(2025, 3, 1),
+                id = 1L,
+            )
+        team1 = Team(league = league, name = "팀A", city = "서울", foundedYear = 2020, id = 1L)
+        team2 = Team(league = league, name = "팀B", city = "서울", foundedYear = 2020, id = 2L)
+    }
+
+    @Nested
+    @DisplayName("POST /backoffice/v1/competitions/{competitionId}/bracket/generate")
+    inner class GenerateBracket {
+        @Test
+        fun `should generate single elimination bracket`() {
+            // given
+            val competitionId = 1L
+            val requestBody =
+                """
+                {
+                    "tournamentType": "SINGLE_ELIMINATION",
+                    "seededTeamIds": [1, 2, 3, 4]
+                }
+                """.trimIndent()
+
+            val bracketEntries =
+                listOf(
+                    BracketEntry(
+                        competition = competition,
+                        roundNumber = 1,
+                        matchNumber = 1,
+                        team1 = team1,
+                        team2 = team2,
+                        bracketType = "WINNERS",
+                        seed1 = 1,
+                        seed2 = 4,
+                        id = 1L,
+                    ),
+                )
+
+            every {
+                bracketGeneratorService.generateSingleElimination(competitionId, listOf(1L, 2L, 3L, 4L))
+            } returns bracketEntries
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/backoffice/v1/competitions/{competitionId}/bracket/generate", competitionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].roundNumber").value(1))
+                .andExpect(jsonPath("$.data[0].bracketType").value("WINNERS"))
+
+            verify(exactly = 1) {
+                bracketGeneratorService.generateSingleElimination(competitionId, listOf(1L, 2L, 3L, 4L))
+            }
+        }
+
+        @Test
+        fun `should generate double elimination bracket`() {
+            // given
+            val competitionId = 1L
+            val requestBody =
+                """
+                {
+                    "tournamentType": "DOUBLE_ELIMINATION",
+                    "seededTeamIds": [1, 2, 3, 4]
+                }
+                """.trimIndent()
+
+            val bracketEntries =
+                listOf(
+                    BracketEntry(
+                        competition = competition,
+                        roundNumber = 1,
+                        matchNumber = 1,
+                        team1 = team1,
+                        team2 = team2,
+                        bracketType = "WINNERS",
+                        seed1 = 1,
+                        seed2 = 4,
+                        id = 1L,
+                    ),
+                )
+
+            every {
+                bracketGeneratorService.generateDoubleElimination(competitionId, listOf(1L, 2L, 3L, 4L))
+            } returns bracketEntries
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/backoffice/v1/competitions/{competitionId}/bracket/generate", competitionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+
+            verify(exactly = 1) {
+                bracketGeneratorService.generateDoubleElimination(competitionId, listOf(1L, 2L, 3L, 4L))
+            }
+        }
+
+        @Test
+        fun `should return 400 when team list is empty`() {
+            // given
+            val competitionId = 1L
+            val requestBody =
+                """
+                {
+                    "tournamentType": "SINGLE_ELIMINATION",
+                    "seededTeamIds": []
+                }
+                """.trimIndent()
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/backoffice/v1/competitions/{competitionId}/bracket/generate", competitionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody),
+                ).andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `should return 400 when duplicate teams exist`() {
+            // given
+            val competitionId = 1L
+            val requestBody =
+                """
+                {
+                    "tournamentType": "SINGLE_ELIMINATION",
+                    "seededTeamIds": [1, 2, 1]
+                }
+                """.trimIndent()
+
+            every {
+                bracketGeneratorService.generateSingleElimination(competitionId, listOf(1L, 2L, 1L))
+            } throws
+                InvalidInputException(
+                    code = "DUPLICATE_TEAMS",
+                    message = "중복된 팀이 존재합니다",
+                )
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/backoffice/v1/competitions/{competitionId}/bracket/generate", competitionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody),
+                ).andExpect(status().isBadRequest)
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /backoffice/v1/competitions/{competitionId}/bracket/{entryId}/advance")
+    inner class AdvanceWinner {
+        @Test
+        fun `should advance winner successfully`() {
+            // given
+            val competitionId = 1L
+            val entryId = 1L
+            val winnerTeamId = 1L
+            val requestBody =
+                """
+                {
+                    "winnerTeamId": $winnerTeamId
+                }
+                """.trimIndent()
+
+            val updatedEntry =
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = 1,
+                    team1 = team1,
+                    team2 = team2,
+                    winner = team1,
+                    bracketType = "WINNERS",
+                    seed1 = 1,
+                    seed2 = 2,
+                    id = 1L,
+                )
+
+            every { bracketGeneratorService.advanceWinner(entryId, winnerTeamId) } returns updatedEntry
+
+            // when & then
+            mockMvc
+                .perform(
+                    put(
+                        "/backoffice/v1/competitions/{competitionId}/bracket/{entryId}/advance",
+                        competitionId,
+                        entryId,
+                    ).contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.winner.id").value(1))
+                .andExpect(jsonPath("$.data.isCompleted").value(true))
+
+            verify(exactly = 1) { bracketGeneratorService.advanceWinner(entryId, winnerTeamId) }
+        }
+
+        @Test
+        fun `should return 404 when bracket entry not found`() {
+            // given
+            val competitionId = 1L
+            val entryId = 999L
+            val winnerTeamId = 1L
+            val requestBody =
+                """
+                {
+                    "winnerTeamId": $winnerTeamId
+                }
+                """.trimIndent()
+
+            every {
+                bracketGeneratorService.advanceWinner(entryId, winnerTeamId)
+            } throws BracketEntryNotFoundException(entryId)
+
+            // when & then
+            mockMvc
+                .perform(
+                    put(
+                        "/backoffice/v1/competitions/{competitionId}/bracket/{entryId}/advance",
+                        competitionId,
+                        entryId,
+                    ).contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody),
+                ).andExpect(status().isNotFound)
+        }
+
+        @Test
+        fun `should return 400 when winner team not found`() {
+            // given
+            val competitionId = 1L
+            val entryId = 1L
+            val winnerTeamId = 999L
+            val requestBody =
+                """
+                {
+                    "winnerTeamId": $winnerTeamId
+                }
+                """.trimIndent()
+
+            every {
+                bracketGeneratorService.advanceWinner(entryId, winnerTeamId)
+            } throws
+                InvalidInputException(
+                    code = "TEAM_NOT_FOUND",
+                    message = "팀을 찾을 수 없습니다: $winnerTeamId",
+                )
+
+            // when & then
+            mockMvc
+                .perform(
+                    put(
+                        "/backoffice/v1/competitions/{competitionId}/bracket/{entryId}/advance",
+                        competitionId,
+                        entryId,
+                    ).contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody),
+                ).andExpect(status().isBadRequest)
+        }
+    }
+}

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminControllerGenerateTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminControllerGenerateTest.kt
@@ -1,0 +1,227 @@
+package com.nextup.backoffice.controller.schedule
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.schedule.LeagueSchedule
+import com.nextup.core.domain.team.Team
+import com.nextup.core.service.schedule.LeagueScheduleService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+
+class ScheduleAdminControllerGenerateTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var scheduleService: LeagueScheduleService
+
+    @BeforeEach
+    fun setUp() {
+        scheduleService = mockk(relaxed = true)
+        val controller = ScheduleAdminController(scheduleService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+    }
+
+    @Test
+    fun `should generate round robin schedule for 4 teams`() {
+        // given
+        val schedules = createSchedules(teamCount = 4, matchCount = 6)
+
+        every {
+            scheduleService.generateRoundRobinSchedule(
+                competitionId = 1L,
+                teamIds = listOf(1L, 2L, 3L, 4L),
+                doubleRoundRobin = false,
+            )
+        } returns schedules
+
+        // when & then
+        mockMvc
+            .post("/api/backoffice/competitions/1/schedule/generate") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "teamIds": [1, 2, 3, 4],
+                        "doubleRoundRobin": false
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isCreated() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data") { isArray() }
+                jsonPath("$.data.length()") { value(6) }
+            }
+
+        verify {
+            scheduleService.generateRoundRobinSchedule(
+                competitionId = 1L,
+                teamIds = listOf(1L, 2L, 3L, 4L),
+                doubleRoundRobin = false,
+            )
+        }
+    }
+
+    @Test
+    fun `should generate double round robin schedule`() {
+        // given
+        val schedules = createSchedules(teamCount = 3, matchCount = 6)
+
+        every {
+            scheduleService.generateRoundRobinSchedule(
+                competitionId = 1L,
+                teamIds = listOf(1L, 2L, 3L),
+                doubleRoundRobin = true,
+            )
+        } returns schedules
+
+        // when & then
+        mockMvc
+            .post("/api/backoffice/competitions/1/schedule/generate") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "teamIds": [1, 2, 3],
+                        "doubleRoundRobin": true
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isCreated() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data") { isArray() }
+                jsonPath("$.data.length()") { value(6) }
+            }
+
+        verify {
+            scheduleService.generateRoundRobinSchedule(
+                competitionId = 1L,
+                teamIds = listOf(1L, 2L, 3L),
+                doubleRoundRobin = true,
+            )
+        }
+    }
+
+    @Test
+    fun `should generate schedule with default doubleRoundRobin false`() {
+        // given
+        val schedules = createSchedules(teamCount = 3, matchCount = 3)
+
+        every {
+            scheduleService.generateRoundRobinSchedule(
+                competitionId = 1L,
+                teamIds = listOf(1L, 2L, 3L),
+                doubleRoundRobin = false,
+            )
+        } returns schedules
+
+        // when & then
+        mockMvc
+            .post("/api/backoffice/competitions/1/schedule/generate") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "teamIds": [1, 2, 3]
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isCreated() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data") { isArray() }
+                jsonPath("$.data.length()") { value(3) }
+            }
+    }
+
+    @Test
+    fun `should return 400 when teamIds is empty`() {
+        // when & then
+        mockMvc
+            .post("/api/backoffice/competitions/1/schedule/generate") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "teamIds": [],
+                        "doubleRoundRobin": false
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isBadRequest() }
+            }
+    }
+
+    @Test
+    fun `should return 400 when teamIds is missing`() {
+        // when & then
+        mockMvc
+            .post("/api/backoffice/competitions/1/schedule/generate") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "doubleRoundRobin": false
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isBadRequest() }
+            }
+    }
+
+    // ========== Helper Methods ==========
+
+    private fun createSchedules(
+        teamCount: Int,
+        matchCount: Int,
+    ): List<LeagueSchedule> {
+        val competition = createCompetition()
+        val teams = (1L..teamCount.toLong()).map { createTeam("팀$it", it) }
+
+        return (1..matchCount).map { i ->
+            val homeTeam = teams[(i - 1) % teamCount]
+            val awayTeam = teams[((i - 1) + 1) % teamCount]
+
+            LeagueSchedule.create(
+                competition = competition,
+                round = (i - 1) / (teamCount / 2) + 1,
+                matchNumber = i,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledDate = LocalDate.now().plusWeeks((i - 1).toLong()),
+            )
+        }
+    }
+
+    private fun createCompetition(): Competition {
+        val association = Association(name = "서울시야구협회", abbreviation = "서야협", region = "서울")
+        val league = League(association = association, name = "서울시 리그", foundedYear = 2020)
+        return Competition(
+            league = league,
+            name = "2024 시즌",
+            year = 2024,
+            startDate = LocalDate.now().minusDays(30),
+            id = 1L,
+        )
+    }
+
+    private fun createTeam(
+        name: String,
+        id: Long,
+    ): Team {
+        val association = Association(name = "서울시야구협회", abbreviation = "서야협", region = "서울")
+        val league = League(association = association, name = "서울시 리그", foundedYear = 2020)
+        return Team(
+            league = league,
+            name = name,
+            city = "서울",
+            foundedYear = 2020,
+            id = id,
+        )
+    }
+}

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminControllerValidationTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminControllerValidationTest.kt
@@ -1,0 +1,223 @@
+package com.nextup.backoffice.controller.schedule
+
+import com.nextup.core.domain.schedule.ConflictType
+import com.nextup.core.domain.schedule.ScheduleConflict
+import com.nextup.core.service.schedule.LeagueScheduleService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+import java.time.LocalTime
+
+class ScheduleAdminControllerValidationTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var scheduleService: LeagueScheduleService
+
+    @BeforeEach
+    fun setUp() {
+        scheduleService = mockk(relaxed = true)
+        val controller = ScheduleAdminController(scheduleService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+    }
+
+    @Test
+    fun `should validate schedule and return no conflicts`() {
+        // given
+        every {
+            scheduleService.validateSchedule(
+                competitionId = 1L,
+                round = 1,
+                matchNumber = 1,
+                homeTeamId = 1L,
+                awayTeamId = 2L,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+        } returns emptyList()
+
+        // when & then
+        mockMvc
+            .post("/api/backoffice/competitions/1/schedule/validate") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "round": 1,
+                        "matchNumber": 1,
+                        "homeTeamId": 1,
+                        "awayTeamId": 2,
+                        "scheduledDate": "2024-05-01",
+                        "scheduledTime": "14:00:00",
+                        "venue": "구장A"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data") { isArray() }
+                jsonPath("$.data.length()") { value(0) }
+            }
+    }
+
+    @Test
+    fun `should validate schedule and return team conflicts`() {
+        // given
+        val conflicts =
+            listOf(
+                ScheduleConflict(
+                    type = ConflictType.TEAM_TIME_CONFLICT,
+                    conflictingScheduleId = 100L,
+                    description = "홈팀 '팀A'이(가) 2024-05-01 14:00에 다른 경기(팀A vs 팀B)에 배정되어 있습니다.",
+                ),
+            )
+
+        every {
+            scheduleService.validateSchedule(
+                competitionId = 1L,
+                round = 1,
+                matchNumber = 2,
+                homeTeamId = 1L,
+                awayTeamId = 3L,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장B",
+            )
+        } returns conflicts
+
+        // when & then
+        mockMvc
+            .post("/api/backoffice/competitions/1/schedule/validate") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "round": 1,
+                        "matchNumber": 2,
+                        "homeTeamId": 1,
+                        "awayTeamId": 3,
+                        "scheduledDate": "2024-05-01",
+                        "scheduledTime": "14:00:00",
+                        "venue": "구장B"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data") { isArray() }
+                jsonPath("$.data.length()") { value(1) }
+                jsonPath("$.data[0].type") { value("TEAM_TIME_CONFLICT") }
+                jsonPath("$.data[0].conflictingScheduleId") { value(100) }
+                jsonPath("$.data[0].description") { value(conflicts[0].description) }
+            }
+    }
+
+    @Test
+    fun `should validate schedule and return venue conflicts`() {
+        // given
+        val conflicts =
+            listOf(
+                ScheduleConflict(
+                    type = ConflictType.VENUE_TIME_CONFLICT,
+                    conflictingScheduleId = 100L,
+                    description = "경기장 '구장A'에 2024-05-01 14:00에 다른 경기(팀A vs 팀B)가 배정되어 있습니다.",
+                ),
+            )
+
+        every {
+            scheduleService.validateSchedule(
+                competitionId = 1L,
+                round = 1,
+                matchNumber = 2,
+                homeTeamId = 3L,
+                awayTeamId = 4L,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+        } returns conflicts
+
+        // when & then
+        mockMvc
+            .post("/api/backoffice/competitions/1/schedule/validate") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "round": 1,
+                        "matchNumber": 2,
+                        "homeTeamId": 3,
+                        "awayTeamId": 4,
+                        "scheduledDate": "2024-05-01",
+                        "scheduledTime": "14:00:00",
+                        "venue": "구장A"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data") { isArray() }
+                jsonPath("$.data.length()") { value(1) }
+                jsonPath("$.data[0].type") { value("VENUE_TIME_CONFLICT") }
+            }
+    }
+
+    @Test
+    fun `should validate schedule and return multiple conflicts`() {
+        // given
+        val conflicts =
+            listOf(
+                ScheduleConflict(
+                    type = ConflictType.TEAM_TIME_CONFLICT,
+                    conflictingScheduleId = 100L,
+                    description = "홈팀 '팀A'이(가) 2024-05-01 14:00에 다른 경기(팀A vs 팀B)에 배정되어 있습니다.",
+                ),
+                ScheduleConflict(
+                    type = ConflictType.VENUE_TIME_CONFLICT,
+                    conflictingScheduleId = 100L,
+                    description = "경기장 '구장A'에 2024-05-01 14:00에 다른 경기(팀A vs 팀B)가 배정되어 있습니다.",
+                ),
+            )
+
+        every {
+            scheduleService.validateSchedule(
+                competitionId = 1L,
+                round = 1,
+                matchNumber = 2,
+                homeTeamId = 1L,
+                awayTeamId = 3L,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+        } returns conflicts
+
+        // when & then
+        mockMvc
+            .post("/api/backoffice/competitions/1/schedule/validate") {
+                contentType = MediaType.APPLICATION_JSON
+                content =
+                    """
+                    {
+                        "round": 1,
+                        "matchNumber": 2,
+                        "homeTeamId": 1,
+                        "awayTeamId": 3,
+                        "scheduledDate": "2024-05-01",
+                        "scheduledTime": "14:00:00",
+                        "venue": "구장A"
+                    }
+                    """.trimIndent()
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data") { isArray() }
+                jsonPath("$.data.length()") { value(2) }
+            }
+    }
+}

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/stadium/StadiumAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/stadium/StadiumAdminControllerTest.kt
@@ -1,0 +1,223 @@
+package com.nextup.backoffice.controller.stadium
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.backoffice.dto.stadium.CreateSlotRequest
+import com.nextup.backoffice.dto.stadium.CreateStadiumRequest
+import com.nextup.backoffice.dto.stadium.UpdateStadiumRequest
+import com.nextup.core.domain.stadium.Stadium
+import com.nextup.core.domain.stadium.StadiumSlot
+import com.nextup.core.service.stadium.StadiumAdminService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalTime
+
+@DisplayName("StadiumAdminController")
+class StadiumAdminControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var stadiumAdminService: StadiumAdminService
+    private lateinit var controller: StadiumAdminController
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        stadiumAdminService = mockk()
+        controller = StadiumAdminController(stadiumAdminService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @Nested
+    @DisplayName("POST /api/backoffice/stadiums")
+    inner class CreateStadium {
+        @Test
+        fun `should create stadium successfully`() {
+            // given
+            val request =
+                CreateStadiumRequest(
+                    name = "잠실 야구장",
+                    address = "서울특별시 송파구 올림픽로 25",
+                    latitude = 37.5121,
+                    longitude = 127.0717,
+                    capacity = 25000,
+                    facilities = "주차장, 샤워실",
+                    contactInfo = "02-1234-5678",
+                )
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            every { stadiumAdminService.createStadium(any()) } returns stadium
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/backoffice/stadiums")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.name").value("잠실 야구장"))
+                .andExpect(jsonPath("$.data.latitude").value(37.5121))
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/backoffice/stadiums/{id}")
+    inner class UpdateStadium {
+        @Test
+        fun `should update stadium successfully`() {
+            // given
+            val request =
+                UpdateStadiumRequest(
+                    address = "서울특별시 송파구 올림픽로 25",
+                    capacity = 26000,
+                )
+            val stadium =
+                createStadium(1L, "잠실 야구장", 37.5121, 127.0717).apply {
+                    update(address = "서울특별시 송파구 올림픽로 25", capacity = 26000)
+                }
+            every {
+                stadiumAdminService.updateStadium(1L, any(), any(), any(), any(), any(), any(), any())
+            } returns stadium
+
+            // when & then
+            mockMvc
+                .perform(
+                    put("/api/backoffice/stadiums/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/backoffice/stadiums/slots")
+    inner class CreateSlots {
+        @Test
+        fun `should create slots successfully`() {
+            // given
+            val requests =
+                listOf(
+                    CreateSlotRequest(
+                        stadiumId = 1L,
+                        date = LocalDate.of(2024, 12, 25),
+                        startTime = LocalTime.of(10, 0),
+                        endTime = LocalTime.of(12, 0),
+                        price = BigDecimal("50000"),
+                    ),
+                    CreateSlotRequest(
+                        stadiumId = 1L,
+                        date = LocalDate.of(2024, 12, 25),
+                        startTime = LocalTime.of(14, 0),
+                        endTime = LocalTime.of(16, 0),
+                        price = BigDecimal("50000"),
+                    ),
+                )
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val slots =
+                listOf(
+                    createSlot(1L, stadium, LocalDate.of(2024, 12, 25)),
+                    createSlot(2L, stadium, LocalDate.of(2024, 12, 25)),
+                )
+            every { stadiumAdminService.createSlots(any()) } returns slots
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/backoffice/stadiums/slots")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requests)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/backoffice/stadiums/{id}/deactivate")
+    inner class DeactivateStadium {
+        @Test
+        fun `should deactivate stadium successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717).apply { deactivate() }
+            every { stadiumAdminService.deactivateStadium(1L) } returns stadium
+
+            // when & then
+            mockMvc
+                .perform(put("/api/backoffice/stadiums/1/deactivate"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.isActive").value(false))
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/backoffice/stadiums/{id}/activate")
+    inner class ActivateStadium {
+        @Test
+        fun `should activate stadium successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            every { stadiumAdminService.activateStadium(1L) } returns stadium
+
+            // when & then
+            mockMvc
+                .perform(put("/api/backoffice/stadiums/1/activate"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.isActive").value(true))
+        }
+    }
+
+    private fun createStadium(
+        id: Long,
+        name: String,
+        latitude: Double,
+        longitude: Double,
+    ): Stadium {
+        val stadium =
+            Stadium.create(
+                name = name,
+                address = "서울특별시",
+                latitude = latitude,
+                longitude = longitude,
+            )
+        val idField = Stadium::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(stadium, id)
+        return stadium
+    }
+
+    private fun createSlot(
+        id: Long,
+        stadium: Stadium,
+        date: LocalDate,
+    ): StadiumSlot {
+        val slot =
+            StadiumSlot.create(
+                stadium = stadium,
+                date = date,
+                startTime = LocalTime.of(10, 0),
+                endTime = LocalTime.of(12, 0),
+            )
+        val idField = StadiumSlot::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(slot, id)
+        return slot
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/AppealNotFoundException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/AppealNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.nextup.common.exception
+
+class AppealNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "APPEAL_NOT_FOUND",
+        message = "이의 제기를 찾을 수 없습니다: $id",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/AttendanceExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/AttendanceExceptions.kt
@@ -1,0 +1,31 @@
+package com.nextup.common.exception
+
+/**
+ * 출석 투표를 찾을 수 없을 때 발생하는 예외
+ */
+class AttendancePollNotFoundException(
+    pollId: Long,
+) : NotFoundException("ATTENDANCE_POLL_NOT_FOUND", "출석 투표를 찾을 수 없습니다: $pollId")
+
+/**
+ * 출석 투표가 닫혀있을 때 발생하는 예외
+ */
+class AttendancePollClosedException(
+    pollId: Long,
+) : InvalidStateException("ATTENDANCE_POLL_CLOSED", "출석 투표가 마감되었습니다: $pollId")
+
+/**
+ * 이미 투표했을 때 발생하는 예외
+ */
+class AlreadyVotedException(
+    pollId: Long,
+    playerId: Long,
+) : InvalidStateException("ALREADY_VOTED", "이미 투표했습니다 - pollId: $pollId, playerId: $playerId")
+
+/**
+ * 활동 점수를 찾을 수 없을 때 발생하는 예외
+ */
+class ActivityScoreNotFoundException(
+    teamId: Long,
+    memberId: Long,
+) : NotFoundException("ACTIVITY_SCORE_NOT_FOUND", "활동 점수를 찾을 수 없습니다 - teamId: $teamId, memberId: $memberId")

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/BracketEntryNotFoundException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/BracketEntryNotFoundException.kt
@@ -1,0 +1,11 @@
+package com.nextup.common.exception
+
+/**
+ * 대진표 엔트리를 찾을 수 없을 때 발생하는 예외
+ */
+class BracketEntryNotFoundException(
+    bracketEntryId: Long,
+) : NotFoundException(
+        "BRACKET_ENTRY_NOT_FOUND",
+        "대진표 엔트리를 찾을 수 없습니다: $bracketEntryId",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/CertificateExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/CertificateExceptions.kt
@@ -1,0 +1,41 @@
+package com.nextup.common.exception
+
+/**
+ * 증명서를 찾을 수 없을 때 발생하는 예외
+ */
+class CertificateNotFoundException(
+    certificateId: Long,
+) : NotFoundException(
+        code = "CERTIFICATE_NOT_FOUND",
+        message = "증명서를 찾을 수 없습니다: $certificateId",
+    )
+
+/**
+ * 증명서 발급 번호로 찾을 수 없을 때 발생하는 예외
+ */
+class CertificateNotFoundByIssueNumberException(
+    issueNumber: String,
+) : NotFoundException(
+        code = "CERTIFICATE_NOT_FOUND",
+        message = "증명서를 찾을 수 없습니다: $issueNumber",
+    )
+
+/**
+ * 만료된 증명서 접근 시 발생하는 예외
+ */
+class CertificateExpiredException(
+    issueNumber: String,
+) : InvalidStateException(
+        code = "CERTIFICATE_EXPIRED",
+        message = "만료된 증명서입니다: $issueNumber",
+    )
+
+/**
+ * 취소된 증명서 접근 시 발생하는 예외
+ */
+class CertificateRevokedException(
+    issueNumber: String,
+) : InvalidStateException(
+        code = "CERTIFICATE_REVOKED",
+        message = "취소된 증명서입니다: $issueNumber",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/DeviceTokenNotFoundException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/DeviceTokenNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.nextup.common.exception
+
+class DeviceTokenNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "DEVICE_TOKEN_NOT_FOUND",
+        message = "디바이스 토큰을 찾을 수 없습니다: $id",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/DisciplineExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/DisciplineExceptions.kt
@@ -1,0 +1,32 @@
+package com.nextup.common.exception
+
+/**
+ * 징계를 찾을 수 없을 때 발생하는 예외
+ */
+class DisciplineNotFoundException(
+    disciplineId: Long,
+) : NotFoundException(
+        "DISCIPLINE_NOT_FOUND",
+        "Discipline not found: $disciplineId",
+    )
+
+/**
+ * 징계 상태가 유효하지 않을 때 발생하는 예외
+ */
+class InvalidDisciplineStateException(
+    message: String,
+) : InvalidStateException(
+        "INVALID_DISCIPLINE_STATE",
+        message,
+    )
+
+/**
+ * 선수가 출장 불가 상태일 때 발생하는 예외
+ */
+class PlayerIneligibleException(
+    playerId: Long,
+    reason: String,
+) : BusinessException(
+        "PLAYER_INELIGIBLE",
+        "Player $playerId is ineligible to play: $reason",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/ElectionExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/ElectionExceptions.kt
@@ -1,0 +1,29 @@
+package com.nextup.common.exception
+
+/**
+ * 선거를 찾을 수 없을 때 발생하는 예외
+ */
+class ElectionNotFoundException(
+    electionId: Long,
+) : NotFoundException(
+        code = "ELECTION_NOT_FOUND",
+        message = "Election not found: $electionId",
+    )
+
+/**
+ * 후보자를 찾을 수 없을 때 발생하는 예외
+ */
+class CandidateNotFoundException(
+    candidateId: Long,
+) : NotFoundException(
+        code = "CANDIDATE_NOT_FOUND",
+        message = "Candidate not found: $candidateId",
+    )
+
+/**
+ * 중복 투표 시 발생하는 예외
+ */
+class DuplicateVoteException(
+    code: String = "DUPLICATE_VOTE",
+    message: String = "User has already voted in this election",
+) : BusinessException(code, message)

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/LineupExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/LineupExceptions.kt
@@ -38,6 +38,16 @@ class InvalidDhRuleException(
     )
 
 /**
+ * 참석하지 않는 선수가 라인업에 포함되었을 때 발생하는 예외
+ */
+class NonAttendingPlayerInLineupException(
+    playerIds: Set<Long>,
+) : LineupValidationException(
+        "NON_ATTENDING_PLAYER_IN_LINEUP",
+        "라인업에 참석(ATTENDING)이 아닌 선수가 포함되어 있습니다. 선수 ID: $playerIds",
+    )
+
+/**
  * 대진표를 찾을 수 없을 때 발생하는 예외
  */
 class ScheduleNotFoundException(

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/LineupExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/LineupExceptions.kt
@@ -1,0 +1,58 @@
+package com.nextup.common.exception
+
+/**
+ * 라인업 검증 예외 기본 클래스
+ */
+open class LineupValidationException(
+    code: String,
+    message: String,
+) : InvalidInputException(code, message)
+
+/**
+ * 라인업에 동일 선수가 중복 등록되었을 때 발생하는 예외
+ */
+class DuplicatePlayerInLineupException(
+    playerIds: Set<Long>,
+) : LineupValidationException(
+        "DUPLICATE_PLAYER_IN_LINEUP",
+        "라인업에 중복된 선수가 있습니다. 중복 선수 ID: $playerIds",
+    )
+
+/**
+ * 라인업에 포수가 없을 때 발생하는 예외
+ */
+class NoCatcherInLineupException :
+    LineupValidationException(
+        "NO_CATCHER_IN_LINEUP",
+        "라인업에 포수(C)가 최소 1명 필요합니다.",
+    )
+
+/**
+ * DH 규칙 위반 시 발생하는 예외
+ */
+class InvalidDhRuleException(
+    message: String,
+) : LineupValidationException(
+        "INVALID_DH_RULE",
+        message,
+    )
+
+/**
+ * 대진표를 찾을 수 없을 때 발생하는 예외
+ */
+class ScheduleNotFoundException(
+    scheduleId: Long,
+) : NotFoundException(
+        "SCHEDULE_NOT_FOUND",
+        "Schedule not found: $scheduleId",
+    )
+
+/**
+ * 대진표 상태가 유효하지 않을 때 발생하는 예외
+ */
+class InvalidScheduleStateException(
+    message: String,
+) : InvalidStateException(
+        "INVALID_SCHEDULE_STATE",
+        message,
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/MatchRequestNotFoundException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/MatchRequestNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.nextup.common.exception
+
+class MatchRequestNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "MATCH_REQUEST_NOT_FOUND",
+        message = "매칭 요청을 찾을 수 없습니다: $id",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/MatchResponseNotFoundException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/MatchResponseNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.nextup.common.exception
+
+class MatchResponseNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "MATCH_RESPONSE_NOT_FOUND",
+        message = "매칭 응답을 찾을 수 없습니다: $id",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/NotificationNotFoundException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/NotificationNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.nextup.common.exception
+
+class NotificationNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "NOTIFICATION_NOT_FOUND",
+        message = "알림을 찾을 수 없습니다: $id",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/PitchEventNotFoundException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/PitchEventNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.nextup.common.exception
+
+/**
+ * 투구 이벤트를 찾을 수 없을 때 발생하는 예외
+ */
+class PitchEventNotFoundException(
+    id: Long,
+) : NotFoundException("PITCH_EVENT_NOT_FOUND", "PitchEvent not found: $id")

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
@@ -56,3 +56,19 @@ class GameNotFoundException(
 class InvalidGameStateException(
     message: String,
 ) : InvalidStateException("INVALID_GAME_STATE", message)
+
+/**
+ * Undo가 불가능한 상태일 때 발생하는 예외
+ */
+class UndoNotAvailableException(
+    reason: String,
+) : InvalidStateException("UNDO_NOT_AVAILABLE", reason)
+
+/**
+ * 되돌릴 이벤트가 없을 때 발생하는 예외
+ */
+class NoEventToUndoException :
+    NotFoundException(
+        "NO_EVENT_TO_UNDO",
+        "되돌릴 이벤트가 없습니다",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/RecruitmentNotFoundException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/RecruitmentNotFoundException.kt
@@ -1,0 +1,8 @@
+package com.nextup.common.exception
+
+class RecruitmentNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "RECRUITMENT_NOT_FOUND",
+        message = "모집 공고를 찾을 수 없습니다: $id",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/StadiumExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/StadiumExceptions.kt
@@ -1,0 +1,39 @@
+package com.nextup.common.exception
+
+/**
+ * 구장을 찾을 수 없을 때 발생하는 예외
+ */
+class StadiumNotFoundException(
+    stadiumId: Long,
+) : NotFoundException(
+        "STADIUM_NOT_FOUND",
+        "Stadium not found: $stadiumId",
+    )
+
+/**
+ * 구장 슬롯을 찾을 수 없을 때 발생하는 예외
+ */
+class SlotNotFoundException(
+    slotId: Long,
+) : NotFoundException(
+        "SLOT_NOT_FOUND",
+        "Stadium slot not found: $slotId",
+    )
+
+/**
+ * 구장 예약을 찾을 수 없을 때 발생하는 예외
+ */
+class BookingNotFoundException(
+    bookingId: Long,
+) : NotFoundException(
+        "BOOKING_NOT_FOUND",
+        "Stadium booking not found: $bookingId",
+    )
+
+/**
+ * 슬롯이 예약 가능하지 않을 때 발생하는 예외
+ */
+class SlotNotAvailableException(
+    code: String,
+    message: String,
+) : BusinessException(code, message)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/appeal/Appeal.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/appeal/Appeal.kt
@@ -1,0 +1,116 @@
+package com.nextup.core.domain.appeal
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.game.Game
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+/**
+ * 이의 제기/정정 신청 엔티티
+ *
+ * 경기 기록에 대한 선수/감독의 이의 제기를 관리합니다.
+ */
+@Entity
+@Table(
+    name = "appeals",
+    indexes = [
+        Index(name = "idx_appeals_game_id", columnList = "game_id"),
+        Index(name = "idx_appeals_appealer_id", columnList = "appealer_id"),
+        Index(name = "idx_appeals_status", columnList = "status"),
+        Index(
+            name = "idx_appeals_game_status",
+            columnList = "game_id, status",
+        ),
+    ],
+)
+class Appeal private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    val game: Game,
+    @Column(name = "appealer_id", nullable = false)
+    val appealerId: Long,
+    @Column(name = "appealer_name", nullable = false, length = 100)
+    val appealerName: String,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    val type: AppealType,
+    @Column(nullable = false, length = 200)
+    val title: String,
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val description: String,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: AppealStatus = AppealStatus.PENDING,
+    @Column(name = "reviewer_id")
+    var reviewerId: Long? = null,
+    @Column(name = "reviewer_comment", columnDefinition = "TEXT")
+    var reviewerComment: String? = null,
+    @Column(name = "reviewed_at")
+    var reviewedAt: LocalDateTime? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 이의 제기를 승인합니다.
+     */
+    fun approve(
+        reviewerId: Long,
+        comment: String?,
+    ) {
+        require(status == AppealStatus.PENDING) {
+            "대기 중인 이의 제기만 승인할 수 있습니다"
+        }
+        this.status = AppealStatus.APPROVED
+        this.reviewerId = reviewerId
+        this.reviewerComment = comment
+        this.reviewedAt = LocalDateTime.now()
+    }
+
+    /**
+     * 이의 제기를 반려합니다.
+     */
+    fun reject(
+        reviewerId: Long,
+        comment: String,
+    ) {
+        require(status == AppealStatus.PENDING) {
+            "대기 중인 이의 제기만 반려할 수 있습니다"
+        }
+        require(comment.isNotBlank()) {
+            "반려 사유는 필수입니다"
+        }
+        this.status = AppealStatus.REJECTED
+        this.reviewerId = reviewerId
+        this.reviewerComment = comment
+        this.reviewedAt = LocalDateTime.now()
+    }
+
+    companion object {
+        /**
+         * 이의 제기를 생성합니다.
+         */
+        fun create(
+            game: Game,
+            appealerId: Long,
+            appealerName: String,
+            type: AppealType,
+            title: String,
+            description: String,
+        ): Appeal {
+            require(appealerId > 0) { "신청자 ID는 필수입니다" }
+            require(appealerName.isNotBlank()) { "신청자 이름은 필수입니다" }
+            require(title.isNotBlank()) { "제목은 필수입니다" }
+            require(description.isNotBlank()) { "상세 설명은 필수입니다" }
+
+            return Appeal(
+                game = game,
+                appealerId = appealerId,
+                appealerName = appealerName,
+                type = type,
+                title = title,
+                description = description,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/appeal/AppealStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/appeal/AppealStatus.kt
@@ -1,0 +1,7 @@
+package com.nextup.core.domain.appeal
+
+enum class AppealStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/appeal/AppealType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/appeal/AppealType.kt
@@ -1,0 +1,8 @@
+package com.nextup.core.domain.appeal
+
+enum class AppealType {
+    SCORING_ERROR,
+    RECORD_CORRECTION,
+    RULE_VIOLATION,
+    OTHER,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/ActivityScore.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/ActivityScore.kt
@@ -1,0 +1,107 @@
+package com.nextup.core.domain.attendance
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamMember
+import jakarta.persistence.*
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * 활동 점수 엔티티
+ *
+ * 팀원의 경기 참여율, 연습 참석률, 기여도 점수 등을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "activity_scores",
+    indexes = [
+        Index(name = "idx_as_team_id", columnList = "team_id"),
+        Index(name = "idx_as_member_id", columnList = "member_id"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_as_team_member",
+            columnNames = ["team_id", "member_id"],
+        ),
+    ],
+)
+class ActivityScore private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    val team: Team,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: TeamMember,
+    @Column(name = "game_participation_rate", nullable = false, precision = 5, scale = 2)
+    var gameParticipationRate: BigDecimal = BigDecimal.ZERO,
+    @Column(name = "practice_attendance_rate", nullable = false, precision = 5, scale = 2)
+    var practiceAttendanceRate: BigDecimal = BigDecimal.ZERO,
+    @Column(name = "contribution_score", nullable = false, precision = 5, scale = 2)
+    var contributionScore: BigDecimal = BigDecimal.ZERO,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 전체 활동 점수를 계산합니다.
+     * 경기 참여율 40% + 연습 참석률 40% + 기여도 20%
+     */
+    fun calculateTotalScore(): BigDecimal =
+        (
+            gameParticipationRate.multiply(BigDecimal("0.4"))
+                .add(practiceAttendanceRate.multiply(BigDecimal("0.4")))
+                .add(contributionScore.multiply(BigDecimal("0.2")))
+        ).setScale(2, RoundingMode.HALF_UP)
+
+    /**
+     * 경기 참여율을 업데이트합니다.
+     */
+    fun updateGameParticipationRate(rate: BigDecimal) {
+        require(rate >= BigDecimal.ZERO && rate <= BigDecimal(100)) {
+            "경기 참여율은 0~100 범위여야 합니다."
+        }
+        this.gameParticipationRate = rate.setScale(2, RoundingMode.HALF_UP)
+    }
+
+    /**
+     * 연습 참석률을 업데이트합니다.
+     */
+    fun updatePracticeAttendanceRate(rate: BigDecimal) {
+        require(rate >= BigDecimal.ZERO && rate <= BigDecimal(100)) {
+            "연습 참석률은 0~100 범위여야 합니다."
+        }
+        this.practiceAttendanceRate = rate.setScale(2, RoundingMode.HALF_UP)
+    }
+
+    /**
+     * 기여도 점수를 업데이트합니다.
+     */
+    fun updateContributionScore(score: BigDecimal) {
+        require(score >= BigDecimal.ZERO && score <= BigDecimal(100)) {
+            "기여도 점수는 0~100 범위여야 합니다."
+        }
+        this.contributionScore = score.setScale(2, RoundingMode.HALF_UP)
+    }
+
+    companion object {
+        /**
+         * 활동 점수를 생성합니다.
+         *
+         * @param team 팀
+         * @param member 팀원
+         * @return 생성된 ActivityScore
+         */
+        fun create(
+            team: Team,
+            member: TeamMember,
+        ): ActivityScore =
+            ActivityScore(
+                team = team,
+                member = member,
+                gameParticipationRate = BigDecimal.ZERO,
+                practiceAttendanceRate = BigDecimal.ZERO,
+                contributionScore = BigDecimal.ZERO,
+            )
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/AttendancePoll.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/AttendancePoll.kt
@@ -1,0 +1,109 @@
+package com.nextup.core.domain.attendance
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.team.Team
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+/**
+ * 출석 투표 엔티티
+ *
+ * 팀 이벤트(경기, 연습 등)에 대한 참석 여부를 조사하는 투표를 관리합니다.
+ * Rich Domain Model 원칙에 따라 비즈니스 로직을 Entity 내부에 캡슐화합니다.
+ */
+@Entity
+@Table(
+    name = "attendance_polls",
+    indexes = [
+        Index(name = "idx_ap_team_id", columnList = "team_id"),
+        Index(name = "idx_ap_status", columnList = "status"),
+        Index(name = "idx_ap_event_date", columnList = "event_date"),
+    ],
+)
+class AttendancePoll private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    val team: Team,
+    @Column(nullable = false, length = 200)
+    var title: String,
+    @Column(name = "event_date", nullable = false)
+    val eventDate: LocalDateTime,
+    @Column(nullable = false)
+    val deadline: LocalDateTime,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: PollStatus = PollStatus.OPEN,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 투표가 진행 중인지 확인합니다.
+     */
+    fun isOpen(): Boolean = status == PollStatus.OPEN
+
+    /**
+     * 투표가 마감되었는지 확인합니다.
+     */
+    fun isClosed(): Boolean = status == PollStatus.CLOSED
+
+    /**
+     * 마감 시간이 지났는지 확인합니다.
+     */
+    fun isExpired(): Boolean = LocalDateTime.now().isAfter(deadline)
+
+    /**
+     * 투표를 마감합니다.
+     */
+    fun close() {
+        check(isOpen()) { "이미 마감된 투표입니다." }
+        this.status = PollStatus.CLOSED
+    }
+
+    /**
+     * 투표가 가능한 상태인지 확인합니다.
+     */
+    fun canVote(): Boolean = isOpen() && !isExpired()
+
+    /**
+     * 제목을 수정합니다.
+     */
+    fun updateTitle(newTitle: String) {
+        require(newTitle.isNotBlank()) { "제목은 비어있을 수 없습니다." }
+        this.title = newTitle
+    }
+
+    companion object {
+        /**
+         * 출석 투표를 생성합니다.
+         *
+         * @param team 팀
+         * @param title 투표 제목
+         * @param eventDate 이벤트 날짜
+         * @param deadline 투표 마감 시간
+         * @return 생성된 AttendancePoll
+         */
+        fun create(
+            team: Team,
+            title: String,
+            eventDate: LocalDateTime,
+            deadline: LocalDateTime,
+        ): AttendancePoll {
+            require(title.isNotBlank()) { "제목은 비어있을 수 없습니다." }
+            require(eventDate.isAfter(LocalDateTime.now())) {
+                "이벤트 날짜는 현재 시간 이후여야 합니다."
+            }
+            require(deadline.isBefore(eventDate)) {
+                "마감 시간은 이벤트 날짜보다 이전이어야 합니다."
+            }
+
+            return AttendancePoll(
+                team = team,
+                title = title,
+                eventDate = eventDate,
+                deadline = deadline,
+                status = PollStatus.OPEN,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/AttendanceVote.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/AttendanceVote.kt
@@ -1,0 +1,82 @@
+package com.nextup.core.domain.attendance
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.player.Player
+import jakarta.persistence.*
+
+/**
+ * 출석 투표 응답 엔티티
+ *
+ * 선수의 특정 출석 투표에 대한 응답을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "poll_votes",
+    indexes = [
+        Index(name = "idx_pv_poll_id", columnList = "poll_id"),
+        Index(name = "idx_pv_player_id", columnList = "player_id"),
+        Index(name = "idx_pv_vote_type", columnList = "vote_type"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_pv_poll_player",
+            columnNames = ["poll_id", "player_id"],
+        ),
+    ],
+)
+class AttendanceVote private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poll_id", nullable = false)
+    val poll: AttendancePoll,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "player_id", nullable = false)
+    val player: Player,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "vote_type", nullable = false, length = 20)
+    var voteType: VoteType,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 투표를 변경합니다.
+     */
+    fun changeVote(newVoteType: VoteType) {
+        check(poll.canVote()) { "투표를 변경할 수 없습니다. 마감되었거나 기한이 지났습니다." }
+        this.voteType = newVoteType
+    }
+
+    /**
+     * 참석 의사를 표시했는지 확인합니다.
+     */
+    fun isAttending(): Boolean = voteType == VoteType.ATTEND
+
+    /**
+     * 불참 의사를 표시했는지 확인합니다.
+     */
+    fun isAbsent(): Boolean = voteType == VoteType.ABSENT
+
+    companion object {
+        /**
+         * 출석 투표를 생성합니다.
+         *
+         * @param poll 출석 투표
+         * @param player 선수
+         * @param voteType 투표 유형
+         * @return 생성된 AttendanceVote
+         */
+        fun create(
+            poll: AttendancePoll,
+            player: Player,
+            voteType: VoteType,
+        ): AttendanceVote {
+            check(poll.canVote()) { "투표가 마감되었거나 기한이 지났습니다." }
+
+            return AttendanceVote(
+                poll = poll,
+                player = player,
+                voteType = voteType,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/PollStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/PollStatus.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.domain.attendance
+
+/**
+ * 출석 투표 상태
+ */
+enum class PollStatus {
+    /**
+     * 진행 중
+     */
+    OPEN,
+
+    /**
+     * 마감
+     */
+    CLOSED,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/VoteType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/VoteType.kt
@@ -1,0 +1,21 @@
+package com.nextup.core.domain.attendance
+
+/**
+ * 출석 투표 유형
+ */
+enum class VoteType {
+    /**
+     * 참석
+     */
+    ATTEND,
+
+    /**
+     * 불참
+     */
+    ABSENT,
+
+    /**
+     * 미정
+     */
+    UNDECIDED,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/certificate/Certificate.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/certificate/Certificate.kt
@@ -1,0 +1,95 @@
+package com.nextup.core.domain.certificate
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.player.Player
+import jakarta.persistence.*
+import java.time.Instant
+import java.util.*
+
+/**
+ * 기록 증명서 엔티티
+ *
+ * 선수의 경기 기록을 증명하는 공식 문서입니다.
+ * QR 코드를 통해 진위 여부를 확인할 수 있습니다.
+ */
+@Entity
+@Table(
+    name = "certificates",
+    indexes = [
+        Index(name = "idx_certificates_issue_number", columnList = "issue_number", unique = true),
+        Index(name = "idx_certificates_player_id", columnList = "player_id"),
+        Index(name = "idx_certificates_status", columnList = "status"),
+        Index(name = "idx_certificates_expires_at", columnList = "expires_at"),
+    ],
+)
+class Certificate private constructor(
+    @Column(name = "issue_number", nullable = false, unique = true, length = 36)
+    val issueNumber: String,
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "player_id", nullable = false)
+    val player: Player,
+    @Column(name = "issued_at", nullable = false)
+    val issuedAt: Instant,
+    @Column(name = "expires_at", nullable = false)
+    val expiresAt: Instant,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: CertificateStatus = CertificateStatus.VALID,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    companion object {
+        /**
+         * 새로운 증명서를 발급합니다.
+         *
+         * @param player 선수
+         * @param validityDays 유효 기간 (일)
+         * @return 발급된 증명서
+         */
+        fun issue(
+            player: Player,
+            validityDays: Long = 365,
+        ): Certificate {
+            val now = Instant.now()
+            return Certificate(
+                issueNumber = UUID.randomUUID().toString(),
+                player = player,
+                issuedAt = now,
+                expiresAt = now.plusSeconds(validityDays * 24 * 60 * 60),
+                status = CertificateStatus.VALID,
+            )
+        }
+    }
+
+    /**
+     * 증명서가 유효한지 확인합니다.
+     */
+    fun isValid(): Boolean = status == CertificateStatus.VALID && !isExpired()
+
+    /**
+     * 증명서가 만료되었는지 확인합니다.
+     */
+    fun isExpired(): Boolean = Instant.now().isAfter(expiresAt)
+
+    /**
+     * 증명서가 취소되었는지 확인합니다.
+     */
+    fun isRevoked(): Boolean = status == CertificateStatus.REVOKED
+
+    /**
+     * 증명서를 취소합니다.
+     */
+    fun revoke() {
+        require(status == CertificateStatus.VALID) { "이미 취소되었거나 만료된 증명서입니다." }
+        this.status = CertificateStatus.REVOKED
+    }
+
+    /**
+     * 만료된 증명서를 만료 상태로 변경합니다.
+     */
+    fun markAsExpired() {
+        require(isExpired()) { "아직 만료되지 않은 증명서입니다." }
+        this.status = CertificateStatus.EXPIRED
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/certificate/CertificateStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/certificate/CertificateStatus.kt
@@ -1,0 +1,21 @@
+package com.nextup.core.domain.certificate
+
+/**
+ * 증명서 상태
+ */
+enum class CertificateStatus {
+    /**
+     * 유효한 증명서
+     */
+    VALID,
+
+    /**
+     * 만료된 증명서
+     */
+    EXPIRED,
+
+    /**
+     * 취소된 증명서
+     */
+    REVOKED,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/BracketEntry.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/BracketEntry.kt
@@ -1,0 +1,64 @@
+package com.nextup.core.domain.competition
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.team.Team
+import jakarta.persistence.*
+
+/**
+ * 대진표 엔트리 엔티티
+ *
+ * 토너먼트 대회의 각 매치를 나타냅니다.
+ */
+@Entity
+@Table(
+    name = "bracket_entries",
+    indexes = [
+        Index(name = "idx_bracket_entries_competition", columnList = "competition_id"),
+    ],
+)
+class BracketEntry(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "competition_id", nullable = false)
+    val competition: Competition,
+    @Column(nullable = false)
+    val roundNumber: Int,
+    @Column(nullable = false)
+    val matchNumber: Int,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team1_id")
+    val team1: Team?,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team2_id")
+    val team2: Team?,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "winner_id")
+    var winner: Team? = null,
+    @Column(nullable = false, length = 20)
+    val bracketType: String = "WINNERS",
+    @Column(nullable = true)
+    val seed1: Int? = null,
+    @Column(nullable = true)
+    val seed2: Int? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 승자를 기록합니다.
+     */
+    fun recordWinner(winnerTeam: Team) {
+        require(winner == null) { "이미 승자가 결정된 경기입니다" }
+        require(winnerTeam == team1 || winnerTeam == team2) { "참가팀만 승자로 지정할 수 있습니다" }
+        winner = winnerTeam
+    }
+
+    /**
+     * 부전승 경기인지 확인합니다.
+     */
+    fun isBye(): Boolean = team1 == null || team2 == null
+
+    /**
+     * 경기가 완료되었는지 확인합니다.
+     */
+    fun isCompleted(): Boolean = winner != null || isBye()
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/Competition.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/Competition.kt
@@ -45,6 +45,8 @@ class Competition(
     var description: String? = null,
     @Column(name = "max_teams")
     val maxTeams: Int? = null,
+    @Column(name = "playoff_teams")
+    var playoffTeams: Int? = null,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/TournamentType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/TournamentType.kt
@@ -1,0 +1,11 @@
+package com.nextup.core.domain.competition
+
+/**
+ * 토너먼트 유형
+ */
+enum class TournamentType(
+    val displayName: String,
+) {
+    SINGLE_ELIMINATION("단일 토너먼트"),
+    DOUBLE_ELIMINATION("더블 토너먼트"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/discipline/Discipline.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/discipline/Discipline.kt
@@ -1,0 +1,198 @@
+package com.nextup.core.domain.discipline
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.player.Player
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+/**
+ * 징계 엔티티
+ *
+ * 선수에 대한 징계 정보를 관리합니다.
+ * - WARNING: 경고 (누적될 수 있음)
+ * - SUSPENSION: 출장 정지 (특정 경기 수만큼)
+ * - BAN: 영구 제재
+ */
+@Entity
+@Table(
+    name = "disciplines",
+    indexes = [
+        Index(name = "idx_disciplines_player_id", columnList = "player_id"),
+        Index(name = "idx_disciplines_competition_id", columnList = "competition_id"),
+        Index(name = "idx_disciplines_status", columnList = "status"),
+        Index(
+            name = "idx_disciplines_player_competition_status",
+            columnList = "player_id, competition_id, status"
+        ),
+    ],
+)
+class Discipline private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "player_id", nullable = false)
+    val player: Player,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "competition_id", nullable = false)
+    val competition: Competition,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    val type: DisciplineType,
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val reason: String,
+    @Column(name = "suspension_games")
+    val suspensionGames: Int? = null,
+    @Column(nullable = false, name = "issued_at")
+    val issuedAt: LocalDateTime = LocalDateTime.now(),
+    @Column(name = "expires_at")
+    val expiresAt: LocalDateTime? = null,
+    @Column(nullable = false, name = "issued_by", length = 255)
+    val issuedBy: String,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: DisciplineStatus = DisciplineStatus.ACTIVE,
+    @Column(name = "served_games")
+    var servedGames: Int = 0,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 징계를 취소합니다.
+     */
+    fun cancel() {
+        require(status == DisciplineStatus.ACTIVE) {
+            "활성 상태의 징계만 취소할 수 있습니다."
+        }
+        status = DisciplineStatus.CANCELLED
+    }
+
+    /**
+     * 징계가 현재 유효한지 확인합니다.
+     */
+    fun isEffective(): Boolean {
+        if (status != DisciplineStatus.ACTIVE) return false
+
+        // 만료일이 설정된 경우 만료 확인
+        expiresAt?.let {
+            if (LocalDateTime.now().isAfter(it)) {
+                return false
+            }
+        }
+
+        // SUSPENSION의 경우 이행 경기 수 확인
+        if (type == DisciplineType.SUSPENSION) {
+            suspensionGames?.let {
+                if (servedGames >= it) {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
+
+    /**
+     * 출장 정지 징계의 경기를 하나 소화합니다.
+     */
+    fun incrementServedGames() {
+        require(type == DisciplineType.SUSPENSION) {
+            "출장 정지 징계만 경기를 소화할 수 있습니다."
+        }
+        require(status == DisciplineStatus.ACTIVE) {
+            "활성 상태의 징계만 경기를 소화할 수 있습니다."
+        }
+
+        servedGames++
+
+        // 모든 경기를 소화한 경우 이행 완료 처리
+        suspensionGames?.let {
+            if (servedGames >= it) {
+                markServed()
+            }
+        }
+    }
+
+    /**
+     * 징계를 이행 완료 처리합니다.
+     */
+    fun markServed() {
+        require(type == DisciplineType.SUSPENSION) {
+            "출장 정지 징계만 이행 완료 처리할 수 있습니다."
+        }
+        require(status == DisciplineStatus.ACTIVE) {
+            "활성 상태의 징계만 이행 완료 처리할 수 있습니다."
+        }
+
+        status = DisciplineStatus.SERVED
+    }
+
+    companion object {
+        /**
+         * 경고 징계를 생성합니다.
+         */
+        fun createWarning(
+            player: Player,
+            competition: Competition,
+            reason: String,
+            issuedBy: String,
+            expiresAt: LocalDateTime? = null,
+        ): Discipline {
+            require(reason.isNotBlank()) { "징계 사유는 필수입니다." }
+            require(issuedBy.isNotBlank()) { "징계 발급자는 필수입니다." }
+
+            return Discipline(
+                player = player,
+                competition = competition,
+                type = DisciplineType.WARNING,
+                reason = reason,
+                issuedBy = issuedBy,
+                expiresAt = expiresAt,
+            )
+        }
+
+        /**
+         * 출장 정지 징계를 생성합니다.
+         */
+        fun createSuspension(
+            player: Player,
+            competition: Competition,
+            reason: String,
+            suspensionGames: Int,
+            issuedBy: String,
+        ): Discipline {
+            require(reason.isNotBlank()) { "징계 사유는 필수입니다." }
+            require(issuedBy.isNotBlank()) { "징계 발급자는 필수입니다." }
+            require(suspensionGames > 0) { "출장 정지 경기 수는 1 이상이어야 합니다." }
+
+            return Discipline(
+                player = player,
+                competition = competition,
+                type = DisciplineType.SUSPENSION,
+                reason = reason,
+                suspensionGames = suspensionGames,
+                issuedBy = issuedBy,
+            )
+        }
+
+        /**
+         * 영구 제재 징계를 생성합니다.
+         */
+        fun createBan(
+            player: Player,
+            competition: Competition,
+            reason: String,
+            issuedBy: String,
+        ): Discipline {
+            require(reason.isNotBlank()) { "징계 사유는 필수입니다." }
+            require(issuedBy.isNotBlank()) { "징계 발급자는 필수입니다." }
+
+            return Discipline(
+                player = player,
+                competition = competition,
+                type = DisciplineType.BAN,
+                reason = reason,
+                issuedBy = issuedBy,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/discipline/DisciplineStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/discipline/DisciplineStatus.kt
@@ -1,0 +1,12 @@
+package com.nextup.core.domain.discipline
+
+/**
+ * 징계 상태
+ */
+enum class DisciplineStatus(
+    val displayName: String,
+) {
+    ACTIVE("활성"),
+    SERVED("이행 완료"),
+    CANCELLED("취소"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/discipline/DisciplineType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/discipline/DisciplineType.kt
@@ -1,0 +1,12 @@
+package com.nextup.core.domain.discipline
+
+/**
+ * 징계 유형
+ */
+enum class DisciplineType(
+    val displayName: String,
+) {
+    WARNING("경고"),
+    SUSPENSION("출장 정지"),
+    BAN("영구 제재"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/election/Candidate.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/election/Candidate.kt
@@ -1,0 +1,77 @@
+package com.nextup.core.domain.election
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+
+/**
+ * 후보자 엔티티
+ *
+ * 선거에 출마한 후보자를 나타냅니다.
+ */
+@Entity
+@Table(
+    name = "candidates",
+    indexes = [
+        Index(name = "idx_candidates_election", columnList = "election_id"),
+        Index(name = "idx_candidates_member", columnList = "member_id"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_candidates_election_member",
+            columnNames = ["election_id", "member_id"],
+        ),
+    ],
+)
+class Candidate private constructor(
+    @Column(name = "election_id", nullable = false)
+    val electionId: Long,
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long,
+    @Column(name = "member_name", nullable = false, length = 100)
+    val memberName: String,
+    @Column(length = 1000)
+    val statement: String? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Candidate) return false
+        if (id == 0L) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    override fun toString(): String =
+        "Candidate(id=$id, electionId=$electionId, memberId=$memberId, memberName='$memberName')"
+
+    companion object {
+        /**
+         * Candidate를 생성합니다.
+         *
+         * @param electionId 선거 ID
+         * @param memberId 회원 ID
+         * @param memberName 회원 이름
+         * @param statement 공약/소견
+         * @return 생성된 Candidate
+         * @throws IllegalArgumentException 회원 이름이 비어있는 경우
+         */
+        fun create(
+            electionId: Long,
+            memberId: Long,
+            memberName: String,
+            statement: String? = null,
+        ): Candidate {
+            require(memberName.isNotBlank()) { "Member name cannot be blank" }
+
+            return Candidate(
+                electionId = electionId,
+                memberId = memberId,
+                memberName = memberName,
+                statement = statement,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/election/Election.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/election/Election.kt
@@ -1,0 +1,135 @@
+package com.nextup.core.domain.election
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * 선거 엔티티
+ *
+ * 팀 내에서 진행되는 선거/투표를 나타냅니다.
+ */
+@Entity
+@Table(
+    name = "elections",
+    indexes = [
+        Index(name = "idx_elections_team", columnList = "team_id"),
+        Index(name = "idx_elections_status", columnList = "status"),
+        Index(name = "idx_elections_start_at", columnList = "start_at"),
+        Index(name = "idx_elections_end_at", columnList = "end_at"),
+    ],
+)
+class Election private constructor(
+    @Column(name = "team_id", nullable = false)
+    val teamId: Long,
+    @Column(nullable = false, length = 200)
+    val title: String,
+    @Column(length = 1000)
+    val description: String? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "election_type", nullable = false, length = 50)
+    val electionType: ElectionType,
+    @Column(name = "start_at", nullable = false)
+    val startAt: Instant,
+    @Column(name = "end_at", nullable = false)
+    val endAt: Instant,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    var status: ElectionStatus = ElectionStatus.SCHEDULED,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 투표가 진행 중인지 확인합니다.
+     */
+    fun isVotingOpen(): Boolean {
+        val now = Instant.now()
+        return status == ElectionStatus.IN_PROGRESS && now.isAfter(startAt) && now.isBefore(endAt)
+    }
+
+    /**
+     * 선거를 시작합니다.
+     *
+     * @throws IllegalStateException 이미 시작되었거나 취소된 경우
+     */
+    fun start() {
+        require(status == ElectionStatus.SCHEDULED) {
+            "Cannot start election: current status is $status"
+        }
+        status = ElectionStatus.IN_PROGRESS
+    }
+
+    /**
+     * 선거를 완료합니다.
+     *
+     * @throws IllegalStateException 진행 중이 아닌 경우
+     */
+    fun complete() {
+        require(status == ElectionStatus.IN_PROGRESS) {
+            "Cannot complete election: current status is $status"
+        }
+        status = ElectionStatus.COMPLETED
+    }
+
+    /**
+     * 선거를 취소합니다.
+     *
+     * @throws IllegalStateException 이미 완료되었거나 취소된 경우
+     */
+    fun cancel() {
+        require(status != ElectionStatus.COMPLETED && status != ElectionStatus.CANCELLED) {
+            "Cannot cancel election: current status is $status"
+        }
+        status = ElectionStatus.CANCELLED
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Election) return false
+        if (id == 0L) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    override fun toString(): String =
+        "Election(id=$id, teamId=$teamId, title='$title', type=$electionType, status=$status)"
+
+    companion object {
+        /**
+         * Election을 생성합니다.
+         *
+         * @param teamId 팀 ID
+         * @param title 선거 제목
+         * @param description 선거 설명
+         * @param electionType 선거 유형
+         * @param startAt 시작 시간
+         * @param endAt 종료 시간
+         * @return 생성된 Election
+         * @throws IllegalArgumentException 제목이 비어있거나 종료 시간이 시작 시간보다 이전인 경우
+         */
+        fun create(
+            teamId: Long,
+            title: String,
+            description: String? = null,
+            electionType: ElectionType,
+            startAt: Instant,
+            endAt: Instant,
+        ): Election {
+            require(title.isNotBlank()) { "Title cannot be blank" }
+            require(endAt.isAfter(startAt)) {
+                "End time must be after start time"
+            }
+
+            return Election(
+                teamId = teamId,
+                title = title,
+                description = description,
+                electionType = electionType,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/election/ElectionStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/election/ElectionStatus.kt
@@ -1,0 +1,26 @@
+package com.nextup.core.domain.election
+
+/**
+ * 선거 상태
+ */
+enum class ElectionStatus {
+    /**
+     * 예정됨
+     */
+    SCHEDULED,
+
+    /**
+     * 진행 중
+     */
+    IN_PROGRESS,
+
+    /**
+     * 완료됨
+     */
+    COMPLETED,
+
+    /**
+     * 취소됨
+     */
+    CANCELLED,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/election/ElectionType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/election/ElectionType.kt
@@ -1,0 +1,21 @@
+package com.nextup.core.domain.election
+
+/**
+ * 선거 유형
+ */
+enum class ElectionType {
+    /**
+     * 구단주 선출
+     */
+    OWNER_ELECTION,
+
+    /**
+     * 주장 선출
+     */
+    CAPTAIN_ELECTION,
+
+    /**
+     * 일반 투표
+     */
+    GENERAL,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/election/ElectionVote.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/election/ElectionVote.kt
@@ -1,0 +1,75 @@
+package com.nextup.core.domain.election
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * 투표 엔티티
+ *
+ * 선거에 대한 투표 기록을 나타냅니다.
+ */
+@Entity
+@Table(
+    name = "election_votes",
+    indexes = [
+        Index(name = "idx_election_votes_election", columnList = "election_id"),
+        Index(name = "idx_election_votes_candidate", columnList = "candidate_id"),
+        Index(name = "idx_election_votes_voter", columnList = "voter_id"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_election_votes_election_voter",
+            columnNames = ["election_id", "voter_id"],
+        ),
+    ],
+)
+class ElectionVote private constructor(
+    @Column(name = "election_id", nullable = false)
+    val electionId: Long,
+    @Column(name = "voter_id", nullable = false)
+    val voterId: Long,
+    @Column(name = "candidate_id", nullable = false)
+    val candidateId: Long,
+    @Column(name = "voted_at", nullable = false)
+    val votedAt: Instant,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ElectionVote) return false
+        if (id == 0L) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    override fun toString(): String =
+        "ElectionVote(id=$id, electionId=$electionId, voterId=$voterId, candidateId=$candidateId)"
+
+    companion object {
+        /**
+         * ElectionVote를 생성합니다.
+         *
+         * @param electionId 선거 ID
+         * @param voterId 투표자 ID
+         * @param candidateId 후보자 ID
+         * @param votedAt 투표 시간
+         * @return 생성된 ElectionVote
+         */
+        fun create(
+            electionId: Long,
+            voterId: Long,
+            candidateId: Long,
+            votedAt: Instant = Instant.now(),
+        ): ElectionVote =
+            ElectionVote(
+                electionId = electionId,
+                voterId = voterId,
+                candidateId = candidateId,
+                votedAt = votedAt,
+            )
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
@@ -325,6 +325,86 @@ class BattingRecord(
     }
 
     /**
+     * 타석 결과를 역방향으로 롤백합니다 (Undo용).
+     * applyPlateAppearanceResult의 역연산입니다.
+     */
+    fun revertPlateAppearanceResult(
+        result: PlateAppearanceResult,
+        rbis: Int = 0,
+    ) {
+        plateAppearances--
+
+        when (result) {
+            PlateAppearanceResult.SINGLE -> {
+                atBats--
+                hits--
+            }
+            PlateAppearanceResult.DOUBLE -> {
+                atBats--
+                hits--
+                doubles--
+            }
+            PlateAppearanceResult.TRIPLE -> {
+                atBats--
+                hits--
+                triples--
+            }
+            PlateAppearanceResult.HOME_RUN -> {
+                atBats--
+                hits--
+                homeRuns--
+                runs--
+            }
+            PlateAppearanceResult.STRIKEOUT -> {
+                atBats--
+                strikeouts--
+            }
+            PlateAppearanceResult.GROUND_OUT,
+            PlateAppearanceResult.FLY_OUT,
+            PlateAppearanceResult.LINE_OUT,
+            PlateAppearanceResult.FIELDERS_CHOICE,
+            PlateAppearanceResult.ERROR,
+            -> {
+                atBats--
+            }
+            PlateAppearanceResult.WALK -> {
+                walks--
+            }
+            PlateAppearanceResult.INTENTIONAL_WALK -> {
+                intentionalWalks--
+            }
+            PlateAppearanceResult.HIT_BY_PITCH -> {
+                hitByPitch--
+            }
+            PlateAppearanceResult.SACRIFICE_FLY -> {
+                sacrificeFlies--
+            }
+            PlateAppearanceResult.SACRIFICE_BUNT -> {
+                sacrificeBunts--
+            }
+            PlateAppearanceResult.DOUBLE_PLAY,
+            PlateAppearanceResult.TRIPLE_PLAY,
+            -> {
+                atBats--
+                groundedIntoDoublePlays--
+            }
+            PlateAppearanceResult.INTERFERENCE -> {
+                // 방해는 타수에 포함되지 않음
+            }
+        }
+
+        this.runsBattedIn -= rbis
+    }
+
+    /**
+     * 득점을 취소합니다 (Undo용).
+     */
+    fun revertRun() {
+        require(runs > 0) { "취소할 득점이 없습니다." }
+        runs--
+    }
+
+    /**
      * 기록 유효성을 검증합니다.
      */
     fun validate() {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -49,6 +49,8 @@ class Game(
     var endedAt: LocalDateTime? = null,
     @Column(length = 500)
     var note: String? = null,
+    @Column(name = "forfeit_reason", length = 500)
+    var forfeitReason: String? = null,
     @Embedded
     var gameState: GameState = GameState(),
     @Id
@@ -133,14 +135,49 @@ class Game(
 
     /**
      * 몰수패 처리합니다.
+     *
+     * 승리팀에 7점, 패배팀에 0점을 자동 반영하고,
+     * 각 GameTeam의 결과(WIN/LOSS)를 설정합니다.
+     *
+     * @param winnerTeamId 몰수승 팀 ID
+     * @param reason 몰수 사유
+     * @param gameTeams 해당 경기에 참여하는 GameTeam 목록 (정확히 2개)
      */
-    fun forfeit(reason: String) {
+    fun forfeit(
+        winnerTeamId: Long,
+        reason: String,
+        gameTeams: List<GameTeam>,
+    ) {
         require(status == GameStatus.SCHEDULED || status.isOngoing()) {
             "예정 또는 진행 중인 경기만 몰수 처리할 수 있습니다."
         }
+        require(gameTeams.size == 2) {
+            "몰수 처리를 위해서는 정확히 2개의 GameTeam이 필요합니다."
+        }
+        require(gameTeams.any { it.team.id == winnerTeamId }) {
+            "승리팀 ID($winnerTeamId)가 해당 경기에 참여하는 팀이 아닙니다."
+        }
+
         status = GameStatus.FORFEITED
         endedAt = LocalDateTime.now()
+        forfeitReason = reason
         note = (note?.let { "$it\n" } ?: "") + "몰수 사유: $reason"
+
+        // 승리팀 7:0 점수 반영
+        gameTeams.forEach { gameTeam ->
+            if (gameTeam.team.id == winnerTeamId) {
+                gameTeam.updateScore(totalScore = FORFEIT_WIN_SCORE, totalHits = 0, totalErrors = 0)
+                gameTeam.updateResult(GameResult.WIN)
+            } else {
+                gameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+                gameTeam.updateResult(GameResult.LOSS)
+            }
+        }
+    }
+
+    companion object {
+        /** 몰수승 점수 */
+        const val FORFEIT_WIN_SCORE = 7
     }
 
     /**
@@ -154,6 +191,33 @@ class Game(
             status = GameStatus.SCHEDULED
         }
         scheduledAt = newScheduledAt
+    }
+
+    /**
+     * Undo가 가능한 상태인지 확인합니다.
+     */
+    fun canUndo(): Boolean = status == GameStatus.IN_PROGRESS
+
+    /**
+     * 이전 이닝 상태로 복원합니다 (Undo 시 이닝/아웃 카운트 롤백용).
+     */
+    fun restoreInningState(
+        inning: Int,
+        isTop: Boolean,
+        outs: Int,
+    ) {
+        require(status.isOngoing()) { "진행 중인 경기만 상태를 복원할 수 있습니다." }
+        this.currentInning = inning
+        this.isTopInning = isTop
+        gameState.restoreOuts(outs)
+    }
+
+    /**
+     * 타순을 되돌립니다 (Undo 시 타순 롤백용).
+     */
+    fun revertBatter() {
+        require(status.isOngoing()) { "진행 중인 경기만 타순을 되돌릴 수 있습니다." }
+        gameState.revertBatter(isHomeTeam = !isTopInning)
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -54,10 +54,16 @@ class GameEvent(
     val rbis: Int = 0,
     @Column(name = "event_timestamp", nullable = false)
     val eventTimestamp: Instant = Instant.now(),
+    @Column(nullable = false)
+    var undone: Boolean = false,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 ) : BaseTimeEntity() {
+    fun markUndone() {
+        undone = true
+    }
+
     companion object {
         /**
          * 타석 결과 이벤트를 생성합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
@@ -138,6 +138,48 @@ class GameState(
     }
 
     /**
+     * 타순을 한 칸 되돌립니다 (Undo 시 타순 롤백용).
+     * @param isHomeTeam 홈팀 여부
+     */
+    fun revertBatter(isHomeTeam: Boolean) {
+        if (isHomeTeam) {
+            homeBattingOrder = if (homeBattingOrder == 1) 9 else homeBattingOrder - 1
+        } else {
+            awayBattingOrder = if (awayBattingOrder == 1) 9 else awayBattingOrder - 1
+        }
+    }
+
+    /**
+     * 아웃 카운트를 복원합니다 (Undo용).
+     */
+    fun restoreOuts(outs: Int) {
+        require(outs in 0..3) { "아웃 카운트는 0-3 사이여야 합니다: $outs" }
+        this.outs = outs
+    }
+
+    /**
+     * 주자를 JSON 문자열로부터 복원합니다 (Undo용).
+     * JSON 형식: "1루:playerId,2루:playerId,3루:playerId" 또는 null
+     */
+    fun restoreRunners(runnersJson: String?) {
+        clearBases()
+        if (runnersJson.isNullOrBlank()) return
+
+        runnersJson.split(",").forEach { entry ->
+            val parts = entry.split(":")
+            if (parts.size == 2) {
+                val base = parts[0].trim()
+                val playerId = parts[1].trim().toLongOrNull()
+                when (base) {
+                    "1루" -> runnerOnFirstId = playerId
+                    "2루" -> runnerOnSecondId = playerId
+                    "3루" -> runnerOnThirdId = playerId
+                }
+            }
+        }
+    }
+
+    /**
      * 주자가 있는지 확인합니다.
      */
     fun hasRunner(base: Base): Boolean = getRunner(base) != null

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameTeam.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameTeam.kt
@@ -148,6 +148,34 @@ class GameTeam(
     }
 
     /**
+     * 특정 이닝에서 득점을 차감합니다 (Undo용).
+     */
+    fun subtractRunInInning(
+        inning: Int,
+        runs: Int = 1,
+    ) {
+        require(inning >= 1) { "이닝은 1 이상이어야 합니다." }
+        require(runs >= 0) { "점수는 0 이상이어야 합니다." }
+
+        val scores = inningScores?.split(",")?.toMutableList() ?: mutableListOf()
+
+        if (inning <= scores.size) {
+            val currentScore = scores[inning - 1].toIntOrNull() ?: 0
+            scores[inning - 1] = maxOf(0, currentScore - runs).toString()
+            inningScores = scores.joinToString(",")
+        }
+
+        totalScore = maxOf(0, totalScore - runs)
+    }
+
+    /**
+     * 안타를 차감합니다 (Undo용).
+     */
+    fun subtractHit() {
+        totalHits = maxOf(0, totalHits - 1)
+    }
+
+    /**
      * 특정 이닝의 점수를 조회합니다.
      */
     fun getInningScore(inning: Int): Int {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupSubmission.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupSubmission.kt
@@ -86,17 +86,20 @@ class LineupSubmission private constructor(
      * - 동일 선수 중복 등록 검증
      * - 포수(C) 필수 검증
      * - DH 규칙 검증
+     * - 참석자만 라인업 등록 검증 (attendingPlayerIds 제공 시)
      *
+     * @param attendingPlayerIds 참석(ATTENDING) 상태인 선수 ID 목록 (nullable, null이면 참석 검증 생략)
      * @throws com.nextup.common.exception.DuplicatePlayerInLineupException 동일 선수 중복 시
      * @throws com.nextup.common.exception.NoCatcherInLineupException 포수 미지정 시
      * @throws com.nextup.common.exception.InvalidDhRuleException DH 규칙 위반 시
+     * @throws com.nextup.common.exception.NonAttendingPlayerInLineupException 참석하지 않는 선수 포함 시
      */
-    fun submit() {
+    fun submit(attendingPlayerIds: Set<Long>? = null) {
         require(status.canSubmit()) {
             "제출 가능한 상태가 아닙니다. 현재 상태: ${status.displayName}"
         }
         // 라인업 비즈니스 규칙 검증
-        LineupValidator.validate(_entries)
+        LineupValidator.validate(_entries, attendingPlayerIds)
         this.status = LineupSubmissionStatus.SUBMITTED
         this.submittedAt = Instant.now()
         // 재제출 시 이전 반려 정보 초기화

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupSubmission.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupSubmission.kt
@@ -81,11 +81,22 @@ class LineupSubmission private constructor(
 
     /**
      * 라인업을 기록원에게 제출합니다.
+     *
+     * 제출 전 라인업 검증을 수행합니다:
+     * - 동일 선수 중복 등록 검증
+     * - 포수(C) 필수 검증
+     * - DH 규칙 검증
+     *
+     * @throws com.nextup.common.exception.DuplicatePlayerInLineupException 동일 선수 중복 시
+     * @throws com.nextup.common.exception.NoCatcherInLineupException 포수 미지정 시
+     * @throws com.nextup.common.exception.InvalidDhRuleException DH 규칙 위반 시
      */
     fun submit() {
         require(status.canSubmit()) {
             "제출 가능한 상태가 아닙니다. 현재 상태: ${status.displayName}"
         }
+        // 라인업 비즈니스 규칙 검증
+        LineupValidator.validate(_entries)
         this.status = LineupSubmissionStatus.SUBMITTED
         this.submittedAt = Instant.now()
         // 재제출 시 이전 반려 정보 초기화

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
@@ -1,0 +1,79 @@
+package com.nextup.core.domain.game
+
+import com.nextup.common.exception.DuplicatePlayerInLineupException
+import com.nextup.common.exception.InvalidDhRuleException
+import com.nextup.common.exception.NoCatcherInLineupException
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.PositionCategory
+
+/**
+ * 라인업 검증 도메인 서비스
+ *
+ * 라인업 제출 시 비즈니스 규칙을 검증합니다.
+ */
+object LineupValidator {
+    /**
+     * 라인업 엔트리 전체를 검증합니다.
+     *
+     * @param entries 검증할 라인업 엔트리 목록
+     * @throws DuplicatePlayerInLineupException 동일 선수가 중복 등록된 경우
+     * @throws NoCatcherInLineupException 포수가 없는 경우
+     * @throws InvalidDhRuleException DH 규칙 위반 시
+     */
+    fun validate(entries: List<LineupEntry>) {
+        val starters = entries.filter { it.isStarter }
+        validateNoDuplicatePlayers(entries)
+        validateCatcherExists(starters)
+        validateDhRule(starters)
+    }
+
+    /**
+     * 동일 선수 중복 등록 검증
+     *
+     * 같은 playerId가 2번 이상 등록되면 예외를 발생시킵니다.
+     */
+    private fun validateNoDuplicatePlayers(entries: List<LineupEntry>) {
+        val playerIds = entries.map { it.player.id }
+        val duplicates = playerIds.groupBy { it }.filter { it.value.size > 1 }.keys
+        if (duplicates.isNotEmpty()) {
+            throw DuplicatePlayerInLineupException(duplicates)
+        }
+    }
+
+    /**
+     * 포수(C) 필수 검증
+     *
+     * 선발 라인업에 포수가 최소 1명 있어야 합니다.
+     */
+    private fun validateCatcherExists(starters: List<LineupEntry>) {
+        val hasCatcher = starters.any { it.position.category == PositionCategory.CATCHER }
+        if (!hasCatcher) {
+            throw NoCatcherInLineupException()
+        }
+    }
+
+    /**
+     * DH 규칙 검증
+     *
+     * DH 지정 시:
+     * - DH가 있으면 투수는 타순에 없어야 합니다 (DH가 투수 대신 타격)
+     * - DH 없이 투수가 타순에 있는 것은 허용됩니다 (투수 직접 타격)
+     */
+    private fun validateDhRule(starters: List<LineupEntry>) {
+        val hasDh = starters.any { it.position == Position.DESIGNATED_HITTER }
+        if (!hasDh) {
+            return
+        }
+
+        val pitchersWithBattingOrder =
+            starters.filter {
+                it.position.category == PositionCategory.PITCHER && it.battingOrder != null
+            }
+
+        if (pitchersWithBattingOrder.isNotEmpty()) {
+            throw InvalidDhRuleException(
+                "DH가 지정된 경우 투수는 타순에 배치할 수 없습니다.",
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
@@ -3,6 +3,7 @@ package com.nextup.core.domain.game
 import com.nextup.common.exception.DuplicatePlayerInLineupException
 import com.nextup.common.exception.InvalidDhRuleException
 import com.nextup.common.exception.NoCatcherInLineupException
+import com.nextup.common.exception.NonAttendingPlayerInLineupException
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.player.PositionCategory
 
@@ -16,15 +17,23 @@ object LineupValidator {
      * 라인업 엔트리 전체를 검증합니다.
      *
      * @param entries 검증할 라인업 엔트리 목록
+     * @param attendingPlayerIds 참석(ATTENDING) 상태인 선수 ID 목록 (nullable, null이면 검증 생략)
      * @throws DuplicatePlayerInLineupException 동일 선수가 중복 등록된 경우
      * @throws NoCatcherInLineupException 포수가 없는 경우
      * @throws InvalidDhRuleException DH 규칙 위반 시
+     * @throws NonAttendingPlayerInLineupException 참석하지 않는 선수가 라인업에 포함된 경우
      */
-    fun validate(entries: List<LineupEntry>) {
+    fun validate(
+        entries: List<LineupEntry>,
+        attendingPlayerIds: Set<Long>? = null,
+    ) {
         val starters = entries.filter { it.isStarter }
         validateNoDuplicatePlayers(entries)
         validateCatcherExists(starters)
         validateDhRule(starters)
+        if (attendingPlayerIds != null) {
+            validateOnlyAttendingPlayers(entries, attendingPlayerIds)
+        }
     }
 
     /**
@@ -74,6 +83,23 @@ object LineupValidator {
             throw InvalidDhRuleException(
                 "DH가 지정된 경우 투수는 타순에 배치할 수 없습니다.",
             )
+        }
+    }
+
+    /**
+     * 참석(ATTENDING) 선수만 라인업에 포함되었는지 검증
+     *
+     * AttendanceVote에서 ATTENDING 상태인 선수만 라인업에 등록 가능합니다.
+     */
+    private fun validateOnlyAttendingPlayers(
+        entries: List<LineupEntry>,
+        attendingPlayerIds: Set<Long>,
+    ) {
+        val lineupPlayerIds = entries.map { it.player.id }.toSet()
+        val nonAttendingPlayerIds = lineupPlayerIds - attendingPlayerIds
+
+        if (nonAttendingPlayerIds.isNotEmpty()) {
+            throw NonAttendingPlayerInLineupException(nonAttendingPlayerIds)
         }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchEvent.kt
@@ -1,0 +1,116 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+
+/**
+ * 투구 이벤트 엔티티
+ *
+ * 경기 중 발생하는 개별 투구를 기록합니다.
+ * 각 투구마다 투구 번호, 결과, 볼카운트를 추적합니다.
+ */
+@Entity
+@Table(
+    name = "pitch_events",
+    indexes = [
+        Index(name = "idx_pitch_events_game", columnList = "game_id"),
+        Index(name = "idx_pitch_events_game_inning", columnList = "game_id, inning, is_top_inning"),
+        Index(name = "idx_pitch_events_pitcher", columnList = "pitcher_id"),
+        Index(name = "idx_pitch_events_batter", columnList = "batter_id"),
+        Index(name = "idx_pitch_events_game_pitch_number", columnList = "game_id, pitch_number"),
+    ],
+)
+class PitchEvent(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    val game: Game,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pitcher_id", nullable = false)
+    val pitcher: GamePlayer,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "batter_id", nullable = false)
+    val batter: GamePlayer,
+    @Column(nullable = false)
+    val inning: Int,
+    @Column(name = "is_top_inning", nullable = false)
+    val isTopInning: Boolean,
+    @Column(name = "pitch_number", nullable = false)
+    val pitchNumber: Int,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    val result: PitchResult,
+    @Column(name = "ball_count", nullable = false)
+    val ballCount: Int,
+    @Column(name = "strike_count", nullable = false)
+    val strikeCount: Int,
+    @Column(length = 500)
+    val description: String? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    init {
+        require(inning >= 1) { "이닝은 1 이상이어야 합니다: $inning" }
+        require(pitchNumber >= 1) { "투구 번호는 1 이상이어야 합니다: $pitchNumber" }
+        require(ballCount in 0..4) { "볼카운트는 0-4 사이여야 합니다: $ballCount" }
+        require(strikeCount in 0..3) { "스트라이크 카운트는 0-3 사이여야 합니다: $strikeCount" }
+    }
+
+    /**
+     * 현재 볼카운트를 문자열로 반환합니다 (예: "2B-1S").
+     */
+    val countDisplay: String
+        get() = "${ballCount}B-${strikeCount}S"
+
+    /**
+     * 풀카운트인지 확인합니다 (3-2 카운트).
+     */
+    val isFullCount: Boolean
+        get() = ballCount == 3 && strikeCount == 2
+
+    /**
+     * 타자에게 유리한 카운트인지 확인합니다 (볼이 스트라이크보다 많음).
+     */
+    val isHitterCount: Boolean
+        get() = ballCount > strikeCount
+
+    /**
+     * 투수에게 유리한 카운트인지 확인합니다 (스트라이크가 볼보다 많음).
+     */
+    val isPitcherCount: Boolean
+        get() = strikeCount > ballCount
+
+    companion object {
+        /**
+         * 투구 이벤트를 생성합니다.
+         */
+        fun create(
+            game: Game,
+            pitcher: GamePlayer,
+            batter: GamePlayer,
+            pitchNumber: Int,
+            result: PitchResult,
+            ballCount: Int,
+            strikeCount: Int,
+            description: String? = null,
+        ): PitchEvent {
+            require(pitcher.isPitcher) { "투수 포지션의 선수만 투구할 수 있습니다." }
+            require(pitcher.gameTeam.game.id == game.id) { "투수는 해당 경기의 선수여야 합니다." }
+            require(batter.gameTeam.game.id == game.id) { "타자는 해당 경기의 선수여야 합니다." }
+            require(pitcher.gameTeam.id != batter.gameTeam.id) { "투수와 타자는 서로 다른 팀이어야 합니다." }
+
+            return PitchEvent(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                pitchNumber = pitchNumber,
+                result = result,
+                ballCount = ballCount,
+                strikeCount = strikeCount,
+                description = description,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchResult.kt
@@ -1,0 +1,44 @@
+package com.nextup.core.domain.game
+
+/**
+ * 투구 결과
+ *
+ * 개별 투구의 결과를 정의합니다.
+ */
+enum class PitchResult(
+    val displayName: String,
+    val description: String,
+    val affectsBall: Boolean,
+    val affectsStrike: Boolean,
+) {
+    BALL("볼", "스트라이크 존 밖으로 벗어난 투구", true, false),
+    STRIKE("스트라이크", "정규 스트라이크 (헛스윙 제외)", false, true),
+    FOUL("파울", "파울 지역으로 타구", false, false),
+    SWING_MISS("헛스윙", "타자가 스윙했으나 공을 맞추지 못함", false, true),
+    IN_PLAY("인플레이", "타구가 페어 지역에 들어감", false, false),
+    ;
+
+    /**
+     * 볼카운트에 영향을 주는지 확인합니다.
+     */
+    val incrementsBall: Boolean
+        get() = affectsBall
+
+    /**
+     * 스트라이크 카운트에 영향을 주는지 확인합니다.
+     */
+    val incrementsStrike: Boolean
+        get() = affectsStrike
+
+    /**
+     * 파울인지 확인합니다.
+     */
+    val isFoul: Boolean
+        get() = this == FOUL
+
+    /**
+     * 인플레이인지 확인합니다.
+     */
+    val isInPlay: Boolean
+        get() = this == IN_PLAY
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
@@ -417,6 +417,58 @@ class PitchingRecord(
     }
 
     /**
+     * 타자 대결 결과를 역방향으로 롤백합니다 (Undo용).
+     * applyBatterFaced의 역연산입니다.
+     */
+    fun revertBatterFaced(result: PlateAppearanceResult) {
+        battersFaced--
+
+        when (result) {
+            PlateAppearanceResult.SINGLE,
+            PlateAppearanceResult.DOUBLE,
+            PlateAppearanceResult.TRIPLE,
+            -> {
+                hitsAllowed--
+            }
+            PlateAppearanceResult.HOME_RUN -> {
+                hitsAllowed--
+                homeRunsAllowed--
+            }
+            PlateAppearanceResult.STRIKEOUT -> {
+                strikeouts--
+            }
+            PlateAppearanceResult.WALK,
+            PlateAppearanceResult.INTENTIONAL_WALK,
+            -> {
+                walksAllowed--
+            }
+            PlateAppearanceResult.HIT_BY_PITCH -> {
+                hitBatsmen--
+            }
+            else -> {
+                // 다른 결과는 투수 기록에 직접적인 영향 없음
+            }
+        }
+    }
+
+    /**
+     * 아웃 카운트를 롤백합니다 (Undo용).
+     */
+    fun revertOut() {
+        require(inningsPitchedOuts > 0) { "롤백할 아웃 카운트가 없습니다." }
+        inningsPitchedOuts--
+    }
+
+    /**
+     * 자책점을 롤백합니다 (Undo용).
+     */
+    fun revertEarnedRun(runs: Int) {
+        require(runs >= 0) { "롤백할 자책점은 0 이상이어야 합니다." }
+        earnedRuns -= runs
+        runsAllowed -= runs
+    }
+
+    /**
      * 기록 유효성을 검증합니다.
      */
     fun validate() {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/match/MatchRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/match/MatchRequest.kt
@@ -1,0 +1,112 @@
+package com.nextup.core.domain.match
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.team.Team
+import jakarta.persistence.*
+import java.time.Instant
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+/**
+ * 매칭 요청 엔티티
+ *
+ * 팀 간 연습 경기 매칭을 위한 요청을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "match_requests",
+    indexes = [
+        Index(name = "idx_match_requests_team_id", columnList = "team_id"),
+        Index(name = "idx_match_requests_status", columnList = "status"),
+        Index(name = "idx_match_requests_preferred_date", columnList = "preferred_date"),
+        Index(name = "idx_match_requests_skill_level", columnList = "skill_level"),
+    ],
+)
+class MatchRequest private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    val team: Team,
+    @Column(name = "preferred_date", nullable = false)
+    val preferredDate: LocalDate,
+    @Column(name = "preferred_time", length = 50)
+    val preferredTime: String?,
+    @Column(name = "preferred_location", length = 500)
+    val preferredLocation: String?,
+    @Column(columnDefinition = "TEXT")
+    val message: String?,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "skill_level", nullable = false, length = 20)
+    val skillLevel: SkillLevel,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: MatchRequestStatus = MatchRequestStatus.OPEN,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 매칭 요청을 취소합니다.
+     */
+    fun cancel() {
+        require(status == MatchRequestStatus.OPEN) {
+            "OPEN 상태의 요청만 취소할 수 있습니다"
+        }
+        this.status = MatchRequestStatus.CANCELLED
+    }
+
+    /**
+     * 매칭을 완료합니다.
+     */
+    fun match() {
+        require(status == MatchRequestStatus.OPEN) {
+            "OPEN 상태의 요청만 매칭할 수 있습니다"
+        }
+        this.status = MatchRequestStatus.MATCHED
+    }
+
+    /**
+     * 요청이 만료되었는지 확인합니다.
+     * 요청 생성 후 30일이 지나면 만료됩니다.
+     */
+    fun isExpired(): Boolean {
+        val daysSinceCreation = ChronoUnit.DAYS.between(createdAt, Instant.now())
+        return daysSinceCreation >= 30
+    }
+
+    /**
+     * 만료 상태로 변경합니다.
+     */
+    fun expire() {
+        require(status == MatchRequestStatus.OPEN) {
+            "OPEN 상태의 요청만 만료시킬 수 있습니다"
+        }
+        this.status = MatchRequestStatus.EXPIRED
+    }
+
+    companion object {
+        /**
+         * 매칭 요청을 생성합니다.
+         */
+        fun create(
+            team: Team,
+            preferredDate: LocalDate,
+            preferredTime: String?,
+            preferredLocation: String?,
+            message: String?,
+            skillLevel: SkillLevel,
+        ): MatchRequest {
+            require(preferredDate >= LocalDate.now()) {
+                "선호 날짜는 오늘 이후여야 합니다"
+            }
+
+            return MatchRequest(
+                team = team,
+                preferredDate = preferredDate,
+                preferredTime = preferredTime,
+                preferredLocation = preferredLocation,
+                message = message,
+                skillLevel = skillLevel,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/match/MatchRequestStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/match/MatchRequestStatus.kt
@@ -1,0 +1,8 @@
+package com.nextup.core.domain.match
+
+enum class MatchRequestStatus {
+    OPEN,
+    MATCHED,
+    CANCELLED,
+    EXPIRED,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/match/MatchResponse.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/match/MatchResponse.kt
@@ -1,0 +1,77 @@
+package com.nextup.core.domain.match
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.team.Team
+import jakarta.persistence.*
+
+/**
+ * 매칭 응답 엔티티
+ *
+ * 매칭 요청에 대한 다른 팀의 응답을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "match_responses",
+    indexes = [
+        Index(name = "idx_match_responses_match_request_id", columnList = "match_request_id"),
+        Index(name = "idx_match_responses_respond_team_id", columnList = "respond_team_id"),
+        Index(name = "idx_match_responses_status", columnList = "status"),
+    ],
+)
+class MatchResponse private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "match_request_id", nullable = false)
+    val matchRequest: MatchRequest,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "respond_team_id", nullable = false)
+    val respondTeam: Team,
+    @Column(columnDefinition = "TEXT")
+    val message: String?,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: MatchResponseStatus = MatchResponseStatus.PENDING,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 응답을 수락합니다.
+     */
+    fun accept() {
+        require(status == MatchResponseStatus.PENDING) {
+            "PENDING 상태의 응답만 수락할 수 있습니다"
+        }
+        this.status = MatchResponseStatus.ACCEPTED
+    }
+
+    /**
+     * 응답을 거절합니다.
+     */
+    fun reject() {
+        require(status == MatchResponseStatus.PENDING) {
+            "PENDING 상태의 응답만 거절할 수 있습니다"
+        }
+        this.status = MatchResponseStatus.REJECTED
+    }
+
+    companion object {
+        /**
+         * 매칭 응답을 생성합니다.
+         */
+        fun create(
+            matchRequest: MatchRequest,
+            respondTeam: Team,
+            message: String?,
+        ): MatchResponse {
+            require(matchRequest.status == MatchRequestStatus.OPEN) {
+                "OPEN 상태의 요청에만 응답할 수 있습니다"
+            }
+
+            return MatchResponse(
+                matchRequest = matchRequest,
+                respondTeam = respondTeam,
+                message = message,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/match/MatchResponseStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/match/MatchResponseStatus.kt
@@ -1,0 +1,7 @@
+package com.nextup.core.domain.match
+
+enum class MatchResponseStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/match/SkillLevel.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/match/SkillLevel.kt
@@ -1,0 +1,8 @@
+package com.nextup.core.domain.match
+
+enum class SkillLevel {
+    BEGINNER,
+    INTERMEDIATE,
+    ADVANCED,
+    ANY,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/DevicePlatform.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/DevicePlatform.kt
@@ -1,0 +1,21 @@
+package com.nextup.core.domain.notification
+
+/**
+ * 디바이스 플랫폼
+ */
+enum class DevicePlatform {
+    /**
+     * iOS
+     */
+    IOS,
+
+    /**
+     * Android
+     */
+    ANDROID,
+
+    /**
+     * Web
+     */
+    WEB,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/DeviceToken.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/DeviceToken.kt
@@ -1,0 +1,51 @@
+package com.nextup.core.domain.notification
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+
+/**
+ * 디바이스 토큰 엔티티
+ *
+ * FCM 푸시 알림을 위한 디바이스 토큰을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "device_tokens",
+    indexes = [
+        Index(name = "idx_device_tokens_user_id", columnList = "user_id"),
+        Index(name = "idx_device_tokens_token", columnList = "token", unique = true),
+        Index(name = "idx_device_tokens_user_platform", columnList = "user_id, platform"),
+    ],
+)
+class DeviceToken private constructor(
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+    @Column(nullable = false, length = 500)
+    val token: String,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    val platform: DevicePlatform,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    companion object {
+        /**
+         * 디바이스 토큰을 생성합니다.
+         */
+        fun create(
+            userId: Long,
+            token: String,
+            platform: DevicePlatform,
+        ): DeviceToken {
+            require(userId > 0) { "사용자 ID는 필수입니다" }
+            require(token.isNotBlank()) { "토큰은 필수입니다" }
+
+            return DeviceToken(
+                userId = userId,
+                token = token,
+                platform = platform,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/Notification.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/Notification.kt
@@ -1,0 +1,94 @@
+package com.nextup.core.domain.notification
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+/**
+ * 알림 엔티티
+ *
+ * 사용자에게 전송되는 푸시 알림을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "notifications",
+    indexes = [
+        Index(name = "idx_notifications_user_id", columnList = "user_id"),
+        Index(name = "idx_notifications_type", columnList = "type"),
+        Index(name = "idx_notifications_user_type", columnList = "user_id, type"),
+        Index(name = "idx_notifications_sent_at", columnList = "sent_at"),
+    ],
+)
+class Notification private constructor(
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    val type: NotificationType,
+    @Column(nullable = false, length = 200)
+    val title: String,
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val body: String,
+    @Column(columnDefinition = "TEXT")
+    val data: String? = null,
+    @Column(name = "read_at")
+    var readAt: LocalDateTime? = null,
+    @Column(name = "sent_at")
+    var sentAt: LocalDateTime? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 알림을 읽음 처리합니다.
+     */
+    fun markAsRead() {
+        if (readAt == null) {
+            readAt = LocalDateTime.now()
+        }
+    }
+
+    /**
+     * 알림 전송을 기록합니다.
+     */
+    fun markAsSent() {
+        if (sentAt == null) {
+            sentAt = LocalDateTime.now()
+        }
+    }
+
+    /**
+     * 알림이 읽혔는지 확인합니다.
+     */
+    fun isRead(): Boolean = readAt != null
+
+    /**
+     * 알림이 전송되었는지 확인합니다.
+     */
+    fun isSent(): Boolean = sentAt != null
+
+    companion object {
+        /**
+         * 알림을 생성합니다.
+         */
+        fun create(
+            userId: Long,
+            type: NotificationType,
+            title: String,
+            body: String,
+            data: String? = null,
+        ): Notification {
+            require(userId > 0) { "사용자 ID는 필수입니다" }
+            require(title.isNotBlank()) { "제목은 필수입니다" }
+            require(body.isNotBlank()) { "내용은 필수입니다" }
+
+            return Notification(
+                userId = userId,
+                type = type,
+                title = title,
+                body = body,
+                data = data,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/NotificationPreference.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/NotificationPreference.kt
@@ -1,0 +1,74 @@
+package com.nextup.core.domain.notification
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+
+/**
+ * 알림 설정 엔티티
+ *
+ * 사용자별 알림 타입에 대한 수신 설정을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "notification_preferences",
+    indexes = [
+        Index(name = "idx_notification_preferences_user_id", columnList = "user_id"),
+        Index(
+            name = "idx_notification_preferences_user_type",
+            columnList = "user_id, type",
+            unique = true,
+        ),
+    ],
+)
+class NotificationPreference private constructor(
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    val type: NotificationType,
+    @Column(nullable = false)
+    var enabled: Boolean = true,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 알림을 활성화합니다.
+     */
+    fun enable() {
+        enabled = true
+    }
+
+    /**
+     * 알림을 비활성화합니다.
+     */
+    fun disable() {
+        enabled = false
+    }
+
+    /**
+     * 활성화 상태를 토글합니다.
+     */
+    fun toggle() {
+        enabled = !enabled
+    }
+
+    companion object {
+        /**
+         * 알림 설정을 생성합니다.
+         */
+        fun create(
+            userId: Long,
+            type: NotificationType,
+            enabled: Boolean = true,
+        ): NotificationPreference {
+            require(userId > 0) { "사용자 ID는 필수입니다" }
+
+            return NotificationPreference(
+                userId = userId,
+                type = type,
+                enabled = enabled,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/NotificationType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/NotificationType.kt
@@ -1,0 +1,26 @@
+package com.nextup.core.domain.notification
+
+/**
+ * 알림 타입
+ */
+enum class NotificationType {
+    /**
+     * 경기 시작 알림
+     */
+    GAME_START,
+
+    /**
+     * 팀 공지사항
+     */
+    TEAM_NOTICE,
+
+    /**
+     * 출석 독려
+     */
+    ATTENDANCE_NUDGE,
+
+    /**
+     * 기록 알림
+     */
+    RECORD_ALERT,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/recruitment/RecruitmentStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/recruitment/RecruitmentStatus.kt
@@ -1,0 +1,7 @@
+package com.nextup.core.domain.recruitment
+
+enum class RecruitmentStatus {
+    OPEN,
+    CLOSED,
+    EXPIRED,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/recruitment/TeamRecruitment.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/recruitment/TeamRecruitment.kt
@@ -1,0 +1,131 @@
+package com.nextup.core.domain.recruitment
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.team.Team
+import jakarta.persistence.*
+import java.time.LocalDate
+
+/**
+ * 팀 모집 공고 엔티티
+ *
+ * 팀의 선수 모집 공고를 관리합니다.
+ */
+@Entity
+@Table(
+    name = "team_recruitments",
+    indexes = [
+        Index(name = "idx_team_recruitments_team_id", columnList = "team_id"),
+        Index(name = "idx_team_recruitments_status", columnList = "status"),
+        Index(name = "idx_team_recruitments_deadline", columnList = "deadline"),
+        Index(
+            name = "idx_team_recruitments_team_status",
+            columnList = "team_id, status",
+        ),
+    ],
+)
+class TeamRecruitment private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    val team: Team,
+    @Column(nullable = false, length = 200)
+    var title: String,
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var description: String,
+    @Column(name = "positions_needed", nullable = false, length = 255)
+    var positionsNeeded: String,
+    @Column(name = "age_range", length = 50)
+    var ageRange: String? = null,
+    @Column(name = "skill_level", length = 50)
+    var skillLevel: String? = null,
+    @Column(length = 255)
+    var location: String? = null,
+    @Column(nullable = false)
+    var deadline: LocalDate,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: RecruitmentStatus = RecruitmentStatus.OPEN,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 모집 공고를 마감합니다.
+     */
+    fun close() {
+        require(status == RecruitmentStatus.OPEN) {
+            "진행 중인 모집 공고만 마감할 수 있습니다"
+        }
+        this.status = RecruitmentStatus.CLOSED
+    }
+
+    /**
+     * 모집 기한이 지났는지 확인합니다.
+     */
+    fun isExpired(): Boolean = LocalDate.now().isAfter(deadline)
+
+    /**
+     * 모집 공고 정보를 업데이트합니다.
+     */
+    fun update(
+        title: String? = null,
+        description: String? = null,
+        positionsNeeded: String? = null,
+        deadline: LocalDate? = null,
+    ) {
+        require(status == RecruitmentStatus.OPEN) {
+            "진행 중인 모집 공고만 수정할 수 있습니다"
+        }
+        title?.let {
+            require(it.isNotBlank()) { "제목은 필수입니다" }
+            this.title = it
+        }
+        description?.let {
+            require(it.isNotBlank()) { "설명은 필수입니다" }
+            this.description = it
+        }
+        positionsNeeded?.let {
+            require(it.isNotBlank()) { "모집 포지션은 필수입니다" }
+            this.positionsNeeded = it
+        }
+        deadline?.let {
+            require(it.isAfter(LocalDate.now())) {
+                "마감일은 현재 날짜보다 이후여야 합니다"
+            }
+            this.deadline = it
+        }
+    }
+
+    companion object {
+        /**
+         * 팀 모집 공고를 생성합니다.
+         */
+        fun create(
+            team: Team,
+            title: String,
+            description: String,
+            positionsNeeded: String,
+            ageRange: String?,
+            skillLevel: String?,
+            location: String?,
+            deadline: LocalDate,
+        ): TeamRecruitment {
+            require(title.isNotBlank()) { "제목은 필수입니다" }
+            require(description.isNotBlank()) { "설명은 필수입니다" }
+            require(positionsNeeded.isNotBlank()) { "모집 포지션은 필수입니다" }
+            require(deadline.isAfter(LocalDate.now())) {
+                "마감일은 현재 날짜보다 이후여야 합니다"
+            }
+
+            return TeamRecruitment(
+                team = team,
+                title = title,
+                description = description,
+                positionsNeeded = positionsNeeded,
+                ageRange = ageRange,
+                skillLevel = skillLevel,
+                location = location,
+                deadline = deadline,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/LeagueSchedule.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/LeagueSchedule.kt
@@ -62,6 +62,14 @@ class LeagueSchedule private constructor(
     var game: Game? = null
         protected set
 
+    @Column(name = "postponed_reason", length = 500)
+    var postponedReason: String? = null
+        protected set
+
+    @Column(name = "original_date")
+    var originalDate: LocalDate? = null
+        protected set
+
     /**
      * 경기를 연결합니다.
      */
@@ -76,10 +84,17 @@ class LeagueSchedule private constructor(
     /**
      * 대진표를 연기합니다.
      */
-    fun postpone() {
+    fun postpone(reason: String) {
         require(status == ScheduleStatus.SCHEDULED) {
             "예정 상태의 대진표만 연기할 수 있습니다. 현재 상태: ${status.displayName}"
         }
+        require(reason.isNotBlank()) {
+            "연기 사유는 필수입니다."
+        }
+        if (this.originalDate == null) {
+            this.originalDate = this.scheduledDate
+        }
+        this.postponedReason = reason
         this.status = ScheduleStatus.POSTPONED
     }
 
@@ -119,6 +134,7 @@ class LeagueSchedule private constructor(
         this.venue = newVenue
         if (status == ScheduleStatus.POSTPONED) {
             this.status = ScheduleStatus.SCHEDULED
+            this.postponedReason = null
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/LeagueSchedule.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/LeagueSchedule.kt
@@ -1,0 +1,165 @@
+package com.nextup.core.domain.schedule
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.team.Team
+import jakarta.persistence.*
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 대진표 엔티티
+ *
+ * 대회(Competition) 내의 라운드별 경기 일정을 나타냅니다.
+ * 대진표 항목은 실제 경기(Game)와 연결될 수 있습니다.
+ */
+@Entity
+@Table(
+    name = "league_schedules",
+    indexes = [
+        Index(name = "idx_league_schedules_competition", columnList = "competition_id"),
+        Index(name = "idx_league_schedules_date", columnList = "scheduled_date"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_league_schedules_competition_round_match",
+            columnNames = ["competition_id", "round", "match_number"],
+        ),
+    ],
+)
+class LeagueSchedule private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "competition_id", nullable = false)
+    val competition: Competition,
+    @Column(nullable = false)
+    val round: Int,
+    @Column(name = "match_number", nullable = false)
+    val matchNumber: Int,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "home_team_id", nullable = false)
+    val homeTeam: Team,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "away_team_id", nullable = false)
+    val awayTeam: Team,
+    @Column(name = "scheduled_date", nullable = false)
+    var scheduledDate: LocalDate,
+    @Column(name = "scheduled_time")
+    var scheduledTime: LocalTime? = null,
+    @Column(length = 255)
+    var venue: String? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: ScheduleStatus = ScheduleStatus.SCHEDULED
+        protected set
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id")
+    var game: Game? = null
+        protected set
+
+    /**
+     * 경기를 연결합니다.
+     */
+    fun linkGame(game: Game) {
+        require(status == ScheduleStatus.SCHEDULED || status == ScheduleStatus.POSTPONED) {
+            "예정 또는 연기 상태의 대진표만 경기를 연결할 수 있습니다. 현재 상태: ${status.displayName}"
+        }
+        this.game = game
+        this.status = ScheduleStatus.GAME_CREATED
+    }
+
+    /**
+     * 대진표를 연기합니다.
+     */
+    fun postpone() {
+        require(status == ScheduleStatus.SCHEDULED) {
+            "예정 상태의 대진표만 연기할 수 있습니다. 현재 상태: ${status.displayName}"
+        }
+        this.status = ScheduleStatus.POSTPONED
+    }
+
+    /**
+     * 대진표를 취소합니다.
+     */
+    fun cancel() {
+        require(status != ScheduleStatus.COMPLETED) {
+            "완료된 대진표는 취소할 수 없습니다."
+        }
+        this.status = ScheduleStatus.CANCELLED
+    }
+
+    /**
+     * 대진표를 완료합니다.
+     */
+    fun complete() {
+        require(status == ScheduleStatus.GAME_CREATED) {
+            "경기가 생성된 대진표만 완료할 수 있습니다. 현재 상태: ${status.displayName}"
+        }
+        this.status = ScheduleStatus.COMPLETED
+    }
+
+    /**
+     * 일정을 변경합니다.
+     */
+    fun reschedule(
+        newDate: LocalDate,
+        newTime: LocalTime? = this.scheduledTime,
+        newVenue: String? = this.venue,
+    ) {
+        require(status == ScheduleStatus.SCHEDULED || status == ScheduleStatus.POSTPONED) {
+            "예정 또는 연기 상태의 대진표만 일정을 변경할 수 있습니다. 현재 상태: ${status.displayName}"
+        }
+        this.scheduledDate = newDate
+        this.scheduledTime = newTime
+        this.venue = newVenue
+        if (status == ScheduleStatus.POSTPONED) {
+            this.status = ScheduleStatus.SCHEDULED
+        }
+    }
+
+    companion object {
+        fun create(
+            competition: Competition,
+            round: Int,
+            matchNumber: Int,
+            homeTeam: Team,
+            awayTeam: Team,
+            scheduledDate: LocalDate,
+            scheduledTime: LocalTime? = null,
+            venue: String? = null,
+        ): LeagueSchedule {
+            require(round > 0) { "라운드는 1 이상이어야 합니다." }
+            require(matchNumber > 0) { "경기 번호는 1 이상이어야 합니다." }
+            require(homeTeam.id != awayTeam.id) { "홈팀과 원정팀은 같을 수 없습니다." }
+
+            return LeagueSchedule(
+                competition = competition,
+                round = round,
+                matchNumber = matchNumber,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledDate = scheduledDate,
+                scheduledTime = scheduledTime,
+                venue = venue,
+            )
+        }
+    }
+}
+
+/**
+ * 대진표 상태
+ */
+enum class ScheduleStatus(
+    val displayName: String,
+) {
+    SCHEDULED("예정"),
+    GAME_CREATED("경기 생성"),
+    POSTPONED("연기"),
+    CANCELLED("취소"),
+    COMPLETED("완료"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/RoundRobinScheduleGenerator.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/RoundRobinScheduleGenerator.kt
@@ -1,0 +1,137 @@
+package com.nextup.core.domain.schedule
+
+/**
+ * 라운드 로빈 대진표 자동 생성기
+ *
+ * N개 팀이 참가할 때, 모든 팀이 한 번씩 맞붙는 풀리그 대진표를 생성합니다.
+ * Circle Method 알고리즘을 사용합니다.
+ */
+class RoundRobinScheduleGenerator {
+    data class MatchPair(
+        val homeTeamId: Long,
+        val awayTeamId: Long,
+        val round: Int,
+    )
+
+    /**
+     * 라운드 로빈 대진표를 생성합니다.
+     *
+     * @param teamIds 참가 팀 ID 목록
+     * @param doubleRoundRobin true면 홈/원정 교대로 2회전 (기본 false)
+     * @return 라운드별 매치 목록
+     */
+    fun generate(
+        teamIds: List<Long>,
+        doubleRoundRobin: Boolean = false,
+    ): List<MatchPair> {
+        require(teamIds.size >= 2) { "최소 2개 팀이 필요합니다" }
+        require(teamIds.distinct().size == teamIds.size) { "중복된 팀이 있습니다" }
+
+        val teams = teamIds.toMutableList()
+        val isOdd = teams.size % 2 == 1
+
+        // 홀수 팀이면 BYE 추가 (더미 팀 ID = -1L)
+        if (isOdd) {
+            teams.add(-1L)
+        }
+
+        val n = teams.size
+        val rounds = n - 1
+        val matches = mutableListOf<MatchPair>()
+
+        // Circle Method: 첫 번째 팀 고정, 나머지 회전
+        for (round in 1..rounds) {
+            val roundMatches = generateRound(teams, round)
+            matches.addAll(roundMatches)
+        }
+
+        // Double round robin이면 홈/원정 교대로 추가 라운드 생성
+        if (doubleRoundRobin) {
+            val secondRoundMatches =
+                matches.map { match ->
+                    MatchPair(
+                        homeTeamId = match.awayTeamId,
+                        awayTeamId = match.homeTeamId,
+                        round = match.round + rounds,
+                    )
+                }
+            matches.addAll(secondRoundMatches)
+        }
+
+        // BYE 매치 제거
+        return matches.filter { it.homeTeamId != -1L && it.awayTeamId != -1L }
+    }
+
+    /**
+     * 특정 라운드의 매치를 생성합니다.
+     */
+    private fun generateRound(
+        teams: List<Long>,
+        round: Int,
+    ): List<MatchPair> {
+        val n = teams.size
+        val matches = mutableListOf<MatchPair>()
+        val rotation = (round - 1) % (n - 1)
+
+        // Circle Method 회전 배치
+        val rotated = rotateTeams(teams, rotation)
+
+        // 매치 페어링
+        for (i in 0 until n / 2) {
+            val home = rotated[i]
+            val away = rotated[n - 1 - i]
+
+            // 홈/원정 균형: 라운드별로 교대
+            val (homeTeam, awayTeam) =
+                if (shouldSwapHomeAway(i, round)) {
+                    away to home
+                } else {
+                    home to away
+                }
+
+            matches.add(
+                MatchPair(
+                    homeTeamId = homeTeam,
+                    awayTeamId = awayTeam,
+                    round = round,
+                ),
+            )
+        }
+
+        return matches
+    }
+
+    /**
+     * Circle Method 회전을 수행합니다.
+     * 첫 번째 팀(teams[0])은 고정, 나머지 시계 방향 회전
+     */
+    private fun rotateTeams(
+        teams: List<Long>,
+        rotation: Int,
+    ): List<Long> {
+        if (rotation == 0 || teams.size <= 1) return teams
+
+        val fixed = teams[0]
+        val rotating = teams.drop(1)
+
+        // 회전: rotation만큼 오른쪽으로 회전
+        val rotatedIndex = rotation % rotating.size
+        val rotated = rotating.takeLast(rotatedIndex) + rotating.dropLast(rotatedIndex)
+
+        return listOf(fixed) + rotated
+    }
+
+    /**
+     * 홈/원정 균형을 위해 일부 매치의 홈/원정을 교대합니다.
+     */
+    private fun shouldSwapHomeAway(
+        matchIndex: Int,
+        round: Int,
+    ): Boolean {
+        // 라운드가 짝수일 때 첫 번째 매치는 교대
+        // 라운드가 홀수일 때 두 번째 매치는 교대
+        // 이렇게 하면 홈/원정이 균형있게 분배됨
+        return (round % 2 == 0 && matchIndex % 2 == 0) ||
+            (round % 2 == 1 && matchIndex % 2 == 1)
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/ScheduleConflict.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/ScheduleConflict.kt
@@ -1,0 +1,22 @@
+package com.nextup.core.domain.schedule
+
+/**
+ * 대진표 충돌 정보
+ *
+ * 대진표 생성/수정 시 발생할 수 있는 충돌 정보를 담습니다.
+ */
+data class ScheduleConflict(
+    val type: ConflictType,
+    val conflictingScheduleId: Long,
+    val description: String,
+)
+
+/**
+ * 충돌 유형
+ */
+enum class ConflictType(
+    val displayName: String,
+) {
+    TEAM_TIME_CONFLICT("팀 시간 충돌"),
+    VENUE_TIME_CONFLICT("경기장 시간 충돌"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/ScheduleConflictDetector.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/ScheduleConflictDetector.kt
@@ -1,0 +1,175 @@
+package com.nextup.core.domain.schedule
+
+import java.time.LocalDateTime
+
+/**
+ * 대진표 충돌 감지 도메인 서비스
+ *
+ * 대진표 생성/수정 시 발생할 수 있는 충돌을 감지합니다.
+ * - 같은 팀이 동시간대에 여러 경기에 배정되는 충돌
+ * - 같은 경기장에 동시간대에 여러 경기가 배정되는 충돌
+ */
+class ScheduleConflictDetector {
+    /**
+     * 팀 시간 충돌을 감지합니다.
+     *
+     * 같은 팀(홈 또는 원정)이 동일한 날짜/시간에 다른 경기에 배정되어 있는지 확인합니다.
+     *
+     * @param schedule 확인할 대진표
+     * @param existingSchedules 같은 날짜의 기존 대진표 목록
+     * @return 충돌 목록 (충돌 없으면 빈 리스트)
+     */
+    fun detectTeamConflicts(
+        schedule: LeagueSchedule,
+        existingSchedules: List<LeagueSchedule>,
+    ): List<ScheduleConflict> {
+        val conflicts = mutableListOf<ScheduleConflict>()
+
+        // 시간이 지정되지 않은 경우 충돌 검사하지 않음
+        val scheduleTime = schedule.scheduledTime ?: return emptyList()
+        val scheduleDateTime = LocalDateTime.of(schedule.scheduledDate, scheduleTime)
+
+        for (existing in existingSchedules) {
+            // 자기 자신은 제외
+            if (existing.id == schedule.id) continue
+
+            // 시간이 지정되지 않은 대진표는 제외
+            val existingTime = existing.scheduledTime ?: continue
+            val existingDateTime = LocalDateTime.of(existing.scheduledDate, existingTime)
+
+            // 같은 시간대인지 확인 (같은 시간이거나 1시간 이내)
+            if (isTimeConflict(scheduleDateTime, existingDateTime)) {
+                // 홈팀 충돌 확인
+                if (schedule.homeTeam.id == existing.homeTeam.id || schedule.homeTeam.id == existing.awayTeam.id) {
+                    conflicts.add(
+                        ScheduleConflict(
+                            type = ConflictType.TEAM_TIME_CONFLICT,
+                            conflictingScheduleId = existing.id,
+                            description =
+                                "홈팀 '${schedule.homeTeam.name}'이(가) " +
+                                    "${existing.scheduledDate} ${existing.scheduledTime}에 다른 경기(${existing.homeTeam.name} vs ${existing.awayTeam.name})에 배정되어 있습니다.",
+                        ),
+                    )
+                }
+
+                // 원정팀 충돌 확인
+                if (schedule.awayTeam.id == existing.homeTeam.id || schedule.awayTeam.id == existing.awayTeam.id) {
+                    conflicts.add(
+                        ScheduleConflict(
+                            type = ConflictType.TEAM_TIME_CONFLICT,
+                            conflictingScheduleId = existing.id,
+                            description =
+                                "원정팀 '${schedule.awayTeam.name}'이(가) " +
+                                    "${existing.scheduledDate} ${existing.scheduledTime}에 다른 경기(${existing.homeTeam.name} vs ${existing.awayTeam.name})에 배정되어 있습니다.",
+                        ),
+                    )
+                }
+            }
+        }
+
+        return conflicts
+    }
+
+    /**
+     * 경기장 시간 충돌을 감지합니다.
+     *
+     * 같은 경기장에 동일한 날짜/시간에 다른 경기가 배정되어 있는지 확인합니다.
+     *
+     * @param schedule 확인할 대진표
+     * @param existingSchedules 같은 날짜의 기존 대진표 목록
+     * @return 충돌 목록 (충돌 없으면 빈 리스트)
+     */
+    fun detectVenueConflicts(
+        schedule: LeagueSchedule,
+        existingSchedules: List<LeagueSchedule>,
+    ): List<ScheduleConflict> {
+        val conflicts = mutableListOf<ScheduleConflict>()
+
+        // 경기장이나 시간이 지정되지 않은 경우 충돌 검사하지 않음
+        val venue = schedule.venue
+        val scheduleTime = schedule.scheduledTime
+        if (venue.isNullOrBlank() || scheduleTime == null) {
+            return emptyList()
+        }
+
+        val scheduleDateTime = LocalDateTime.of(schedule.scheduledDate, scheduleTime)
+
+        for (existing in existingSchedules) {
+            // 자기 자신은 제외
+            if (existing.id == schedule.id) continue
+
+            // 경기장이나 시간이 지정되지 않은 대진표는 제외
+            val existingVenue = existing.venue
+            val existingTime = existing.scheduledTime
+            if (existingVenue.isNullOrBlank() || existingTime == null) continue
+
+            // 같은 경기장인지 확인 (대소문자 무시, 공백 제거)
+            val isSameVenue =
+                venue.trim().equals(existingVenue.trim(), ignoreCase = true)
+
+            if (isSameVenue) {
+                val existingDateTime = LocalDateTime.of(existing.scheduledDate, existingTime)
+
+                // 같은 시간대인지 확인 (같은 시간이거나 1시간 이내)
+                if (isTimeConflict(scheduleDateTime, existingDateTime)) {
+                    conflicts.add(
+                        ScheduleConflict(
+                            type = ConflictType.VENUE_TIME_CONFLICT,
+                            conflictingScheduleId = existing.id,
+                            description =
+                                "경기장 '$venue'에 " +
+                                    "${existing.scheduledDate} ${existing.scheduledTime}에 다른 경기(${existing.homeTeam.name} vs ${existing.awayTeam.name})가 배정되어 있습니다.",
+                        ),
+                    )
+                }
+            }
+        }
+
+        return conflicts
+    }
+
+    /**
+     * 모든 충돌을 감지합니다.
+     *
+     * 팀 시간 충돌과 경기장 시간 충돌을 모두 확인합니다.
+     *
+     * @param schedule 확인할 대진표
+     * @param existingSchedules 같은 날짜의 기존 대진표 목록
+     * @return 충돌 목록 (충돌 없으면 빈 리스트)
+     */
+    fun detectAllConflicts(
+        schedule: LeagueSchedule,
+        existingSchedules: List<LeagueSchedule>,
+    ): List<ScheduleConflict> {
+        val teamConflicts = detectTeamConflicts(schedule, existingSchedules)
+        val venueConflicts = detectVenueConflicts(schedule, existingSchedules)
+        return teamConflicts + venueConflicts
+    }
+
+    /**
+     * 두 시간이 충돌하는지 확인합니다.
+     *
+     * 같은 시간이거나, 한 경기가 시작할 때 다른 경기가 진행 중인 경우 충돌로 간주합니다.
+     * (경기 시간을 평균 3시간으로 가정)
+     *
+     * @param time1 첫 번째 시간
+     * @param time2 두 번째 시간
+     * @return 충돌 여부
+     */
+    private fun isTimeConflict(
+        time1: LocalDateTime,
+        time2: LocalDateTime,
+    ): Boolean {
+        val gamesDuration = 3L // 경기 시간 (시간 단위)
+
+        // time1이 time2 경기 시간 범위 내에 있는지 확인
+        val isTime1InTime2Range =
+            !time1.isBefore(time2) && time1.isBefore(time2.plusHours(gamesDuration))
+
+        // time2가 time1 경기 시간 범위 내에 있는지 확인
+        val isTime2InTime1Range =
+            !time2.isBefore(time1) && time2.isBefore(time1.plusHours(gamesDuration))
+
+        return isTime1InTime2Range || isTime2InTime1Range
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/BookingStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/BookingStatus.kt
@@ -1,0 +1,21 @@
+package com.nextup.core.domain.stadium
+
+/**
+ * 구장 예약 상태
+ */
+enum class BookingStatus {
+    /**
+     * 예약 확정
+     */
+    CONFIRMED,
+
+    /**
+     * 취소됨
+     */
+    CANCELLED,
+
+    /**
+     * 완료됨
+     */
+    COMPLETED,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/SlotStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/SlotStatus.kt
@@ -1,0 +1,21 @@
+package com.nextup.core.domain.stadium
+
+/**
+ * 구장 슬롯 상태
+ */
+enum class SlotStatus {
+    /**
+     * 예약 가능
+     */
+    AVAILABLE,
+
+    /**
+     * 예약됨
+     */
+    BOOKED,
+
+    /**
+     * 유지보수 중
+     */
+    MAINTENANCE,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/Stadium.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/Stadium.kt
@@ -1,0 +1,109 @@
+package com.nextup.core.domain.stadium
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+
+/**
+ * 구장 엔티티
+ *
+ * 야구장 정보를 관리하며, PostGIS를 활용한 위치 기반 검색을 지원합니다.
+ */
+@Entity
+@Table(
+    name = "stadiums",
+    indexes = [
+        Index(name = "idx_stadiums_is_active", columnList = "is_active"),
+        Index(name = "idx_stadiums_location", columnList = "latitude,longitude"),
+    ],
+)
+class Stadium private constructor(
+    @Column(nullable = false, length = 100)
+    val name: String,
+    @Column(nullable = false, length = 255)
+    var address: String,
+    @Column(nullable = false)
+    var latitude: Double,
+    @Column(nullable = false)
+    var longitude: Double,
+    @Column
+    var capacity: Int? = null,
+    @Column(length = 500)
+    var facilities: String? = null,
+    @Column(length = 255)
+    var contactInfo: String? = null,
+    @Column(length = 1000)
+    var imageUrls: String? = null,
+    @Column(name = "is_active", nullable = false)
+    var isActive: Boolean = true,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    companion object {
+        fun create(
+            name: String,
+            address: String,
+            latitude: Double,
+            longitude: Double,
+            capacity: Int? = null,
+            facilities: String? = null,
+            contactInfo: String? = null,
+            imageUrls: String? = null,
+        ): Stadium {
+            require(name.isNotBlank()) { "Stadium name cannot be blank" }
+            require(address.isNotBlank()) { "Stadium address cannot be blank" }
+            require(latitude in -90.0..90.0) { "Latitude must be between -90 and 90" }
+            require(longitude in -180.0..180.0) { "Longitude must be between -180 and 180" }
+            capacity?.let { require(it > 0) { "Capacity must be positive" } }
+
+            return Stadium(
+                name = name,
+                address = address,
+                latitude = latitude,
+                longitude = longitude,
+                capacity = capacity,
+                facilities = facilities,
+                contactInfo = contactInfo,
+                imageUrls = imageUrls,
+            )
+        }
+    }
+
+    fun update(
+        address: String? = this.address,
+        latitude: Double? = this.latitude,
+        longitude: Double? = this.longitude,
+        capacity: Int? = this.capacity,
+        facilities: String? = this.facilities,
+        contactInfo: String? = this.contactInfo,
+        imageUrls: String? = this.imageUrls,
+    ) {
+        address?.let {
+            require(it.isNotBlank()) { "Address cannot be blank" }
+            this.address = it
+        }
+        latitude?.let {
+            require(it in -90.0..90.0) { "Latitude must be between -90 and 90" }
+            this.latitude = it
+        }
+        longitude?.let {
+            require(it in -180.0..180.0) { "Longitude must be between -180 and 180" }
+            this.longitude = it
+        }
+        capacity?.let {
+            require(it > 0) { "Capacity must be positive" }
+            this.capacity = it
+        }
+        this.facilities = facilities
+        this.contactInfo = contactInfo
+        this.imageUrls = imageUrls
+    }
+
+    fun deactivate() {
+        this.isActive = false
+    }
+
+    fun activate() {
+        this.isActive = true
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/StadiumBooking.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/StadiumBooking.kt
@@ -1,0 +1,81 @@
+package com.nextup.core.domain.stadium
+
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * 구장 예약 엔티티
+ *
+ * 팀의 구장 슬롯 예약 정보를 관리합니다.
+ */
+@Entity
+@Table(
+    name = "stadium_bookings",
+    indexes = [
+        Index(name = "idx_stadium_bookings_slot", columnList = "slot_id"),
+        Index(name = "idx_stadium_bookings_team", columnList = "team_id"),
+        Index(name = "idx_stadium_bookings_status", columnList = "status"),
+    ],
+)
+class StadiumBooking private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "slot_id", nullable = false)
+    val slot: StadiumSlot,
+    @Column(nullable = false, name = "team_id")
+    val teamId: Long,
+    @Column(nullable = false, name = "booked_by")
+    val bookedBy: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: BookingStatus = BookingStatus.CONFIRMED,
+    @Column(nullable = false, name = "booked_at")
+    val bookedAt: Instant = Instant.now(),
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    companion object {
+        fun create(
+            slot: StadiumSlot,
+            teamId: Long,
+            bookedBy: Long,
+        ): StadiumBooking {
+            require(teamId > 0) { "Team ID must be positive" }
+            require(bookedBy > 0) { "Booked by user ID must be positive" }
+
+            return StadiumBooking(
+                slot = slot,
+                teamId = teamId,
+                bookedBy = bookedBy,
+            )
+        }
+    }
+
+    /**
+     * 예약을 취소합니다.
+     */
+    fun cancel() {
+        if (status != BookingStatus.CONFIRMED) {
+            throw InvalidStateException(
+                "BOOKING_CANNOT_BE_CANCELLED",
+                "Booking cannot be cancelled. Current status: $status",
+            )
+        }
+        this.status = BookingStatus.CANCELLED
+    }
+
+    /**
+     * 예약을 완료 처리합니다.
+     */
+    fun complete() {
+        if (status != BookingStatus.CONFIRMED) {
+            throw InvalidStateException(
+                "BOOKING_CANNOT_BE_COMPLETED",
+                "Booking cannot be completed. Current status: $status",
+            )
+        }
+        this.status = BookingStatus.COMPLETED
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/StadiumSlot.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/StadiumSlot.kt
@@ -1,0 +1,108 @@
+package com.nextup.core.domain.stadium
+
+import com.nextup.common.exception.SlotNotAvailableException
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 구장 슬롯 엔티티
+ *
+ * 구장의 특정 날짜/시간대 예약 가능 슬롯을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "stadium_slots",
+    indexes = [
+        Index(name = "idx_stadium_slots_stadium_date", columnList = "stadium_id,date"),
+        Index(name = "idx_stadium_slots_status", columnList = "status"),
+    ],
+)
+class StadiumSlot private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stadium_id", nullable = false)
+    val stadium: Stadium,
+    @Column(nullable = false)
+    val date: LocalDate,
+    @Column(nullable = false, name = "start_time")
+    val startTime: LocalTime,
+    @Column(nullable = false, name = "end_time")
+    val endTime: LocalTime,
+    @Column(precision = 10, scale = 2)
+    var price: BigDecimal? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: SlotStatus = SlotStatus.AVAILABLE,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    companion object {
+        fun create(
+            stadium: Stadium,
+            date: LocalDate,
+            startTime: LocalTime,
+            endTime: LocalTime,
+            price: BigDecimal? = null,
+        ): StadiumSlot {
+            require(startTime.isBefore(endTime)) { "Start time must be before end time" }
+            price?.let { require(it > BigDecimal.ZERO) { "Price must be positive" } }
+
+            return StadiumSlot(
+                stadium = stadium,
+                date = date,
+                startTime = startTime,
+                endTime = endTime,
+                price = price,
+            )
+        }
+    }
+
+    /**
+     * 슬롯을 예약 상태로 변경합니다.
+     */
+    fun book() {
+        if (status != SlotStatus.AVAILABLE) {
+            throw SlotNotAvailableException(
+                "SLOT_NOT_AVAILABLE",
+                "Slot is not available for booking. Current status: $status",
+            )
+        }
+        this.status = SlotStatus.BOOKED
+    }
+
+    /**
+     * 예약을 취소하고 슬롯을 다시 사용 가능 상태로 만듭니다.
+     */
+    fun cancel() {
+        if (status != SlotStatus.BOOKED) {
+            throw SlotNotAvailableException(
+                "SLOT_NOT_BOOKED",
+                "Slot is not booked. Current status: $status",
+            )
+        }
+        this.status = SlotStatus.AVAILABLE
+    }
+
+    /**
+     * 슬롯을 유지보수 상태로 변경합니다.
+     */
+    fun maintain() {
+        this.status = SlotStatus.MAINTENANCE
+    }
+
+    /**
+     * 유지보수 상태를 해제하고 사용 가능 상태로 변경합니다.
+     */
+    fun endMaintenance() {
+        if (status != SlotStatus.MAINTENANCE) {
+            throw SlotNotAvailableException(
+                "SLOT_NOT_IN_MAINTENANCE",
+                "Slot is not in maintenance. Current status: $status",
+            )
+        }
+        this.status = SlotStatus.AVAILABLE
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/team/Team.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/team/Team.kt
@@ -22,11 +22,11 @@ class Team(
     @JoinColumn(name = "league_id", nullable = false)
     val league: League,
     @Column(nullable = false, length = 100)
-    val name: String,
+    var name: String,
     @Column(length = 20)
-    val abbreviation: String? = null,
+    var abbreviation: String? = null,
     @Column(nullable = false, length = 100)
-    val city: String,
+    var city: String,
     @Column(nullable = false)
     val foundedYear: Int,
     @Column(length = 255)
@@ -60,5 +60,17 @@ class Team(
         this.logoUrl = logoUrl
         this.primaryColor = primaryColor
         this.secondaryColor = secondaryColor
+    }
+
+    fun updateBasicInfo(
+        name: String? = null,
+        city: String? = null,
+        abbreviation: String? = null,
+    ) {
+        name?.let { this.name = it }
+        city?.let { this.city = it }
+        if (abbreviation != null) {
+            this.abbreviation = abbreviation
+        }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/dto/certificate/CertificateDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/dto/certificate/CertificateDto.kt
@@ -1,0 +1,93 @@
+package com.nextup.core.dto.certificate
+
+import com.nextup.core.domain.certificate.CertificateStatus
+import java.time.Instant
+
+/**
+ * 증명서 발급 요청 DTO
+ */
+data class IssueCertificateRequest(
+    val validityDays: Long = 365,
+)
+
+/**
+ * 증명서 상세 정보 DTO
+ */
+data class CertificateDto(
+    val id: Long,
+    val issueNumber: String,
+    val playerId: Long,
+    val playerName: String,
+    val issuedAt: Instant,
+    val expiresAt: Instant,
+    val status: CertificateStatus,
+    val playerCareer: PlayerCareerDto,
+    val qrCodeData: String,
+)
+
+/**
+ * 선수 경력 정보 DTO
+ */
+data class PlayerCareerDto(
+    val totalGames: Int,
+    val battingStats: CareerBattingStatsDto?,
+    val pitchingStats: CareerPitchingStatsDto?,
+    val competitionHistory: List<CompetitionHistoryDto>,
+)
+
+/**
+ * 통산 타격 기록 DTO
+ */
+data class CareerBattingStatsDto(
+    val games: Int,
+    val plateAppearances: Int,
+    val atBats: Int,
+    val hits: Int,
+    val doubles: Int,
+    val triples: Int,
+    val homeRuns: Int,
+    val runsBattedIn: Int,
+    val stolenBases: Int,
+    val battingAverage: Double,
+    val onBasePercentage: Double,
+    val sluggingPercentage: Double,
+)
+
+/**
+ * 통산 투수 기록 DTO
+ */
+data class CareerPitchingStatsDto(
+    val games: Int,
+    val wins: Int,
+    val losses: Int,
+    val saves: Int,
+    val holds: Int,
+    val inningsPitched: Double,
+    val strikeouts: Int,
+    val walks: Int,
+    val earnedRuns: Int,
+    val earnedRunAverage: Double,
+    val walksAndHitsPerInningPitched: Double,
+)
+
+/**
+ * 대회 이력 DTO
+ */
+data class CompetitionHistoryDto(
+    val year: Int,
+    val competitionName: String,
+    val teamName: String,
+    val games: Int,
+)
+
+/**
+ * 증명서 검증 응답 DTO
+ */
+data class CertificateVerificationDto(
+    val valid: Boolean,
+    val issueNumber: String,
+    val playerName: String,
+    val issuedAt: Instant,
+    val expiresAt: Instant,
+    val status: CertificateStatus,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/PdfGeneratorPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/PdfGeneratorPort.kt
@@ -1,0 +1,18 @@
+package com.nextup.core.port
+
+import com.nextup.core.service.game.dto.ScoresheetDto
+
+/**
+ * PDF 생성 포트 인터페이스
+ *
+ * Infrastructure 계층에서 실제 PDF 라이브러리를 사용하여 구현합니다.
+ */
+interface PdfGeneratorPort {
+    /**
+     * 공식 기록지 데이터를 PDF로 변환합니다.
+     *
+     * @param scoresheet 공식 기록지 데이터
+     * @return PDF 바이트 배열
+     */
+    fun generateScoresheetPdf(scoresheet: ScoresheetDto): ByteArray
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/attendance/ActivityScoreRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/attendance/ActivityScoreRepositoryPort.kt
@@ -1,0 +1,62 @@
+package com.nextup.core.port.attendance
+
+import com.nextup.core.domain.attendance.ActivityScore
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamMember
+
+/**
+ * 활동 점수 Repository Port
+ *
+ * Hexagonal Architecture의 Port 역할을 수행합니다.
+ * Infrastructure 계층에서 이 인터페이스를 구현합니다.
+ */
+interface ActivityScoreRepositoryPort {
+    /**
+     * 활동 점수를 저장합니다.
+     */
+    fun save(activityScore: ActivityScore): ActivityScore
+
+    /**
+     * ID로 활동 점수를 조회합니다.
+     */
+    fun findById(id: Long): ActivityScore?
+
+    /**
+     * 팀과 멤버로 활동 점수를 조회합니다.
+     */
+    fun findByTeamAndMember(
+        team: Team,
+        member: TeamMember,
+    ): ActivityScore?
+
+    /**
+     * 팀 ID와 멤버 ID로 활동 점수를 조회합니다.
+     */
+    fun findByTeamIdAndMemberId(
+        teamId: Long,
+        memberId: Long,
+    ): ActivityScore?
+
+    /**
+     * 팀의 모든 활동 점수를 조회합니다.
+     */
+    fun findByTeam(team: Team): List<ActivityScore>
+
+    /**
+     * 팀 ID로 모든 활동 점수를 조회합니다.
+     */
+    fun findByTeamId(teamId: Long): List<ActivityScore>
+
+    /**
+     * 활동 점수를 삭제합니다.
+     */
+    fun delete(activityScore: ActivityScore)
+
+    /**
+     * 팀과 멤버 조합이 존재하는지 확인합니다.
+     */
+    fun existsByTeamAndMember(
+        team: Team,
+        member: TeamMember,
+    ): Boolean
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/attendance/AttendancePollRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/attendance/AttendancePollRepositoryPort.kt
@@ -1,0 +1,49 @@
+package com.nextup.core.port.attendance
+
+import com.nextup.core.domain.attendance.AttendancePoll
+import com.nextup.core.domain.attendance.PollStatus
+import com.nextup.core.domain.team.Team
+
+/**
+ * 출석 투표 Repository Port
+ *
+ * Hexagonal Architecture의 Port 역할을 수행합니다.
+ * Infrastructure 계층에서 이 인터페이스를 구현합니다.
+ */
+interface AttendancePollRepositoryPort {
+    /**
+     * 출석 투표를 저장합니다.
+     */
+    fun save(attendancePoll: AttendancePoll): AttendancePoll
+
+    /**
+     * ID로 출석 투표를 조회합니다.
+     */
+    fun findById(id: Long): AttendancePoll?
+
+    /**
+     * 팀의 출석 투표 목록을 조회합니다.
+     */
+    fun findByTeam(
+        team: Team,
+        status: PollStatus? = null,
+    ): List<AttendancePoll>
+
+    /**
+     * 팀 ID로 출석 투표 목록을 조회합니다.
+     */
+    fun findByTeamId(
+        teamId: Long,
+        status: PollStatus? = null,
+    ): List<AttendancePoll>
+
+    /**
+     * 출석 투표를 삭제합니다.
+     */
+    fun delete(attendancePoll: AttendancePoll)
+
+    /**
+     * ID로 존재 여부를 확인합니다.
+     */
+    fun existsById(id: Long): Boolean
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/attendance/AttendanceVoteRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/attendance/AttendanceVoteRepositoryPort.kt
@@ -1,0 +1,67 @@
+package com.nextup.core.port.attendance
+
+import com.nextup.core.domain.attendance.AttendancePoll
+import com.nextup.core.domain.attendance.AttendanceVote
+import com.nextup.core.domain.player.Player
+
+/**
+ * 출석 투표 응답 Repository Port
+ *
+ * Hexagonal Architecture의 Port 역할을 수행합니다.
+ * Infrastructure 계층에서 이 인터페이스를 구현합니다.
+ */
+interface AttendanceVoteRepositoryPort {
+    /**
+     * 출석 투표 응답을 저장합니다.
+     */
+    fun save(attendanceVote: AttendanceVote): AttendanceVote
+
+    /**
+     * ID로 출석 투표 응답을 조회합니다.
+     */
+    fun findById(id: Long): AttendanceVote?
+
+    /**
+     * 투표와 선수로 응답을 조회합니다.
+     */
+    fun findByPollAndPlayer(
+        poll: AttendancePoll,
+        player: Player,
+    ): AttendanceVote?
+
+    /**
+     * 투표 ID와 선수 ID로 응답을 조회합니다.
+     */
+    fun findByPollIdAndPlayerId(
+        pollId: Long,
+        playerId: Long,
+    ): AttendanceVote?
+
+    /**
+     * 투표의 모든 응답을 조회합니다.
+     */
+    fun findByPoll(poll: AttendancePoll): List<AttendanceVote>
+
+    /**
+     * 투표 ID로 모든 응답을 조회합니다.
+     */
+    fun findByPollId(pollId: Long): List<AttendanceVote>
+
+    /**
+     * 선수의 모든 투표 응답을 조회합니다.
+     */
+    fun findByPlayer(player: Player): List<AttendanceVote>
+
+    /**
+     * 출석 투표 응답을 삭제합니다.
+     */
+    fun delete(attendanceVote: AttendanceVote)
+
+    /**
+     * 투표와 선수 조합이 존재하는지 확인합니다.
+     */
+    fun existsByPollAndPlayer(
+        poll: AttendancePoll,
+        player: Player,
+    ): Boolean
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/AppealRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/AppealRepositoryPort.kt
@@ -1,0 +1,18 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.appeal.Appeal
+import com.nextup.core.domain.appeal.AppealStatus
+
+interface AppealRepositoryPort {
+    fun save(appeal: Appeal): Appeal
+
+    fun findByIdOrNull(id: Long): Appeal?
+
+    fun findByGameId(gameId: Long): List<Appeal>
+
+    fun findByAppealerId(appealerId: Long): List<Appeal>
+
+    fun findByStatus(status: AppealStatus): List<Appeal>
+
+    fun findAll(): List<Appeal>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BracketEntryRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BracketEntryRepositoryPort.kt
@@ -1,0 +1,18 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.competition.BracketEntry
+
+/**
+ * 대진표 엔트리 저장소 포트
+ */
+interface BracketEntryRepositoryPort {
+    fun save(bracketEntry: BracketEntry): BracketEntry
+
+    fun saveAll(entries: List<BracketEntry>): List<BracketEntry>
+
+    fun findByCompetitionId(competitionId: Long): List<BracketEntry>
+
+    fun findByIdOrNull(id: Long): BracketEntry?
+
+    fun deleteByCompetitionId(competitionId: Long)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CandidateRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CandidateRepositoryPort.kt
@@ -1,0 +1,36 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.election.Candidate
+
+/**
+ * Candidate Repository Port
+ */
+interface CandidateRepositoryPort {
+    /**
+     * Candidate를 저장합니다.
+     */
+    fun save(candidate: Candidate): Candidate
+
+    /**
+     * ID로 Candidate를 조회합니다.
+     */
+    fun findById(id: Long): Candidate?
+
+    /**
+     * 선거 ID로 모든 Candidate를 조회합니다.
+     */
+    fun findAllByElectionId(electionId: Long): List<Candidate>
+
+    /**
+     * 선거 ID와 회원 ID로 Candidate를 조회합니다.
+     */
+    fun findByElectionIdAndMemberId(
+        electionId: Long,
+        memberId: Long,
+    ): Candidate?
+
+    /**
+     * Candidate를 삭제합니다.
+     */
+    fun delete(candidate: Candidate)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CertificateRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CertificateRepositoryPort.kt
@@ -1,0 +1,43 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.certificate.Certificate
+import com.nextup.core.domain.certificate.CertificateStatus
+
+/**
+ * Certificate Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface CertificateRepositoryPort {
+    /**
+     * 증명서를 저장합니다.
+     */
+    fun save(certificate: Certificate): Certificate
+
+    /**
+     * ID로 증명서를 조회합니다.
+     */
+    fun findById(id: Long): Certificate?
+
+    /**
+     * 발급 번호로 증명서를 조회합니다.
+     */
+    fun findByIssueNumber(issueNumber: String): Certificate?
+
+    /**
+     * 선수 ID로 모든 증명서를 조회합니다.
+     */
+    fun findAllByPlayerId(playerId: Long): List<Certificate>
+
+    /**
+     * 선수 ID와 상태로 증명서를 조회합니다.
+     */
+    fun findAllByPlayerIdAndStatus(
+        playerId: Long,
+        status: CertificateStatus,
+    ): List<Certificate>
+
+    /**
+     * 증명서를 삭제합니다.
+     */
+    fun delete(certificate: Certificate)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/DeviceTokenRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/DeviceTokenRepositoryPort.kt
@@ -1,0 +1,15 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.notification.DeviceToken
+
+interface DeviceTokenRepositoryPort {
+    fun save(deviceToken: DeviceToken): DeviceToken
+
+    fun findByIdOrNull(id: Long): DeviceToken?
+
+    fun findByUserId(userId: Long): List<DeviceToken>
+
+    fun deleteByToken(token: String)
+
+    fun findByToken(token: String): DeviceToken?
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/DisciplineRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/DisciplineRepositoryPort.kt
@@ -1,0 +1,40 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.discipline.Discipline
+import com.nextup.core.domain.discipline.DisciplineStatus
+
+/**
+ * Discipline Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface DisciplineRepositoryPort {
+    fun save(discipline: Discipline): Discipline
+
+    fun findAll(): List<Discipline>
+
+    fun findByIdOrNull(id: Long): Discipline?
+
+    fun delete(discipline: Discipline)
+
+    fun deleteById(id: Long)
+
+    fun existsById(id: Long): Boolean
+
+    fun findByPlayerId(playerId: Long): List<Discipline>
+
+    fun findByPlayerIdAndCompetitionId(
+        playerId: Long,
+        competitionId: Long,
+    ): List<Discipline>
+
+    fun findByCompetitionId(competitionId: Long): List<Discipline>
+
+    fun findByStatus(status: DisciplineStatus): List<Discipline>
+
+    fun findActiveByPlayerId(playerId: Long): List<Discipline>
+
+    fun findActiveByPlayerIdAndCompetitionId(
+        playerId: Long,
+        competitionId: Long,
+    ): List<Discipline>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/ElectionRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/ElectionRepositoryPort.kt
@@ -1,0 +1,28 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.election.Election
+
+/**
+ * Election Repository Port
+ */
+interface ElectionRepositoryPort {
+    /**
+     * Election을 저장합니다.
+     */
+    fun save(election: Election): Election
+
+    /**
+     * ID로 Election을 조회합니다.
+     */
+    fun findById(id: Long): Election?
+
+    /**
+     * 팀 ID로 모든 Election을 조회합니다.
+     */
+    fun findAllByTeamId(teamId: Long): List<Election>
+
+    /**
+     * Election을 삭제합니다.
+     */
+    fun delete(election: Election)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/ElectionVoteRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/ElectionVoteRepositoryPort.kt
@@ -1,0 +1,31 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.election.ElectionVote
+
+/**
+ * ElectionVote Repository Port
+ */
+interface ElectionVoteRepositoryPort {
+    /**
+     * ElectionVote를 저장합니다.
+     */
+    fun save(electionVote: ElectionVote): ElectionVote
+
+    /**
+     * 선거 ID로 모든 ElectionVote를 조회합니다.
+     */
+    fun findAllByElectionId(electionId: Long): List<ElectionVote>
+
+    /**
+     * 선거 ID와 투표자 ID로 ElectionVote를 조회합니다.
+     */
+    fun findByElectionIdAndVoterId(
+        electionId: Long,
+        voterId: Long,
+    ): ElectionVote?
+
+    /**
+     * 선거 ID로 투표 수를 집계합니다 (후보자별).
+     */
+    fun countByElectionIdGroupByCandidateId(electionId: Long): Map<Long, Long>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
@@ -17,6 +17,11 @@ interface GameEventRepositoryPort {
     fun delete(gameEvent: GameEvent)
 
     /**
+     * 경기의 마지막 활성 이벤트를 조회합니다 (undone=false 중 가장 최근).
+     */
+    fun findLastActiveEvent(gameId: Long): GameEvent?
+
+    /**
      * 특정 투수-타자 매치업의 타석 결과를 조회합니다.
      */
     fun findPlateAppearancesByPitcherAndBatter(

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.game.Game
+import java.time.LocalDateTime
 
 /**
  * Game Repository Port
@@ -21,4 +22,22 @@ interface GameRepositoryPort {
      * 여러 ID로 Game을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
      */
     fun findAllByIds(ids: List<Long>): List<Game>
+
+    /**
+     * 대회 ID로 경기 목록을 조회합니다.
+     */
+    fun findByCompetitionId(competitionId: Long): List<Game>
+
+    /**
+     * 날짜 범위로 경기를 조회합니다.
+     */
+    fun findByScheduledAtBetween(
+        start: LocalDateTime,
+        end: LocalDateTime,
+    ): List<Game>
+
+    /**
+     * Game을 GameTeam과 함께 조회합니다. (N+1 방지)
+     */
+    fun findByIdWithTeams(id: Long): Game?
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameTeamRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameTeamRepositoryPort.kt
@@ -57,4 +57,18 @@ interface GameTeamRepositoryPort {
      * 대회 ID로 모든 GameTeam을 조회합니다. (전체 - 남은 경기 계산용)
      */
     fun findAllByCompetitionId(competitionId: Long): List<GameTeam>
+
+    /**
+     * 두 팀 간의 완료된 경기 목록을 조회합니다. (Game과 상대 GameTeam 포함)
+     *
+     * @param teamId 조회 대상 팀 ID
+     * @param opponentId 상대 팀 ID
+     * @param competitionId 대회 ID 필터 (선택사항)
+     * @return 완료된 경기의 GameTeam 목록 (teamId에 해당하는 GameTeam만 반환)
+     */
+    fun findCompletedGamesBetweenTeams(
+        teamId: Long,
+        opponentId: Long,
+        competitionId: Long? = null,
+    ): List<GameTeam>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/LeagueScheduleRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/LeagueScheduleRepositoryPort.kt
@@ -53,4 +53,12 @@ interface LeagueScheduleRepositoryPort {
         round: Int,
         matchNumber: Int,
     ): Boolean
+
+    /**
+     * 대회별 + 날짜별 대진표 조회 (충돌 감지용)
+     */
+    fun findByCompetitionIdAndScheduledDate(
+        competitionId: Long,
+        scheduledDate: java.time.LocalDate,
+    ): List<LeagueSchedule>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/LeagueScheduleRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/LeagueScheduleRepositoryPort.kt
@@ -1,0 +1,56 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.schedule.LeagueSchedule
+import com.nextup.core.domain.schedule.ScheduleStatus
+
+/**
+ * LeagueSchedule Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface LeagueScheduleRepositoryPort {
+    fun save(schedule: LeagueSchedule): LeagueSchedule
+
+    fun findByIdOrNull(id: Long): LeagueSchedule?
+
+    fun delete(schedule: LeagueSchedule)
+
+    fun deleteById(id: Long)
+
+    /**
+     * 대회별 대진표 전체 조회
+     */
+    fun findByCompetitionId(competitionId: Long): List<LeagueSchedule>
+
+    /**
+     * 대회별 + 라운드별 대진표 조회
+     */
+    fun findByCompetitionIdAndRound(
+        competitionId: Long,
+        round: Int
+    ): List<LeagueSchedule>
+
+    /**
+     * 대회별 + 상태별 대진표 조회
+     */
+    fun findByCompetitionIdAndStatus(
+        competitionId: Long,
+        status: ScheduleStatus
+    ): List<LeagueSchedule>
+
+    /**
+     * 날짜 범위로 대진표 조회
+     */
+    fun findByScheduledDateBetween(
+        startDate: java.time.LocalDate,
+        endDate: java.time.LocalDate,
+    ): List<LeagueSchedule>
+
+    /**
+     * 중복 대진표 확인
+     */
+    fun existsByCompetitionIdAndRoundAndMatchNumber(
+        competitionId: Long,
+        round: Int,
+        matchNumber: Int,
+    ): Boolean
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MatchRequestRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MatchRequestRepositoryPort.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.match.MatchRequest
+import com.nextup.core.domain.match.MatchRequestStatus
+
+interface MatchRequestRepositoryPort {
+    fun save(matchRequest: MatchRequest): MatchRequest
+
+    fun findByIdOrNull(id: Long): MatchRequest?
+
+    fun findByTeamId(teamId: Long): List<MatchRequest>
+
+    fun findAllOpen(): List<MatchRequest>
+
+    fun findByStatus(status: MatchRequestStatus): List<MatchRequest>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MatchResponseRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MatchResponseRepositoryPort.kt
@@ -1,0 +1,13 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.match.MatchResponse
+
+interface MatchResponseRepositoryPort {
+    fun save(matchResponse: MatchResponse): MatchResponse
+
+    fun findByIdOrNull(id: Long): MatchResponse?
+
+    fun findByMatchRequestId(matchRequestId: Long): List<MatchResponse>
+
+    fun findByRespondTeamId(respondTeamId: Long): List<MatchResponse>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/NotificationPreferenceRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/NotificationPreferenceRepositoryPort.kt
@@ -1,0 +1,15 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.notification.NotificationPreference
+import com.nextup.core.domain.notification.NotificationType
+
+interface NotificationPreferenceRepositoryPort {
+    fun save(preference: NotificationPreference): NotificationPreference
+
+    fun findByUserId(userId: Long): List<NotificationPreference>
+
+    fun findByUserIdAndType(
+        userId: Long,
+        type: NotificationType,
+    ): NotificationPreference?
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/NotificationRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/NotificationRepositoryPort.kt
@@ -1,0 +1,18 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.notification.Notification
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface NotificationRepositoryPort {
+    fun save(notification: Notification): Notification
+
+    fun findByIdOrNull(id: Long): Notification?
+
+    fun findByUserId(
+        userId: Long,
+        pageable: Pageable,
+    ): Page<Notification>
+
+    fun findByUserId(userId: Long): List<Notification>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchEventRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchEventRepositoryPort.kt
@@ -1,0 +1,49 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.game.PitchEvent
+
+/**
+ * 투구 이벤트 Repository Port
+ *
+ * 투구 이벤트 데이터 접근을 위한 인터페이스입니다.
+ */
+interface PitchEventRepositoryPort {
+    /**
+     * 투구 이벤트를 저장합니다.
+     */
+    fun save(pitchEvent: PitchEvent): PitchEvent
+
+    /**
+     * ID로 투구 이벤트를 조회합니다.
+     */
+    fun findByIdOrNull(id: Long): PitchEvent?
+
+    /**
+     * 경기 ID로 투구 이벤트 목록을 조회합니다.
+     */
+    fun findByGameId(gameId: Long): List<PitchEvent>
+
+    /**
+     * 경기 ID와 이닝으로 투구 이벤트 목록을 조회합니다.
+     */
+    fun findByGameIdAndInning(
+        gameId: Long,
+        inning: Int,
+        isTopInning: Boolean,
+    ): List<PitchEvent>
+
+    /**
+     * 투수 ID로 투구 이벤트 목록을 조회합니다.
+     */
+    fun findByPitcherId(pitcherId: Long): List<PitchEvent>
+
+    /**
+     * 타자 ID로 투구 이벤트 목록을 조회합니다.
+     */
+    fun findByBatterId(batterId: Long): List<PitchEvent>
+
+    /**
+     * 경기의 다음 투구 번호를 조회합니다.
+     */
+    fun getNextPitchNumber(gameId: Long): Int
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonBattingStatsRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonBattingStatsRepositoryPort.kt
@@ -66,4 +66,26 @@ interface SeasonBattingStatsRepositoryPort {
         minPlateAppearances: Int,
         limit: Int,
     ): List<SeasonBattingStats>
+
+    fun findTopByHits(
+        year: Int,
+        limit: Int,
+    ): List<SeasonBattingStats>
+
+    fun findTopByStolenBases(
+        year: Int,
+        limit: Int,
+    ): List<SeasonBattingStats>
+
+    fun findTopByOnBasePercentage(
+        year: Int,
+        minPlateAppearances: Int,
+        limit: Int,
+    ): List<SeasonBattingStats>
+
+    fun findTopBySlugging(
+        year: Int,
+        minPlateAppearances: Int,
+        limit: Int,
+    ): List<SeasonBattingStats>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumBookingRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumBookingRepositoryPort.kt
@@ -1,0 +1,27 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.domain.stadium.StadiumBooking
+
+/**
+ * 구장 예약 리포지토리 포트 인터페이스
+ */
+interface StadiumBookingRepositoryPort {
+    fun save(booking: StadiumBooking): StadiumBooking
+
+    fun findByIdOrNull(id: Long): StadiumBooking?
+
+    fun findBySlotId(slotId: Long): List<StadiumBooking>
+
+    fun findByTeamId(teamId: Long): List<StadiumBooking>
+
+    fun findByTeamIdAndStatus(
+        teamId: Long,
+        status: BookingStatus,
+    ): List<StadiumBooking>
+
+    fun existsBySlotIdAndStatus(
+        slotId: Long,
+        status: BookingStatus,
+    ): Boolean
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumRepositoryPort.kt
@@ -1,0 +1,30 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.stadium.Stadium
+
+/**
+ * 구장 리포지토리 포트 인터페이스
+ */
+interface StadiumRepositoryPort {
+    fun save(stadium: Stadium): Stadium
+
+    fun findByIdOrNull(id: Long): Stadium?
+
+    fun findAll(): List<Stadium>
+
+    fun findAllActive(): List<Stadium>
+
+    /**
+     * 특정 위치 근처의 구장을 검색합니다 (PostGIS 활용).
+     *
+     * @param latitude 위도
+     * @param longitude 경도
+     * @param radiusKm 검색 반경 (킬로미터)
+     * @return 검색 반경 내의 구장 목록
+     */
+    fun findNearby(
+        latitude: Double,
+        longitude: Double,
+        radiusKm: Double,
+    ): List<Stadium>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumSlotRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumSlotRepositoryPort.kt
@@ -1,0 +1,30 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.stadium.SlotStatus
+import com.nextup.core.domain.stadium.StadiumSlot
+import java.time.LocalDate
+
+/**
+ * 구장 슬롯 리포지토리 포트 인터페이스
+ */
+interface StadiumSlotRepositoryPort {
+    fun save(slot: StadiumSlot): StadiumSlot
+
+    fun findByIdOrNull(id: Long): StadiumSlot?
+
+    fun findByStadiumIdAndDate(
+        stadiumId: Long,
+        date: LocalDate,
+    ): List<StadiumSlot>
+
+    fun findByStadiumIdAndDateBetween(
+        stadiumId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<StadiumSlot>
+
+    fun findByStadiumIdAndStatus(
+        stadiumId: Long,
+        status: SlotStatus,
+    ): List<StadiumSlot>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamMemberRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamMemberRepositoryPort.kt
@@ -56,4 +56,11 @@ interface TeamMemberRepositoryPort {
     fun delete(teamMember: TeamMember)
 
     fun deleteById(id: Long)
+
+    fun findByPlayerIdActive(playerId: Long): List<TeamMember>
+
+    fun countByTeamIdAndStatus(
+        teamId: Long,
+        status: TeamMemberStatus,
+    ): Long
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamRecruitmentRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamRecruitmentRepositoryPort.kt
@@ -1,0 +1,18 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.recruitment.RecruitmentStatus
+import com.nextup.core.domain.recruitment.TeamRecruitment
+
+interface TeamRecruitmentRepositoryPort {
+    fun save(recruitment: TeamRecruitment): TeamRecruitment
+
+    fun findByIdOrNull(id: Long): TeamRecruitment?
+
+    fun findByTeamId(teamId: Long): List<TeamRecruitment>
+
+    fun findAllOpen(): List<TeamRecruitment>
+
+    fun findByStatus(status: RecruitmentStatus): List<TeamRecruitment>
+
+    fun delete(recruitment: TeamRecruitment)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/service/QrCodeGeneratorPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/service/QrCodeGeneratorPort.kt
@@ -1,0 +1,19 @@
+package com.nextup.core.port.service
+
+/**
+ * QR 코드 생성 Port
+ * Core 모듈의 서비스 인터페이스 - Infrastructure에서 구현
+ */
+interface QrCodeGeneratorPort {
+    /**
+     * QR 코드를 생성합니다.
+     *
+     * @param content QR 코드에 인코딩할 내용
+     * @param size QR 코드 크기 (픽셀)
+     * @return Base64 인코딩된 PNG 이미지
+     */
+    fun generate(
+        content: String,
+        size: Int = 300,
+    ): String
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/PitchEventService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/PitchEventService.kt
@@ -1,0 +1,81 @@
+package com.nextup.core.service
+
+import com.nextup.core.domain.game.PitchEvent
+import com.nextup.core.domain.game.PitchResult
+
+/**
+ * 투구 이벤트 Service Interface
+ *
+ * 투구 이벤트 관련 비즈니스 로직을 정의합니다.
+ */
+interface PitchEventService {
+    /**
+     * 투구 이벤트를 기록합니다.
+     */
+    fun recordPitch(
+        gameId: Long,
+        pitcherId: Long,
+        batterId: Long,
+        result: PitchResult,
+        description: String? = null,
+    ): PitchEvent
+
+    /**
+     * 투구 이벤트를 조회합니다.
+     */
+    fun getPitchEvent(pitchEventId: Long): PitchEvent
+
+    /**
+     * 경기의 투구 이벤트 목록을 조회합니다.
+     */
+    fun getGamePitchEvents(gameId: Long): List<PitchEvent>
+
+    /**
+     * 경기의 특정 이닝 투구 이벤트 목록을 조회합니다.
+     */
+    fun getInningPitchEvents(
+        gameId: Long,
+        inning: Int,
+        isTopInning: Boolean,
+    ): List<PitchEvent>
+
+    /**
+     * 경기의 현재 볼카운트를 조회합니다.
+     */
+    fun getCurrentBallCount(gameId: Long): Pair<Int, Int>
+
+    /**
+     * 투수의 투구 통계를 계산합니다.
+     */
+    fun calculatePitcherStats(pitcherId: Long): PitcherPitchStats
+
+    /**
+     * 타자별 투구 통계를 계산합니다.
+     */
+    fun calculateBatterPitchStats(batterId: Long): BatterPitchStats
+}
+
+/**
+ * 투수 투구 통계
+ */
+data class PitcherPitchStats(
+    val totalPitches: Int,
+    val strikes: Int,
+    val balls: Int,
+    val fouls: Int,
+    val inPlayPitches: Int,
+    val strikePercentage: Double,
+    val avgPitchesPerAtBat: Double,
+)
+
+/**
+ * 타자 투구 통계
+ */
+data class BatterPitchStats(
+    val totalPitches: Int,
+    val strikes: Int,
+    val balls: Int,
+    val fouls: Int,
+    val swingAndMiss: Int,
+    val avgPitchesPerAtBat: Double,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/appeal/AppealService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/appeal/AppealService.kt
@@ -1,0 +1,124 @@
+package com.nextup.core.service.appeal
+
+import com.nextup.common.exception.AppealNotFoundException
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.core.domain.appeal.Appeal
+import com.nextup.core.domain.appeal.AppealStatus
+import com.nextup.core.port.repository.AppealRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.service.appeal.dto.CreateAppealRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 이의 제기 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class AppealService(
+    private val appealRepository: AppealRepositoryPort,
+    private val gameRepository: GameRepositoryPort,
+) {
+    /**
+     * 이의 제기를 생성합니다.
+     */
+    @Transactional
+    fun createAppeal(request: CreateAppealRequest): Appeal {
+        val game =
+            gameRepository.findByIdOrNull(request.gameId)
+                ?: throw GameNotFoundException(request.gameId)
+
+        val appeal =
+            Appeal.create(
+                game = game,
+                appealerId = request.appealerId,
+                appealerName = request.appealerName,
+                type = request.type,
+                title = request.title,
+                description = request.description,
+            )
+
+        return appealRepository.save(appeal)
+    }
+
+    /**
+     * 경기별 이의 제기 목록을 조회합니다.
+     */
+    fun getAppealsByGame(gameId: Long): List<Appeal> = appealRepository.findByGameId(gameId)
+
+    /**
+     * 신청자별 이의 제기 목록을 조회합니다.
+     */
+    fun getAppealsByAppealer(appealerId: Long): List<Appeal> = appealRepository.findByAppealerId(appealerId)
+
+    /**
+     * 대기 중인 모든 이의 제기를 조회합니다.
+     */
+    fun getAllPendingAppeals(): List<Appeal> = appealRepository.findByStatus(AppealStatus.PENDING)
+
+    /**
+     * 모든 이의 제기를 조회합니다.
+     */
+    fun getAllAppeals(): List<Appeal> = appealRepository.findAll()
+
+    /**
+     * 특정 상태의 이의 제기를 조회합니다.
+     */
+    fun getAppealsByStatus(status: AppealStatus): List<Appeal> = appealRepository.findByStatus(status)
+
+    /**
+     * ID로 이의 제기를 조회합니다.
+     */
+    fun getById(id: Long): Appeal =
+        appealRepository.findByIdOrNull(id)
+            ?: throw AppealNotFoundException(id)
+
+    /**
+     * 이의 제기를 승인합니다.
+     */
+    @Transactional
+    fun approveAppeal(
+        appealId: Long,
+        reviewerId: Long,
+        comment: String?,
+    ): Appeal {
+        val appeal = getById(appealId)
+
+        try {
+            appeal.approve(reviewerId, comment)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidStateException(
+                "INVALID_APPEAL_STATE",
+                e.message ?: "Cannot approve appeal",
+            )
+        }
+
+        return appeal
+    }
+
+    /**
+     * 이의 제기를 반려합니다.
+     */
+    @Transactional
+    fun rejectAppeal(
+        appealId: Long,
+        reviewerId: Long,
+        comment: String,
+    ): Appeal {
+        val appeal = getById(appealId)
+
+        try {
+            appeal.reject(reviewerId, comment)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidStateException(
+                "INVALID_APPEAL_STATE",
+                e.message ?: "Cannot reject appeal",
+            )
+        }
+
+        return appeal
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/appeal/dto/AppealDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/appeal/dto/AppealDto.kt
@@ -1,0 +1,31 @@
+package com.nextup.core.service.appeal.dto
+
+import com.nextup.core.domain.appeal.AppealType
+
+/**
+ * 이의 제기 생성 요청 DTO
+ */
+data class CreateAppealRequest(
+    val gameId: Long,
+    val appealerId: Long,
+    val appealerName: String,
+    val type: AppealType,
+    val title: String,
+    val description: String,
+)
+
+/**
+ * 이의 제기 승인 요청 DTO
+ */
+data class ApproveAppealRequest(
+    val reviewerId: Long,
+    val comment: String? = null,
+)
+
+/**
+ * 이의 제기 반려 요청 DTO
+ */
+data class RejectAppealRequest(
+    val reviewerId: Long,
+    val comment: String,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/attendance/ActivityService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/attendance/ActivityService.kt
@@ -1,0 +1,74 @@
+package com.nextup.core.service.attendance
+
+import com.nextup.core.domain.attendance.ActivityScore
+import java.math.BigDecimal
+
+/**
+ * 활동 점수 관리 서비스 인터페이스
+ *
+ * 팀원의 활동 점수를 관리하는 비즈니스 로직을 정의합니다.
+ */
+interface ActivityService {
+    /**
+     * 팀원의 활동 점수를 조회합니다.
+     * 존재하지 않으면 새로 생성합니다.
+     *
+     * @param teamId 팀 ID
+     * @param memberId 팀원 ID
+     * @return ActivityScore
+     */
+    fun getActivityScore(
+        teamId: Long,
+        memberId: Long,
+    ): ActivityScore
+
+    /**
+     * 팀의 모든 활동 점수를 조회합니다.
+     *
+     * @param teamId 팀 ID
+     * @return 활동 점수 목록
+     */
+    fun listActivityScores(teamId: Long): List<ActivityScore>
+
+    /**
+     * 경기 참여율을 업데이트합니다.
+     *
+     * @param teamId 팀 ID
+     * @param memberId 팀원 ID
+     * @param rate 참여율 (0~100)
+     * @return 업데이트된 ActivityScore
+     */
+    fun updateGameParticipationRate(
+        teamId: Long,
+        memberId: Long,
+        rate: BigDecimal,
+    ): ActivityScore
+
+    /**
+     * 연습 참석률을 업데이트합니다.
+     *
+     * @param teamId 팀 ID
+     * @param memberId 팀원 ID
+     * @param rate 참석률 (0~100)
+     * @return 업데이트된 ActivityScore
+     */
+    fun updatePracticeAttendanceRate(
+        teamId: Long,
+        memberId: Long,
+        rate: BigDecimal,
+    ): ActivityScore
+
+    /**
+     * 기여도 점수를 업데이트합니다.
+     *
+     * @param teamId 팀 ID
+     * @param memberId 팀원 ID
+     * @param score 기여도 점수 (0~100)
+     * @return 업데이트된 ActivityScore
+     */
+    fun updateContributionScore(
+        teamId: Long,
+        memberId: Long,
+        score: BigDecimal,
+    ): ActivityScore
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/attendance/AttendanceService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/attendance/AttendanceService.kt
@@ -1,0 +1,79 @@
+package com.nextup.core.service.attendance
+
+import com.nextup.core.domain.attendance.AttendancePoll
+import com.nextup.core.domain.attendance.AttendanceVote
+import com.nextup.core.domain.attendance.PollStatus
+import com.nextup.core.domain.attendance.VoteType
+
+/**
+ * 출석 관리 서비스 인터페이스
+ *
+ * 출석 투표와 투표 응답을 관리하는 비즈니스 로직을 정의합니다.
+ */
+interface AttendanceService {
+    /**
+     * 출석 투표를 생성합니다.
+     *
+     * @param teamId 팀 ID
+     * @param title 투표 제목
+     * @param eventDate 이벤트 날짜 (ISO-8601)
+     * @param deadline 투표 마감 시간 (ISO-8601)
+     * @return 생성된 AttendancePoll
+     */
+    fun createPoll(
+        teamId: Long,
+        title: String,
+        eventDate: String,
+        deadline: String,
+    ): AttendancePoll
+
+    /**
+     * 출석 투표에 응답합니다.
+     *
+     * @param pollId 투표 ID
+     * @param playerId 선수 ID
+     * @param voteType 투표 유형
+     * @return 생성된 AttendanceVote
+     */
+    fun submitVote(
+        pollId: Long,
+        playerId: Long,
+        voteType: VoteType,
+    ): AttendanceVote
+
+    /**
+     * 출석 투표를 조회합니다.
+     *
+     * @param pollId 투표 ID
+     * @return AttendancePoll
+     */
+    fun getPoll(pollId: Long): AttendancePoll
+
+    /**
+     * 팀의 출석 투표 목록을 조회합니다.
+     *
+     * @param teamId 팀 ID
+     * @param status 투표 상태 (선택)
+     * @return 출석 투표 목록
+     */
+    fun listPolls(
+        teamId: Long,
+        status: PollStatus? = null,
+    ): List<AttendancePoll>
+
+    /**
+     * 출석 투표를 마감합니다.
+     *
+     * @param pollId 투표 ID
+     * @return 마감된 AttendancePoll
+     */
+    fun closePoll(pollId: Long): AttendancePoll
+
+    /**
+     * 출석 투표의 응답 목록을 조회합니다.
+     *
+     * @param pollId 투표 ID
+     * @return 투표 응답 목록
+     */
+    fun listVotes(pollId: Long): List<AttendanceVote>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/attendance/NudgeService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/attendance/NudgeService.kt
@@ -1,0 +1,87 @@
+package com.nextup.core.service.attendance
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.notification.NotificationType
+import com.nextup.core.port.repository.AttendanceVoteRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.service.notification.NotificationService
+import com.nextup.core.service.notification.dto.SendNotificationRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 출석 재촉 서비스
+ *
+ * 미투표자에게 출석 투표를 독려하는 알림을 전송합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class NudgeService(
+    private val gameRepository: GameRepositoryPort,
+    private val attendanceVoteRepository: AttendanceVoteRepositoryPort,
+    private val notificationService: NotificationService,
+) {
+    /**
+     * 미투표자에게 출석 투표 독려 알림을 전송합니다.
+     *
+     * @param gameId 경기 ID
+     * @param customMessage 사용자 정의 메시지 (선택)
+     * @return 알림 전송 결과 (전송 수, 미투표자 이름 목록)
+     */
+    @Transactional
+    fun nudgeNonVoters(
+        gameId: Long,
+        customMessage: String? = null,
+    ): NudgeResult {
+        // 1. 경기 조회
+        val game =
+            gameRepository.findByIdOrNull(gameId)
+                ?: throw GameNotFoundException(gameId)
+
+        // 2. 미투표자 조회 (hasResponded == false)
+        val nonVoters = attendanceVoteRepository.findNonVotersByGameId(gameId)
+
+        if (nonVoters.isEmpty()) {
+            return NudgeResult(notifiedCount = 0, nonVoterNames = emptyList())
+        }
+
+        // 3. 각 미투표자에게 알림 전송
+        val nonVoterNames = mutableListOf<String>()
+        var notifiedCount = 0
+
+        nonVoters.forEach { vote ->
+            val userName = vote.member.user.nickname
+            nonVoterNames.add(userName)
+
+            val title = "출석 투표 요청"
+            val body =
+                customMessage
+                    ?: "경기(${game.scheduledAt})에 대한 출석 투표를 진행해주세요."
+
+            val request =
+                SendNotificationRequest(
+                    userId = vote.member.user.id,
+                    type = NotificationType.ATTENDANCE_NUDGE,
+                    title = title,
+                    body = body,
+                    data = "gameId=$gameId",
+                )
+
+            notificationService.sendNotification(request)
+            notifiedCount++
+        }
+
+        return NudgeResult(
+            notifiedCount = notifiedCount,
+            nonVoterNames = nonVoterNames,
+        )
+    }
+}
+
+/**
+ * 출석 재촉 결과
+ */
+data class NudgeResult(
+    val notifiedCount: Int,
+    val nonVoterNames: List<String>,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/bracket/BracketGeneratorService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/bracket/BracketGeneratorService.kt
@@ -1,0 +1,37 @@
+package com.nextup.core.service.bracket
+
+import com.nextup.core.domain.competition.BracketEntry
+
+/**
+ * 대진표 생성 서비스 인터페이스
+ */
+interface BracketGeneratorService {
+    /**
+     * 단일 토너먼트 대진표를 생성합니다.
+     */
+    fun generateSingleElimination(
+        competitionId: Long,
+        seededTeamIds: List<Long>,
+    ): List<BracketEntry>
+
+    /**
+     * 더블 토너먼트 대진표를 생성합니다.
+     */
+    fun generateDoubleElimination(
+        competitionId: Long,
+        seededTeamIds: List<Long>,
+    ): List<BracketEntry>
+
+    /**
+     * 대진표를 조회합니다.
+     */
+    fun getBracket(competitionId: Long): List<BracketEntry>
+
+    /**
+     * 승자를 진행시킵니다.
+     */
+    fun advanceWinner(
+        bracketEntryId: Long,
+        winnerTeamId: Long,
+    ): BracketEntry
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/certificate/CertificateService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/certificate/CertificateService.kt
@@ -1,0 +1,63 @@
+package com.nextup.core.service.certificate
+
+import com.nextup.core.dto.certificate.CertificateDto
+import com.nextup.core.dto.certificate.CertificateVerificationDto
+
+/**
+ * 증명서 서비스 인터페이스
+ *
+ * 증명서 발급, 조회, 검증 기능을 제공합니다.
+ * Infrastructure 계층에서 구현됩니다.
+ */
+interface CertificateService {
+    /**
+     * 선수의 기록 증명서를 발급합니다.
+     *
+     * @param playerId 선수 ID
+     * @param validityDays 유효 기간 (일)
+     * @return 발급된 증명서 DTO
+     */
+    fun issueCertificate(
+        playerId: Long,
+        validityDays: Long = 365,
+    ): CertificateDto
+
+    /**
+     * 증명서를 조회합니다.
+     *
+     * @param certificateId 증명서 ID
+     * @return 증명서 DTO
+     */
+    fun getCertificate(certificateId: Long): CertificateDto
+
+    /**
+     * 발급 번호로 증명서를 조회합니다.
+     *
+     * @param issueNumber 발급 번호
+     * @return 증명서 DTO
+     */
+    fun getCertificateByIssueNumber(issueNumber: String): CertificateDto
+
+    /**
+     * 증명서의 유효성을 검증합니다.
+     *
+     * @param issueNumber 발급 번호
+     * @return 검증 결과 DTO
+     */
+    fun verifyCertificate(issueNumber: String): CertificateVerificationDto
+
+    /**
+     * 선수의 모든 증명서를 조회합니다.
+     *
+     * @param playerId 선수 ID
+     * @return 증명서 DTO 리스트
+     */
+    fun getPlayerCertificates(playerId: Long): List<CertificateDto>
+
+    /**
+     * 증명서를 취소합니다.
+     *
+     * @param certificateId 증명서 ID
+     */
+    fun revokeCertificate(certificateId: Long)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/discipline/DisciplineService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/discipline/DisciplineService.kt
@@ -1,0 +1,227 @@
+package com.nextup.core.service.discipline
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.DisciplineNotFoundException
+import com.nextup.common.exception.InvalidDisciplineStateException
+import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.core.domain.discipline.Discipline
+import com.nextup.core.domain.discipline.DisciplineStatus
+import com.nextup.core.domain.discipline.DisciplineType
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.DisciplineRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * 징계 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class DisciplineService(
+    private val disciplineRepository: DisciplineRepositoryPort,
+    private val playerRepository: PlayerRepositoryPort,
+    private val competitionRepository: CompetitionRepositoryPort,
+) {
+    /**
+     * 경고 징계를 발급합니다.
+     */
+    @Transactional
+    fun issueWarning(
+        playerId: Long,
+        competitionId: Long,
+        reason: String,
+        issuedBy: String,
+        expiresAt: LocalDateTime? = null,
+    ): Discipline {
+        val player =
+            playerRepository.findByIdOrNull(playerId)
+                ?: throw PlayerNotFoundException(playerId)
+
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        val discipline =
+            Discipline.createWarning(
+                player = player,
+                competition = competition,
+                reason = reason,
+                issuedBy = issuedBy,
+                expiresAt = expiresAt,
+            )
+
+        return disciplineRepository.save(discipline)
+    }
+
+    /**
+     * 출장 정지 징계를 발급합니다.
+     */
+    @Transactional
+    fun issueSuspension(
+        playerId: Long,
+        competitionId: Long,
+        reason: String,
+        suspensionGames: Int,
+        issuedBy: String,
+    ): Discipline {
+        val player =
+            playerRepository.findByIdOrNull(playerId)
+                ?: throw PlayerNotFoundException(playerId)
+
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        val discipline =
+            Discipline.createSuspension(
+                player = player,
+                competition = competition,
+                reason = reason,
+                suspensionGames = suspensionGames,
+                issuedBy = issuedBy,
+            )
+
+        return disciplineRepository.save(discipline)
+    }
+
+    /**
+     * 영구 제재 징계를 발급합니다.
+     */
+    @Transactional
+    fun issueBan(
+        playerId: Long,
+        competitionId: Long,
+        reason: String,
+        issuedBy: String,
+    ): Discipline {
+        val player =
+            playerRepository.findByIdOrNull(playerId)
+                ?: throw PlayerNotFoundException(playerId)
+
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        val discipline =
+            Discipline.createBan(
+                player = player,
+                competition = competition,
+                reason = reason,
+                issuedBy = issuedBy,
+            )
+
+        return disciplineRepository.save(discipline)
+    }
+
+    /**
+     * 징계를 취소합니다.
+     */
+    @Transactional
+    fun cancelDiscipline(disciplineId: Long): Discipline {
+        val discipline = getById(disciplineId)
+
+        try {
+            discipline.cancel()
+        } catch (e: IllegalArgumentException) {
+            throw InvalidDisciplineStateException(
+                e.message ?: "Cannot cancel discipline"
+            )
+        }
+
+        return discipline
+    }
+
+    /**
+     * ID로 징계를 조회합니다.
+     */
+    fun getById(id: Long): Discipline =
+        disciplineRepository.findByIdOrNull(id)
+            ?: throw DisciplineNotFoundException(id)
+
+    /**
+     * 모든 징계를 조회합니다.
+     */
+    fun getAll(): List<Discipline> = disciplineRepository.findAll()
+
+    /**
+     * 선수의 모든 징계를 조회합니다.
+     */
+    fun getDisciplinesByPlayer(playerId: Long): List<Discipline> = disciplineRepository.findByPlayerId(playerId)
+
+    /**
+     * 선수의 대회별 징계를 조회합니다.
+     */
+    fun getDisciplinesByPlayerAndCompetition(
+        playerId: Long,
+        competitionId: Long,
+    ): List<Discipline> = disciplineRepository.findByPlayerIdAndCompetitionId(playerId, competitionId)
+
+    /**
+     * 대회의 모든 징계를 조회합니다.
+     */
+    fun getDisciplinesByCompetition(competitionId: Long): List<Discipline> =
+        disciplineRepository.findByCompetitionId(competitionId)
+
+    /**
+     * 특정 상태의 징계를 조회합니다.
+     */
+    fun getDisciplinesByStatus(status: DisciplineStatus): List<Discipline> = disciplineRepository.findByStatus(status)
+
+    /**
+     * 선수의 활성 징계를 조회합니다.
+     */
+    fun getActiveDisciplines(
+        playerId: Long,
+        competitionId: Long,
+    ): List<Discipline> =
+        disciplineRepository.findActiveByPlayerIdAndCompetitionId(playerId, competitionId)
+            .filter { it.isEffective() }
+
+    /**
+     * 선수가 출장 가능한지 확인합니다.
+     */
+    fun canPlayerPlay(
+        playerId: Long,
+        competitionId: Long,
+    ): Boolean {
+        val activeDisciplines = getActiveDisciplines(playerId, competitionId)
+
+        // BAN이 있으면 출장 불가
+        if (activeDisciplines.any { it.type == DisciplineType.BAN }) {
+            return false
+        }
+
+        // 유효한 SUSPENSION이 있으면 출장 불가
+        if (
+            activeDisciplines.any {
+                it.type == DisciplineType.SUSPENSION && it.isEffective()
+            }
+        ) {
+            return false
+        }
+
+        return true
+    }
+
+    /**
+     * 출장 정지 징계의 경기를 소화합니다.
+     */
+    @Transactional
+    fun incrementServedGames(disciplineId: Long): Discipline {
+        val discipline = getById(disciplineId)
+
+        try {
+            discipline.incrementServedGames()
+        } catch (e: IllegalArgumentException) {
+            throw InvalidDisciplineStateException(
+                e.message ?: "Cannot increment served games"
+            )
+        }
+
+        return discipline
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/ElectionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/ElectionService.kt
@@ -1,0 +1,208 @@
+package com.nextup.core.service.election
+
+import com.nextup.common.exception.CandidateNotFoundException
+import com.nextup.common.exception.DuplicateVoteException
+import com.nextup.common.exception.ElectionNotFoundException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.core.domain.election.Candidate
+import com.nextup.core.domain.election.Election
+import com.nextup.core.domain.election.ElectionVote
+import com.nextup.core.port.repository.CandidateRepositoryPort
+import com.nextup.core.port.repository.ElectionRepositoryPort
+import com.nextup.core.port.repository.ElectionVoteRepositoryPort
+import com.nextup.core.service.election.dto.*
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Election Service
+ *
+ * 팀 내 선거/투표 비즈니스 로직을 처리합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class ElectionService(
+    private val electionRepository: ElectionRepositoryPort,
+    private val candidateRepository: CandidateRepositoryPort,
+    private val electionVoteRepository: ElectionVoteRepositoryPort,
+) {
+    /**
+     * 선거를 생성합니다.
+     */
+    @Transactional
+    fun createElection(request: CreateElectionRequest): ElectionResponse {
+        val election =
+            Election.create(
+                teamId = request.teamId,
+                title = request.title,
+                description = request.description,
+                electionType = request.electionType,
+                startAt = request.startAt,
+                endAt = request.endAt,
+            )
+        return electionRepository.save(election).toResponse()
+    }
+
+    /**
+     * 선거를 시작합니다.
+     */
+    @Transactional
+    fun startElection(electionId: Long): ElectionResponse {
+        val election = findElection(electionId)
+        election.start()
+        return election.toResponse()
+    }
+
+    /**
+     * 선거를 완료합니다.
+     */
+    @Transactional
+    fun completeElection(electionId: Long): ElectionResponse {
+        val election = findElection(electionId)
+        election.complete()
+        return election.toResponse()
+    }
+
+    /**
+     * 선거를 취소합니다.
+     */
+    @Transactional
+    fun cancelElection(electionId: Long): ElectionResponse {
+        val election = findElection(electionId)
+        election.cancel()
+        return election.toResponse()
+    }
+
+    /**
+     * 후보자를 등록합니다.
+     */
+    @Transactional
+    fun registerCandidate(request: RegisterCandidateRequest): CandidateResponse {
+        val election = findElection(request.electionId)
+
+        // 선거가 진행 중이거나 완료된 경우 후보자 등록 불가
+        if (election.status != com.nextup.core.domain.election.ElectionStatus.SCHEDULED) {
+            throw InvalidStateException(
+                code = "CANNOT_REGISTER_CANDIDATE",
+                message = "Cannot register candidate: election status is ${election.status}",
+            )
+        }
+
+        // 이미 등록된 후보자인지 확인
+        val existingCandidate =
+            candidateRepository.findByElectionIdAndMemberId(
+                request.electionId,
+                request.memberId,
+            )
+        if (existingCandidate != null) {
+            throw InvalidStateException(
+                code = "CANDIDATE_ALREADY_REGISTERED",
+                message = "Member ${request.memberId} is already registered as a candidate",
+            )
+        }
+
+        val candidate =
+            Candidate.create(
+                electionId = request.electionId,
+                memberId = request.memberId,
+                memberName = request.memberName,
+                statement = request.statement,
+            )
+        return candidateRepository.save(candidate).toResponse()
+    }
+
+    /**
+     * 투표합니다.
+     */
+    @Transactional
+    fun vote(request: CastVoteRequest): CandidateResponse {
+        val election = findElection(request.electionId)
+
+        // 투표 가능 여부 확인
+        if (!election.isVotingOpen()) {
+            throw InvalidStateException(
+                code = "VOTING_NOT_OPEN",
+                message = "Voting is not open for this election",
+            )
+        }
+
+        // 이미 투표했는지 확인
+        val existingVote =
+            electionVoteRepository.findByElectionIdAndVoterId(
+                request.electionId,
+                request.voterId,
+            )
+        if (existingVote != null) {
+            throw DuplicateVoteException()
+        }
+
+        // 후보자 존재 여부 확인
+        val candidate = findCandidate(request.candidateId)
+        if (candidate.electionId != request.electionId) {
+            throw InvalidStateException(
+                code = "CANDIDATE_NOT_IN_ELECTION",
+                message = "Candidate ${request.candidateId} is not in election ${request.electionId}",
+            )
+        }
+
+        val vote =
+            ElectionVote.create(
+                electionId = request.electionId,
+                voterId = request.voterId,
+                candidateId = request.candidateId,
+            )
+        electionVoteRepository.save(vote)
+
+        return candidate.toResponse()
+    }
+
+    /**
+     * 선거 결과를 조회합니다.
+     */
+    fun getResults(electionId: Long): ElectionResultResponse {
+        val election = findElection(electionId)
+        val candidates = candidateRepository.findAllByElectionId(electionId)
+        val voteCounts = electionVoteRepository.countByElectionIdGroupByCandidateId(electionId)
+
+        val candidateResults =
+            candidates.map { candidate ->
+                CandidateResultResponse(
+                    candidate = candidate.toResponse(),
+                    voteCount = voteCounts[candidate.id] ?: 0,
+                )
+            }.sortedByDescending { it.voteCount }
+
+        val totalVotes = voteCounts.values.sum()
+
+        return ElectionResultResponse(
+            election = election.toResponse(),
+            candidates = candidateResults,
+            totalVotes = totalVotes,
+        )
+    }
+
+    /**
+     * 팀의 모든 선거를 조회합니다.
+     */
+    fun getElectionsByTeam(teamId: Long): List<ElectionResponse> =
+        electionRepository.findAllByTeamId(teamId).toResponse()
+
+    /**
+     * 선거를 ID로 조회합니다.
+     */
+    fun getElectionById(electionId: Long): ElectionResponse = findElection(electionId).toResponse()
+
+    /**
+     * Election을 조회하고 없으면 예외를 던집니다.
+     */
+    private fun findElection(electionId: Long): Election =
+        electionRepository.findById(electionId)
+            ?: throw ElectionNotFoundException(electionId)
+
+    /**
+     * Candidate를 조회하고 없으면 예외를 던집니다.
+     */
+    private fun findCandidate(candidateId: Long): Candidate =
+        candidateRepository.findById(candidateId)
+            ?: throw CandidateNotFoundException(candidateId)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/CandidateResponse.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/CandidateResponse.kt
@@ -1,0 +1,34 @@
+package com.nextup.core.service.election.dto
+
+import com.nextup.core.domain.election.Candidate
+import java.time.Instant
+
+/**
+ * 후보자 응답 DTO
+ */
+data class CandidateResponse(
+    val id: Long,
+    val electionId: Long,
+    val memberId: Long,
+    val memberName: String,
+    val statement: String?,
+    val createdAt: Instant,
+)
+
+/**
+ * Candidate를 CandidateResponse로 변환합니다.
+ */
+fun Candidate.toResponse(): CandidateResponse =
+    CandidateResponse(
+        id = this.id,
+        electionId = this.electionId,
+        memberId = this.memberId,
+        memberName = this.memberName,
+        statement = this.statement,
+        createdAt = this.createdAt,
+    )
+
+/**
+ * Candidate 리스트를 CandidateResponse 리스트로 변환합니다.
+ */
+fun List<Candidate>.toResponse(): List<CandidateResponse> = this.map { it.toResponse() }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/CastVoteRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/CastVoteRequest.kt
@@ -1,0 +1,10 @@
+package com.nextup.core.service.election.dto
+
+/**
+ * 투표 요청 DTO
+ */
+data class CastVoteRequest(
+    val electionId: Long,
+    val voterId: Long,
+    val candidateId: Long,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/CreateElectionRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/CreateElectionRequest.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.service.election.dto
+
+import com.nextup.core.domain.election.ElectionType
+import java.time.Instant
+
+/**
+ * 선거 생성 요청 DTO
+ */
+data class CreateElectionRequest(
+    val teamId: Long,
+    val title: String,
+    val description: String?,
+    val electionType: ElectionType,
+    val startAt: Instant,
+    val endAt: Instant,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/ElectionResponse.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/ElectionResponse.kt
@@ -1,0 +1,44 @@
+package com.nextup.core.service.election.dto
+
+import com.nextup.core.domain.election.Election
+import com.nextup.core.domain.election.ElectionStatus
+import com.nextup.core.domain.election.ElectionType
+import java.time.Instant
+
+/**
+ * 선거 응답 DTO
+ */
+data class ElectionResponse(
+    val id: Long,
+    val teamId: Long,
+    val title: String,
+    val description: String?,
+    val electionType: ElectionType,
+    val startAt: Instant,
+    val endAt: Instant,
+    val status: ElectionStatus,
+    val isVotingOpen: Boolean,
+    val createdAt: Instant,
+)
+
+/**
+ * Election을 ElectionResponse로 변환합니다.
+ */
+fun Election.toResponse(): ElectionResponse =
+    ElectionResponse(
+        id = this.id,
+        teamId = this.teamId,
+        title = this.title,
+        description = this.description,
+        electionType = this.electionType,
+        startAt = this.startAt,
+        endAt = this.endAt,
+        status = this.status,
+        isVotingOpen = this.isVotingOpen(),
+        createdAt = this.createdAt,
+    )
+
+/**
+ * Election 리스트를 ElectionResponse 리스트로 변환합니다.
+ */
+fun List<Election>.toResponse(): List<ElectionResponse> = this.map { it.toResponse() }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/ElectionResultResponse.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/ElectionResultResponse.kt
@@ -1,0 +1,18 @@
+package com.nextup.core.service.election.dto
+
+/**
+ * 선거 결과 응답 DTO
+ */
+data class ElectionResultResponse(
+    val election: ElectionResponse,
+    val candidates: List<CandidateResultResponse>,
+    val totalVotes: Long,
+)
+
+/**
+ * 후보자 결과 응답 DTO
+ */
+data class CandidateResultResponse(
+    val candidate: CandidateResponse,
+    val voteCount: Long,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/RegisterCandidateRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/RegisterCandidateRequest.kt
@@ -1,0 +1,11 @@
+package com.nextup.core.service.election.dto
+
+/**
+ * 후보자 등록 요청 DTO
+ */
+data class RegisterCandidateRequest(
+    val electionId: Long,
+    val memberId: Long,
+    val memberName: String,
+    val statement: String?,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScheduleService.kt
@@ -1,0 +1,39 @@
+package com.nextup.core.service.game
+
+import com.nextup.core.service.game.dto.GameDetailDto
+import com.nextup.core.service.game.dto.GameSummaryDto
+import java.time.LocalDate
+
+/**
+ * 경기 일정 조회 서비스 인터페이스
+ */
+interface GameScheduleService {
+    /**
+     * 경기 목록을 조회합니다. (날짜/팀 필터, 페이징)
+     */
+    fun getGames(
+        date: LocalDate? = null,
+        teamId: Long? = null,
+        competitionId: Long? = null,
+        page: Int = 0,
+        size: Int = 20,
+    ): List<GameSummaryDto>
+
+    /**
+     * 경기 상세 정보를 조회합니다.
+     */
+    fun getGameDetail(gameId: Long): GameDetailDto
+
+    /**
+     * 팀별 경기 일정을 조회합니다.
+     */
+    fun getGamesByTeam(teamId: Long): List<GameSummaryDto>
+
+    /**
+     * 팀의 다가오는 경기를 조회합니다.
+     */
+    fun getUpcomingGamesByTeam(
+        teamId: Long,
+        limit: Int = 5,
+    ): List<GameSummaryDto>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.service.game
 
 import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.service.game.dto.GameEndReason
 import com.nextup.core.service.game.dto.PlateAppearanceRequest
 
@@ -49,4 +50,12 @@ interface GameScorerService {
         gameId: Long,
         reason: GameEndReason,
     ): Game
+
+    /**
+     * 마지막 이벤트를 되돌립니다.
+     *
+     * @param gameId 경기 ID
+     * @return 되돌려진 이벤트
+     */
+    fun undoLastEvent(gameId: Long): GameEvent
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
@@ -58,4 +58,20 @@ interface GameScorerService {
      * @return 되돌려진 이벤트
      */
     fun undoLastEvent(gameId: Long): GameEvent
+
+    /**
+     * 경기를 몰수 처리합니다.
+     *
+     * 승리팀에 7점, 패배팀에 0점을 자동 반영하고 경기를 종료합니다.
+     *
+     * @param gameId 경기 ID
+     * @param winnerTeamId 몰수승 팀 ID
+     * @param reason 몰수 사유
+     * @return 몰수 처리된 경기
+     */
+    fun forfeitGame(
+        gameId: Long,
+        winnerTeamId: Long,
+        reason: String,
+    ): Game
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/ScoresheetService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/ScoresheetService.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.service.game
+
+import com.nextup.core.service.game.dto.ScoresheetDto
+
+/**
+ * 공식 기록지 서비스 인터페이스
+ */
+interface ScoresheetService {
+    /**
+     * 경기의 공식 기록지 데이터를 조회합니다.
+     *
+     * @param gameId 경기 ID
+     * @return 공식 기록지 데이터
+     */
+    fun getScoresheet(gameId: Long): ScoresheetDto
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/GameScheduleDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/GameScheduleDto.kt
@@ -1,0 +1,49 @@
+package com.nextup.core.service.game.dto
+
+import com.nextup.core.domain.game.GameStatus
+import java.time.LocalDateTime
+
+/**
+ * 경기 일정 요약 DTO
+ */
+data class GameSummaryDto(
+    val gameId: Long,
+    val competitionId: Long,
+    val competitionName: String,
+    val homeTeamId: Long,
+    val homeTeamName: String,
+    val awayTeamId: Long,
+    val awayTeamName: String,
+    val scheduledAt: LocalDateTime,
+    val status: GameStatus,
+    val homeScore: Int,
+    val awayScore: Int,
+    val location: String?,
+    val fieldName: String?,
+)
+
+/**
+ * 경기 상세 DTO
+ */
+data class GameDetailDto(
+    val gameId: Long,
+    val competitionId: Long,
+    val competitionName: String,
+    val homeTeamId: Long,
+    val homeTeamName: String,
+    val awayTeamId: Long,
+    val awayTeamName: String,
+    val scheduledAt: LocalDateTime,
+    val status: GameStatus,
+    val homeScore: Int,
+    val awayScore: Int,
+    val location: String?,
+    val fieldName: String?,
+    val gameNumber: Int?,
+    val currentInning: String,
+    val totalInnings: Int,
+    val startedAt: LocalDateTime?,
+    val endedAt: LocalDateTime?,
+    val note: String?,
+    val forfeitReason: String?,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/ScoresheetDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/ScoresheetDto.kt
@@ -1,0 +1,130 @@
+package com.nextup.core.service.game.dto
+
+import java.time.LocalDateTime
+
+/**
+ * 공식 기록지 데이터
+ *
+ * 경기의 모든 기록을 포함하는 완전한 데이터 구조
+ */
+data class ScoresheetDto(
+    val gameInfo: GameInfoDto,
+    val teams: TeamsScoresheetDto,
+    val inningScores: InningScoresDto,
+    val battingRecords: BattingRecordsDto,
+    val pitchingRecords: PitchingRecordsDto,
+    val keyEvents: List<KeyEventDto>,
+)
+
+/**
+ * 경기 기본 정보
+ */
+data class GameInfoDto(
+    val gameId: Long,
+    val competitionName: String,
+    val gameNumber: Int?,
+    val scheduledAt: LocalDateTime,
+    val startedAt: LocalDateTime?,
+    val endedAt: LocalDateTime?,
+    val location: String?,
+    val fieldName: String?,
+    val status: String,
+    val currentInning: String,
+    val totalInnings: Int,
+)
+
+/**
+ * 양 팀 정보
+ */
+data class TeamsScoresheetDto(
+    val home: TeamScoresheetInfoDto,
+    val away: TeamScoresheetInfoDto,
+)
+
+/**
+ * 팀 기록지 정보
+ */
+data class TeamScoresheetInfoDto(
+    val teamId: Long,
+    val teamName: String,
+    val totalScore: Int,
+    val totalHits: Int,
+    val totalErrors: Int,
+    val result: String,
+)
+
+/**
+ * 이닝별 점수
+ */
+data class InningScoresDto(
+    val innings: Int,
+    val homeScores: List<Int>,
+    val awayScores: List<Int>,
+)
+
+/**
+ * 타격 기록
+ */
+data class BattingRecordsDto(
+    val home: List<BatterScoresheetDto>,
+    val away: List<BatterScoresheetDto>,
+)
+
+/**
+ * 타자 기록지 정보
+ */
+data class BatterScoresheetDto(
+    val playerId: Long,
+    val name: String,
+    val backNumber: Int?,
+    val position: String,
+    val battingOrder: Int?,
+    val plateAppearances: Int,
+    val atBats: Int,
+    val runs: Int,
+    val hits: Int,
+    val doubles: Int,
+    val triples: Int,
+    val homeRuns: Int,
+    val rbis: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val stolenBases: Int,
+    val avg: String,
+)
+
+/**
+ * 투수 기록
+ */
+data class PitchingRecordsDto(
+    val home: List<PitcherScoresheetDto>,
+    val away: List<PitcherScoresheetDto>,
+)
+
+/**
+ * 투수 기록지 정보
+ */
+data class PitcherScoresheetDto(
+    val playerId: Long,
+    val name: String,
+    val backNumber: Int?,
+    val isStartingPitcher: Boolean,
+    val inningsPitched: String,
+    val hitsAllowed: Int,
+    val runsAllowed: Int,
+    val earnedRuns: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val homeRunsAllowed: Int,
+    val decision: String?,
+    val era: String,
+)
+
+/**
+ * 주요 이벤트
+ */
+data class KeyEventDto(
+    val inning: String,
+    val description: String,
+    val timestamp: String,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/lineup/LineupService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/lineup/LineupService.kt
@@ -1,9 +1,11 @@
 package com.nextup.core.service.lineup
 
+import com.nextup.core.domain.game.AttendanceStatus
 import com.nextup.core.domain.game.LineupEntry
 import com.nextup.core.domain.game.LineupSubmission
 import com.nextup.core.domain.game.LineupSubmissionStatus
 import com.nextup.core.domain.player.Position
+import com.nextup.core.port.repository.AttendanceVoteRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.LineupEntryRepositoryPort
 import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
@@ -27,6 +29,7 @@ class LineupService(
     private val teamRepository: TeamRepositoryPort,
     private val playerRepository: PlayerRepositoryPort,
     private val userRepository: UserRepositoryPort,
+    private val attendanceVoteRepository: AttendanceVoteRepositoryPort,
 ) {
     // ========== 라인업 제출 관리 ==========
 
@@ -43,19 +46,19 @@ class LineupService(
     ): LineupSubmission {
         val game =
             gameRepository.findByIdOrNull(gameId)
-                ?: throw IllegalArgumentException("경기 ID $gameId 를 찾을 수 없습니다.")
+                ?: throw IllegalArgumentException("경기 ID \$gameId 를 찾을 수 없습니다.")
 
         val team =
             teamRepository.findByIdOrNull(teamId)
-                ?: throw IllegalArgumentException("팀 ID $teamId 를 찾을 수 없습니다.")
+                ?: throw IllegalArgumentException("팀 ID \$teamId 를 찾을 수 없습니다.")
 
         val user =
             userRepository.findByIdOrNull(submittedByUserId)
-                ?: throw IllegalArgumentException("사용자 ID $submittedByUserId 를 찾을 수 없습니다.")
+                ?: throw IllegalArgumentException("사용자 ID \$submittedByUserId 를 찾을 수 없습니다.")
 
         // 이미 존재하는 라인업 확인
         lineupSubmissionRepository.findByGameIdAndTeamId(gameId, teamId)?.let {
-            throw IllegalArgumentException("이미 해당 경기/팀의 라인업이 존재합니다. (ID: ${it.id})")
+            throw IllegalArgumentException("이미 해당 경기/팀의 라인업이 존재합니다. (ID: \${it.id})")
         }
 
         val submission = LineupSubmission.create(game, team, user)
@@ -67,7 +70,7 @@ class LineupService(
      */
     fun getLineupSubmission(submissionId: Long): LineupSubmission =
         lineupSubmissionRepository.findByIdOrNull(submissionId)
-            ?: throw IllegalArgumentException("라인업 제출 ID $submissionId 를 찾을 수 없습니다.")
+            ?: throw IllegalArgumentException("라인업 제출 ID \$submissionId 를 찾을 수 없습니다.")
 
     /**
      * 경기의 모든 라인업 제출을 조회합니다.
@@ -115,17 +118,17 @@ class LineupService(
 
         val player =
             playerRepository.findByIdOrNull(playerId)
-                ?: throw IllegalArgumentException("선수 ID $playerId 를 찾을 수 없습니다.")
+                ?: throw IllegalArgumentException("선수 ID \$playerId 를 찾을 수 없습니다.")
 
         // 중복 선수 검증
         lineupEntryRepository.findBySubmissionIdAndPlayerId(submissionId, playerId)?.let {
-            throw IllegalArgumentException("이미 라인업에 등록된 선수입니다. (선수: ${player.name})")
+            throw IllegalArgumentException("이미 라인업에 등록된 선수입니다. (선수: \${player.name})")
         }
 
         // 중복 타순 검증 (선발인 경우에만)
         if (isStarter && battingOrder != null) {
             lineupEntryRepository.findBySubmissionIdAndBattingOrder(submissionId, battingOrder)?.let {
-                throw IllegalArgumentException("이미 해당 타순에 선수가 등록되어 있습니다. (타순: $battingOrder)")
+                throw IllegalArgumentException("이미 해당 타순에 선수가 등록되어 있습니다. (타순: \$battingOrder)")
             }
         }
 
@@ -164,7 +167,7 @@ class LineupService(
         return entries.map { input ->
             val player =
                 playerRepository.findByIdOrNull(input.playerId)
-                    ?: throw IllegalArgumentException("선수 ID ${input.playerId} 를 찾을 수 없습니다.")
+                    ?: throw IllegalArgumentException("선수 ID \${input.playerId} 를 찾을 수 없습니다.")
 
             val entry =
                 LineupEntry(
@@ -193,7 +196,7 @@ class LineupService(
      * 라인업을 기록원에게 제출합니다.
      *
      * LineupSubmission.submit() 내부에서 LineupValidator를 통해
-     * 포수 필수, 중복 선수, DH 규칙 등을 검증합니다.
+     * 포수 필수, 중복 선수, DH 규칙, 참석자만 등록 등을 검증합니다.
      */
     @Transactional
     fun submitLineup(submissionId: Long): LineupSubmission {
@@ -202,12 +205,35 @@ class LineupService(
         // 최소 인원 검증 (9명 이상)
         val starters = submission.entries.filter { it.isStarter }
         require(starters.size >= 9) {
-            "선발 라인업은 최소 9명이 필요합니다. (현재: ${starters.size}명)"
+            "선발 라인업은 최소 9명이 필요합니다. (현재: \${starters.size}명)"
         }
 
-        // 필수 포지션 + 중복 선수 + DH 규칙 검증은 submit() 내부에서 수행
-        submission.submit()
+        // 참석(ATTENDING) 선수 ID 목록 조회
+        val attendingPlayerIds = getAttendingPlayerIds(submission.game.id, submission.team.id)
+
+        // 필수 포지션 + 중복 선수 + DH 규칙 + 참석자만 등록 검증은 submit() 내부에서 수행
+        submission.submit(attendingPlayerIds)
         return lineupSubmissionRepository.save(submission)
+    }
+
+    /**
+     * 경기의 특정 팀에서 참석(ATTENDING) 상태인 선수 ID 목록을 조회합니다.
+     */
+    private fun getAttendingPlayerIds(
+        gameId: Long,
+        teamId: Long,
+    ): Set<Long> {
+        val attendingVotes =
+            attendanceVoteRepository.findByGameIdAndStatus(
+                gameId,
+                AttendanceStatus.ATTENDING,
+            )
+
+        // 해당 팀 소속 선수만 필터링
+        return attendingVotes
+            .filter { it.member.team.id == teamId }
+            .map { it.member.player.id }
+            .toSet()
     }
 
     /**
@@ -222,7 +248,7 @@ class LineupService(
 
         val scorer =
             userRepository.findByIdOrNull(scorerUserId)
-                ?: throw IllegalArgumentException("기록원 ID $scorerUserId 를 찾을 수 없습니다.")
+                ?: throw IllegalArgumentException("기록원 ID \$scorerUserId 를 찾을 수 없습니다.")
 
         submission.confirm(scorer)
         return lineupSubmissionRepository.save(submission)
@@ -241,7 +267,7 @@ class LineupService(
 
         val scorer =
             userRepository.findByIdOrNull(scorerUserId)
-                ?: throw IllegalArgumentException("기록원 ID $scorerUserId 를 찾을 수 없습니다.")
+                ?: throw IllegalArgumentException("기록원 ID \$scorerUserId 를 찾을 수 없습니다.")
 
         submission.reject(scorer, reason)
         return lineupSubmissionRepository.save(submission)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/lineup/LineupService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/lineup/LineupService.kt
@@ -4,7 +4,6 @@ import com.nextup.core.domain.game.LineupEntry
 import com.nextup.core.domain.game.LineupSubmission
 import com.nextup.core.domain.game.LineupSubmissionStatus
 import com.nextup.core.domain.player.Position
-import com.nextup.core.domain.player.PositionCategory
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.LineupEntryRepositoryPort
 import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
@@ -192,21 +191,21 @@ class LineupService(
 
     /**
      * 라인업을 기록원에게 제출합니다.
+     *
+     * LineupSubmission.submit() 내부에서 LineupValidator를 통해
+     * 포수 필수, 중복 선수, DH 규칙 등을 검증합니다.
      */
     @Transactional
     fun submitLineup(submissionId: Long): LineupSubmission {
         val submission = getLineupSubmission(submissionId)
-        val entries = lineupEntryRepository.findAllBySubmissionId(submissionId)
 
         // 최소 인원 검증 (9명 이상)
-        val starters = entries.filter { it.isStarter }
+        val starters = submission.entries.filter { it.isStarter }
         require(starters.size >= 9) {
             "선발 라인업은 최소 9명이 필요합니다. (현재: ${starters.size}명)"
         }
 
-        // 포지션 검증 (필수 포지션 확인)
-        validateRequiredPositions(starters)
-
+        // 필수 포지션 + 중복 선수 + DH 규칙 검증은 submit() 내부에서 수행
         submission.submit()
         return lineupSubmissionRepository.save(submission)
     }
@@ -269,24 +268,6 @@ class LineupService(
         val uniqueBattingOrders = starterBattingOrders.toSet()
         require(starterBattingOrders.size == uniqueBattingOrders.size) {
             "라인업에 중복된 타순이 있습니다."
-        }
-    }
-
-    /**
-     * 필수 포지션 검증
-     * 야구에서 필수적인 포지션들이 모두 채워졌는지 확인합니다.
-     */
-    private fun validateRequiredPositions(starters: List<LineupEntry>) {
-        val positionCategories = starters.map { it.position.category }.toSet()
-
-        // 투수는 필수
-        require(positionCategories.contains(PositionCategory.PITCHER)) {
-            "투수가 지정되지 않았습니다."
-        }
-
-        // 포수는 필수
-        require(positionCategories.contains(PositionCategory.CATCHER)) {
-            "포수가 지정되지 않았습니다."
         }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/match/MatchingService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/match/MatchingService.kt
@@ -1,0 +1,175 @@
+package com.nextup.core.service.match
+
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.common.exception.MatchRequestNotFoundException
+import com.nextup.common.exception.MatchResponseNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.match.MatchRequest
+import com.nextup.core.domain.match.MatchResponse
+import com.nextup.core.port.repository.MatchRequestRepositoryPort
+import com.nextup.core.port.repository.MatchResponseRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.match.dto.CreateMatchRequestDto
+import com.nextup.core.service.match.dto.CreateMatchResponseDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 매칭 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class MatchingService(
+    private val matchRequestRepository: MatchRequestRepositoryPort,
+    private val matchResponseRepository: MatchResponseRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+) {
+    /**
+     * 매칭 요청을 생성합니다.
+     */
+    @Transactional
+    fun createRequest(dto: CreateMatchRequestDto): MatchRequest {
+        val team =
+            teamRepository.findByIdOrNull(dto.teamId)
+                ?: throw TeamNotFoundException(dto.teamId)
+
+        val matchRequest =
+            MatchRequest.create(
+                team = team,
+                preferredDate = dto.preferredDate,
+                preferredTime = dto.preferredTime,
+                preferredLocation = dto.preferredLocation,
+                message = dto.message,
+                skillLevel = dto.skillLevel,
+            )
+
+        return matchRequestRepository.save(matchRequest)
+    }
+
+    /**
+     * OPEN 상태의 모든 매칭 요청을 조회합니다.
+     */
+    fun getOpenRequests(): List<MatchRequest> = matchRequestRepository.findAllOpen()
+
+    /**
+     * 매칭 요청에 응답합니다.
+     */
+    @Transactional
+    fun respondToRequest(dto: CreateMatchResponseDto): MatchResponse {
+        val matchRequest =
+            matchRequestRepository.findByIdOrNull(dto.matchRequestId)
+                ?: throw MatchRequestNotFoundException(dto.matchRequestId)
+
+        val respondTeam =
+            teamRepository.findByIdOrNull(dto.respondTeamId)
+                ?: throw TeamNotFoundException(dto.respondTeamId)
+
+        val matchResponse =
+            try {
+                MatchResponse.create(
+                    matchRequest = matchRequest,
+                    respondTeam = respondTeam,
+                    message = dto.message,
+                )
+            } catch (e: IllegalArgumentException) {
+                throw InvalidStateException(
+                    "INVALID_MATCH_REQUEST_STATE",
+                    e.message ?: "Cannot respond to match request",
+                )
+            }
+
+        return matchResponseRepository.save(matchResponse)
+    }
+
+    /**
+     * 매칭 응답을 수락하고 요청을 MATCHED 상태로 변경합니다.
+     */
+    @Transactional
+    fun acceptResponse(
+        requestId: Long,
+        responseId: Long,
+    ): MatchRequest {
+        val matchRequest =
+            matchRequestRepository.findByIdOrNull(requestId)
+                ?: throw MatchRequestNotFoundException(requestId)
+
+        val matchResponse =
+            matchResponseRepository.findByIdOrNull(responseId)
+                ?: throw MatchResponseNotFoundException(responseId)
+
+        try {
+            matchResponse.accept()
+            matchRequest.match()
+        } catch (e: IllegalArgumentException) {
+            throw InvalidStateException(
+                "INVALID_MATCH_STATE",
+                e.message ?: "Cannot accept match response",
+            )
+        }
+
+        return matchRequest
+    }
+
+    /**
+     * 매칭 요청을 취소합니다.
+     */
+    @Transactional
+    fun cancelRequest(requestId: Long): MatchRequest {
+        val matchRequest =
+            matchRequestRepository.findByIdOrNull(requestId)
+                ?: throw MatchRequestNotFoundException(requestId)
+
+        try {
+            matchRequest.cancel()
+        } catch (e: IllegalArgumentException) {
+            throw InvalidStateException(
+                "INVALID_MATCH_REQUEST_STATE",
+                e.message ?: "Cannot cancel match request",
+            )
+        }
+
+        return matchRequest
+    }
+
+    /**
+     * ID로 매칭 요청을 조회합니다.
+     */
+    fun getRequestById(id: Long): MatchRequest =
+        matchRequestRepository.findByIdOrNull(id)
+            ?: throw MatchRequestNotFoundException(id)
+
+    /**
+     * 매칭 요청에 대한 응답 목록을 조회합니다.
+     */
+    fun getResponsesByRequest(requestId: Long): List<MatchResponse> {
+        // 요청 존재 여부 확인
+        matchRequestRepository.findByIdOrNull(requestId)
+            ?: throw MatchRequestNotFoundException(requestId)
+
+        return matchResponseRepository.findByMatchRequestId(requestId)
+    }
+
+    /**
+     * 팀의 매칭 요청 목록을 조회합니다.
+     */
+    fun getRequestsByTeam(teamId: Long): List<MatchRequest> {
+        // 팀 존재 여부 확인
+        teamRepository.findByIdOrNull(teamId)
+            ?: throw TeamNotFoundException(teamId)
+
+        return matchRequestRepository.findByTeamId(teamId)
+    }
+
+    /**
+     * 팀의 매칭 응답 목록을 조회합니다.
+     */
+    fun getResponsesByTeam(teamId: Long): List<MatchResponse> {
+        // 팀 존재 여부 확인
+        teamRepository.findByIdOrNull(teamId)
+            ?: throw TeamNotFoundException(teamId)
+
+        return matchResponseRepository.findByRespondTeamId(teamId)
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/match/dto/CreateMatchRequestDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/match/dto/CreateMatchRequestDto.kt
@@ -1,0 +1,13 @@
+package com.nextup.core.service.match.dto
+
+import com.nextup.core.domain.match.SkillLevel
+import java.time.LocalDate
+
+data class CreateMatchRequestDto(
+    val teamId: Long,
+    val preferredDate: LocalDate,
+    val preferredTime: String?,
+    val preferredLocation: String?,
+    val message: String?,
+    val skillLevel: SkillLevel,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/match/dto/CreateMatchResponseDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/match/dto/CreateMatchResponseDto.kt
@@ -1,0 +1,7 @@
+package com.nextup.core.service.match.dto
+
+data class CreateMatchResponseDto(
+    val matchRequestId: Long,
+    val respondTeamId: Long,
+    val message: String?,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
@@ -1,0 +1,142 @@
+package com.nextup.core.service.notification
+
+import com.nextup.common.exception.DeviceTokenNotFoundException
+import com.nextup.common.exception.NotificationNotFoundException
+import com.nextup.core.domain.notification.DeviceToken
+import com.nextup.core.domain.notification.Notification
+import com.nextup.core.domain.notification.NotificationPreference
+import com.nextup.core.port.repository.DeviceTokenRepositoryPort
+import com.nextup.core.port.repository.NotificationPreferenceRepositoryPort
+import com.nextup.core.port.repository.NotificationRepositoryPort
+import com.nextup.core.service.notification.dto.RegisterDeviceRequest
+import com.nextup.core.service.notification.dto.SendNotificationRequest
+import com.nextup.core.service.notification.dto.UpdatePreferenceRequest
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 알림 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class NotificationService(
+    private val notificationRepository: NotificationRepositoryPort,
+    private val deviceTokenRepository: DeviceTokenRepositoryPort,
+    private val preferenceRepository: NotificationPreferenceRepositoryPort,
+) {
+    /**
+     * 알림을 전송합니다.
+     */
+    @Transactional
+    fun sendNotification(request: SendNotificationRequest): Notification {
+        val notification =
+            Notification.create(
+                userId = request.userId,
+                type = request.type,
+                title = request.title,
+                body = request.body,
+                data = request.data,
+            )
+
+        notification.markAsSent()
+        return notificationRepository.save(notification)
+    }
+
+    /**
+     * 사용자의 알림 목록을 조회합니다 (페이징).
+     */
+    fun getUserNotifications(
+        userId: Long,
+        pageable: Pageable,
+    ): Page<Notification> = notificationRepository.findByUserId(userId, pageable)
+
+    /**
+     * 사용자의 알림 목록을 조회합니다.
+     */
+    fun getUserNotifications(userId: Long): List<Notification> = notificationRepository.findByUserId(userId)
+
+    /**
+     * 알림을 읽음 처리합니다.
+     */
+    @Transactional
+    fun markAsRead(notificationId: Long): Notification {
+        val notification = getById(notificationId)
+        notification.markAsRead()
+        return notification
+    }
+
+    /**
+     * ID로 알림을 조회합니다.
+     */
+    fun getById(id: Long): Notification =
+        notificationRepository.findByIdOrNull(id)
+            ?: throw NotificationNotFoundException(id)
+
+    /**
+     * 디바이스 토큰을 등록합니다.
+     */
+    @Transactional
+    fun registerDevice(request: RegisterDeviceRequest): DeviceToken {
+        // 기존 토큰이 있으면 삭제 (중복 방지)
+        deviceTokenRepository.findByToken(request.token)?.let {
+            deviceTokenRepository.deleteByToken(request.token)
+        }
+
+        val deviceToken =
+            DeviceToken.create(
+                userId = request.userId,
+                token = request.token,
+                platform = request.platform,
+            )
+
+        return deviceTokenRepository.save(deviceToken)
+    }
+
+    /**
+     * 디바이스 토큰을 삭제합니다.
+     */
+    @Transactional
+    fun removeDevice(tokenId: Long) {
+        val deviceToken =
+            deviceTokenRepository.findByIdOrNull(tokenId)
+                ?: throw DeviceTokenNotFoundException(tokenId)
+
+        deviceTokenRepository.deleteByToken(deviceToken.token)
+    }
+
+    /**
+     * 사용자의 디바이스 토큰 목록을 조회합니다.
+     */
+    fun getUserDevices(userId: Long): List<DeviceToken> = deviceTokenRepository.findByUserId(userId)
+
+    /**
+     * 알림 설정을 업데이트합니다.
+     */
+    @Transactional
+    fun updatePreference(request: UpdatePreferenceRequest): NotificationPreference {
+        val preference =
+            preferenceRepository.findByUserIdAndType(request.userId, request.type)
+                ?: NotificationPreference.create(
+                    userId = request.userId,
+                    type = request.type,
+                    enabled = request.enabled,
+                )
+
+        if (request.enabled) {
+            preference.enable()
+        } else {
+            preference.disable()
+        }
+
+        return preferenceRepository.save(preference)
+    }
+
+    /**
+     * 사용자의 알림 설정 목록을 조회합니다.
+     */
+    fun getUserPreferences(userId: Long): List<NotificationPreference> = preferenceRepository.findByUserId(userId)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/notification/dto/RegisterDeviceRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/notification/dto/RegisterDeviceRequest.kt
@@ -1,0 +1,12 @@
+package com.nextup.core.service.notification.dto
+
+import com.nextup.core.domain.notification.DevicePlatform
+
+/**
+ * 디바이스 등록 요청 DTO
+ */
+data class RegisterDeviceRequest(
+    val userId: Long,
+    val token: String,
+    val platform: DevicePlatform,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/notification/dto/SendNotificationRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/notification/dto/SendNotificationRequest.kt
@@ -1,0 +1,14 @@
+package com.nextup.core.service.notification.dto
+
+import com.nextup.core.domain.notification.NotificationType
+
+/**
+ * 알림 전송 요청 DTO
+ */
+data class SendNotificationRequest(
+    val userId: Long,
+    val type: NotificationType,
+    val title: String,
+    val body: String,
+    val data: String? = null,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/notification/dto/UpdatePreferenceRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/notification/dto/UpdatePreferenceRequest.kt
@@ -1,0 +1,12 @@
+package com.nextup.core.service.notification.dto
+
+import com.nextup.core.domain.notification.NotificationType
+
+/**
+ * 알림 설정 수정 요청 DTO
+ */
+data class UpdatePreferenceRequest(
+    val userId: Long,
+    val type: NotificationType,
+    val enabled: Boolean,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/player/PlayerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/player/PlayerService.kt
@@ -1,0 +1,45 @@
+package com.nextup.core.service.player
+
+import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.core.domain.player.Player
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 선수 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class PlayerService(
+    private val playerRepository: PlayerRepositoryPort,
+) {
+    /**
+     * ID로 선수를 조회합니다.
+     */
+    fun getById(id: Long): Player =
+        playerRepository.findByIdOrNull(id)
+            ?: throw PlayerNotFoundException(id)
+
+    /**
+     * 모든 선수를 조회합니다.
+     */
+    fun getAll(): List<Player> = playerRepository.findAll()
+
+    /**
+     * 이름으로 선수를 조회합니다.
+     */
+    fun getByName(name: String): List<Player> = playerRepository.findByName(name)
+
+    /**
+     * 이름에 포함된 문자열로 선수를 검색합니다.
+     */
+    fun searchByName(name: String): List<Player> = playerRepository.findByNameContaining(name)
+
+    /**
+     * 활성 선수 목록을 조회합니다.
+     */
+    fun getActivePlayers(): List<Player> = playerRepository.findActivePlayers()
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/TeamRecruitmentService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/TeamRecruitmentService.kt
@@ -1,0 +1,126 @@
+package com.nextup.core.service.recruitment
+
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.common.exception.RecruitmentNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.recruitment.RecruitmentStatus
+import com.nextup.core.domain.recruitment.TeamRecruitment
+import com.nextup.core.port.repository.TeamRecruitmentRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.recruitment.dto.CreateRecruitmentRequest
+import com.nextup.core.service.recruitment.dto.UpdateRecruitmentRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 팀 모집 공고 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class TeamRecruitmentService(
+    private val recruitmentRepository: TeamRecruitmentRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+) {
+    /**
+     * 팀 모집 공고를 생성합니다.
+     */
+    @Transactional
+    fun createRecruitment(request: CreateRecruitmentRequest): TeamRecruitment {
+        val team =
+            teamRepository.findByIdOrNull(request.teamId)
+                ?: throw TeamNotFoundException(request.teamId)
+
+        val recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = request.title,
+                description = request.description,
+                positionsNeeded = request.positionsNeeded,
+                ageRange = request.ageRange,
+                skillLevel = request.skillLevel,
+                location = request.location,
+                deadline = request.deadline,
+            )
+
+        return recruitmentRepository.save(recruitment)
+    }
+
+    /**
+     * 팀 모집 공고를 수정합니다.
+     */
+    @Transactional
+    fun updateRecruitment(
+        id: Long,
+        request: UpdateRecruitmentRequest,
+    ): TeamRecruitment {
+        val recruitment = getById(id)
+
+        try {
+            recruitment.update(
+                title = request.title,
+                description = request.description,
+                positionsNeeded = request.positionsNeeded,
+                deadline = request.deadline,
+            )
+        } catch (e: IllegalArgumentException) {
+            throw InvalidStateException(
+                "INVALID_RECRUITMENT_STATE",
+                e.message ?: "Cannot update recruitment",
+            )
+        }
+
+        return recruitment
+    }
+
+    /**
+     * 팀 모집 공고를 마감합니다.
+     */
+    @Transactional
+    fun closeRecruitment(id: Long): TeamRecruitment {
+        val recruitment = getById(id)
+
+        try {
+            recruitment.close()
+        } catch (e: IllegalArgumentException) {
+            throw InvalidStateException(
+                "INVALID_RECRUITMENT_STATE",
+                e.message ?: "Cannot close recruitment",
+            )
+        }
+
+        return recruitment
+    }
+
+    /**
+     * ID로 모집 공고를 조회합니다.
+     */
+    fun getById(id: Long): TeamRecruitment =
+        recruitmentRepository.findByIdOrNull(id)
+            ?: throw RecruitmentNotFoundException(id)
+
+    /**
+     * 팀별 모집 공고 목록을 조회합니다.
+     */
+    fun getByTeam(teamId: Long): List<TeamRecruitment> = recruitmentRepository.findByTeamId(teamId)
+
+    /**
+     * 모든 진행 중인 모집 공고를 조회합니다.
+     */
+    fun getAllOpen(): List<TeamRecruitment> = recruitmentRepository.findAllOpen()
+
+    /**
+     * 특정 상태의 모집 공고를 조회합니다.
+     */
+    fun getByStatus(status: RecruitmentStatus): List<TeamRecruitment> = recruitmentRepository.findByStatus(status)
+
+    /**
+     * 모집 공고를 삭제합니다.
+     */
+    @Transactional
+    fun deleteRecruitment(id: Long) {
+        val recruitment = getById(id)
+        recruitmentRepository.delete(recruitment)
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/dto/CreateRecruitmentRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/dto/CreateRecruitmentRequest.kt
@@ -1,0 +1,14 @@
+package com.nextup.core.service.recruitment.dto
+
+import java.time.LocalDate
+
+data class CreateRecruitmentRequest(
+    val teamId: Long,
+    val title: String,
+    val description: String,
+    val positionsNeeded: String,
+    val ageRange: String?,
+    val skillLevel: String?,
+    val location: String?,
+    val deadline: LocalDate,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/dto/UpdateRecruitmentRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/dto/UpdateRecruitmentRequest.kt
@@ -1,0 +1,10 @@
+package com.nextup.core.service.recruitment.dto
+
+import java.time.LocalDate
+
+data class UpdateRecruitmentRequest(
+    val title: String?,
+    val description: String?,
+    val positionsNeeded: String?,
+    val deadline: LocalDate?,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/report/CompetitionReportService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/report/CompetitionReportService.kt
@@ -1,0 +1,27 @@
+package com.nextup.core.service.report
+
+import com.nextup.core.service.report.dto.CompetitionReportDto
+import com.nextup.core.service.report.dto.CompetitionSummaryDto
+
+/**
+ * 대회 리포트 서비스
+ *
+ * 대회의 종합 리포트 및 요약 정보를 제공합니다.
+ */
+interface CompetitionReportService {
+    /**
+     * 대회의 전체 리포트를 조회합니다.
+     *
+     * @param competitionId 대회 ID
+     * @return 대회 리포트 (순위표, 요약 통계 포함)
+     */
+    fun getReport(competitionId: Long): CompetitionReportDto
+
+    /**
+     * 대회의 요약 정보만 조회합니다.
+     *
+     * @param competitionId 대회 ID
+     * @return 대회 요약 통계
+     */
+    fun getReportSummary(competitionId: Long): CompetitionSummaryDto
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/report/dto/CompetitionReportDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/report/dto/CompetitionReportDto.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.service.report.dto
+
+import com.nextup.core.service.standings.dto.TeamStandingDto
+
+/**
+ * 대회 리포트 DTO
+ *
+ * 대회의 순위표, 주요 통계, 요약 정보를 포함합니다.
+ */
+data class CompetitionReportDto(
+    val competitionId: Long,
+    val competitionName: String,
+    val season: Int,
+    val standings: List<TeamStandingDto>,
+    val summary: CompetitionSummaryDto,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/report/dto/CompetitionSummaryDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/report/dto/CompetitionSummaryDto.kt
@@ -1,0 +1,19 @@
+package com.nextup.core.service.report.dto
+
+/**
+ * 대회 요약 DTO
+ *
+ * 대회의 주요 통계 정보를 제공합니다.
+ */
+data class CompetitionSummaryDto(
+    val competitionId: Long,
+    val totalGames: Int,
+    val completedGames: Int,
+    val totalRuns: Int,
+    val averageRunsPerGame: Double,
+    val totalHits: Int,
+    val totalHomeRuns: Int,
+    val totalStrikeouts: Int,
+    val highestScoringGame: HighScoringGameDto?,
+    val longestWinStreak: WinStreakDto?,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/report/dto/HighScoringGameDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/report/dto/HighScoringGameDto.kt
@@ -1,0 +1,14 @@
+package com.nextup.core.service.report.dto
+
+import java.time.LocalDate
+
+/**
+ * 최다 득점 경기 DTO
+ */
+data class HighScoringGameDto(
+    val gameId: Long,
+    val homeTeamName: String,
+    val awayTeamName: String,
+    val totalRuns: Int,
+    val date: LocalDate,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/report/dto/WinStreakDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/report/dto/WinStreakDto.kt
@@ -1,0 +1,9 @@
+package com.nextup.core.service.report.dto
+
+/**
+ * 연승 기록 DTO
+ */
+data class WinStreakDto(
+    val teamName: String,
+    val streakLength: Int,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/schedule/LeagueScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/schedule/LeagueScheduleService.kt
@@ -5,6 +5,8 @@ import com.nextup.common.exception.InvalidScheduleStateException
 import com.nextup.common.exception.ScheduleNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.schedule.LeagueSchedule
+import com.nextup.core.domain.schedule.ScheduleConflict
+import com.nextup.core.domain.schedule.ScheduleConflictDetector
 import com.nextup.core.port.repository.CompetitionRepositoryPort
 import com.nextup.core.port.repository.LeagueScheduleRepositoryPort
 import com.nextup.core.port.repository.TeamRepositoryPort
@@ -26,6 +28,8 @@ class LeagueScheduleService(
     private val competitionRepository: CompetitionRepositoryPort,
     private val teamRepository: TeamRepositoryPort,
 ) {
+    private val conflictDetector = ScheduleConflictDetector()
+
     /**
      * 대진표를 생성합니다.
      */
@@ -71,6 +75,19 @@ class LeagueScheduleService(
                 scheduledTime = scheduledTime,
                 venue = venue,
             )
+
+        // 충돌 감지
+        val existingSchedules =
+            scheduleRepository.findByCompetitionIdAndScheduledDate(competitionId, scheduledDate)
+        val conflicts = conflictDetector.detectAllConflicts(schedule, existingSchedules)
+
+        if (conflicts.isNotEmpty()) {
+            val conflictMessages =
+                conflicts.joinToString("\n") { "- ${it.description}" }
+            throw InvalidScheduleStateException(
+                "대진표 생성 시 충돌이 감지되었습니다:\n$conflictMessages",
+            )
+        }
 
         return scheduleRepository.save(schedule)
     }
@@ -138,4 +155,52 @@ class LeagueScheduleService(
         competitionId: Long,
         round: Int,
     ): List<LeagueSchedule> = scheduleRepository.findByCompetitionIdAndRound(competitionId, round)
+
+    /**
+     * 대진표를 검증합니다. (Dry-run)
+     *
+     * 실제로 저장하지 않고 충돌만 확인합니다.
+     *
+     * @return 충돌 목록 (충돌 없으면 빈 리스트)
+     */
+    fun validateSchedule(
+        competitionId: Long,
+        round: Int,
+        matchNumber: Int,
+        homeTeamId: Long,
+        awayTeamId: Long,
+        scheduledDate: LocalDate,
+        scheduledTime: LocalTime? = null,
+        venue: String? = null,
+    ): List<ScheduleConflict> {
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        val homeTeam =
+            teamRepository.findByIdOrNull(homeTeamId)
+                ?: throw TeamNotFoundException(homeTeamId)
+
+        val awayTeam =
+            teamRepository.findByIdOrNull(awayTeamId)
+                ?: throw TeamNotFoundException(awayTeamId)
+
+        // 임시 스케줄 생성 (저장하지 않음)
+        val schedule =
+            LeagueSchedule.create(
+                competition = competition,
+                round = round,
+                matchNumber = matchNumber,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledDate = scheduledDate,
+                scheduledTime = scheduledTime,
+                venue = venue,
+            )
+
+        // 충돌 감지
+        val existingSchedules =
+            scheduleRepository.findByCompetitionIdAndScheduledDate(competitionId, scheduledDate)
+        return conflictDetector.detectAllConflicts(schedule, existingSchedules)
+    }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/schedule/LeagueScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/schedule/LeagueScheduleService.kt
@@ -1,0 +1,140 @@
+package com.nextup.core.service.schedule
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidScheduleStateException
+import com.nextup.common.exception.ScheduleNotFoundException
+import com.nextup.core.domain.schedule.LeagueSchedule
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.LeagueScheduleRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 대진표 서비스
+ *
+ * 대회 내 대진표 CRUD 및 상태 관리를 수행합니다.
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class LeagueScheduleService(
+    private val scheduleRepository: LeagueScheduleRepositoryPort,
+    private val competitionRepository: CompetitionRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+) {
+    /**
+     * 대진표를 생성합니다.
+     */
+    @Transactional
+    fun createSchedule(
+        competitionId: Long,
+        round: Int,
+        matchNumber: Int,
+        homeTeamId: Long,
+        awayTeamId: Long,
+        scheduledDate: LocalDate,
+        scheduledTime: LocalTime? = null,
+        venue: String? = null,
+    ): LeagueSchedule {
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        val homeTeam =
+            teamRepository.findByIdOrNull(homeTeamId)
+                ?: throw IllegalArgumentException("홈팀 ID $homeTeamId 를 찾을 수 없습니다.")
+
+        val awayTeam =
+            teamRepository.findByIdOrNull(awayTeamId)
+                ?: throw IllegalArgumentException("원정팀 ID $awayTeamId 를 찾을 수 없습니다.")
+
+        val isDuplicate =
+            scheduleRepository.existsByCompetitionIdAndRoundAndMatchNumber(competitionId, round, matchNumber)
+        if (isDuplicate) {
+            throw InvalidScheduleStateException(
+                "이미 존재하는 대진표입니다. (대회: $competitionId, 라운드: $round, 경기번호: $matchNumber)",
+            )
+        }
+
+        val schedule =
+            LeagueSchedule.create(
+                competition = competition,
+                round = round,
+                matchNumber = matchNumber,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledDate = scheduledDate,
+                scheduledTime = scheduledTime,
+                venue = venue,
+            )
+
+        return scheduleRepository.save(schedule)
+    }
+
+    /**
+     * 대진표를 수정합니다.
+     */
+    @Transactional
+    fun updateSchedule(
+        scheduleId: Long,
+        scheduledDate: LocalDate? = null,
+        scheduledTime: LocalTime? = null,
+        venue: String? = null,
+    ): LeagueSchedule {
+        val schedule = getById(scheduleId)
+
+        if (scheduledDate != null) {
+            try {
+                schedule.reschedule(
+                    scheduledDate,
+                    scheduledTime ?: schedule.scheduledTime,
+                    venue ?: schedule.venue,
+                )
+            } catch (e: IllegalArgumentException) {
+                throw InvalidScheduleStateException(e.message ?: "일정을 변경할 수 없습니다.")
+            }
+        } else {
+            if (venue != null) {
+                schedule.venue = venue
+            }
+            if (scheduledTime != null) {
+                schedule.scheduledTime = scheduledTime
+            }
+        }
+
+        return schedule
+    }
+
+    /**
+     * 대진표를 삭제합니다.
+     */
+    @Transactional
+    fun deleteSchedule(scheduleId: Long) {
+        val schedule = getById(scheduleId)
+        scheduleRepository.delete(schedule)
+    }
+
+    /**
+     * ID로 대진표를 조회합니다.
+     */
+    fun getById(scheduleId: Long): LeagueSchedule =
+        scheduleRepository.findByIdOrNull(scheduleId)
+            ?: throw ScheduleNotFoundException(scheduleId)
+
+    /**
+     * 대회별 전체 대진표를 조회합니다.
+     */
+    fun getSchedulesByCompetition(competitionId: Long): List<LeagueSchedule> =
+        scheduleRepository.findByCompetitionId(competitionId)
+
+    /**
+     * 대회 + 라운드별 대진표를 조회합니다.
+     */
+    fun getSchedulesByRound(
+        competitionId: Long,
+        round: Int,
+    ): List<LeagueSchedule> = scheduleRepository.findByCompetitionIdAndRound(competitionId, round)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/schedule/LeagueScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/schedule/LeagueScheduleService.kt
@@ -5,6 +5,7 @@ import com.nextup.common.exception.InvalidScheduleStateException
 import com.nextup.common.exception.ScheduleNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.schedule.LeagueSchedule
+import com.nextup.core.domain.schedule.RoundRobinScheduleGenerator
 import com.nextup.core.domain.schedule.ScheduleConflict
 import com.nextup.core.domain.schedule.ScheduleConflictDetector
 import com.nextup.core.port.repository.CompetitionRepositoryPort
@@ -29,6 +30,7 @@ class LeagueScheduleService(
     private val teamRepository: TeamRepositoryPort,
 ) {
     private val conflictDetector = ScheduleConflictDetector()
+    private val scheduleGenerator = RoundRobinScheduleGenerator()
 
     /**
      * 대진표를 생성합니다.
@@ -202,5 +204,136 @@ class LeagueScheduleService(
         val existingSchedules =
             scheduleRepository.findByCompetitionIdAndScheduledDate(competitionId, scheduledDate)
         return conflictDetector.detectAllConflicts(schedule, existingSchedules)
+    }
+
+    /**
+     * 라운드 로빈 방식으로 대진표를 자동 생성합니다.
+     *
+     * @param competitionId 대회 ID
+     * @param teamIds 참가 팀 ID 목록
+     * @param doubleRoundRobin true면 홈/원정 교대로 2회전 (기본 false)
+     * @return 생성된 대진표 목록
+     */
+    @Transactional
+    fun generateRoundRobinSchedule(
+        competitionId: Long,
+        teamIds: List<Long>,
+        doubleRoundRobin: Boolean = false,
+    ): List<LeagueSchedule> {
+        // 대회 존재 확인
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        // 팀 존재 확인
+        val teams =
+            teamIds.map { teamId ->
+                teamRepository.findByIdOrNull(teamId)
+                    ?: throw TeamNotFoundException(teamId)
+            }
+
+        // 라운드 로빈 매치 생성
+        val matchPairs = scheduleGenerator.generate(teamIds, doubleRoundRobin)
+
+        // 라운드별 매치 카운터
+        val matchNumbersByRound = mutableMapOf<Int, Int>()
+
+        // LeagueSchedule 엔티티 생성 (날짜는 임시로 현재 날짜 + 라운드 offset)
+        val schedules =
+            matchPairs.map { match ->
+                val homeTeam = teams.first { it.id == match.homeTeamId }
+                val awayTeam = teams.first { it.id == match.awayTeamId }
+
+                // 라운드별 매치 번호 증가
+                val matchNumber = matchNumbersByRound.getOrDefault(match.round, 0) + 1
+                matchNumbersByRound[match.round] = matchNumber
+
+                // 임시 날짜: 현재 날짜 + (라운드 - 1) * 7일 (1주일 간격)
+                val scheduledDate = LocalDate.now().plusWeeks((match.round - 1).toLong())
+
+                LeagueSchedule.create(
+                    competition = competition,
+                    round = match.round,
+                    matchNumber = matchNumber,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledDate = scheduledDate,
+                )
+            }
+
+        // 배치 저장
+        return schedules.map { scheduleRepository.save(it) }
+    }
+
+    /**
+     * 특정 날짜의 모든 경기를 일괄 연기합니다. (우천 순연 등)
+     */
+    @Transactional
+    fun postponeGamesBulk(
+        competitionId: Long,
+        date: LocalDate,
+        reason: String,
+    ): List<LeagueSchedule> {
+        val schedules =
+            scheduleRepository.findByCompetitionIdAndScheduledDate(competitionId, date)
+
+        if (schedules.isEmpty()) {
+            throw InvalidScheduleStateException(
+                "해당 날짜에 연기할 경기가 없습니다. (대회: $competitionId, 날짜: $date)",
+            )
+        }
+
+        schedules.forEach { schedule ->
+            try {
+                schedule.postpone(reason)
+            } catch (e: IllegalArgumentException) {
+                throw InvalidScheduleStateException(
+                    "대진표를 연기할 수 없습니다. (ID: ${schedule.id}, 사유: ${e.message})",
+                )
+            }
+        }
+
+        return schedules
+    }
+
+    /**
+     * 연기된 경기의 일정을 재조정합니다.
+     */
+    @Transactional
+    fun rescheduleGame(
+        scheduleId: Long,
+        newDate: LocalDate,
+        newVenue: String? = null,
+    ): LeagueSchedule {
+        val schedule = getById(scheduleId)
+
+        try {
+            schedule.reschedule(
+                newDate = newDate,
+                newTime = schedule.scheduledTime,
+                newVenue = newVenue ?: schedule.venue,
+            )
+        } catch (e: IllegalArgumentException) {
+            throw InvalidScheduleStateException(
+                e.message ?: "일정을 재조정할 수 없습니다.",
+            )
+        }
+
+        val existingSchedules =
+            scheduleRepository
+                .findByCompetitionIdAndScheduledDate(schedule.competition.id, newDate)
+                .filter { it.id != scheduleId }
+
+        val conflicts = conflictDetector.detectAllConflicts(schedule, existingSchedules)
+
+        if (conflicts.isNotEmpty()) {
+            val conflictMessages =
+                conflicts.joinToString("\n") { "- ${it.description}" }
+            throw InvalidScheduleStateException(
+                "일정 재조정 시 충돌이 감지되었습니다:\n$conflictMessages",
+            )
+        }
+
+        return schedule
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/schedule/LeagueScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/schedule/LeagueScheduleService.kt
@@ -3,6 +3,7 @@ package com.nextup.core.service.schedule
 import com.nextup.common.exception.CompetitionNotFoundException
 import com.nextup.common.exception.InvalidScheduleStateException
 import com.nextup.common.exception.ScheduleNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.schedule.LeagueSchedule
 import com.nextup.core.port.repository.CompetitionRepositoryPort
 import com.nextup.core.port.repository.LeagueScheduleRepositoryPort
@@ -45,11 +46,11 @@ class LeagueScheduleService(
 
         val homeTeam =
             teamRepository.findByIdOrNull(homeTeamId)
-                ?: throw IllegalArgumentException("홈팀 ID $homeTeamId 를 찾을 수 없습니다.")
+                ?: throw TeamNotFoundException(homeTeamId)
 
         val awayTeam =
             teamRepository.findByIdOrNull(awayTeamId)
-                ?: throw IllegalArgumentException("원정팀 ID $awayTeamId 를 찾을 수 없습니다.")
+                ?: throw TeamNotFoundException(awayTeamId)
 
         val isDuplicate =
             scheduleRepository.existsByCompetitionIdAndRoundAndMatchNumber(competitionId, round, matchNumber)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumAdminService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumAdminService.kt
@@ -1,0 +1,123 @@
+package com.nextup.core.service.stadium
+
+import com.nextup.common.exception.StadiumNotFoundException
+import com.nextup.core.domain.stadium.Stadium
+import com.nextup.core.domain.stadium.StadiumSlot
+import com.nextup.core.port.repository.StadiumRepositoryPort
+import com.nextup.core.port.repository.StadiumSlotRepositoryPort
+import com.nextup.core.service.stadium.dto.CreateSlotRequest
+import com.nextup.core.service.stadium.dto.CreateStadiumRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 구장 관리 서비스
+ *
+ * 관리자용 구장 생성, 수정, 슬롯 생성 기능을 제공합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class StadiumAdminService(
+    private val stadiumRepository: StadiumRepositoryPort,
+    private val slotRepository: StadiumSlotRepositoryPort,
+) {
+    /**
+     * 구장을 생성합니다.
+     */
+    @Transactional
+    fun createStadium(request: CreateStadiumRequest): Stadium {
+        val stadium =
+            Stadium.create(
+                name = request.name,
+                address = request.address,
+                latitude = request.latitude,
+                longitude = request.longitude,
+                capacity = request.capacity,
+                facilities = request.facilities,
+                contactInfo = request.contactInfo,
+                imageUrls = request.imageUrls,
+            )
+
+        return stadiumRepository.save(stadium)
+    }
+
+    /**
+     * 구장 정보를 수정합니다.
+     */
+    @Transactional
+    fun updateStadium(
+        id: Long,
+        address: String? = null,
+        latitude: Double? = null,
+        longitude: Double? = null,
+        capacity: Int? = null,
+        facilities: String? = null,
+        contactInfo: String? = null,
+        imageUrls: String? = null,
+    ): Stadium {
+        val stadium =
+            stadiumRepository.findByIdOrNull(id)
+                ?: throw StadiumNotFoundException(id)
+
+        stadium.update(
+            address = address,
+            latitude = latitude,
+            longitude = longitude,
+            capacity = capacity,
+            facilities = facilities,
+            contactInfo = contactInfo,
+            imageUrls = imageUrls,
+        )
+
+        return stadium
+    }
+
+    /**
+     * 구장 슬롯을 생성합니다.
+     */
+    @Transactional
+    fun createSlots(requests: List<CreateSlotRequest>): List<StadiumSlot> {
+        val slots =
+            requests.map { request ->
+                val stadium =
+                    stadiumRepository.findByIdOrNull(request.stadiumId)
+                        ?: throw StadiumNotFoundException(request.stadiumId)
+
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = request.date,
+                    startTime = request.startTime,
+                    endTime = request.endTime,
+                    price = request.price,
+                )
+            }
+
+        return slots.map { slotRepository.save(it) }
+    }
+
+    /**
+     * 구장을 비활성화합니다.
+     */
+    @Transactional
+    fun deactivateStadium(id: Long): Stadium {
+        val stadium =
+            stadiumRepository.findByIdOrNull(id)
+                ?: throw StadiumNotFoundException(id)
+
+        stadium.deactivate()
+        return stadium
+    }
+
+    /**
+     * 구장을 활성화합니다.
+     */
+    @Transactional
+    fun activateStadium(id: Long): Stadium {
+        val stadium =
+            stadiumRepository.findByIdOrNull(id)
+                ?: throw StadiumNotFoundException(id)
+
+        stadium.activate()
+        return stadium
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumService.kt
@@ -1,0 +1,129 @@
+package com.nextup.core.service.stadium
+
+import com.nextup.common.exception.BookingNotFoundException
+import com.nextup.common.exception.SlotNotFoundException
+import com.nextup.common.exception.StadiumNotFoundException
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.domain.stadium.SlotStatus
+import com.nextup.core.domain.stadium.Stadium
+import com.nextup.core.domain.stadium.StadiumBooking
+import com.nextup.core.domain.stadium.StadiumSlot
+import com.nextup.core.port.repository.StadiumBookingRepositoryPort
+import com.nextup.core.port.repository.StadiumRepositoryPort
+import com.nextup.core.port.repository.StadiumSlotRepositoryPort
+import com.nextup.core.service.stadium.dto.BookSlotRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+/**
+ * 구장 서비스
+ *
+ * 일반 사용자용 구장 조회 및 예약 기능을 제공합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class StadiumService(
+    private val stadiumRepository: StadiumRepositoryPort,
+    private val slotRepository: StadiumSlotRepositoryPort,
+    private val bookingRepository: StadiumBookingRepositoryPort,
+) {
+    /**
+     * 위치 기반으로 근처 구장을 검색합니다.
+     */
+    fun searchStadiums(
+        latitude: Double,
+        longitude: Double,
+        radiusKm: Double,
+    ): List<Stadium> = stadiumRepository.findNearby(latitude, longitude, radiusKm)
+
+    /**
+     * ID로 구장을 조회합니다.
+     */
+    fun getById(id: Long): Stadium =
+        stadiumRepository.findByIdOrNull(id)
+            ?: throw StadiumNotFoundException(id)
+
+    /**
+     * 구장의 특정 날짜에 사용 가능한 슬롯을 조회합니다.
+     */
+    fun getAvailableSlots(
+        stadiumId: Long,
+        date: LocalDate,
+    ): List<StadiumSlot> {
+        // 구장 존재 확인
+        getById(stadiumId)
+
+        return slotRepository.findByStadiumIdAndDate(stadiumId, date)
+            .filter { it.status == SlotStatus.AVAILABLE }
+    }
+
+    /**
+     * 구장 슬롯을 예약합니다.
+     */
+    @Transactional
+    fun bookSlot(request: BookSlotRequest): StadiumBooking {
+        val slot =
+            slotRepository.findByIdOrNull(request.slotId)
+                ?: throw SlotNotFoundException(request.slotId)
+
+        // 슬롯 상태 변경 (비즈니스 로직은 Entity에 위임)
+        slot.book()
+
+        // 예약 생성
+        val booking =
+            StadiumBooking.create(
+                slot = slot,
+                teamId = request.teamId,
+                bookedBy = request.bookedBy,
+            )
+
+        return bookingRepository.save(booking)
+    }
+
+    /**
+     * 예약을 취소합니다.
+     */
+    @Transactional
+    fun cancelBooking(bookingId: Long): StadiumBooking {
+        val booking =
+            bookingRepository.findByIdOrNull(bookingId)
+                ?: throw BookingNotFoundException(bookingId)
+
+        // 예약 취소 (비즈니스 로직은 Entity에 위임)
+        booking.cancel()
+
+        // 슬롯 상태도 원복
+        booking.slot.cancel()
+
+        return booking
+    }
+
+    /**
+     * 예약을 완료 처리합니다.
+     */
+    @Transactional
+    fun completeBooking(bookingId: Long): StadiumBooking {
+        val booking =
+            bookingRepository.findByIdOrNull(bookingId)
+                ?: throw BookingNotFoundException(bookingId)
+
+        // 예약 완료 처리
+        booking.complete()
+
+        return booking
+    }
+
+    /**
+     * 팀의 예약 목록을 조회합니다.
+     */
+    fun getTeamBookings(
+        teamId: Long,
+        status: BookingStatus? = null,
+    ): List<StadiumBooking> =
+        if (status != null) {
+            bookingRepository.findByTeamIdAndStatus(teamId, status)
+        } else {
+            bookingRepository.findByTeamId(teamId)
+        }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/dto/BookSlotRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/dto/BookSlotRequest.kt
@@ -1,0 +1,10 @@
+package com.nextup.core.service.stadium.dto
+
+/**
+ * 구장 슬롯 예약 요청 DTO
+ */
+data class BookSlotRequest(
+    val slotId: Long,
+    val teamId: Long,
+    val bookedBy: Long,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/dto/CreateSlotRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/dto/CreateSlotRequest.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.service.stadium.dto
+
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 구장 슬롯 생성 요청 DTO
+ */
+data class CreateSlotRequest(
+    val stadiumId: Long,
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val price: BigDecimal? = null,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/dto/CreateStadiumRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/dto/CreateStadiumRequest.kt
@@ -1,0 +1,15 @@
+package com.nextup.core.service.stadium.dto
+
+/**
+ * 구장 생성 요청 DTO
+ */
+data class CreateStadiumRequest(
+    val name: String,
+    val address: String,
+    val latitude: Double,
+    val longitude: Double,
+    val capacity: Int? = null,
+    val facilities: String? = null,
+    val contactInfo: String? = null,
+    val imageUrls: String? = null,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/dto/SearchStadiumRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/dto/SearchStadiumRequest.kt
@@ -1,0 +1,10 @@
+package com.nextup.core.service.stadium.dto
+
+/**
+ * 구장 검색 요청 DTO
+ */
+data class SearchStadiumRequest(
+    val latitude: Double,
+    val longitude: Double,
+    val radiusKm: Double,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/IndividualRankingService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/IndividualRankingService.kt
@@ -1,0 +1,25 @@
+package com.nextup.core.service.stats
+
+import com.nextup.core.service.stats.dto.BattingCategory
+import com.nextup.core.service.stats.dto.BattingLeaderDto
+import com.nextup.core.service.stats.dto.PitchingCategory
+import com.nextup.core.service.stats.dto.PitchingLeaderDto
+
+/**
+ * 개인 타이틀 리더보드 서비스 인터페이스
+ *
+ * 대회별 카테고리 TOP N 리더보드를 조회합니다.
+ */
+interface IndividualRankingService {
+    fun getBattingLeaders(
+        competitionId: Long,
+        category: BattingCategory,
+        limit: Int = 10,
+    ): List<BattingLeaderDto>
+
+    fun getPitchingLeaders(
+        competitionId: Long,
+        category: PitchingCategory,
+        limit: Int = 10,
+    ): List<PitchingLeaderDto>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/LeaderboardDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/LeaderboardDto.kt
@@ -1,0 +1,40 @@
+package com.nextup.core.service.stats.dto
+
+data class BattingLeaderDto(
+    val rank: Int,
+    val playerId: Long,
+    val playerName: String,
+    val teamName: String,
+    val value: Double,
+    val games: Int,
+    val plateAppearances: Int,
+)
+
+data class PitchingLeaderDto(
+    val rank: Int,
+    val playerId: Long,
+    val playerName: String,
+    val teamName: String,
+    val value: Double,
+    val games: Int,
+    val inningsPitched: Double,
+)
+
+enum class BattingCategory {
+    BATTING_AVG,
+    HOME_RUNS,
+    RBI,
+    HITS,
+    STOLEN_BASES,
+    OBP,
+    SLG,
+    OPS,
+}
+
+enum class PitchingCategory {
+    WINS,
+    SAVES,
+    STRIKEOUTS,
+    ERA,
+    WHIP,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMatchupService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMatchupService.kt
@@ -1,0 +1,39 @@
+package com.nextup.core.service.team
+
+import com.nextup.core.service.team.dto.TeamMatchupDto
+import com.nextup.core.service.team.dto.TeamMatchupGameDto
+
+/**
+ * 팀 간 상대 전적 서비스 인터페이스
+ *
+ * 두 팀 간의 대결 전적 및 경기 기록을 제공합니다.
+ */
+interface TeamMatchupService {
+    /**
+     * 두 팀 간의 상대 전적을 조회합니다.
+     *
+     * @param teamId 조회 대상 팀 ID
+     * @param opponentId 상대 팀 ID
+     * @param competitionId 대회 ID 필터 (선택사항)
+     * @return 팀 간 상대 전적 정보
+     */
+    fun getTeamMatchup(
+        teamId: Long,
+        opponentId: Long,
+        competitionId: Long? = null,
+    ): TeamMatchupDto
+
+    /**
+     * 두 팀 간의 최근 경기 목록을 조회합니다.
+     *
+     * @param teamId 조회 대상 팀 ID
+     * @param opponentId 상대 팀 ID
+     * @param limit 조회할 경기 수 (기본값: 10)
+     * @return 최근 교전 경기 목록
+     */
+    fun getRecentGames(
+        teamId: Long,
+        opponentId: Long,
+        limit: Int = 10,
+    ): List<TeamMatchupGameDto>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.service.team
 
+import com.nextup.core.domain.team.Team
 import com.nextup.core.domain.team.TeamJoinRequest
 import com.nextup.core.domain.team.TeamMember
 import com.nextup.core.domain.team.TeamMemberRole
@@ -125,4 +126,40 @@ interface TeamMembershipService {
         teamId: Long,
         userId: Long,
     ): TeamMember?
+
+    /**
+     * 팀을 생성하고 생성자를 OWNER로 등록합니다.
+     *
+     * @param userId 생성자 사용자 ID
+     * @param team 생성할 팀
+     * @param uniformNumber OWNER의 등번호
+     * @return 생성된 Team
+     */
+    fun createTeamWithOwner(
+        userId: Long,
+        team: Team,
+        uniformNumber: Int,
+    ): Team
+
+    /**
+     * 팀을 삭제합니다. OWNER만 가능하며 멤버가 1명일 때만 삭제 가능합니다.
+     *
+     * @param teamId 팀 ID
+     * @param userId 요청자 사용자 ID
+     * @throws TeamNotFoundException 팀을 찾을 수 없는 경우
+     * @throws InsufficientTeamRoleException OWNER가 아닌 경우
+     * @throws InvalidTeamStateException 멤버가 2명 이상인 경우
+     */
+    fun deleteTeam(
+        teamId: Long,
+        userId: Long,
+    )
+
+    /**
+     * 팀의 활성 멤버 수를 반환합니다.
+     *
+     * @param teamId 팀 ID
+     * @return 활성 멤버 수
+     */
+    fun getTeamMemberCount(teamId: Long): Int
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/team/dto/TeamMatchupDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/team/dto/TeamMatchupDto.kt
@@ -1,0 +1,39 @@
+package com.nextup.core.service.team.dto
+
+import java.time.LocalDate
+
+/**
+ * 팀 간 상대 전적 DTO
+ *
+ * 두 팀의 대결 전적 통계를 담는 DTO
+ */
+data class TeamMatchupDto(
+    val teamId: Long,
+    val teamName: String,
+    val opponentId: Long,
+    val opponentName: String,
+    val wins: Int,
+    val losses: Int,
+    val draws: Int,
+    val totalGames: Int,
+    val runsScored: Int,
+    val runsAllowed: Int,
+    val avgRunsScored: Double,
+    val avgRunsAllowed: Double,
+)
+
+/**
+ * 팀 간 교전 경기 기록 DTO
+ *
+ * 두 팀이 맞붙은 개별 경기 정보를 담는 DTO
+ */
+data class TeamMatchupGameDto(
+    val gameId: Long,
+    val date: LocalDate,
+    val homeTeamId: Long,
+    val awayTeamId: Long,
+    val homeScore: Int,
+    val awayScore: Int,
+    val result: String,
+    val venue: String?,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/title/TitleCategory.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/title/TitleCategory.kt
@@ -1,0 +1,19 @@
+package com.nextup.core.service.title
+
+/**
+ * 개인 타이틀 카테고리
+ */
+enum class TitleCategory(
+    val displayName: String,
+    val isQualificationRequired: Boolean,
+) {
+    BATTING_AVG("타격왕", true),
+    HOME_RUNS("홈런왕", false),
+    RBI("타점왕", false),
+    STOLEN_BASES("도루왕", false),
+    HITS("최다안타", false),
+    WINS("다승왕", false),
+    ERA("평균자책점", true),
+    SAVES("세이브왕", false),
+    STRIKEOUTS("탈삼진왕", false),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/title/TitleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/title/TitleService.kt
@@ -1,0 +1,30 @@
+package com.nextup.core.service.title
+
+import com.nextup.core.service.title.dto.TitleDto
+
+/**
+ * 타이틀 서비스 인터페이스 (Port)
+ *
+ * 대회별 개인 타이틀(타격왕, 홈런왕 등)을 조회합니다.
+ */
+interface TitleService {
+    /**
+     * 대회의 모든 타이틀 정보를 조회합니다.
+     *
+     * @param competitionId 대회 ID
+     * @return 타이틀 목록
+     */
+    fun getTitles(competitionId: Long): List<TitleDto>
+
+    /**
+     * 대회의 특정 카테고리 타이틀을 조회합니다.
+     *
+     * @param competitionId 대회 ID
+     * @param category 타이틀 카테고리
+     * @return 타이틀 정보
+     */
+    fun getTitleByCategory(
+        competitionId: Long,
+        category: TitleCategory,
+    ): TitleDto
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/title/dto/TitleDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/title/dto/TitleDto.kt
@@ -1,0 +1,35 @@
+package com.nextup.core.service.title.dto
+
+import com.nextup.core.service.title.TitleCategory
+
+/**
+ * 타이틀 정보 DTO
+ */
+data class TitleDto(
+    val category: TitleCategory,
+    val displayName: String,
+    val winner: TitleWinnerDto?,
+    val topCandidates: List<TitleCandidateDto>,
+)
+
+/**
+ * 타이틀 수상자 정보
+ */
+data class TitleWinnerDto(
+    val playerId: Long,
+    val playerName: String,
+    val teamName: String,
+    val statValue: Double,
+)
+
+/**
+ * 타이틀 후보자 정보
+ */
+data class TitleCandidateDto(
+    val rank: Int,
+    val playerId: Long,
+    val playerName: String,
+    val teamName: String,
+    val statValue: Double,
+    val isQualified: Boolean,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/appeal/AppealTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/appeal/AppealTest.kt
@@ -1,0 +1,310 @@
+package com.nextup.core.domain.appeal
+
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("Appeal 엔티티")
+class AppealTest {
+    private val mockGame = mockk<Game>(relaxed = true)
+    private val mockLeague = mockk<League>(relaxed = true)
+    private val mockHomeTeam = mockk<Team>(relaxed = true)
+    private val mockAwayTeam = mockk<Team>(relaxed = true)
+
+    init {
+        every { mockGame.id } returns 1L
+        every { mockLeague.id } returns 1L
+        every { mockHomeTeam.id } returns 1L
+        every { mockAwayTeam.id } returns 2L
+    }
+
+    @Test
+    fun `should create appeal successfully`() {
+        // when
+        val appeal =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.SCORING_ERROR,
+                title = "득점 오류 정정 요청",
+                description = "3회말 득점이 잘못 기록되었습니다",
+            )
+
+        // then
+        assertThat(appeal.game).isEqualTo(mockGame)
+        assertThat(appeal.appealerId).isEqualTo(100L)
+        assertThat(appeal.appealerName).isEqualTo("홍길동")
+        assertThat(appeal.type).isEqualTo(AppealType.SCORING_ERROR)
+        assertThat(appeal.title).isEqualTo("득점 오류 정정 요청")
+        assertThat(appeal.description).isEqualTo("3회말 득점이 잘못 기록되었습니다")
+        assertThat(appeal.status).isEqualTo(AppealStatus.PENDING)
+        assertThat(appeal.reviewerId).isNull()
+        assertThat(appeal.reviewerComment).isNull()
+        assertThat(appeal.reviewedAt).isNull()
+    }
+
+    @Test
+    fun `should fail to create appeal with invalid appealer id`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            Appeal.create(
+                game = mockGame,
+                appealerId = 0L,
+                appealerName = "홍길동",
+                type = AppealType.SCORING_ERROR,
+                title = "제목",
+                description = "설명",
+            )
+        }
+    }
+
+    @Test
+    fun `should fail to create appeal with blank appealer name`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "  ",
+                type = AppealType.SCORING_ERROR,
+                title = "제목",
+                description = "설명",
+            )
+        }
+    }
+
+    @Test
+    fun `should fail to create appeal with blank title`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.SCORING_ERROR,
+                title = "  ",
+                description = "설명",
+            )
+        }
+    }
+
+    @Test
+    fun `should fail to create appeal with blank description`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.SCORING_ERROR,
+                title = "제목",
+                description = "  ",
+            )
+        }
+    }
+
+    @Test
+    fun `should approve appeal successfully`() {
+        // given
+        val appeal =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.SCORING_ERROR,
+                title = "득점 오류",
+                description = "설명",
+            )
+
+        // when
+        appeal.approve(reviewerId = 200L, comment = "검토 완료")
+
+        // then
+        assertThat(appeal.status).isEqualTo(AppealStatus.APPROVED)
+        assertThat(appeal.reviewerId).isEqualTo(200L)
+        assertThat(appeal.reviewerComment).isEqualTo("검토 완료")
+        assertThat(appeal.reviewedAt).isNotNull()
+    }
+
+    @Test
+    fun `should approve appeal without comment`() {
+        // given
+        val appeal =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.RECORD_CORRECTION,
+                title = "기록 정정",
+                description = "설명",
+            )
+
+        // when
+        appeal.approve(reviewerId = 200L, comment = null)
+
+        // then
+        assertThat(appeal.status).isEqualTo(AppealStatus.APPROVED)
+        assertThat(appeal.reviewerId).isEqualTo(200L)
+        assertThat(appeal.reviewerComment).isNull()
+        assertThat(appeal.reviewedAt).isNotNull()
+    }
+
+    @Test
+    fun `should fail to approve already approved appeal`() {
+        // given
+        val appeal =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.SCORING_ERROR,
+                title = "제목",
+                description = "설명",
+            )
+        appeal.approve(reviewerId = 200L, comment = "승인")
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            appeal.approve(reviewerId = 300L, comment = "재승인")
+        }
+    }
+
+    @Test
+    fun `should reject appeal successfully`() {
+        // given
+        val appeal =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.RULE_VIOLATION,
+                title = "규칙 위반 신고",
+                description = "설명",
+            )
+
+        // when
+        appeal.reject(reviewerId = 200L, comment = "증거 불충분")
+
+        // then
+        assertThat(appeal.status).isEqualTo(AppealStatus.REJECTED)
+        assertThat(appeal.reviewerId).isEqualTo(200L)
+        assertThat(appeal.reviewerComment).isEqualTo("증거 불충분")
+        assertThat(appeal.reviewedAt).isNotNull()
+    }
+
+    @Test
+    fun `should fail to reject appeal without comment`() {
+        // given
+        val appeal =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.OTHER,
+                title = "기타 사항",
+                description = "설명",
+            )
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            appeal.reject(reviewerId = 200L, comment = "  ")
+        }
+    }
+
+    @Test
+    fun `should fail to reject already rejected appeal`() {
+        // given
+        val appeal =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.SCORING_ERROR,
+                title = "제목",
+                description = "설명",
+            )
+        appeal.reject(reviewerId = 200L, comment = "반려 사유")
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            appeal.reject(reviewerId = 300L, comment = "재반려")
+        }
+    }
+
+    @Test
+    fun `should fail to reject already approved appeal`() {
+        // given
+        val appeal =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "홍길동",
+                type = AppealType.SCORING_ERROR,
+                title = "제목",
+                description = "설명",
+            )
+        appeal.approve(reviewerId = 200L, comment = "승인")
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            appeal.reject(reviewerId = 300L, comment = "반려")
+        }
+    }
+
+    @Test
+    fun `should handle different appeal types`() {
+        // when
+        val scoringError =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 100L,
+                appealerName = "선수1",
+                type = AppealType.SCORING_ERROR,
+                title = "득점 오류",
+                description = "설명",
+            )
+
+        val recordCorrection =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 101L,
+                appealerName = "선수2",
+                type = AppealType.RECORD_CORRECTION,
+                title = "기록 정정",
+                description = "설명",
+            )
+
+        val ruleViolation =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 102L,
+                appealerName = "감독1",
+                type = AppealType.RULE_VIOLATION,
+                title = "규칙 위반",
+                description = "설명",
+            )
+
+        val other =
+            Appeal.create(
+                game = mockGame,
+                appealerId = 103L,
+                appealerName = "감독2",
+                type = AppealType.OTHER,
+                title = "기타",
+                description = "설명",
+            )
+
+        // then
+        assertThat(scoringError.type).isEqualTo(AppealType.SCORING_ERROR)
+        assertThat(recordCorrection.type).isEqualTo(AppealType.RECORD_CORRECTION)
+        assertThat(ruleViolation.type).isEqualTo(AppealType.RULE_VIOLATION)
+        assertThat(other.type).isEqualTo(AppealType.OTHER)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/attendance/ActivityScoreTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/attendance/ActivityScoreTest.kt
@@ -1,0 +1,207 @@
+package com.nextup.core.domain.attendance
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.user.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+
+class ActivityScoreTest {
+    private val association =
+        Association(
+            name = "테스트협회",
+            region = "서울",
+        )
+
+    private val league =
+        League(
+            association = association,
+            name = "테스트 리그",
+            foundedYear = 2024,
+        )
+
+    private val team =
+        Team(
+            league = league,
+            name = "테스트 팀",
+            city = "서울",
+            foundedYear = 2024,
+        )
+
+    private val user =
+        User.createLocalUser(
+            email = "test@test.com",
+            encodedPassword = "encoded123",
+            nickname = "테스트",
+        )
+
+    private val player =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.STARTING_PITCHER,
+        )
+
+    private val member =
+        TeamMember.create(
+            team = team,
+            user = user,
+            player = player,
+            uniformNumber = 10,
+        )
+
+    @Test
+    fun `활동 점수를 생성할 수 있다`() {
+        // when
+        val activityScore =
+            ActivityScore.create(
+                team = team,
+                member = member,
+            )
+
+        // then
+        assertThat(activityScore.team).isEqualTo(team)
+        assertThat(activityScore.member).isEqualTo(member)
+        assertThat(activityScore.gameParticipationRate).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(activityScore.practiceAttendanceRate).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(activityScore.contributionScore).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `경기 참여율을 업데이트할 수 있다`() {
+        // given
+        val activityScore =
+            ActivityScore.create(
+                team = team,
+                member = member,
+            )
+
+        // when
+        activityScore.updateGameParticipationRate(BigDecimal("85.50"))
+
+        // then
+        assertThat(activityScore.gameParticipationRate).isEqualByComparingTo(BigDecimal("85.50"))
+    }
+
+    @Test
+    fun `경기 참여율이 0 미만이면 예외가 발생한다`() {
+        // given
+        val activityScore =
+            ActivityScore.create(
+                team = team,
+                member = member,
+            )
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            activityScore.updateGameParticipationRate(BigDecimal("-1"))
+        }
+    }
+
+    @Test
+    fun `경기 참여율이 100 초과이면 예외가 발생한다`() {
+        // given
+        val activityScore =
+            ActivityScore.create(
+                team = team,
+                member = member,
+            )
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            activityScore.updateGameParticipationRate(BigDecimal("101"))
+        }
+    }
+
+    @Test
+    fun `연습 참석률을 업데이트할 수 있다`() {
+        // given
+        val activityScore =
+            ActivityScore.create(
+                team = team,
+                member = member,
+            )
+
+        // when
+        activityScore.updatePracticeAttendanceRate(BigDecimal("90.25"))
+
+        // then
+        assertThat(activityScore.practiceAttendanceRate).isEqualByComparingTo(BigDecimal("90.25"))
+    }
+
+    @Test
+    fun `기여도 점수를 업데이트할 수 있다`() {
+        // given
+        val activityScore =
+            ActivityScore.create(
+                team = team,
+                member = member,
+            )
+
+        // when
+        activityScore.updateContributionScore(BigDecimal("75.00"))
+
+        // then
+        assertThat(activityScore.contributionScore).isEqualByComparingTo(BigDecimal("75.00"))
+    }
+
+    @Test
+    fun `전체 활동 점수를 계산할 수 있다`() {
+        // given
+        val activityScore =
+            ActivityScore.create(
+                team = team,
+                member = member,
+            )
+        activityScore.updateGameParticipationRate(BigDecimal("80.00"))
+        activityScore.updatePracticeAttendanceRate(BigDecimal("90.00"))
+        activityScore.updateContributionScore(BigDecimal("70.00"))
+
+        // when
+        val totalScore = activityScore.calculateTotalScore()
+
+        // then
+        // 80 * 0.4 + 90 * 0.4 + 70 * 0.2 = 32 + 36 + 14 = 82
+        assertThat(totalScore).isEqualByComparingTo(BigDecimal("82.00"))
+    }
+
+    @Test
+    fun `모든 점수가 0이면 전체 점수도 0이다`() {
+        // given
+        val activityScore =
+            ActivityScore.create(
+                team = team,
+                member = member,
+            )
+
+        // when
+        val totalScore = activityScore.calculateTotalScore()
+
+        // then
+        assertThat(totalScore).isEqualByComparingTo(BigDecimal("0.00"))
+    }
+
+    @Test
+    fun `모든 점수가 100이면 전체 점수도 100이다`() {
+        // given
+        val activityScore =
+            ActivityScore.create(
+                team = team,
+                member = member,
+            )
+        activityScore.updateGameParticipationRate(BigDecimal("100.00"))
+        activityScore.updatePracticeAttendanceRate(BigDecimal("100.00"))
+        activityScore.updateContributionScore(BigDecimal("100.00"))
+
+        // when
+        val totalScore = activityScore.calculateTotalScore()
+
+        // then
+        assertThat(totalScore).isEqualByComparingTo(BigDecimal("100.00"))
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/attendance/AttendancePollTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/attendance/AttendancePollTest.kt
@@ -1,0 +1,195 @@
+package com.nextup.core.domain.attendance
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class AttendancePollTest {
+    private val association =
+        Association(
+            name = "테스트협회",
+            region = "서울",
+        )
+
+    private val league =
+        League(
+            association = association,
+            name = "테스트 리그",
+            foundedYear = 2024,
+        )
+
+    private val team =
+        Team(
+            league = league,
+            name = "테스트 팀",
+            city = "서울",
+            foundedYear = 2024,
+        )
+
+    @Test
+    fun `출석 투표를 생성할 수 있다`() {
+        // given
+        val title = "이번 주 일요일 경기 출석 조사"
+        val eventDate = LocalDateTime.now().plusDays(7)
+        val deadline = LocalDateTime.now().plusDays(5)
+
+        // when
+        val poll =
+            AttendancePoll.create(
+                team = team,
+                title = title,
+                eventDate = eventDate,
+                deadline = deadline,
+            )
+
+        // then
+        assertThat(poll.title).isEqualTo(title)
+        assertThat(poll.eventDate).isEqualTo(eventDate)
+        assertThat(poll.deadline).isEqualTo(deadline)
+        assertThat(poll.status).isEqualTo(PollStatus.OPEN)
+        assertThat(poll.isOpen()).isTrue()
+    }
+
+    @Test
+    fun `제목이 비어있으면 예외가 발생한다`() {
+        // given
+        val eventDate = LocalDateTime.now().plusDays(7)
+        val deadline = LocalDateTime.now().plusDays(5)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            AttendancePoll.create(
+                team = team,
+                title = "",
+                eventDate = eventDate,
+                deadline = deadline,
+            )
+        }
+    }
+
+    @Test
+    fun `이벤트 날짜가 과거이면 예외가 발생한다`() {
+        // given
+        val eventDate = LocalDateTime.now().minusDays(1)
+        val deadline = LocalDateTime.now().minusDays(2)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            AttendancePoll.create(
+                team = team,
+                title = "테스트 투표",
+                eventDate = eventDate,
+                deadline = deadline,
+            )
+        }
+    }
+
+    @Test
+    fun `마감 시간이 이벤트 날짜 이후이면 예외가 발생한다`() {
+        // given
+        val eventDate = LocalDateTime.now().plusDays(7)
+        val deadline = LocalDateTime.now().plusDays(10)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            AttendancePoll.create(
+                team = team,
+                title = "테스트 투표",
+                eventDate = eventDate,
+                deadline = deadline,
+            )
+        }
+    }
+
+    @Test
+    fun `투표를 마감할 수 있다`() {
+        // given
+        val poll =
+            AttendancePoll.create(
+                team = team,
+                title = "테스트 투표",
+                eventDate = LocalDateTime.now().plusDays(7),
+                deadline = LocalDateTime.now().plusDays(5),
+            )
+
+        // when
+        poll.close()
+
+        // then
+        assertThat(poll.isClosed()).isTrue()
+        assertThat(poll.isOpen()).isFalse()
+    }
+
+    @Test
+    fun `이미 마감된 투표를 다시 마감하면 예외가 발생한다`() {
+        // given
+        val poll =
+            AttendancePoll.create(
+                team = team,
+                title = "테스트 투표",
+                eventDate = LocalDateTime.now().plusDays(7),
+                deadline = LocalDateTime.now().plusDays(5),
+            )
+        poll.close()
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            poll.close()
+        }
+    }
+
+    @Test
+    fun `마감 시간이 지나면 투표할 수 없다`() {
+        // given
+        val poll =
+            AttendancePoll.create(
+                team = team,
+                title = "테스트 투표",
+                eventDate = LocalDateTime.now().plusDays(7),
+                deadline = LocalDateTime.now().minusMinutes(1),
+            )
+
+        // when & then
+        assertThat(poll.isExpired()).isTrue()
+        assertThat(poll.canVote()).isFalse()
+    }
+
+    @Test
+    fun `제목을 수정할 수 있다`() {
+        // given
+        val poll =
+            AttendancePoll.create(
+                team = team,
+                title = "원래 제목",
+                eventDate = LocalDateTime.now().plusDays(7),
+                deadline = LocalDateTime.now().plusDays(5),
+            )
+
+        // when
+        poll.updateTitle("변경된 제목")
+
+        // then
+        assertThat(poll.title).isEqualTo("변경된 제목")
+    }
+
+    @Test
+    fun `제목을 빈 문자열로 수정하면 예외가 발생한다`() {
+        // given
+        val poll =
+            AttendancePoll.create(
+                team = team,
+                title = "원래 제목",
+                eventDate = LocalDateTime.now().plusDays(7),
+                deadline = LocalDateTime.now().plusDays(5),
+            )
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            poll.updateTitle("")
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/attendance/AttendanceVoteTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/attendance/AttendanceVoteTest.kt
@@ -1,0 +1,138 @@
+package com.nextup.core.domain.attendance
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class AttendanceVoteTest {
+    private val association =
+        Association(
+            name = "테스트협회",
+            region = "서울",
+        )
+
+    private val league =
+        League(
+            association = association,
+            name = "테스트 리그",
+            foundedYear = 2024,
+        )
+
+    private val team =
+        Team(
+            league = league,
+            name = "테스트 팀",
+            city = "서울",
+            foundedYear = 2024,
+        )
+
+    private val poll =
+        AttendancePoll.create(
+            team = team,
+            title = "테스트 투표",
+            eventDate = LocalDateTime.now().plusDays(7),
+            deadline = LocalDateTime.now().plusDays(5),
+        )
+
+    private val player =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.STARTING_PITCHER,
+        )
+
+    @Test
+    fun `출석 투표 응답을 생성할 수 있다`() {
+        // when
+        val vote =
+            AttendanceVote.create(
+                poll = poll,
+                player = player,
+                voteType = VoteType.ATTEND,
+            )
+
+        // then
+        assertThat(vote.poll).isEqualTo(poll)
+        assertThat(vote.player).isEqualTo(player)
+        assertThat(vote.voteType).isEqualTo(VoteType.ATTEND)
+    }
+
+    @Test
+    fun `투표를 변경할 수 있다`() {
+        // given
+        val vote =
+            AttendanceVote.create(
+                poll = poll,
+                player = player,
+                voteType = VoteType.UNDECIDED,
+            )
+
+        // when
+        vote.changeVote(VoteType.ATTEND)
+
+        // then
+        assertThat(vote.voteType).isEqualTo(VoteType.ATTEND)
+    }
+
+    @Test
+    fun `마감된 투표는 변경할 수 없다`() {
+        // given - 투표를 먼저 생성 후 마감
+        val vote =
+            AttendanceVote.create(
+                poll = poll,
+                player = player,
+                voteType = VoteType.UNDECIDED,
+            )
+        poll.close()
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            vote.changeVote(VoteType.ATTEND)
+        }
+    }
+
+    @Test
+    fun `참석 의사 확인이 가능하다`() {
+        // given
+        val attendVote =
+            AttendanceVote.create(
+                poll = poll,
+                player = player,
+                voteType = VoteType.ATTEND,
+            )
+
+        val absentVote =
+            AttendanceVote.create(
+                poll = poll,
+                player = player,
+                voteType = VoteType.ABSENT,
+            )
+
+        // when & then
+        assertThat(attendVote.isAttending()).isTrue()
+        assertThat(attendVote.isAbsent()).isFalse()
+
+        assertThat(absentVote.isAttending()).isFalse()
+        assertThat(absentVote.isAbsent()).isTrue()
+    }
+
+    @Test
+    fun `마감된 투표에는 새로운 응답을 생성할 수 없다`() {
+        // given
+        poll.close()
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            AttendanceVote.create(
+                poll = poll,
+                player = player,
+                voteType = VoteType.ATTEND,
+            )
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/certificate/CertificateTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/certificate/CertificateTest.kt
@@ -1,0 +1,104 @@
+package com.nextup.core.domain.certificate
+
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.time.LocalDate
+
+class CertificateTest {
+    @Test
+    fun `should issue certificate with valid player`() {
+        // given
+        val player = createPlayer()
+
+        // when
+        val certificate = Certificate.issue(player, validityDays = 365)
+
+        // then
+        assertThat(certificate.player).isEqualTo(player)
+        assertThat(certificate.issueNumber).isNotBlank()
+        assertThat(certificate.status).isEqualTo(CertificateStatus.VALID)
+        assertThat(certificate.issuedAt).isBeforeOrEqualTo(Instant.now())
+        assertThat(certificate.expiresAt).isAfter(certificate.issuedAt)
+    }
+
+    @Test
+    fun `should return true when certificate is valid and not expired`() {
+        // given
+        val player = createPlayer()
+        val certificate = Certificate.issue(player, validityDays = 365)
+
+        // when & then
+        assertThat(certificate.isValid()).isTrue()
+        assertThat(certificate.isExpired()).isFalse()
+        assertThat(certificate.isRevoked()).isFalse()
+    }
+
+    @Test
+    fun `should revoke valid certificate`() {
+        // given
+        val player = createPlayer()
+        val certificate = Certificate.issue(player, validityDays = 365)
+
+        // when
+        certificate.revoke()
+
+        // then
+        assertThat(certificate.status).isEqualTo(CertificateStatus.REVOKED)
+        assertThat(certificate.isRevoked()).isTrue()
+        assertThat(certificate.isValid()).isFalse()
+    }
+
+    @Test
+    fun `should throw exception when revoking already revoked certificate`() {
+        // given
+        val player = createPlayer()
+        val certificate = Certificate.issue(player, validityDays = 365)
+        certificate.revoke()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            certificate.revoke()
+        }
+    }
+
+    @Test
+    fun `should mark expired certificate as expired`() {
+        // given
+        val player = createPlayer()
+        val certificate = Certificate.issue(player, validityDays = -1) // 이미 만료됨
+
+        // when
+        certificate.markAsExpired()
+
+        // then
+        assertThat(certificate.status).isEqualTo(CertificateStatus.EXPIRED)
+        assertThat(certificate.isExpired()).isTrue()
+    }
+
+    @Test
+    fun `should throw exception when marking non-expired certificate as expired`() {
+        // given
+        val player = createPlayer()
+        val certificate = Certificate.issue(player, validityDays = 365)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            certificate.markAsExpired()
+        }
+    }
+
+    private fun createPlayer(): Player =
+        Player(
+            name = "홍길동",
+            birthDate = LocalDate.of(1990, 1, 1),
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            primaryPosition = Position.STARTING_PITCHER,
+        )
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/BracketEntryTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/BracketEntryTest.kt
@@ -1,0 +1,199 @@
+package com.nextup.core.domain.competition
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class BracketEntryTest {
+    @Test
+    fun `should record winner when no winner exists`() {
+        // given
+        val (competition, team1, team2) = createTestData()
+        val bracketEntry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = team1,
+                team2 = team2,
+            )
+
+        // when
+        bracketEntry.recordWinner(team1)
+
+        // then
+        assertThat(bracketEntry.winner).isEqualTo(team1)
+    }
+
+    @Test
+    fun `should throw exception when recording winner twice`() {
+        // given
+        val (competition, team1, team2) = createTestData()
+        val bracketEntry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = team1,
+                team2 = team2,
+            )
+        bracketEntry.recordWinner(team1)
+
+        // when & then
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                bracketEntry.recordWinner(team2)
+            }
+        assertThat(exception.message).isEqualTo("이미 승자가 결정된 경기입니다")
+    }
+
+    @Test
+    fun `should throw exception when recording non-participant as winner`() {
+        // given
+        val (competition, team1, team2) = createTestData()
+        val association = Association(name = "다른 협회")
+        val league = League(association = association, name = "다른 리그", foundedYear = 2020)
+        val otherTeam = Team(league = league, name = "다른 팀", city = "부산", foundedYear = 2020)
+
+        val bracketEntry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = team1,
+                team2 = team2,
+            )
+
+        // when & then
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                bracketEntry.recordWinner(otherTeam)
+            }
+        assertThat(exception.message).isEqualTo("참가팀만 승자로 지정할 수 있습니다")
+    }
+
+    @Test
+    fun `should return true for isBye when team1 is null`() {
+        // given
+        val (competition, _, team2) = createTestData()
+        val bracketEntry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = null,
+                team2 = team2,
+            )
+
+        // when & then
+        assertThat(bracketEntry.isBye()).isTrue()
+    }
+
+    @Test
+    fun `should return true for isBye when team2 is null`() {
+        // given
+        val (competition, team1, _) = createTestData()
+        val bracketEntry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = team1,
+                team2 = null,
+            )
+
+        // when & then
+        assertThat(bracketEntry.isBye()).isTrue()
+    }
+
+    @Test
+    fun `should return false for isBye when both teams exist`() {
+        // given
+        val (competition, team1, team2) = createTestData()
+        val bracketEntry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = team1,
+                team2 = team2,
+            )
+
+        // when & then
+        assertThat(bracketEntry.isBye()).isFalse()
+    }
+
+    @Test
+    fun `should return true for isCompleted when winner exists`() {
+        // given
+        val (competition, team1, team2) = createTestData()
+        val bracketEntry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = team1,
+                team2 = team2,
+            )
+        bracketEntry.recordWinner(team1)
+
+        // when & then
+        assertThat(bracketEntry.isCompleted()).isTrue()
+    }
+
+    @Test
+    fun `should return true for isCompleted when it is a bye`() {
+        // given
+        val (competition, team1, _) = createTestData()
+        val bracketEntry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = team1,
+                team2 = null,
+            )
+
+        // when & then
+        assertThat(bracketEntry.isCompleted()).isTrue()
+    }
+
+    @Test
+    fun `should return false for isCompleted when no winner and not a bye`() {
+        // given
+        val (competition, team1, team2) = createTestData()
+        val bracketEntry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = team1,
+                team2 = team2,
+            )
+
+        // when & then
+        assertThat(bracketEntry.isCompleted()).isFalse()
+    }
+
+    private fun createTestData(): Triple<Competition, Team, Team> {
+        val association = Association(name = "테스트 협회")
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020)
+        val competition =
+            Competition(
+                league = league,
+                name = "2025 춘계 토너먼트",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.TOURNAMENT,
+                startDate = LocalDate.of(2025, 3, 1),
+            )
+        val team1 = Team(league = league, name = "팀A", city = "서울", foundedYear = 2020)
+        val team2 = Team(league = league, name = "팀B", city = "서울", foundedYear = 2020)
+
+        return Triple(competition, team1, team2)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/discipline/DisciplineTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/discipline/DisciplineTest.kt
@@ -1,0 +1,473 @@
+package com.nextup.core.domain.discipline
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("Discipline 엔티티 테스트")
+class DisciplineTest {
+    private lateinit var player: Player
+    private lateinit var competition: Competition
+
+    @BeforeEach
+    fun setUp() {
+        val association =
+            Association(
+                name = "서울시야구협회",
+                abbreviation = "SBA",
+                region = "서울",
+            )
+
+        val league =
+            League(
+                association = association,
+                name = "1부 리그",
+                abbreviation = "1st",
+                foundedYear = 2020,
+                divisionLevel = 1,
+            )
+
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+            )
+
+        player =
+            Player(
+                name = "홍길동",
+                birthDate = LocalDate.of(1995, 5, 15),
+                primaryPosition = Position.CATCHER,
+                throwingHand = ThrowingHand.RIGHT,
+                battingHand = BattingHand.RIGHT,
+            )
+    }
+
+    @Nested
+    @DisplayName("경고 징계 생성")
+    inner class CreateWarning {
+        @Test
+        fun `경고 징계를 생성할 수 있다`() {
+            // when
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "과도한 항의",
+                    issuedBy = "심판장",
+                )
+
+            // then
+            assertThat(discipline.type).isEqualTo(DisciplineType.WARNING)
+            assertThat(discipline.reason).isEqualTo("과도한 항의")
+            assertThat(discipline.issuedBy).isEqualTo("심판장")
+            assertThat(discipline.status).isEqualTo(DisciplineStatus.ACTIVE)
+            assertThat(discipline.suspensionGames).isNull()
+        }
+
+        @Test
+        fun `만료일이 설정된 경고 징계를 생성할 수 있다`() {
+            // given
+            val expiresAt = LocalDateTime.now().plusMonths(3)
+
+            // when
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                    expiresAt = expiresAt,
+                )
+
+            // then
+            assertThat(discipline.expiresAt).isEqualTo(expiresAt)
+        }
+
+        @Test
+        fun `징계 사유가 비어있으면 생성할 수 없다`() {
+            // when & then
+            assertThatThrownBy {
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "",
+                    issuedBy = "심판장",
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("징계 사유는 필수입니다.")
+        }
+
+        @Test
+        fun `발급자가 비어있으면 생성할 수 없다`() {
+            // when & then
+            assertThatThrownBy {
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "",
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("징계 발급자는 필수입니다.")
+        }
+    }
+
+    @Nested
+    @DisplayName("출장 정지 징계 생성")
+    inner class CreateSuspension {
+        @Test
+        fun `출장 정지 징계를 생성할 수 있다`() {
+            // when
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 3,
+                    issuedBy = "기술위원장",
+                )
+
+            // then
+            assertThat(discipline.type).isEqualTo(DisciplineType.SUSPENSION)
+            assertThat(discipline.reason).isEqualTo("폭력 행위")
+            assertThat(discipline.suspensionGames).isEqualTo(3)
+            assertThat(discipline.servedGames).isEqualTo(0)
+            assertThat(discipline.status).isEqualTo(DisciplineStatus.ACTIVE)
+        }
+
+        @Test
+        fun `출장 정지 경기 수가 0이면 생성할 수 없다`() {
+            // when & then
+            assertThatThrownBy {
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 0,
+                    issuedBy = "기술위원장",
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("출장 정지 경기 수는 1 이상이어야 합니다.")
+        }
+
+        @Test
+        fun `출장 정지 경기 수가 음수이면 생성할 수 없다`() {
+            // when & then
+            assertThatThrownBy {
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = -1,
+                    issuedBy = "기술위원장",
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("영구 제재 징계 생성")
+    inner class CreateBan {
+        @Test
+        fun `영구 제재 징계를 생성할 수 있다`() {
+            // when
+            val discipline =
+                Discipline.createBan(
+                    player = player,
+                    competition = competition,
+                    reason = "승부 조작",
+                    issuedBy = "협회장",
+                )
+
+            // then
+            assertThat(discipline.type).isEqualTo(DisciplineType.BAN)
+            assertThat(discipline.reason).isEqualTo("승부 조작")
+            assertThat(discipline.status).isEqualTo(DisciplineStatus.ACTIVE)
+            assertThat(discipline.suspensionGames).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("징계 취소")
+    inner class Cancel {
+        @Test
+        fun `활성 상태의 징계를 취소할 수 있다`() {
+            // given
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+
+            // when
+            discipline.cancel()
+
+            // then
+            assertThat(discipline.status).isEqualTo(DisciplineStatus.CANCELLED)
+        }
+
+        @Test
+        fun `이행 완료된 징계는 취소할 수 없다`() {
+            // given
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 1,
+                    issuedBy = "기술위원장",
+                )
+            discipline.incrementServedGames() // 이행 완료 처리
+
+            // when & then
+            assertThatThrownBy { discipline.cancel() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("활성 상태의 징계만 취소할 수 있습니다.")
+        }
+
+        @Test
+        fun `취소된 징계는 다시 취소할 수 없다`() {
+            // given
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+            discipline.cancel()
+
+            // when & then
+            assertThatThrownBy { discipline.cancel() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("유효성 확인")
+    inner class IsEffective {
+        @Test
+        fun `활성 상태의 징계는 유효하다`() {
+            // given
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+
+            // then
+            assertThat(discipline.isEffective()).isTrue()
+        }
+
+        @Test
+        fun `취소된 징계는 유효하지 않다`() {
+            // given
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+            discipline.cancel()
+
+            // then
+            assertThat(discipline.isEffective()).isFalse()
+        }
+
+        @Test
+        fun `만료된 징계는 유효하지 않다`() {
+            // given
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                    expiresAt = LocalDateTime.now().minusDays(1),
+                )
+
+            // then
+            assertThat(discipline.isEffective()).isFalse()
+        }
+
+        @Test
+        fun `모든 경기를 소화한 출장 정지는 유효하지 않다`() {
+            // given
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 2,
+                    issuedBy = "기술위원장",
+                )
+            discipline.incrementServedGames()
+            discipline.incrementServedGames()
+
+            // then
+            assertThat(discipline.isEffective()).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("소화 경기 수 증가")
+    inner class IncrementServedGames {
+        @Test
+        fun `출장 정지 징계의 소화 경기 수를 증가시킬 수 있다`() {
+            // given
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 3,
+                    issuedBy = "기술위원장",
+                )
+
+            // when
+            discipline.incrementServedGames()
+
+            // then
+            assertThat(discipline.servedGames).isEqualTo(1)
+            assertThat(discipline.status).isEqualTo(DisciplineStatus.ACTIVE)
+        }
+
+        @Test
+        fun `모든 경기를 소화하면 이행 완료 상태가 된다`() {
+            // given
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 2,
+                    issuedBy = "기술위원장",
+                )
+
+            // when
+            discipline.incrementServedGames()
+            discipline.incrementServedGames()
+
+            // then
+            assertThat(discipline.servedGames).isEqualTo(2)
+            assertThat(discipline.status).isEqualTo(DisciplineStatus.SERVED)
+        }
+
+        @Test
+        fun `경고 징계는 소화 경기 수를 증가시킬 수 없다`() {
+            // given
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+
+            // when & then
+            assertThatThrownBy { discipline.incrementServedGames() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("출장 정지 징계만 경기를 소화할 수 있습니다.")
+        }
+
+        @Test
+        fun `취소된 징계는 소화 경기 수를 증가시킬 수 없다`() {
+            // given
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 3,
+                    issuedBy = "기술위원장",
+                )
+            discipline.cancel()
+
+            // when & then
+            assertThatThrownBy { discipline.incrementServedGames() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("활성 상태의 징계만 경기를 소화할 수 있습니다.")
+        }
+    }
+
+    @Nested
+    @DisplayName("이행 완료 처리")
+    inner class MarkServed {
+        @Test
+        fun `출장 정지 징계를 이행 완료 처리할 수 있다`() {
+            // given
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 3,
+                    issuedBy = "기술위원장",
+                )
+
+            // when
+            discipline.markServed()
+
+            // then
+            assertThat(discipline.status).isEqualTo(DisciplineStatus.SERVED)
+        }
+
+        @Test
+        fun `경고 징계는 이행 완료 처리할 수 없다`() {
+            // given
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+
+            // when & then
+            assertThatThrownBy { discipline.markServed() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("출장 정지 징계만 이행 완료 처리할 수 있습니다.")
+        }
+
+        @Test
+        fun `취소된 징계는 이행 완료 처리할 수 없다`() {
+            // given
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 3,
+                    issuedBy = "기술위원장",
+                )
+            discipline.cancel()
+
+            // when & then
+            assertThatThrownBy { discipline.markServed() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/election/CandidateTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/election/CandidateTest.kt
@@ -1,0 +1,67 @@
+package com.nextup.core.domain.election
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CandidateTest {
+    @Test
+    fun `should create candidate with valid data`() {
+        // given
+        val electionId = 1L
+        val memberId = 100L
+        val memberName = "홍길동"
+        val statement = "열심히 하겠습니다"
+
+        // when
+        val candidate =
+            Candidate.create(
+                electionId = electionId,
+                memberId = memberId,
+                memberName = memberName,
+                statement = statement,
+            )
+
+        // then
+        assertThat(candidate.electionId).isEqualTo(electionId)
+        assertThat(candidate.memberId).isEqualTo(memberId)
+        assertThat(candidate.memberName).isEqualTo(memberName)
+        assertThat(candidate.statement).isEqualTo(statement)
+    }
+
+    @Test
+    fun `should create candidate without statement`() {
+        // given
+        val electionId = 1L
+        val memberId = 100L
+        val memberName = "홍길동"
+
+        // when
+        val candidate =
+            Candidate.create(
+                electionId = electionId,
+                memberId = memberId,
+                memberName = memberName,
+                statement = null,
+            )
+
+        // then
+        assertThat(candidate.electionId).isEqualTo(electionId)
+        assertThat(candidate.memberId).isEqualTo(memberId)
+        assertThat(candidate.memberName).isEqualTo(memberName)
+        assertThat(candidate.statement).isNull()
+    }
+
+    @Test
+    fun `should throw exception when member name is blank`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            Candidate.create(
+                electionId = 1L,
+                memberId = 100L,
+                memberName = "",
+                statement = null,
+            )
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/election/ElectionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/election/ElectionTest.kt
@@ -1,0 +1,325 @@
+package com.nextup.core.domain.election
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class ElectionTest {
+    @Test
+    fun `should create election with valid data`() {
+        // given
+        val teamId = 1L
+        val title = "구단주 선출"
+        val description = "2024년 구단주 선출"
+        val electionType = ElectionType.OWNER_ELECTION
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+
+        // when
+        val election =
+            Election.create(
+                teamId = teamId,
+                title = title,
+                description = description,
+                electionType = electionType,
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        // then
+        assertThat(election.teamId).isEqualTo(teamId)
+        assertThat(election.title).isEqualTo(title)
+        assertThat(election.description).isEqualTo(description)
+        assertThat(election.electionType).isEqualTo(electionType)
+        assertThat(election.startAt).isEqualTo(startAt)
+        assertThat(election.endAt).isEqualTo(endAt)
+        assertThat(election.status).isEqualTo(ElectionStatus.SCHEDULED)
+    }
+
+    @Test
+    fun `should throw exception when title is blank`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            Election.create(
+                teamId = 1L,
+                title = "",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception when end time is before start time`() {
+        // given
+        val startAt = Instant.now().plus(7, ChronoUnit.DAYS)
+        val endAt = startAt.minus(1, ChronoUnit.DAYS)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        }
+    }
+
+    @Test
+    fun `should start election when status is SCHEDULED`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        // when
+        election.start()
+
+        // then
+        assertThat(election.status).isEqualTo(ElectionStatus.IN_PROGRESS)
+    }
+
+    @Test
+    fun `should throw exception when starting already started election`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        election.start()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            election.start()
+        }
+    }
+
+    @Test
+    fun `should complete election when status is IN_PROGRESS`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        election.start()
+
+        // when
+        election.complete()
+
+        // then
+        assertThat(election.status).isEqualTo(ElectionStatus.COMPLETED)
+    }
+
+    @Test
+    fun `should throw exception when completing not started election`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            election.complete()
+        }
+    }
+
+    @Test
+    fun `should cancel election when status is SCHEDULED`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        // when
+        election.cancel()
+
+        // then
+        assertThat(election.status).isEqualTo(ElectionStatus.CANCELLED)
+    }
+
+    @Test
+    fun `should cancel election when status is IN_PROGRESS`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        election.start()
+
+        // when
+        election.cancel()
+
+        // then
+        assertThat(election.status).isEqualTo(ElectionStatus.CANCELLED)
+    }
+
+    @Test
+    fun `should throw exception when canceling completed election`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        election.start()
+        election.complete()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            election.cancel()
+        }
+    }
+
+    @Test
+    fun `should return true when voting is open`() {
+        // given
+        val startAt = Instant.now().minus(1, ChronoUnit.HOURS)
+        val endAt = Instant.now().plus(1, ChronoUnit.HOURS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        election.start()
+
+        // when
+        val isVotingOpen = election.isVotingOpen()
+
+        // then
+        assertThat(isVotingOpen).isTrue()
+    }
+
+    @Test
+    fun `should return false when voting is not started yet`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.HOURS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        election.start()
+
+        // when
+        val isVotingOpen = election.isVotingOpen()
+
+        // then
+        assertThat(isVotingOpen).isFalse()
+    }
+
+    @Test
+    fun `should return false when voting is ended`() {
+        // given
+        val startAt = Instant.now().minus(2, ChronoUnit.HOURS)
+        val endAt = Instant.now().minus(1, ChronoUnit.HOURS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+        election.start()
+
+        // when
+        val isVotingOpen = election.isVotingOpen()
+
+        // then
+        assertThat(isVotingOpen).isFalse()
+    }
+
+    @Test
+    fun `should return false when election status is not IN_PROGRESS`() {
+        // given
+        val startAt = Instant.now().minus(1, ChronoUnit.HOURS)
+        val endAt = Instant.now().plus(1, ChronoUnit.HOURS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = null,
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        // when
+        val isVotingOpen = election.isVotingOpen()
+
+        // then
+        assertThat(isVotingOpen).isFalse()
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/election/ElectionVoteTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/election/ElectionVoteTest.kt
@@ -1,0 +1,53 @@
+package com.nextup.core.domain.election
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class ElectionVoteTest {
+    @Test
+    fun `should create election vote with valid data`() {
+        // given
+        val electionId = 1L
+        val voterId = 100L
+        val candidateId = 10L
+        val votedAt = Instant.now()
+
+        // when
+        val vote =
+            ElectionVote.create(
+                electionId = electionId,
+                voterId = voterId,
+                candidateId = candidateId,
+                votedAt = votedAt,
+            )
+
+        // then
+        assertThat(vote.electionId).isEqualTo(electionId)
+        assertThat(vote.voterId).isEqualTo(voterId)
+        assertThat(vote.candidateId).isEqualTo(candidateId)
+        assertThat(vote.votedAt).isEqualTo(votedAt)
+    }
+
+    @Test
+    fun `should create election vote with default votedAt`() {
+        // given
+        val electionId = 1L
+        val voterId = 100L
+        val candidateId = 10L
+
+        // when
+        val vote =
+            ElectionVote.create(
+                electionId = electionId,
+                voterId = voterId,
+                candidateId = candidateId,
+            )
+
+        // then
+        assertThat(vote.electionId).isEqualTo(electionId)
+        assertThat(vote.voterId).isEqualTo(voterId)
+        assertThat(vote.candidateId).isEqualTo(candidateId)
+        assertThat(vote.votedAt).isNotNull()
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -5,6 +5,7 @@ import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -17,11 +18,12 @@ import java.time.LocalDateTime
 @DisplayName("Game 엔티티 테스트")
 class GameTest {
     private lateinit var competition: Competition
+    private lateinit var league: League
 
     @BeforeEach
     fun setUp() {
         val association = Association(name = "서울시야구협회", region = "서울")
-        val league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        league = League(association = association, name = "1부 리그", foundedYear = 2020)
         competition =
             Competition(
                 league = league,
@@ -40,6 +42,19 @@ class GameTest {
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실야구장",
             status = status,
+        )
+
+    private fun createTeam(
+        name: String,
+        city: String = "서울",
+        id: Long = 0L,
+    ): Team =
+        Team(
+            league = league,
+            name = name,
+            city = city,
+            foundedYear = 2020,
+            id = id,
         )
 
     @Nested
@@ -213,17 +228,137 @@ class GameTest {
     @Nested
     @DisplayName("몰수패")
     inner class Forfeit {
+        private lateinit var homeTeam: Team
+        private lateinit var awayTeam: Team
+
+        @BeforeEach
+        fun setUpTeams() {
+            homeTeam = createTeam("홈팀", id = 1L)
+            awayTeam = createTeam("원정팀", city = "부산", id = 2L)
+        }
+
+        private fun createGameTeams(game: Game): List<GameTeam> =
+            listOf(
+                GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME),
+                GameTeam(game = game, team = awayTeam, homeAway = HomeAway.AWAY),
+            )
+
         @Test
-        fun `예정된 경기를 몰수 처리할 수 있다`() {
+        fun `예정된 경기를 몰수 처리하면 7대0 점수가 반영된다`() {
             // given
             val game = createGame(status = GameStatus.SCHEDULED)
+            val gameTeams = createGameTeams(game)
 
             // when
-            game.forfeit("상대팀 불참")
+            game.forfeit(
+                winnerTeamId = homeTeam.id,
+                reason = "상대팀 불참",
+                gameTeams = gameTeams,
+            )
 
             // then
             assertThat(game.status).isEqualTo(GameStatus.FORFEITED)
+            assertThat(game.forfeitReason).isEqualTo("상대팀 불참")
             assertThat(game.note).contains("상대팀 불참")
+            assertThat(game.endedAt).isNotNull()
+
+            val winnerGameTeam = gameTeams.first { it.team.id == homeTeam.id }
+            val loserGameTeam = gameTeams.first { it.team.id == awayTeam.id }
+
+            assertThat(winnerGameTeam.totalScore).isEqualTo(7)
+            assertThat(winnerGameTeam.result).isEqualTo(GameResult.WIN)
+            assertThat(loserGameTeam.totalScore).isEqualTo(0)
+            assertThat(loserGameTeam.result).isEqualTo(GameResult.LOSS)
+        }
+
+        @Test
+        fun `진행 중인 경기도 몰수 처리할 수 있다`() {
+            // given
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            val gameTeams = createGameTeams(game)
+
+            // when
+            game.forfeit(
+                winnerTeamId = awayTeam.id,
+                reason = "홈팀 규정 위반",
+                gameTeams = gameTeams,
+            )
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.FORFEITED)
+            val winnerGameTeam = gameTeams.first { it.team.id == awayTeam.id }
+            val loserGameTeam = gameTeams.first { it.team.id == homeTeam.id }
+
+            assertThat(winnerGameTeam.totalScore).isEqualTo(7)
+            assertThat(winnerGameTeam.result).isEqualTo(GameResult.WIN)
+            assertThat(loserGameTeam.totalScore).isEqualTo(0)
+            assertThat(loserGameTeam.result).isEqualTo(GameResult.LOSS)
+        }
+
+        @Test
+        fun `이미 종료된 경기는 몰수 처리할 수 없다`() {
+            // given
+            val game = createGame(status = GameStatus.FINISHED)
+            val gameTeams = createGameTeams(game)
+
+            // when & then
+            assertThatThrownBy {
+                game.forfeit(
+                    winnerTeamId = homeTeam.id,
+                    reason = "사유",
+                    gameTeams = gameTeams,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `취소된 경기는 몰수 처리할 수 없다`() {
+            // given
+            val game = createGame(status = GameStatus.CANCELLED)
+            val gameTeams = createGameTeams(game)
+
+            // when & then
+            assertThatThrownBy {
+                game.forfeit(
+                    winnerTeamId = homeTeam.id,
+                    reason = "사유",
+                    gameTeams = gameTeams,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `참여하지 않는 팀을 승리팀으로 지정하면 예외가 발생한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            val gameTeams = createGameTeams(game)
+
+            // when & then
+            assertThatThrownBy {
+                game.forfeit(
+                    winnerTeamId = 9999L,
+                    reason = "사유",
+                    gameTeams = gameTeams,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("참여하는 팀이 아닙니다")
+        }
+
+        @Test
+        fun `몰수 사유가 forfeitReason 필드에 기록된다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            val gameTeams = createGameTeams(game)
+
+            // when
+            game.forfeit(
+                winnerTeamId = homeTeam.id,
+                reason = "인원 미달로 경기 불가",
+                gameTeams = gameTeams,
+            )
+
+            // then
+            assertThat(game.forfeitReason).isEqualTo("인원 미달로 경기 불가")
         }
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupSubmissionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupSubmissionTest.kt
@@ -2,6 +2,8 @@ package com.nextup.core.domain.game
 
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.team.Team
 import com.nextup.core.domain.user.User
 import org.assertj.core.api.Assertions.assertThat
@@ -33,7 +35,7 @@ class LineupSubmissionTest {
     @Test
     fun `should submit lineup when status is DRAFT`() {
         // given
-        val submission = createLineupSubmission()
+        val submission = createLineupSubmissionWithEntries()
 
         // when
         submission.submit()
@@ -46,7 +48,7 @@ class LineupSubmissionTest {
     @Test
     fun `should throw exception when submitting already submitted lineup`() {
         // given
-        val submission = createLineupSubmission().apply { submit() }
+        val submission = createLineupSubmissionWithEntries().apply { submit() }
 
         // when & then
         val exception =
@@ -59,7 +61,7 @@ class LineupSubmissionTest {
     @Test
     fun `should confirm lineup when status is SUBMITTED`() {
         // given
-        val submission = createLineupSubmission().apply { submit() }
+        val submission = createLineupSubmissionWithEntries().apply { submit() }
         val scorer = createScorer()
 
         // when
@@ -88,7 +90,7 @@ class LineupSubmissionTest {
     @Test
     fun `should reject lineup with reason when status is SUBMITTED`() {
         // given
-        val submission = createLineupSubmission().apply { submit() }
+        val submission = createLineupSubmissionWithEntries().apply { submit() }
         val scorer = createScorer()
         val reason = "선수 등록번호 확인 필요"
 
@@ -119,7 +121,7 @@ class LineupSubmissionTest {
     fun `should resubmit lineup when status is REJECTED`() {
         // given
         val submission =
-            createLineupSubmission().apply {
+            createLineupSubmissionWithEntries().apply {
                 submit()
                 reject(createScorer(), "수정 필요")
             }
@@ -138,7 +140,7 @@ class LineupSubmissionTest {
     fun `should not allow editing confirmed lineup`() {
         // given
         val submission =
-            createLineupSubmission().apply {
+            createLineupSubmissionWithEntries().apply {
                 submit()
                 confirm(createScorer())
             }
@@ -149,6 +151,45 @@ class LineupSubmissionTest {
                 submission.submit()
             }
         assertThat(exception.message).contains("제출 가능한 상태가 아닙니다")
+    }
+
+    private fun createLineupSubmissionWithEntries(): LineupSubmission {
+        val submission = createLineupSubmission()
+        addValidEntries(submission)
+        return submission
+    }
+
+    private fun addValidEntries(submission: LineupSubmission) {
+        val positions =
+            listOf(
+                Position.STARTING_PITCHER,
+                Position.CATCHER,
+                Position.FIRST_BASE,
+                Position.SECOND_BASE,
+                Position.THIRD_BASE,
+                Position.SHORTSTOP,
+                Position.LEFT_FIELD,
+                Position.CENTER_FIELD,
+                Position.RIGHT_FIELD,
+            )
+        positions.forEachIndexed { index, position ->
+            val player =
+                Player(
+                    name = "선수${index + 1}",
+                    primaryPosition = position,
+                    id = (index + 1).toLong(),
+                )
+            submission.addEntry(
+                LineupEntry(
+                    submission = submission,
+                    player = player,
+                    position = position,
+                    battingOrder = index + 1,
+                    backNumber = index + 1,
+                    isStarter = true,
+                ),
+            )
+        }
     }
 
     private fun createLineupSubmission(): LineupSubmission =

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
@@ -1,0 +1,253 @@
+package com.nextup.core.domain.game
+
+import com.nextup.common.exception.DuplicatePlayerInLineupException
+import com.nextup.common.exception.InvalidDhRuleException
+import com.nextup.common.exception.NoCatcherInLineupException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.user.User
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class LineupValidatorTest {
+    @Test
+    fun `should pass validation with valid lineup`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+
+        // when & then
+        assertThatCode {
+            LineupValidator.validate(entries)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should throw NoCatcherInLineupException when no catcher in starters`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createLineupWithoutCatcher(submission)
+
+        // when & then
+        assertThrows<NoCatcherInLineupException> {
+            LineupValidator.validate(entries)
+        }
+    }
+
+    @Test
+    fun `should throw DuplicatePlayerInLineupException when same player appears twice`() {
+        // given
+        val submission = createLineupSubmission()
+        val samePlayer = createPlayer("홍길동", Position.FIRST_BASE, 1L)
+        val entries =
+            listOf(
+                createEntry(submission, samePlayer, Position.FIRST_BASE, 3, true),
+                createEntry(submission, samePlayer, Position.THIRD_BASE, 5, true),
+            )
+
+        // when & then
+        assertThrows<DuplicatePlayerInLineupException> {
+            LineupValidator.validate(entries)
+        }
+    }
+
+    @Test
+    fun `should throw InvalidDhRuleException when DH and pitcher both have batting order`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createLineupWithDhAndPitcherBatting(submission)
+
+        // when & then
+        assertThrows<InvalidDhRuleException> {
+            LineupValidator.validate(entries)
+        }
+    }
+
+    @Test
+    fun `should pass when DH exists and pitcher has no batting order`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineupWithDh(submission)
+
+        // when & then
+        assertThatCode {
+            LineupValidator.validate(entries)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should pass when no DH and pitcher bats`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createLineupWithPitcherBatting(submission)
+
+        // when & then
+        assertThatCode {
+            LineupValidator.validate(entries)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should allow non-starter duplicate check to include substitutes`() {
+        // given
+        val submission = createLineupSubmission()
+        val player = createPlayer("김대기", Position.LEFT_FIELD, 10L)
+        val entries =
+            listOf(
+                createEntry(
+                    submission,
+                    createPlayer("투수", Position.STARTING_PITCHER, 1L),
+                    Position.STARTING_PITCHER,
+                    1,
+                    true
+                ),
+                createEntry(submission, createPlayer("포수", Position.CATCHER, 2L), Position.CATCHER, 2, true),
+                createEntry(submission, player, Position.LEFT_FIELD, 3, true),
+                createEntry(submission, player, Position.RIGHT_FIELD, null, false),
+            )
+
+        // when & then - same player as starter AND substitute is a duplicate
+        assertThrows<DuplicatePlayerInLineupException> {
+            LineupValidator.validate(entries)
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    private fun createValidLineup(submission: LineupSubmission): List<LineupEntry> =
+        listOf(
+            createEntry(
+                submission,
+                createPlayer("투수", Position.STARTING_PITCHER, 1L),
+                Position.STARTING_PITCHER,
+                1,
+                true
+            ),
+            createEntry(submission, createPlayer("포수", Position.CATCHER, 2L), Position.CATCHER, 2, true),
+            createEntry(submission, createPlayer("1루수", Position.FIRST_BASE, 3L), Position.FIRST_BASE, 3, true),
+            createEntry(submission, createPlayer("2루수", Position.SECOND_BASE, 4L), Position.SECOND_BASE, 4, true),
+            createEntry(submission, createPlayer("3루수", Position.THIRD_BASE, 5L), Position.THIRD_BASE, 5, true),
+            createEntry(submission, createPlayer("유격수", Position.SHORTSTOP, 6L), Position.SHORTSTOP, 6, true),
+            createEntry(submission, createPlayer("좌익수", Position.LEFT_FIELD, 7L), Position.LEFT_FIELD, 7, true),
+            createEntry(submission, createPlayer("중견수", Position.CENTER_FIELD, 8L), Position.CENTER_FIELD, 8, true),
+            createEntry(submission, createPlayer("우익수", Position.RIGHT_FIELD, 9L), Position.RIGHT_FIELD, 9, true),
+        )
+
+    private fun createLineupWithoutCatcher(submission: LineupSubmission): List<LineupEntry> =
+        listOf(
+            createEntry(
+                submission,
+                createPlayer("투수", Position.STARTING_PITCHER, 1L),
+                Position.STARTING_PITCHER,
+                1,
+                true
+            ),
+            createEntry(submission, createPlayer("1루수", Position.FIRST_BASE, 3L), Position.FIRST_BASE, 2, true),
+            createEntry(submission, createPlayer("2루수", Position.SECOND_BASE, 4L), Position.SECOND_BASE, 3, true),
+        )
+
+    private fun createLineupWithDhAndPitcherBatting(submission: LineupSubmission): List<LineupEntry> =
+        listOf(
+            createEntry(
+                submission,
+                createPlayer("투수", Position.STARTING_PITCHER, 1L),
+                Position.STARTING_PITCHER,
+                1,
+                true
+            ),
+            createEntry(submission, createPlayer("포수", Position.CATCHER, 2L), Position.CATCHER, 2, true),
+            createEntry(
+                submission,
+                createPlayer("DH", Position.DESIGNATED_HITTER, 10L),
+                Position.DESIGNATED_HITTER,
+                3,
+                true
+            ),
+        )
+
+    private fun createValidLineupWithDh(submission: LineupSubmission): List<LineupEntry> =
+        listOf(
+            createEntry(
+                submission,
+                createPlayer("투수", Position.STARTING_PITCHER, 1L),
+                Position.STARTING_PITCHER,
+                null,
+                true
+            ),
+            createEntry(submission, createPlayer("포수", Position.CATCHER, 2L), Position.CATCHER, 2, true),
+            createEntry(
+                submission,
+                createPlayer("DH", Position.DESIGNATED_HITTER, 10L),
+                Position.DESIGNATED_HITTER,
+                1,
+                true
+            ),
+        )
+
+    private fun createLineupWithPitcherBatting(submission: LineupSubmission): List<LineupEntry> =
+        listOf(
+            createEntry(
+                submission,
+                createPlayer("투수", Position.STARTING_PITCHER, 1L),
+                Position.STARTING_PITCHER,
+                9,
+                true
+            ),
+            createEntry(submission, createPlayer("포수", Position.CATCHER, 2L), Position.CATCHER, 2, true),
+        )
+
+    private fun createEntry(
+        submission: LineupSubmission,
+        player: Player,
+        position: Position,
+        battingOrder: Int?,
+        isStarter: Boolean,
+    ): LineupEntry =
+        LineupEntry(
+            submission = submission,
+            player = player,
+            position = position,
+            battingOrder = battingOrder,
+            backNumber = null,
+            isStarter = isStarter,
+        )
+
+    private fun createPlayer(
+        name: String,
+        position: Position,
+        id: Long,
+    ): Player =
+        Player(
+            name = name,
+            primaryPosition = position,
+            id = id,
+        )
+
+    private fun createLineupSubmission(): LineupSubmission {
+        val association = Association(name = "서울시야구협회", abbreviation = "서야협", region = "서울")
+        val league = League(association = association, name = "서울시 리그", foundedYear = 2020)
+        val competition =
+            Competition(
+                league = league,
+                name = "2024 시즌",
+                year = 2024,
+                startDate = LocalDate.now().minusDays(30),
+            )
+        val game =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.now().plusDays(1),
+                location = "서울야구장",
+            )
+        val team = Team(league = league, name = "Tigers", city = "서울", foundedYear = 2020)
+        val user = User.createLocalUser(email = "manager@test.com", encodedPassword = "encoded", nickname = "감독")
+        return LineupSubmission.create(game, team, user)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
@@ -3,6 +3,7 @@ package com.nextup.core.domain.game
 import com.nextup.common.exception.DuplicatePlayerInLineupException
 import com.nextup.common.exception.InvalidDhRuleException
 import com.nextup.common.exception.NoCatcherInLineupException
+import com.nextup.common.exception.NonAttendingPlayerInLineupException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.league.League
@@ -116,6 +117,92 @@ class LineupValidatorTest {
         // when & then - same player as starter AND substitute is a duplicate
         assertThrows<DuplicatePlayerInLineupException> {
             LineupValidator.validate(entries)
+        }
+    }
+
+    @Test
+    fun `should pass when all players are attending`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        val attendingPlayerIds = setOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L)
+
+        // when & then
+        assertThatCode {
+            LineupValidator.validate(entries, attendingPlayerIds)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should throw NonAttendingPlayerInLineupException when non-attending player in lineup`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        val attendingPlayerIds = setOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L)
+
+        // when & then
+        val exception =
+            assertThrows<NonAttendingPlayerInLineupException> {
+                LineupValidator.validate(entries, attendingPlayerIds)
+            }
+        assertThatCode {
+            exception.message?.contains("9")
+        }
+    }
+
+    @Test
+    fun `should throw NonAttendingPlayerInLineupException when multiple non-attending players`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        val attendingPlayerIds = setOf(1L, 2L, 3L, 4L, 5L, 6L)
+
+        // when & then
+        assertThrows<NonAttendingPlayerInLineupException> {
+            LineupValidator.validate(entries, attendingPlayerIds)
+        }
+    }
+
+    @Test
+    fun `should skip attendance validation when attendingPlayerIds is null`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+
+        // when & then - should pass even if we don't provide attendance info
+        assertThatCode {
+            LineupValidator.validate(entries, null)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should validate attendance for both starters and substitutes`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries =
+            listOf(
+                createEntry(
+                    submission,
+                    createPlayer("투수", Position.STARTING_PITCHER, 1L),
+                    Position.STARTING_PITCHER,
+                    1,
+                    true
+                ),
+                createEntry(submission, createPlayer("포수", Position.CATCHER, 2L), Position.CATCHER, 2, true),
+                createEntry(submission, createPlayer("1루수", Position.FIRST_BASE, 3L), Position.FIRST_BASE, 3, true),
+                createEntry(
+                    submission,
+                    createPlayer("대기선수", Position.LEFT_FIELD, 10L),
+                    Position.LEFT_FIELD,
+                    null,
+                    false
+                ),
+            )
+        val attendingPlayerIds = setOf(1L, 2L, 3L)
+
+        // when & then - substitute (player 10) is not attending
+        assertThrows<NonAttendingPlayerInLineupException> {
+            LineupValidator.validate(entries, attendingPlayerIds)
         }
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchEventTest.kt
@@ -1,0 +1,300 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class PitchEventTest {
+    @Test
+    fun `투구 이벤트를 생성할 수 있다`() {
+        // given
+        val game = createGame()
+        val pitcher = createPitcher(game)
+        val batter = createBatter(game)
+
+        // when
+        val pitchEvent =
+            PitchEvent.create(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                pitchNumber = 1,
+                result = PitchResult.STRIKE,
+                ballCount = 0,
+                strikeCount = 1,
+                description = "스트라이크",
+            )
+
+        // then
+        assertThat(pitchEvent.game).isEqualTo(game)
+        assertThat(pitchEvent.pitcher).isEqualTo(pitcher)
+        assertThat(pitchEvent.batter).isEqualTo(batter)
+        assertThat(pitchEvent.pitchNumber).isEqualTo(1)
+        assertThat(pitchEvent.result).isEqualTo(PitchResult.STRIKE)
+        assertThat(pitchEvent.ballCount).isEqualTo(0)
+        assertThat(pitchEvent.strikeCount).isEqualTo(1)
+        assertThat(pitchEvent.countDisplay).isEqualTo("0B-1S")
+    }
+
+    @Test
+    fun `투수가 아닌 선수는 투구할 수 없다`() {
+        // given
+        val game = createGame()
+        val pitcher = createBatter(game) // 타자를 투수로 사용
+        val batter = createBatter(game)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            PitchEvent.create(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                pitchNumber = 1,
+                result = PitchResult.STRIKE,
+                ballCount = 0,
+                strikeCount = 1,
+            )
+        }
+    }
+
+    @Test
+    fun `투수와 타자는 서로 다른 팀이어야 한다`() {
+        // given
+        val game = createGame()
+        val homeTeam = createHomeTeam(game)
+        val pitcher = createGamePlayer(homeTeam, Position.STARTING_PITCHER)
+        val batter = createGamePlayer(homeTeam, Position.FIRST_BASE) // 같은 팀
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            PitchEvent.create(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                pitchNumber = 1,
+                result = PitchResult.STRIKE,
+                ballCount = 0,
+                strikeCount = 1,
+            )
+        }
+    }
+
+    @Test
+    fun `투구 번호는 1 이상이어야 한다`() {
+        // given
+        val game = createGame()
+        val pitcher = createPitcher(game)
+        val batter = createBatter(game)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            PitchEvent.create(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                pitchNumber = 0,
+                result = PitchResult.STRIKE,
+                ballCount = 0,
+                strikeCount = 1,
+            )
+        }
+    }
+
+    @Test
+    fun `볼카운트는 0-4 사이여야 한다`() {
+        // given
+        val game = createGame()
+        val pitcher = createPitcher(game)
+        val batter = createBatter(game)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            PitchEvent.create(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                pitchNumber = 1,
+                result = PitchResult.BALL,
+                ballCount = 5,
+                strikeCount = 0,
+            )
+        }
+    }
+
+    @Test
+    fun `스트라이크 카운트는 0-3 사이여야 한다`() {
+        // given
+        val game = createGame()
+        val pitcher = createPitcher(game)
+        val batter = createBatter(game)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            PitchEvent.create(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                pitchNumber = 1,
+                result = PitchResult.STRIKE,
+                ballCount = 0,
+                strikeCount = 4,
+            )
+        }
+    }
+
+    @Test
+    fun `풀카운트를 확인할 수 있다`() {
+        // given
+        val game = createGame()
+        val pitcher = createPitcher(game)
+        val batter = createBatter(game)
+
+        // when
+        val pitchEvent =
+            PitchEvent.create(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                pitchNumber = 1,
+                result = PitchResult.BALL,
+                ballCount = 3,
+                strikeCount = 2,
+            )
+
+        // then
+        assertThat(pitchEvent.isFullCount).isTrue()
+    }
+
+    @Test
+    fun `타자에게 유리한 카운트를 확인할 수 있다`() {
+        // given
+        val game = createGame()
+        val pitcher = createPitcher(game)
+        val batter = createBatter(game)
+
+        // when
+        val pitchEvent =
+            PitchEvent.create(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                pitchNumber = 1,
+                result = PitchResult.BALL,
+                ballCount = 3,
+                strikeCount = 1,
+            )
+
+        // then
+        assertThat(pitchEvent.isHitterCount).isTrue()
+        assertThat(pitchEvent.isPitcherCount).isFalse()
+    }
+
+    @Test
+    fun `투수에게 유리한 카운트를 확인할 수 있다`() {
+        // given
+        val game = createGame()
+        val pitcher = createPitcher(game)
+        val batter = createBatter(game)
+
+        // when
+        val pitchEvent =
+            PitchEvent.create(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                pitchNumber = 1,
+                result = PitchResult.STRIKE,
+                ballCount = 1,
+                strikeCount = 2,
+            )
+
+        // then
+        assertThat(pitchEvent.isPitcherCount).isTrue()
+        assertThat(pitchEvent.isHitterCount).isFalse()
+    }
+
+    // Helper methods
+    private fun createGame(): Game {
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
+        val competition =
+            Competition(
+                league = league,
+                name = "테스트 대회",
+                year = 2024,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2024, 3, 1),
+                id = 1L,
+            )
+
+        return Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2024, 6, 1, 14, 0),
+            status = GameStatus.IN_PROGRESS,
+            currentInning = 1,
+            id = 1L,
+        )
+    }
+
+    private fun createHomeTeam(game: Game): GameTeam {
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
+        val team = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        return GameTeam(
+            game = game,
+            team = team,
+            homeAway = HomeAway.HOME,
+            id = 1L,
+        )
+    }
+
+    private fun createAwayTeam(game: Game): GameTeam {
+        val association = Association(name = "테스트 협회", id = 2L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 2L)
+        val team = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        return GameTeam(
+            game = game,
+            team = team,
+            homeAway = HomeAway.AWAY,
+            id = 2L,
+        )
+    }
+
+    private fun createPitcher(game: Game): GamePlayer {
+        val awayTeam = createAwayTeam(game)
+        return createGamePlayer(awayTeam, Position.STARTING_PITCHER)
+    }
+
+    private fun createBatter(game: Game): GamePlayer {
+        val homeTeam = createHomeTeam(game)
+        return createGamePlayer(homeTeam, Position.FIRST_BASE)
+    }
+
+    private fun createGamePlayer(
+        gameTeam: GameTeam,
+        position: Position,
+    ): GamePlayer {
+        val player =
+            Player(
+                name = "선수",
+                birthDate = LocalDate.of(1995, 1, 1),
+                primaryPosition = position,
+            )
+        return GamePlayer(
+            gameTeam = gameTeam,
+            player = player,
+            position = position,
+            battingOrder = 1,
+        )
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/match/MatchRequestTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/match/MatchRequestTest.kt
@@ -1,0 +1,180 @@
+package com.nextup.core.domain.match
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class MatchRequestTest {
+    private val association = Association(name = "테스트 협회")
+    private val league = League(association = association, name = "테스트 리그", foundedYear = 2020)
+    private val team =
+        Team(
+            league = league,
+            name = "테스트 팀",
+            city = "서울",
+            foundedYear = 2020,
+        )
+
+    @Test
+    fun `should create match request with valid data`() {
+        // given & when
+        val matchRequest =
+            MatchRequest.create(
+                team = team,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = "14:00-17:00",
+                preferredLocation = "서울 야구장",
+                message = "연습 경기 희망합니다",
+                skillLevel = SkillLevel.INTERMEDIATE,
+            )
+
+        // then
+        assertThat(matchRequest.team).isEqualTo(team)
+        assertThat(matchRequest.preferredDate).isEqualTo(LocalDate.now().plusDays(7))
+        assertThat(matchRequest.preferredTime).isEqualTo("14:00-17:00")
+        assertThat(matchRequest.preferredLocation).isEqualTo("서울 야구장")
+        assertThat(matchRequest.message).isEqualTo("연습 경기 희망합니다")
+        assertThat(matchRequest.skillLevel).isEqualTo(SkillLevel.INTERMEDIATE)
+        assertThat(matchRequest.status).isEqualTo(MatchRequestStatus.OPEN)
+    }
+
+    @Test
+    fun `should throw exception when preferred date is in the past`() {
+        // given & when & then
+        assertThatThrownBy {
+            MatchRequest.create(
+                team = team,
+                preferredDate = LocalDate.now().minusDays(1),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("선호 날짜는 오늘 이후여야 합니다")
+    }
+
+    @Test
+    fun `should cancel open match request`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = team,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+
+        // when
+        matchRequest.cancel()
+
+        // then
+        assertThat(matchRequest.status).isEqualTo(MatchRequestStatus.CANCELLED)
+    }
+
+    @Test
+    fun `should throw exception when canceling non-open match request`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = team,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+        matchRequest.match()
+
+        // when & then
+        assertThatThrownBy { matchRequest.cancel() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("OPEN 상태의 요청만 취소할 수 있습니다")
+    }
+
+    @Test
+    fun `should match open request`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = team,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+
+        // when
+        matchRequest.match()
+
+        // then
+        assertThat(matchRequest.status).isEqualTo(MatchRequestStatus.MATCHED)
+    }
+
+    @Test
+    fun `should throw exception when matching non-open request`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = team,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+        matchRequest.cancel()
+
+        // when & then
+        assertThatThrownBy { matchRequest.match() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("OPEN 상태의 요청만 매칭할 수 있습니다")
+    }
+
+    @Test
+    fun `should expire open request`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = team,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+
+        // when
+        matchRequest.expire()
+
+        // then
+        assertThat(matchRequest.status).isEqualTo(MatchRequestStatus.EXPIRED)
+    }
+
+    @Test
+    fun `should throw exception when expiring non-open request`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = team,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+        matchRequest.match()
+
+        // when & then
+        assertThatThrownBy { matchRequest.expire() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("OPEN 상태의 요청만 만료시킬 수 있습니다")
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/match/MatchResponseTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/match/MatchResponseTest.kt
@@ -1,0 +1,185 @@
+package com.nextup.core.domain.match
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class MatchResponseTest {
+    private val association = Association(name = "테스트 협회")
+    private val league = League(association = association, name = "테스트 리그", foundedYear = 2020)
+    private val requestTeam =
+        Team(
+            league = league,
+            name = "요청 팀",
+            city = "서울",
+            foundedYear = 2020,
+        )
+    private val respondTeam =
+        Team(
+            league = league,
+            name = "응답 팀",
+            city = "부산",
+            foundedYear = 2021,
+        )
+
+    @Test
+    fun `should create match response for open request`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = requestTeam,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+
+        // when
+        val matchResponse =
+            MatchResponse.create(
+                matchRequest = matchRequest,
+                respondTeam = respondTeam,
+                message = "함께 경기하고 싶습니다",
+            )
+
+        // then
+        assertThat(matchResponse.matchRequest).isEqualTo(matchRequest)
+        assertThat(matchResponse.respondTeam).isEqualTo(respondTeam)
+        assertThat(matchResponse.message).isEqualTo("함께 경기하고 싶습니다")
+        assertThat(matchResponse.status).isEqualTo(MatchResponseStatus.PENDING)
+    }
+
+    @Test
+    fun `should throw exception when creating response for non-open request`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = requestTeam,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+        matchRequest.cancel()
+
+        // when & then
+        assertThatThrownBy {
+            MatchResponse.create(
+                matchRequest = matchRequest,
+                respondTeam = respondTeam,
+                message = null,
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("OPEN 상태의 요청에만 응답할 수 있습니다")
+    }
+
+    @Test
+    fun `should accept pending response`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = requestTeam,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+        val matchResponse =
+            MatchResponse.create(
+                matchRequest = matchRequest,
+                respondTeam = respondTeam,
+                message = null,
+            )
+
+        // when
+        matchResponse.accept()
+
+        // then
+        assertThat(matchResponse.status).isEqualTo(MatchResponseStatus.ACCEPTED)
+    }
+
+    @Test
+    fun `should throw exception when accepting non-pending response`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = requestTeam,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+        val matchResponse =
+            MatchResponse.create(
+                matchRequest = matchRequest,
+                respondTeam = respondTeam,
+                message = null,
+            )
+        matchResponse.reject()
+
+        // when & then
+        assertThatThrownBy { matchResponse.accept() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("PENDING 상태의 응답만 수락할 수 있습니다")
+    }
+
+    @Test
+    fun `should reject pending response`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = requestTeam,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+        val matchResponse =
+            MatchResponse.create(
+                matchRequest = matchRequest,
+                respondTeam = respondTeam,
+                message = null,
+            )
+
+        // when
+        matchResponse.reject()
+
+        // then
+        assertThat(matchResponse.status).isEqualTo(MatchResponseStatus.REJECTED)
+    }
+
+    @Test
+    fun `should throw exception when rejecting non-pending response`() {
+        // given
+        val matchRequest =
+            MatchRequest.create(
+                team = requestTeam,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = null,
+                preferredLocation = null,
+                message = null,
+                skillLevel = SkillLevel.ANY,
+            )
+        val matchResponse =
+            MatchResponse.create(
+                matchRequest = matchRequest,
+                respondTeam = respondTeam,
+                message = null,
+            )
+        matchResponse.accept()
+
+        // when & then
+        assertThatThrownBy { matchResponse.reject() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("PENDING 상태의 응답만 거절할 수 있습니다")
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/notification/DeviceTokenTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/notification/DeviceTokenTest.kt
@@ -1,0 +1,77 @@
+package com.nextup.core.domain.notification
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class DeviceTokenTest {
+    @Test
+    fun `should create device token with valid data`() {
+        // given & when
+        val deviceToken =
+            DeviceToken.create(
+                userId = 1L,
+                token = "fcm-token-12345",
+                platform = DevicePlatform.IOS,
+            )
+
+        // then
+        assertThat(deviceToken.userId).isEqualTo(1L)
+        assertThat(deviceToken.token).isEqualTo("fcm-token-12345")
+        assertThat(deviceToken.platform).isEqualTo(DevicePlatform.IOS)
+    }
+
+    @Test
+    fun `should fail when userId is invalid`() {
+        // given & when & then
+        assertThatThrownBy {
+            DeviceToken.create(
+                userId = 0L,
+                token = "fcm-token-12345",
+                platform = DevicePlatform.IOS,
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("사용자 ID는 필수입니다")
+    }
+
+    @Test
+    fun `should fail when token is blank`() {
+        // given & when & then
+        assertThatThrownBy {
+            DeviceToken.create(
+                userId = 1L,
+                token = "",
+                platform = DevicePlatform.IOS,
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("토큰은 필수입니다")
+    }
+
+    @Test
+    fun `should create device token for different platforms`() {
+        // given & when
+        val iosToken =
+            DeviceToken.create(
+                userId = 1L,
+                token = "ios-token",
+                platform = DevicePlatform.IOS,
+            )
+        val androidToken =
+            DeviceToken.create(
+                userId = 1L,
+                token = "android-token",
+                platform = DevicePlatform.ANDROID,
+            )
+        val webToken =
+            DeviceToken.create(
+                userId = 1L,
+                token = "web-token",
+                platform = DevicePlatform.WEB,
+            )
+
+        // then
+        assertThat(iosToken.platform).isEqualTo(DevicePlatform.IOS)
+        assertThat(androidToken.platform).isEqualTo(DevicePlatform.ANDROID)
+        assertThat(webToken.platform).isEqualTo(DevicePlatform.WEB)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/notification/NotificationPreferenceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/notification/NotificationPreferenceTest.kt
@@ -1,0 +1,105 @@
+package com.nextup.core.domain.notification
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class NotificationPreferenceTest {
+    @Test
+    fun `should create notification preference with default enabled`() {
+        // given & when
+        val preference =
+            NotificationPreference.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+            )
+
+        // then
+        assertThat(preference.userId).isEqualTo(1L)
+        assertThat(preference.type).isEqualTo(NotificationType.GAME_START)
+        assertThat(preference.enabled).isTrue()
+    }
+
+    @Test
+    fun `should create notification preference with disabled`() {
+        // given & when
+        val preference =
+            NotificationPreference.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                enabled = false,
+            )
+
+        // then
+        assertThat(preference.enabled).isFalse()
+    }
+
+    @Test
+    fun `should fail when userId is invalid`() {
+        // given & when & then
+        assertThatThrownBy {
+            NotificationPreference.create(
+                userId = 0L,
+                type = NotificationType.GAME_START,
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("사용자 ID는 필수입니다")
+    }
+
+    @Test
+    fun `should enable notification`() {
+        // given
+        val preference =
+            NotificationPreference.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                enabled = false,
+            )
+
+        // when
+        preference.enable()
+
+        // then
+        assertThat(preference.enabled).isTrue()
+    }
+
+    @Test
+    fun `should disable notification`() {
+        // given
+        val preference =
+            NotificationPreference.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                enabled = true,
+            )
+
+        // when
+        preference.disable()
+
+        // then
+        assertThat(preference.enabled).isFalse()
+    }
+
+    @Test
+    fun `should toggle notification preference`() {
+        // given
+        val preference =
+            NotificationPreference.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                enabled = true,
+            )
+
+        // when
+        preference.toggle()
+
+        // then
+        assertThat(preference.enabled).isFalse()
+
+        // when
+        preference.toggle()
+
+        // then
+        assertThat(preference.enabled).isTrue()
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/notification/NotificationTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/notification/NotificationTest.kt
@@ -1,0 +1,149 @@
+package com.nextup.core.domain.notification
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class NotificationTest {
+    @Test
+    fun `should create notification with valid data`() {
+        // given & when
+        val notification =
+            Notification.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                title = "경기 시작",
+                body = "30분 후 경기가 시작됩니다",
+                data = """{"gameId": 123}""",
+            )
+
+        // then
+        assertThat(notification.userId).isEqualTo(1L)
+        assertThat(notification.type).isEqualTo(NotificationType.GAME_START)
+        assertThat(notification.title).isEqualTo("경기 시작")
+        assertThat(notification.body).isEqualTo("30분 후 경기가 시작됩니다")
+        assertThat(notification.data).isEqualTo("""{"gameId": 123}""")
+        assertThat(notification.readAt).isNull()
+        assertThat(notification.sentAt).isNull()
+    }
+
+    @Test
+    fun `should fail when userId is invalid`() {
+        // given & when & then
+        assertThatThrownBy {
+            Notification.create(
+                userId = 0L,
+                type = NotificationType.GAME_START,
+                title = "경기 시작",
+                body = "30분 후 경기가 시작됩니다",
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("사용자 ID는 필수입니다")
+    }
+
+    @Test
+    fun `should fail when title is blank`() {
+        // given & when & then
+        assertThatThrownBy {
+            Notification.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                title = "",
+                body = "30분 후 경기가 시작됩니다",
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("제목은 필수입니다")
+    }
+
+    @Test
+    fun `should fail when body is blank`() {
+        // given & when & then
+        assertThatThrownBy {
+            Notification.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                title = "경기 시작",
+                body = "",
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("내용은 필수입니다")
+    }
+
+    @Test
+    fun `should mark notification as read`() {
+        // given
+        val notification =
+            Notification.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                title = "경기 시작",
+                body = "30분 후 경기가 시작됩니다",
+            )
+
+        // when
+        notification.markAsRead()
+
+        // then
+        assertThat(notification.readAt).isNotNull()
+        assertThat(notification.isRead()).isTrue()
+    }
+
+    @Test
+    fun `should mark notification as sent`() {
+        // given
+        val notification =
+            Notification.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                title = "경기 시작",
+                body = "30분 후 경기가 시작됩니다",
+            )
+
+        // when
+        notification.markAsSent()
+
+        // then
+        assertThat(notification.sentAt).isNotNull()
+        assertThat(notification.isSent()).isTrue()
+    }
+
+    @Test
+    fun `should not change readAt when already read`() {
+        // given
+        val notification =
+            Notification.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                title = "경기 시작",
+                body = "30분 후 경기가 시작됩니다",
+            )
+        notification.markAsRead()
+        val firstReadAt = notification.readAt
+
+        // when
+        notification.markAsRead()
+
+        // then
+        assertThat(notification.readAt).isEqualTo(firstReadAt)
+    }
+
+    @Test
+    fun `should not change sentAt when already sent`() {
+        // given
+        val notification =
+            Notification.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                title = "경기 시작",
+                body = "30분 후 경기가 시작됩니다",
+            )
+        notification.markAsSent()
+        val firstSentAt = notification.sentAt
+
+        // when
+        notification.markAsSent()
+
+        // then
+        assertThat(notification.sentAt).isEqualTo(firstSentAt)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/recruitment/TeamRecruitmentTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/recruitment/TeamRecruitmentTest.kt
@@ -1,0 +1,291 @@
+package com.nextup.core.domain.recruitment
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class TeamRecruitmentTest {
+    private lateinit var team: Team
+    private lateinit var league: League
+    private lateinit var association: Association
+
+    @BeforeEach
+    fun setUp() {
+        association = Association(name = "테스트 협회")
+        league =
+            League(
+                association = association,
+                name = "테스트 리그",
+                foundedYear = 2020,
+            )
+        team =
+            Team(
+                league = league,
+                name = "테스트 팀",
+                city = "서울",
+                foundedYear = 2020,
+            )
+    }
+
+    @Test
+    fun `should create recruitment with valid data`() {
+        // given
+        val title = "투수 모집"
+        val description = "경험 많은 투수를 모집합니다"
+        val positionsNeeded = "투수,포수"
+        val deadline = LocalDate.now().plusDays(30)
+
+        // when
+        val recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = title,
+                description = description,
+                positionsNeeded = positionsNeeded,
+                ageRange = "20-35",
+                skillLevel = "중급",
+                location = "서울",
+                deadline = deadline,
+            )
+
+        // then
+        assertThat(recruitment.team).isEqualTo(team)
+        assertThat(recruitment.title).isEqualTo(title)
+        assertThat(recruitment.description).isEqualTo(description)
+        assertThat(recruitment.positionsNeeded).isEqualTo(positionsNeeded)
+        assertThat(recruitment.ageRange).isEqualTo("20-35")
+        assertThat(recruitment.skillLevel).isEqualTo("중급")
+        assertThat(recruitment.location).isEqualTo("서울")
+        assertThat(recruitment.deadline).isEqualTo(deadline)
+        assertThat(recruitment.status).isEqualTo(RecruitmentStatus.OPEN)
+    }
+
+    @Test
+    fun `should throw exception when creating recruitment with blank title`() {
+        // given
+        val deadline = LocalDate.now().plusDays(30)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            TeamRecruitment.create(
+                team = team,
+                title = "",
+                description = "설명",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = deadline,
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception when creating recruitment with blank description`() {
+        // given
+        val deadline = LocalDate.now().plusDays(30)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            TeamRecruitment.create(
+                team = team,
+                title = "제목",
+                description = "",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = deadline,
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception when creating recruitment with blank positions`() {
+        // given
+        val deadline = LocalDate.now().plusDays(30)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            TeamRecruitment.create(
+                team = team,
+                title = "제목",
+                description = "설명",
+                positionsNeeded = "",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = deadline,
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception when creating recruitment with past deadline`() {
+        // given
+        val pastDeadline = LocalDate.now().minusDays(1)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            TeamRecruitment.create(
+                team = team,
+                title = "제목",
+                description = "설명",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = pastDeadline,
+            )
+        }
+    }
+
+    @Test
+    fun `should close open recruitment`() {
+        // given
+        val recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "제목",
+                description = "설명",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = LocalDate.now().plusDays(30),
+            )
+
+        // when
+        recruitment.close()
+
+        // then
+        assertThat(recruitment.status).isEqualTo(RecruitmentStatus.CLOSED)
+    }
+
+    @Test
+    fun `should throw exception when closing already closed recruitment`() {
+        // given
+        val recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "제목",
+                description = "설명",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = LocalDate.now().plusDays(30),
+            )
+        recruitment.close()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            recruitment.close()
+        }
+    }
+
+    @Test
+    fun `should return false when deadline has not passed`() {
+        // given
+        val recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "제목",
+                description = "설명",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = LocalDate.now().plusDays(30),
+            )
+
+        // when
+        val isExpired = recruitment.isExpired()
+
+        // then
+        assertThat(isExpired).isFalse()
+    }
+
+    @Test
+    fun `should update recruitment with valid data`() {
+        // given
+        val recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "제목",
+                description = "설명",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = LocalDate.now().plusDays(30),
+            )
+
+        val newTitle = "새 제목"
+        val newDescription = "새 설명"
+        val newPositions = "투수,포수"
+        val newDeadline = LocalDate.now().plusDays(60)
+
+        // when
+        recruitment.update(
+            title = newTitle,
+            description = newDescription,
+            positionsNeeded = newPositions,
+            deadline = newDeadline,
+        )
+
+        // then
+        assertThat(recruitment.title).isEqualTo(newTitle)
+        assertThat(recruitment.description).isEqualTo(newDescription)
+        assertThat(recruitment.positionsNeeded).isEqualTo(newPositions)
+        assertThat(recruitment.deadline).isEqualTo(newDeadline)
+    }
+
+    @Test
+    fun `should throw exception when updating closed recruitment`() {
+        // given
+        val recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "제목",
+                description = "설명",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = LocalDate.now().plusDays(30),
+            )
+        recruitment.close()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            recruitment.update(title = "새 제목")
+        }
+    }
+
+    @Test
+    fun `should throw exception when updating with past deadline`() {
+        // given
+        val recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "제목",
+                description = "설명",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = LocalDate.now().plusDays(30),
+            )
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            recruitment.update(deadline = LocalDate.now().minusDays(1))
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/schedule/LeagueScheduleTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/schedule/LeagueScheduleTest.kt
@@ -1,0 +1,280 @@
+package com.nextup.core.domain.schedule
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class LeagueScheduleTest {
+    @Test
+    fun `should create schedule with SCHEDULED status`() {
+        // given & when
+        val schedule = createSchedule()
+
+        // then
+        assertThat(schedule.status).isEqualTo(ScheduleStatus.SCHEDULED)
+        assertThat(schedule.round).isEqualTo(1)
+        assertThat(schedule.matchNumber).isEqualTo(1)
+        assertThat(schedule.game).isNull()
+    }
+
+    @Test
+    fun `should throw when round is less than 1`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            LeagueSchedule.create(
+                competition = createCompetition(),
+                round = 0,
+                matchNumber = 1,
+                homeTeam = createTeam("홈팀", 1L),
+                awayTeam = createTeam("원정팀", 2L),
+                scheduledDate = LocalDate.now().plusDays(7),
+            )
+        }
+    }
+
+    @Test
+    fun `should throw when matchNumber is less than 1`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            LeagueSchedule.create(
+                competition = createCompetition(),
+                round = 1,
+                matchNumber = 0,
+                homeTeam = createTeam("홈팀", 1L),
+                awayTeam = createTeam("원정팀", 2L),
+                scheduledDate = LocalDate.now().plusDays(7),
+            )
+        }
+    }
+
+    @Test
+    fun `should throw when homeTeam and awayTeam are the same`() {
+        // given
+        val team = createTeam("같은팀", 1L)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            LeagueSchedule.create(
+                competition = createCompetition(),
+                round = 1,
+                matchNumber = 1,
+                homeTeam = team,
+                awayTeam = team,
+                scheduledDate = LocalDate.now().plusDays(7),
+            )
+        }
+    }
+
+    @Test
+    fun `should link game and change status to GAME_CREATED`() {
+        // given
+        val schedule = createSchedule()
+        val game = createGame()
+
+        // when
+        schedule.linkGame(game)
+
+        // then
+        assertThat(schedule.status).isEqualTo(ScheduleStatus.GAME_CREATED)
+        assertThat(schedule.game).isEqualTo(game)
+    }
+
+    @Test
+    fun `should throw when linking game to cancelled schedule`() {
+        // given
+        val schedule = createSchedule()
+        schedule.cancel()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            schedule.linkGame(createGame())
+        }
+    }
+
+    @Test
+    fun `should postpone schedule`() {
+        // given
+        val schedule = createSchedule()
+
+        // when
+        schedule.postpone()
+
+        // then
+        assertThat(schedule.status).isEqualTo(ScheduleStatus.POSTPONED)
+    }
+
+    @Test
+    fun `should throw when postponing non-scheduled schedule`() {
+        // given
+        val schedule = createSchedule()
+        schedule.postpone()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            schedule.postpone()
+        }
+    }
+
+    @Test
+    fun `should cancel schedule`() {
+        // given
+        val schedule = createSchedule()
+
+        // when
+        schedule.cancel()
+
+        // then
+        assertThat(schedule.status).isEqualTo(ScheduleStatus.CANCELLED)
+    }
+
+    @Test
+    fun `should throw when cancelling completed schedule`() {
+        // given
+        val schedule = createSchedule()
+        schedule.linkGame(createGame())
+        schedule.complete()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            schedule.cancel()
+        }
+    }
+
+    @Test
+    fun `should complete schedule with GAME_CREATED status`() {
+        // given
+        val schedule = createSchedule()
+        schedule.linkGame(createGame())
+
+        // when
+        schedule.complete()
+
+        // then
+        assertThat(schedule.status).isEqualTo(ScheduleStatus.COMPLETED)
+    }
+
+    @Test
+    fun `should throw when completing scheduled schedule without game`() {
+        // given
+        val schedule = createSchedule()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            schedule.complete()
+        }
+    }
+
+    @Test
+    fun `should reschedule with new date`() {
+        // given
+        val schedule = createSchedule()
+        val newDate = LocalDate.now().plusDays(14)
+        val newTime = LocalTime.of(15, 0)
+
+        // when
+        schedule.reschedule(newDate, newTime, "새 구장")
+
+        // then
+        assertThat(schedule.scheduledDate).isEqualTo(newDate)
+        assertThat(schedule.scheduledTime).isEqualTo(newTime)
+        assertThat(schedule.venue).isEqualTo("새 구장")
+        assertThat(schedule.status).isEqualTo(ScheduleStatus.SCHEDULED)
+    }
+
+    @Test
+    fun `should reschedule postponed schedule and change status to SCHEDULED`() {
+        // given
+        val schedule = createSchedule()
+        schedule.postpone()
+        val newDate = LocalDate.now().plusDays(14)
+
+        // when
+        schedule.reschedule(newDate)
+
+        // then
+        assertThat(schedule.scheduledDate).isEqualTo(newDate)
+        assertThat(schedule.status).isEqualTo(ScheduleStatus.SCHEDULED)
+    }
+
+    @Test
+    fun `should throw when rescheduling cancelled schedule`() {
+        // given
+        val schedule = createSchedule()
+        schedule.cancel()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            schedule.reschedule(LocalDate.now().plusDays(14))
+        }
+    }
+
+    @Test
+    fun `should link game to postponed schedule`() {
+        // given
+        val schedule = createSchedule()
+        schedule.postpone()
+        val game = createGame()
+
+        // when
+        schedule.linkGame(game)
+
+        // then
+        assertThat(schedule.status).isEqualTo(ScheduleStatus.GAME_CREATED)
+        assertThat(schedule.game).isEqualTo(game)
+    }
+
+    // ========== Helper Methods ==========
+
+    private fun createSchedule(): LeagueSchedule =
+        LeagueSchedule.create(
+            competition = createCompetition(),
+            round = 1,
+            matchNumber = 1,
+            homeTeam = createTeam("홈팀", 1L),
+            awayTeam = createTeam("원정팀", 2L),
+            scheduledDate = LocalDate.now().plusDays(7),
+            scheduledTime = LocalTime.of(14, 0),
+            venue = "서울야구장",
+        )
+
+    private fun createCompetition(): Competition {
+        val association = Association(name = "서울시야구협회", abbreviation = "서야협", region = "서울")
+        val league = League(association = association, name = "서울시 리그", foundedYear = 2020)
+        return Competition(
+            league = league,
+            name = "2024 시즌",
+            year = 2024,
+            startDate = LocalDate.now().minusDays(30),
+        )
+    }
+
+    private fun createTeam(
+        name: String,
+        id: Long
+    ): Team {
+        val association = Association(name = "서울시야구협회", abbreviation = "서야협", region = "서울")
+        val league = League(association = association, name = "서울시 리그", foundedYear = 2020)
+        return Team(
+            league = league,
+            name = name,
+            city = "서울",
+            foundedYear = 2020,
+            id = id,
+        )
+    }
+
+    private fun createGame(): Game =
+        Game(
+            competition = createCompetition(),
+            scheduledAt = LocalDateTime.now().plusDays(7),
+            location = "서울야구장",
+        )
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/schedule/LeagueScheduleTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/schedule/LeagueScheduleTest.kt
@@ -105,7 +105,7 @@ class LeagueScheduleTest {
         val schedule = createSchedule()
 
         // when
-        schedule.postpone()
+        schedule.postpone("우천")
 
         // then
         assertThat(schedule.status).isEqualTo(ScheduleStatus.POSTPONED)
@@ -115,11 +115,11 @@ class LeagueScheduleTest {
     fun `should throw when postponing non-scheduled schedule`() {
         // given
         val schedule = createSchedule()
-        schedule.postpone()
+        schedule.postpone("우천")
 
         // when & then
         assertThrows<IllegalArgumentException> {
-            schedule.postpone()
+            schedule.postpone("우천")
         }
     }
 
@@ -193,7 +193,7 @@ class LeagueScheduleTest {
     fun `should reschedule postponed schedule and change status to SCHEDULED`() {
         // given
         val schedule = createSchedule()
-        schedule.postpone()
+        schedule.postpone("우천")
         val newDate = LocalDate.now().plusDays(14)
 
         // when
@@ -220,7 +220,7 @@ class LeagueScheduleTest {
     fun `should link game to postponed schedule`() {
         // given
         val schedule = createSchedule()
-        schedule.postpone()
+        schedule.postpone("우천")
         val game = createGame()
 
         // when

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/schedule/RoundRobinScheduleGeneratorTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/schedule/RoundRobinScheduleGeneratorTest.kt
@@ -1,0 +1,240 @@
+package com.nextup.core.domain.schedule
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class RoundRobinScheduleGeneratorTest {
+    private val generator = RoundRobinScheduleGenerator()
+
+    @Test
+    fun `2개 팀 - 1라운드, 1경기`() {
+        // given
+        val teamIds = listOf(1L, 2L)
+
+        // when
+        val matches = generator.generate(teamIds)
+
+        // then
+        assertThat(matches).hasSize(1)
+        assertThat(matches[0].round).isEqualTo(1)
+
+        // 모든 팀이 한 번씩 대결
+        val allTeams = matches.flatMap { listOf(it.homeTeamId, it.awayTeamId) }
+        assertThat(allTeams).containsExactlyInAnyOrder(1L, 2L)
+    }
+
+    @Test
+    fun `3개 팀(홀수) - 3라운드, 3경기`() {
+        // given
+        val teamIds = listOf(1L, 2L, 3L)
+
+        // when
+        val matches = generator.generate(teamIds)
+
+        // then
+        assertThat(matches).hasSize(3) // 3C2 = 3 matches
+
+        // 3라운드
+        assertThat(matches.map { it.round }.distinct()).containsExactlyInAnyOrder(1, 2, 3)
+
+        // 각 팀이 정확히 2번씩 경기 (모든 상대와 1번씩)
+        val teamMatchCounts = mutableMapOf<Long, Int>()
+        matches.forEach { match ->
+            teamMatchCounts[match.homeTeamId] = teamMatchCounts.getOrDefault(match.homeTeamId, 0) + 1
+            teamMatchCounts[match.awayTeamId] = teamMatchCounts.getOrDefault(match.awayTeamId, 0) + 1
+        }
+        assertThat(teamMatchCounts.values).allMatch { it == 2 }
+
+        // 모든 팀 조합이 정확히 한 번씩 경기
+        assertAllTeamsPlayOnce(teamIds, matches)
+    }
+
+    @Test
+    fun `4개 팀 - 3라운드, 6경기`() {
+        // given
+        val teamIds = listOf(1L, 2L, 3L, 4L)
+
+        // when
+        val matches = generator.generate(teamIds)
+
+        // then
+        assertThat(matches).hasSize(6) // 4C2 = 6 matches
+
+        // 3라운드
+        assertThat(matches.map { it.round }.distinct()).containsExactlyInAnyOrder(1, 2, 3)
+
+        // 각 라운드마다 2경기씩
+        matches.groupBy { it.round }.forEach { (_, roundMatches) ->
+            assertThat(roundMatches).hasSize(2)
+        }
+
+        // 각 팀이 정확히 3번씩 경기 (모든 상대와 1번씩)
+        val teamMatchCounts = mutableMapOf<Long, Int>()
+        matches.forEach { match ->
+            teamMatchCounts[match.homeTeamId] = teamMatchCounts.getOrDefault(match.homeTeamId, 0) + 1
+            teamMatchCounts[match.awayTeamId] = teamMatchCounts.getOrDefault(match.awayTeamId, 0) + 1
+        }
+        assertThat(teamMatchCounts.values).allMatch { it == 3 }
+
+        // 모든 팀 조합이 정확히 한 번씩 경기
+        assertAllTeamsPlayOnce(teamIds, matches)
+    }
+
+    @Test
+    fun `6개 팀 - 5라운드, 15경기`() {
+        // given
+        val teamIds = listOf(1L, 2L, 3L, 4L, 5L, 6L)
+
+        // when
+        val matches = generator.generate(teamIds)
+
+        // then
+        assertThat(matches).hasSize(15) // 6C2 = 15 matches
+
+        // 5라운드
+        assertThat(matches.map { it.round }.distinct()).containsExactlyInAnyOrder(1, 2, 3, 4, 5)
+
+        // 각 라운드마다 3경기씩
+        matches.groupBy { it.round }.forEach { (_, roundMatches) ->
+            assertThat(roundMatches).hasSize(3)
+        }
+
+        // 각 팀이 정확히 5번씩 경기 (모든 상대와 1번씩)
+        val teamMatchCounts = mutableMapOf<Long, Int>()
+        matches.forEach { match ->
+            teamMatchCounts[match.homeTeamId] = teamMatchCounts.getOrDefault(match.homeTeamId, 0) + 1
+            teamMatchCounts[match.awayTeamId] = teamMatchCounts.getOrDefault(match.awayTeamId, 0) + 1
+        }
+        assertThat(teamMatchCounts.values).allMatch { it == 5 }
+
+        // 모든 팀 조합이 정확히 한 번씩 경기
+        assertAllTeamsPlayOnce(teamIds, matches)
+    }
+
+    @Test
+    fun `더블 라운드 로빈 - 경기 수 2배`() {
+        // given
+        val teamIds = listOf(1L, 2L, 3L, 4L)
+
+        // when
+        val singleRound = generator.generate(teamIds, doubleRoundRobin = false)
+        val doubleRound = generator.generate(teamIds, doubleRoundRobin = true)
+
+        // then
+        assertThat(doubleRound).hasSize(singleRound.size * 2)
+
+        // 각 팀이 정확히 6번씩 경기 (모든 상대와 2번씩: 홈1, 원정1)
+        val teamMatchCounts = mutableMapOf<Long, Int>()
+        doubleRound.forEach { match ->
+            teamMatchCounts[match.homeTeamId] = teamMatchCounts.getOrDefault(match.homeTeamId, 0) + 1
+            teamMatchCounts[match.awayTeamId] = teamMatchCounts.getOrDefault(match.awayTeamId, 0) + 1
+        }
+        assertThat(teamMatchCounts.values).allMatch { it == 6 }
+    }
+
+    @Test
+    fun `더블 라운드 로빈 - 홈과 원정 교대`() {
+        // given
+        val teamIds = listOf(1L, 2L)
+
+        // when
+        val matches = generator.generate(teamIds, doubleRoundRobin = true)
+
+        // then
+        assertThat(matches).hasSize(2)
+
+        // 첫 번째 경기와 두 번째 경기가 홈/원정 교대
+        val firstMatch = matches[0]
+        val secondMatch = matches[1]
+
+        assertThat(firstMatch.homeTeamId).isEqualTo(secondMatch.awayTeamId)
+        assertThat(firstMatch.awayTeamId).isEqualTo(secondMatch.homeTeamId)
+    }
+
+    @Test
+    fun `모든 팀이 서로 한 번씩 경기`() {
+        // given
+        val teamIds = listOf(1L, 2L, 3L, 4L, 5L)
+
+        // when
+        val matches = generator.generate(teamIds)
+
+        // then
+        assertAllTeamsPlayOnce(teamIds, matches)
+    }
+
+    @Test
+    fun `각 라운드에서 팀은 중복 출전하지 않음`() {
+        // given
+        val teamIds = listOf(1L, 2L, 3L, 4L, 5L, 6L)
+
+        // when
+        val matches = generator.generate(teamIds)
+
+        // then
+        matches.groupBy { it.round }.forEach { (round, roundMatches) ->
+            val teamsInRound = roundMatches.flatMap { listOf(it.homeTeamId, it.awayTeamId) }
+            // 각 라운드에서 팀은 정확히 한 번씩만 출전
+            assertThat(teamsInRound).hasSize(teamsInRound.distinct().size)
+                .withFailMessage("라운드 $round 에서 팀이 중복 출전했습니다")
+        }
+    }
+
+    @Test
+    fun `중복 팀 ID - 예외 발생`() {
+        // given
+        val teamIds = listOf(1L, 2L, 1L, 3L) // 1L 중복
+
+        // when & then
+        assertThatThrownBy {
+            generator.generate(teamIds)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("중복된 팀이 있습니다")
+    }
+
+    @Test
+    fun `1개 팀 - 예외 발생`() {
+        // given
+        val teamIds = listOf(1L)
+
+        // when & then
+        assertThatThrownBy {
+            generator.generate(teamIds)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("최소 2개 팀이 필요합니다")
+    }
+
+    @Test
+    fun `빈 팀 목록 - 예외 발생`() {
+        // given
+        val teamIds = emptyList<Long>()
+
+        // when & then
+        assertThatThrownBy {
+            generator.generate(teamIds)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("최소 2개 팀이 필요합니다")
+    }
+
+    /**
+     * 모든 팀이 서로 정확히 한 번씩 경기했는지 검증
+     */
+    private fun assertAllTeamsPlayOnce(
+        teamIds: List<Long>,
+        matches: List<RoundRobinScheduleGenerator.MatchPair>,
+    ) {
+        val matchPairSet = mutableSetOf<Set<Long>>()
+
+        matches.forEach { match ->
+            val pair = setOf(match.homeTeamId, match.awayTeamId)
+            assertThat(matchPairSet).doesNotContain(pair)
+                .withFailMessage("팀 조합 $pair 가 중복 경기했습니다")
+            matchPairSet.add(pair)
+        }
+
+        // 전체 경기 수 = nC2
+        val expectedMatches = teamIds.size * (teamIds.size - 1) / 2
+        assertThat(matches).hasSize(expectedMatches)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/schedule/ScheduleConflictDetectorTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/schedule/ScheduleConflictDetectorTest.kt
@@ -1,0 +1,508 @@
+package com.nextup.core.domain.schedule
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+class ScheduleConflictDetectorTest {
+    private lateinit var detector: ScheduleConflictDetector
+    private lateinit var association: Association
+    private lateinit var league: League
+    private lateinit var competition: Competition
+    private lateinit var teamA: Team
+    private lateinit var teamB: Team
+    private lateinit var teamC: Team
+    private lateinit var teamD: Team
+
+    @BeforeEach
+    fun setUp() {
+        detector = ScheduleConflictDetector()
+
+        association =
+            Association(
+                name = "Test Association",
+                abbreviation = "TA",
+                region = "서울",
+            )
+
+        league =
+            League(
+                association = association,
+                name = "Test League",
+                abbreviation = "TL",
+                foundedYear = 2024,
+                divisionLevel = 1,
+            )
+
+        competition =
+            Competition(
+                league = league,
+                name = "2024 시즌",
+                year = 2024,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2024, 3, 1),
+            )
+
+        teamA =
+            Team(
+                league = league,
+                name = "팀A",
+                city = "서울",
+                foundedYear = 2020,
+                id = 1L,
+            )
+
+        teamB =
+            Team(
+                league = league,
+                name = "팀B",
+                city = "서울",
+                foundedYear = 2020,
+                id = 2L,
+            )
+
+        teamC =
+            Team(
+                league = league,
+                name = "팀C",
+                city = "서울",
+                foundedYear = 2020,
+                id = 3L,
+            )
+
+        teamD =
+            Team(
+                league = league,
+                name = "팀D",
+                city = "서울",
+                foundedYear = 2020,
+                id = 4L,
+            )
+    }
+
+    private fun createScheduleWithId(
+        id: Long,
+        round: Int,
+        matchNumber: Int,
+        homeTeam: Team,
+        awayTeam: Team,
+        scheduledDate: LocalDate,
+        scheduledTime: LocalTime?,
+        venue: String?,
+    ): LeagueSchedule {
+        val schedule =
+            LeagueSchedule.create(
+                competition = competition,
+                round = round,
+                matchNumber = matchNumber,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledDate = scheduledDate,
+                scheduledTime = scheduledTime,
+                venue = venue,
+            )
+        // Use reflection to set the ID
+        val idField = LeagueSchedule::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(schedule, id)
+        return schedule
+    }
+
+    @Test
+    fun `should detect no conflicts when no existing schedules`() {
+        // given
+        val schedule =
+            createScheduleWithId(
+                id = 1L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+
+        // when
+        val conflicts = detector.detectAllConflicts(schedule, emptyList())
+
+        // then
+        assertThat(conflicts).isEmpty()
+    }
+
+    @Test
+    fun `should detect no conflicts when time is not specified`() {
+        // given
+        val schedule1 =
+            createScheduleWithId(
+                id = 1L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = null,
+                venue = "구장A",
+            )
+
+        val schedule2 =
+            createScheduleWithId(
+                id = 2L,
+                round = 1,
+                matchNumber = 2,
+                homeTeam = teamA,
+                awayTeam = teamC,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = null,
+                venue = "구장A",
+            )
+
+        // when
+        val conflicts = detector.detectAllConflicts(schedule1, listOf(schedule2))
+
+        // then
+        assertThat(conflicts).isEmpty()
+    }
+
+    @Test
+    fun `should detect team conflict when same team plays at same time`() {
+        // given
+        val existingSchedule =
+            createScheduleWithId(
+                id = 100L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+
+        val newSchedule =
+            createScheduleWithId(
+                id = 200L,
+                round = 1,
+                matchNumber = 2,
+                homeTeam = teamA,
+                awayTeam = teamC,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장B",
+            )
+
+        // when
+        val conflicts = detector.detectTeamConflicts(newSchedule, listOf(existingSchedule))
+
+        // then
+        assertThat(conflicts).hasSize(1)
+        assertThat(conflicts[0].type).isEqualTo(ConflictType.TEAM_TIME_CONFLICT)
+        assertThat(conflicts[0].description).contains("팀A")
+    }
+
+    @Test
+    fun `should detect team conflict when away team plays at same time`() {
+        // given
+        val existingSchedule =
+            createScheduleWithId(
+                id = 100L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+
+        val newSchedule =
+            createScheduleWithId(
+                id = 200L,
+                round = 1,
+                matchNumber = 2,
+                homeTeam = teamC,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(15, 0),
+                venue = "구장B",
+            )
+
+        // when
+        val conflicts = detector.detectTeamConflicts(newSchedule, listOf(existingSchedule))
+
+        // then
+        assertThat(conflicts).hasSize(1)
+        assertThat(conflicts[0].type).isEqualTo(ConflictType.TEAM_TIME_CONFLICT)
+        assertThat(conflicts[0].description).contains("팀B")
+    }
+
+    @Test
+    fun `should not detect team conflict when games are 3 hours apart`() {
+        // given
+        val existingSchedule =
+            createScheduleWithId(
+                id = 100L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(10, 0),
+                venue = "구장A",
+            )
+
+        val newSchedule =
+            createScheduleWithId(
+                id = 200L,
+                round = 1,
+                matchNumber = 2,
+                homeTeam = teamA,
+                awayTeam = teamC,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장B",
+            )
+
+        // when
+        val conflicts = detector.detectTeamConflicts(newSchedule, listOf(existingSchedule))
+
+        // then
+        assertThat(conflicts).isEmpty()
+    }
+
+    @Test
+    fun `should detect venue conflict when same venue is used at same time`() {
+        // given
+        val existingSchedule =
+            createScheduleWithId(
+                id = 100L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+
+        val newSchedule =
+            createScheduleWithId(
+                id = 200L,
+                round = 1,
+                matchNumber = 2,
+                homeTeam = teamC,
+                awayTeam = teamD,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+
+        // when
+        val conflicts = detector.detectVenueConflicts(newSchedule, listOf(existingSchedule))
+
+        // then
+        assertThat(conflicts).hasSize(1)
+        assertThat(conflicts[0].type).isEqualTo(ConflictType.VENUE_TIME_CONFLICT)
+        assertThat(conflicts[0].description).contains("구장A")
+    }
+
+    @Test
+    fun `should detect venue conflict case insensitively`() {
+        // given
+        val existingSchedule =
+            createScheduleWithId(
+                id = 100L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+
+        val newSchedule =
+            createScheduleWithId(
+                id = 200L,
+                round = 1,
+                matchNumber = 2,
+                homeTeam = teamC,
+                awayTeam = teamD,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(15, 0),
+                venue = "구장a",
+            )
+
+        // when
+        val conflicts = detector.detectVenueConflicts(newSchedule, listOf(existingSchedule))
+
+        // then
+        assertThat(conflicts).hasSize(1)
+    }
+
+    @Test
+    fun `should not detect venue conflict when venue is not specified`() {
+        // given
+        val existingSchedule =
+            createScheduleWithId(
+                id = 100L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = null,
+            )
+
+        val newSchedule =
+            createScheduleWithId(
+                id = 200L,
+                round = 1,
+                matchNumber = 2,
+                homeTeam = teamC,
+                awayTeam = teamD,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = null,
+            )
+
+        // when
+        val conflicts = detector.detectVenueConflicts(newSchedule, listOf(existingSchedule))
+
+        // then
+        assertThat(conflicts).isEmpty()
+    }
+
+    @Test
+    fun `should not detect venue conflict when venues are 3 hours apart`() {
+        // given
+        val existingSchedule =
+            createScheduleWithId(
+                id = 100L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(10, 0),
+                venue = "구장A",
+            )
+
+        val newSchedule =
+            createScheduleWithId(
+                id = 200L,
+                round = 1,
+                matchNumber = 2,
+                homeTeam = teamC,
+                awayTeam = teamD,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+
+        // when
+        val conflicts = detector.detectVenueConflicts(newSchedule, listOf(existingSchedule))
+
+        // then
+        assertThat(conflicts).isEmpty()
+    }
+
+    @Test
+    fun `should detect both team and venue conflicts`() {
+        // given
+        val existingSchedule =
+            createScheduleWithId(
+                id = 100L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+
+        val newSchedule =
+            createScheduleWithId(
+                id = 200L,
+                round = 1,
+                matchNumber = 2,
+                homeTeam = teamA,
+                awayTeam = teamC,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+
+        // when
+        val conflicts = detector.detectAllConflicts(newSchedule, listOf(existingSchedule))
+
+        // then
+        assertThat(conflicts).hasSize(2)
+        assertThat(conflicts.map { it.type })
+            .containsExactlyInAnyOrder(
+                ConflictType.TEAM_TIME_CONFLICT,
+                ConflictType.VENUE_TIME_CONFLICT,
+            )
+    }
+
+    @Test
+    fun `should detect multiple team conflicts`() {
+        // given
+        val existingSchedule1 =
+            createScheduleWithId(
+                id = 100L,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = teamA,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "구장A",
+            )
+
+        val existingSchedule2 =
+            createScheduleWithId(
+                id = 101L,
+                round = 1,
+                matchNumber = 2,
+                homeTeam = teamC,
+                awayTeam = teamB,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(15, 0),
+                venue = "구장B",
+            )
+
+        val newSchedule =
+            createScheduleWithId(
+                id = 200L,
+                round = 1,
+                matchNumber = 3,
+                homeTeam = teamB,
+                awayTeam = teamD,
+                scheduledDate = LocalDate.of(2024, 5, 1),
+                scheduledTime = LocalTime.of(14, 30),
+                venue = "구장C",
+            )
+
+        // when
+        val conflicts =
+            detector.detectTeamConflicts(
+                newSchedule,
+                listOf(existingSchedule1, existingSchedule2),
+            )
+
+        // then
+        assertThat(conflicts).hasSize(2)
+        assertThat(conflicts.all { it.type == ConflictType.TEAM_TIME_CONFLICT }).isTrue()
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stadium/StadiumBookingTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stadium/StadiumBookingTest.kt
@@ -1,0 +1,169 @@
+package com.nextup.core.domain.stadium
+
+import com.nextup.common.exception.InvalidStateException
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("StadiumBooking")
+class StadiumBookingTest {
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+        @Test
+        fun `should create booking successfully`() {
+            // given
+            val slot = mockk<StadiumSlot>(relaxed = true)
+            every { slot.id } returns 1L
+
+            // when
+            val booking =
+                StadiumBooking.create(
+                    slot = slot,
+                    teamId = 100L,
+                    bookedBy = 200L,
+                )
+
+            // then
+            assertThat(booking.teamId).isEqualTo(100L)
+            assertThat(booking.bookedBy).isEqualTo(200L)
+            assertThat(booking.status).isEqualTo(BookingStatus.CONFIRMED)
+        }
+
+        @Test
+        fun `should throw exception when team ID is not positive`() {
+            // given
+            val slot = mockk<StadiumSlot>(relaxed = true)
+
+            // when & then
+            assertThatThrownBy {
+                StadiumBooking.create(
+                    slot = slot,
+                    teamId = 0L,
+                    bookedBy = 200L,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Team ID must be positive")
+        }
+
+        @Test
+        fun `should throw exception when booked by ID is not positive`() {
+            // given
+            val slot = mockk<StadiumSlot>(relaxed = true)
+
+            // when & then
+            assertThatThrownBy {
+                StadiumBooking.create(
+                    slot = slot,
+                    teamId = 100L,
+                    bookedBy = -1L,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Booked by user ID must be positive")
+        }
+    }
+
+    @Nested
+    @DisplayName("cancel")
+    inner class Cancel {
+        @Test
+        fun `should cancel confirmed booking`() {
+            // given
+            val slot = mockk<StadiumSlot>(relaxed = true)
+            val booking =
+                StadiumBooking.create(
+                    slot = slot,
+                    teamId = 100L,
+                    bookedBy = 200L,
+                )
+
+            // when
+            booking.cancel()
+
+            // then
+            assertThat(booking.status).isEqualTo(BookingStatus.CANCELLED)
+        }
+
+        @Test
+        fun `should throw exception when cancelling already cancelled booking`() {
+            // given
+            val slot = mockk<StadiumSlot>(relaxed = true)
+            val booking =
+                StadiumBooking.create(
+                    slot = slot,
+                    teamId = 100L,
+                    bookedBy = 200L,
+                )
+            booking.cancel()
+
+            // when & then
+            assertThatThrownBy {
+                booking.cancel()
+            }.isInstanceOf(InvalidStateException::class.java)
+                .hasMessageContaining("cannot be cancelled")
+        }
+
+        @Test
+        fun `should throw exception when cancelling completed booking`() {
+            // given
+            val slot = mockk<StadiumSlot>(relaxed = true)
+            val booking =
+                StadiumBooking.create(
+                    slot = slot,
+                    teamId = 100L,
+                    bookedBy = 200L,
+                )
+            booking.complete()
+
+            // when & then
+            assertThatThrownBy {
+                booking.cancel()
+            }.isInstanceOf(InvalidStateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("complete")
+    inner class Complete {
+        @Test
+        fun `should complete confirmed booking`() {
+            // given
+            val slot = mockk<StadiumSlot>(relaxed = true)
+            val booking =
+                StadiumBooking.create(
+                    slot = slot,
+                    teamId = 100L,
+                    bookedBy = 200L,
+                )
+
+            // when
+            booking.complete()
+
+            // then
+            assertThat(booking.status).isEqualTo(BookingStatus.COMPLETED)
+        }
+
+        @Test
+        fun `should throw exception when completing cancelled booking`() {
+            // given
+            val slot = mockk<StadiumSlot>(relaxed = true)
+            val booking =
+                StadiumBooking.create(
+                    slot = slot,
+                    teamId = 100L,
+                    bookedBy = 200L,
+                )
+            booking.cancel()
+
+            // when & then
+            assertThatThrownBy {
+                booking.complete()
+            }.isInstanceOf(InvalidStateException::class.java)
+                .hasMessageContaining("cannot be completed")
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stadium/StadiumSlotTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stadium/StadiumSlotTest.kt
@@ -1,0 +1,244 @@
+package com.nextup.core.domain.stadium
+
+import com.nextup.common.exception.SlotNotAvailableException
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalTime
+
+@DisplayName("StadiumSlot")
+class StadiumSlotTest {
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+        @Test
+        fun `should create slot successfully`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+
+            // when
+            val slot =
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                    price = BigDecimal("50000"),
+                )
+
+            // then
+            assertThat(slot.date).isEqualTo(LocalDate.of(2024, 12, 25))
+            assertThat(slot.startTime).isEqualTo(LocalTime.of(10, 0))
+            assertThat(slot.endTime).isEqualTo(LocalTime.of(12, 0))
+            assertThat(slot.price).isEqualTo(BigDecimal("50000"))
+            assertThat(slot.status).isEqualTo(SlotStatus.AVAILABLE)
+        }
+
+        @Test
+        fun `should throw exception when start time is after end time`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+
+            // when & then
+            assertThatThrownBy {
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(12, 0),
+                    endTime = LocalTime.of(10, 0),
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Start time must be before end time")
+        }
+
+        @Test
+        fun `should throw exception when price is not positive`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+
+            // when & then
+            assertThatThrownBy {
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                    price = BigDecimal("-1000"),
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Price must be positive")
+        }
+    }
+
+    @Nested
+    @DisplayName("book")
+    inner class Book {
+        @Test
+        fun `should book slot successfully when available`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+            val slot =
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                )
+
+            // when
+            slot.book()
+
+            // then
+            assertThat(slot.status).isEqualTo(SlotStatus.BOOKED)
+        }
+
+        @Test
+        fun `should throw exception when slot is already booked`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+            val slot =
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                )
+            slot.book()
+
+            // when & then
+            assertThatThrownBy {
+                slot.book()
+            }.isInstanceOf(SlotNotAvailableException::class.java)
+                .hasMessageContaining("not available for booking")
+        }
+
+        @Test
+        fun `should throw exception when slot is in maintenance`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+            val slot =
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                )
+            slot.maintain()
+
+            // when & then
+            assertThatThrownBy {
+                slot.book()
+            }.isInstanceOf(SlotNotAvailableException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("cancel")
+    inner class Cancel {
+        @Test
+        fun `should cancel booking successfully`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+            val slot =
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                )
+            slot.book()
+
+            // when
+            slot.cancel()
+
+            // then
+            assertThat(slot.status).isEqualTo(SlotStatus.AVAILABLE)
+        }
+
+        @Test
+        fun `should throw exception when slot is not booked`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+            val slot =
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                )
+
+            // when & then
+            assertThatThrownBy {
+                slot.cancel()
+            }.isInstanceOf(SlotNotAvailableException::class.java)
+                .hasMessageContaining("not booked")
+        }
+    }
+
+    @Nested
+    @DisplayName("maintain")
+    inner class Maintain {
+        @Test
+        fun `should set slot to maintenance`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+            val slot =
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                )
+
+            // when
+            slot.maintain()
+
+            // then
+            assertThat(slot.status).isEqualTo(SlotStatus.MAINTENANCE)
+        }
+
+        @Test
+        fun `should end maintenance successfully`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+            val slot =
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                )
+            slot.maintain()
+
+            // when
+            slot.endMaintenance()
+
+            // then
+            assertThat(slot.status).isEqualTo(SlotStatus.AVAILABLE)
+        }
+
+        @Test
+        fun `should throw exception when ending maintenance on non-maintenance slot`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+            val slot =
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                )
+
+            // when & then
+            assertThatThrownBy {
+                slot.endMaintenance()
+            }.isInstanceOf(SlotNotAvailableException::class.java)
+                .hasMessageContaining("not in maintenance")
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stadium/StadiumTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stadium/StadiumTest.kt
@@ -1,0 +1,179 @@
+package com.nextup.core.domain.stadium
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("Stadium")
+class StadiumTest {
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+        @Test
+        fun `should create stadium successfully`() {
+            // when
+            val stadium =
+                Stadium.create(
+                    name = "잠실 야구장",
+                    address = "서울특별시 송파구 올림픽로 25",
+                    latitude = 37.5121,
+                    longitude = 127.0717,
+                    capacity = 25000,
+                    facilities = "주차장, 샤워실",
+                    contactInfo = "02-1234-5678",
+                )
+
+            // then
+            assertThat(stadium.name).isEqualTo("잠실 야구장")
+            assertThat(stadium.latitude).isEqualTo(37.5121)
+            assertThat(stadium.longitude).isEqualTo(127.0717)
+            assertThat(stadium.isActive).isTrue()
+        }
+
+        @Test
+        fun `should throw exception when name is blank`() {
+            // when & then
+            assertThatThrownBy {
+                Stadium.create(
+                    name = "",
+                    address = "서울특별시 송파구",
+                    latitude = 37.5121,
+                    longitude = 127.0717,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Stadium name cannot be blank")
+        }
+
+        @Test
+        fun `should throw exception when latitude is invalid`() {
+            // when & then
+            assertThatThrownBy {
+                Stadium.create(
+                    name = "잠실 야구장",
+                    address = "서울특별시 송파구",
+                    latitude = 91.0,
+                    longitude = 127.0717,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Latitude must be between -90 and 90")
+        }
+
+        @Test
+        fun `should throw exception when longitude is invalid`() {
+            // when & then
+            assertThatThrownBy {
+                Stadium.create(
+                    name = "잠실 야구장",
+                    address = "서울특별시 송파구",
+                    latitude = 37.5121,
+                    longitude = 181.0,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Longitude must be between -180 and 180")
+        }
+
+        @Test
+        fun `should throw exception when capacity is not positive`() {
+            // when & then
+            assertThatThrownBy {
+                Stadium.create(
+                    name = "잠실 야구장",
+                    address = "서울특별시 송파구",
+                    latitude = 37.5121,
+                    longitude = 127.0717,
+                    capacity = -100,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Capacity must be positive")
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    inner class Update {
+        @Test
+        fun `should update stadium info successfully`() {
+            // given
+            val stadium =
+                Stadium.create(
+                    name = "잠실 야구장",
+                    address = "서울특별시 송파구",
+                    latitude = 37.5121,
+                    longitude = 127.0717,
+                )
+
+            // when
+            stadium.update(
+                address = "서울특별시 송파구 올림픽로 25",
+                capacity = 25000,
+                facilities = "주차장, 샤워실",
+            )
+
+            // then
+            assertThat(stadium.address).isEqualTo("서울특별시 송파구 올림픽로 25")
+            assertThat(stadium.capacity).isEqualTo(25000)
+            assertThat(stadium.facilities).isEqualTo("주차장, 샤워실")
+        }
+
+        @Test
+        fun `should throw exception when updating with invalid latitude`() {
+            // given
+            val stadium =
+                Stadium.create(
+                    name = "잠실 야구장",
+                    address = "서울특별시 송파구",
+                    latitude = 37.5121,
+                    longitude = 127.0717,
+                )
+
+            // when & then
+            assertThatThrownBy {
+                stadium.update(latitude = 95.0)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Latitude must be between -90 and 90")
+        }
+    }
+
+    @Nested
+    @DisplayName("activate/deactivate")
+    inner class ActivateDeactivate {
+        @Test
+        fun `should deactivate stadium`() {
+            // given
+            val stadium =
+                Stadium.create(
+                    name = "잠실 야구장",
+                    address = "서울특별시 송파구",
+                    latitude = 37.5121,
+                    longitude = 127.0717,
+                )
+
+            // when
+            stadium.deactivate()
+
+            // then
+            assertThat(stadium.isActive).isFalse()
+        }
+
+        @Test
+        fun `should activate stadium`() {
+            // given
+            val stadium =
+                Stadium.create(
+                    name = "잠실 야구장",
+                    address = "서울특별시 송파구",
+                    latitude = 37.5121,
+                    longitude = 127.0717,
+                )
+            stadium.deactivate()
+
+            // when
+            stadium.activate()
+
+            // then
+            assertThat(stadium.isActive).isTrue()
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/attendance/NudgeServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/attendance/NudgeServiceTest.kt
@@ -1,0 +1,195 @@
+package com.nextup.core.service.attendance
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.game.AttendanceStatus
+import com.nextup.core.domain.game.AttendanceVote
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.notification.NotificationType
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.port.repository.AttendanceVoteRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.service.notification.NotificationService
+import com.nextup.core.service.notification.dto.SendNotificationRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class NudgeServiceTest {
+    private val gameRepository: GameRepositoryPort = mockk()
+    private val attendanceVoteRepository: AttendanceVoteRepositoryPort = mockk()
+    private val notificationService: NotificationService = mockk()
+
+    private val nudgeService =
+        NudgeService(
+            gameRepository = gameRepository,
+            attendanceVoteRepository = attendanceVoteRepository,
+            notificationService = notificationService,
+        )
+
+    @Test
+    fun `should send nudge notifications to non-voters`() {
+        // given
+        val gameId = 1L
+        val game = createGame(gameId)
+        val nonVoter1 = createNonVoter(userId = 10L, userName = "Player1")
+        val nonVoter2 = createNonVoter(userId = 20L, userName = "Player2")
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { attendanceVoteRepository.findNonVotersByGameId(gameId) } returns
+            listOf(nonVoter1, nonVoter2)
+        every { notificationService.sendNotification(any()) } returns mockk()
+
+        // when
+        val result = nudgeService.nudgeNonVoters(gameId)
+
+        // then
+        assertThat(result.notifiedCount).isEqualTo(2)
+        assertThat(result.nonVoterNames).containsExactlyInAnyOrder("Player1", "Player2")
+
+        verify(exactly = 2) { notificationService.sendNotification(any()) }
+    }
+
+    @Test
+    fun `should send custom message when provided`() {
+        // given
+        val gameId = 1L
+        val customMessage = "Please vote for tomorrow's game!"
+        val game = createGame(gameId)
+        val nonVoter = createNonVoter(userId = 10L, userName = "Player1")
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { attendanceVoteRepository.findNonVotersByGameId(gameId) } returns listOf(nonVoter)
+
+        val requestSlot = slot<SendNotificationRequest>()
+        every { notificationService.sendNotification(capture(requestSlot)) } returns mockk()
+
+        // when
+        nudgeService.nudgeNonVoters(gameId, customMessage)
+
+        // then
+        val capturedRequest = requestSlot.captured
+        assertThat(capturedRequest.body).isEqualTo(customMessage)
+        assertThat(capturedRequest.title).isEqualTo("출석 투표 요청")
+        assertThat(capturedRequest.type).isEqualTo(NotificationType.ATTENDANCE_NUDGE)
+        assertThat(capturedRequest.data).isEqualTo("gameId=$gameId")
+    }
+
+    @Test
+    fun `should use default message when custom message is not provided`() {
+        // given
+        val gameId = 1L
+        val scheduledAt = LocalDateTime.of(2026, 3, 15, 14, 0)
+        val game = createGame(gameId, scheduledAt)
+        val nonVoter = createNonVoter(userId = 10L, userName = "Player1")
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { attendanceVoteRepository.findNonVotersByGameId(gameId) } returns listOf(nonVoter)
+
+        val requestSlot = slot<SendNotificationRequest>()
+        every { notificationService.sendNotification(capture(requestSlot)) } returns mockk()
+
+        // when
+        nudgeService.nudgeNonVoters(gameId)
+
+        // then
+        val capturedRequest = requestSlot.captured
+        assertThat(capturedRequest.body).contains("경기($scheduledAt)")
+        assertThat(capturedRequest.body).contains("출석 투표를 진행해주세요")
+    }
+
+    @Test
+    fun `should return empty result when no non-voters exist`() {
+        // given
+        val gameId = 1L
+        val game = createGame(gameId)
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { attendanceVoteRepository.findNonVotersByGameId(gameId) } returns emptyList()
+
+        // when
+        val result = nudgeService.nudgeNonVoters(gameId)
+
+        // then
+        assertThat(result.notifiedCount).isEqualTo(0)
+        assertThat(result.nonVoterNames).isEmpty()
+
+        verify(exactly = 0) { notificationService.sendNotification(any()) }
+    }
+
+    @Test
+    fun `should throw GameNotFoundException when game does not exist`() {
+        // given
+        val gameId = 999L
+
+        every { gameRepository.findByIdOrNull(gameId) } returns null
+
+        // when & then
+        assertThrows<GameNotFoundException> {
+            nudgeService.nudgeNonVoters(gameId)
+        }
+
+        verify(exactly = 0) { attendanceVoteRepository.findNonVotersByGameId(any()) }
+        verify(exactly = 0) { notificationService.sendNotification(any()) }
+    }
+
+    @Test
+    fun `should send notification to each non-voter with correct userId`() {
+        // given
+        val gameId = 1L
+        val game = createGame(gameId)
+        val nonVoter1 = createNonVoter(userId = 10L, userName = "Player1")
+        val nonVoter2 = createNonVoter(userId = 20L, userName = "Player2")
+        val nonVoter3 = createNonVoter(userId = 30L, userName = "Player3")
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { attendanceVoteRepository.findNonVotersByGameId(gameId) } returns
+            listOf(nonVoter1, nonVoter2, nonVoter3)
+
+        val requestSlots = mutableListOf<SendNotificationRequest>()
+        every { notificationService.sendNotification(capture(requestSlots)) } returns mockk()
+
+        // when
+        val result = nudgeService.nudgeNonVoters(gameId)
+
+        // then
+        assertThat(result.notifiedCount).isEqualTo(3)
+        assertThat(requestSlots).hasSize(3)
+        assertThat(requestSlots.map { it.userId }).containsExactlyInAnyOrder(10L, 20L, 30L)
+    }
+
+    private fun createGame(
+        id: Long,
+        scheduledAt: LocalDateTime = LocalDateTime.of(2026, 3, 15, 14, 0),
+    ): Game {
+        val game: Game = mockk(relaxed = true)
+        every { game.id } returns id
+        every { game.scheduledAt } returns scheduledAt
+        every { game.status } returns GameStatus.SCHEDULED
+        return game
+    }
+
+    private fun createNonVoter(
+        userId: Long,
+        userName: String,
+    ): AttendanceVote {
+        val user: com.nextup.core.domain.user.User = mockk(relaxed = true)
+        every { user.id } returns userId
+        every { user.nickname } returns userName
+
+        val member: TeamMember = mockk(relaxed = true)
+        every { member.user } returns user
+
+        val vote: AttendanceVote = mockk(relaxed = true)
+        every { vote.member } returns member
+        every { vote.status } returns AttendanceStatus.UNDECIDED
+        every { vote.hasResponded } returns false
+
+        return vote
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/discipline/DisciplineServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/discipline/DisciplineServiceTest.kt
@@ -1,0 +1,557 @@
+package com.nextup.core.service.discipline
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.DisciplineNotFoundException
+import com.nextup.common.exception.InvalidDisciplineStateException
+import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.discipline.Discipline
+import com.nextup.core.domain.discipline.DisciplineStatus
+import com.nextup.core.domain.discipline.DisciplineType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.DisciplineRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+@DisplayName("DisciplineService")
+class DisciplineServiceTest {
+    private lateinit var disciplineRepository: DisciplineRepositoryPort
+    private lateinit var playerRepository: PlayerRepositoryPort
+    private lateinit var competitionRepository: CompetitionRepositoryPort
+    private lateinit var disciplineService: DisciplineService
+
+    @BeforeEach
+    fun setUp() {
+        disciplineRepository = mockk()
+        playerRepository = mockk()
+        competitionRepository = mockk()
+        disciplineService =
+            DisciplineService(
+                disciplineRepository,
+                playerRepository,
+                competitionRepository,
+            )
+    }
+
+    @Nested
+    @DisplayName("issueWarning")
+    inner class IssueWarning {
+        @Test
+        fun `should issue warning successfully`() {
+            // given
+            val playerId = 1L
+            val competitionId = 1L
+            val player = createPlayer(playerId, "홍길동")
+            val competition = createCompetition(competitionId, "2025 춘계대회")
+
+            every { playerRepository.findByIdOrNull(playerId) } returns player
+            every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+            every { disciplineRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result =
+                disciplineService.issueWarning(
+                    playerId = playerId,
+                    competitionId = competitionId,
+                    reason = "과도한 항의",
+                    issuedBy = "심판장",
+                )
+
+            // then
+            assertThat(result.type).isEqualTo(DisciplineType.WARNING)
+            assertThat(result.reason).isEqualTo("과도한 항의")
+            assertThat(result.issuedBy).isEqualTo("심판장")
+            verify { disciplineRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when player not found`() {
+            // given
+            val playerId = 999L
+            val competitionId = 1L
+            every { playerRepository.findByIdOrNull(playerId) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                disciplineService.issueWarning(
+                    playerId = playerId,
+                    competitionId = competitionId,
+                    reason = "과도한 항의",
+                    issuedBy = "심판장",
+                )
+            }.isInstanceOf(PlayerNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when competition not found`() {
+            // given
+            val playerId = 1L
+            val competitionId = 999L
+            val player = createPlayer(playerId, "홍길동")
+
+            every { playerRepository.findByIdOrNull(playerId) } returns player
+            every { competitionRepository.findByIdOrNull(competitionId) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                disciplineService.issueWarning(
+                    playerId = playerId,
+                    competitionId = competitionId,
+                    reason = "과도한 항의",
+                    issuedBy = "심판장",
+                )
+            }.isInstanceOf(CompetitionNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("issueSuspension")
+    inner class IssueSuspension {
+        @Test
+        fun `should issue suspension successfully`() {
+            // given
+            val playerId = 1L
+            val competitionId = 1L
+            val player = createPlayer(playerId, "홍길동")
+            val competition = createCompetition(competitionId, "2025 춘계대회")
+
+            every { playerRepository.findByIdOrNull(playerId) } returns player
+            every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+            every { disciplineRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result =
+                disciplineService.issueSuspension(
+                    playerId = playerId,
+                    competitionId = competitionId,
+                    reason = "폭력 행위",
+                    suspensionGames = 3,
+                    issuedBy = "기술위원장",
+                )
+
+            // then
+            assertThat(result.type).isEqualTo(DisciplineType.SUSPENSION)
+            assertThat(result.suspensionGames).isEqualTo(3)
+            assertThat(result.servedGames).isEqualTo(0)
+            verify { disciplineRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("issueBan")
+    inner class IssueBan {
+        @Test
+        fun `should issue ban successfully`() {
+            // given
+            val playerId = 1L
+            val competitionId = 1L
+            val player = createPlayer(playerId, "홍길동")
+            val competition = createCompetition(competitionId, "2025 춘계대회")
+
+            every { playerRepository.findByIdOrNull(playerId) } returns player
+            every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+            every { disciplineRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result =
+                disciplineService.issueBan(
+                    playerId = playerId,
+                    competitionId = competitionId,
+                    reason = "승부 조작",
+                    issuedBy = "협회장",
+                )
+
+            // then
+            assertThat(result.type).isEqualTo(DisciplineType.BAN)
+            assertThat(result.reason).isEqualTo("승부 조작")
+            verify { disciplineRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelDiscipline")
+    inner class CancelDiscipline {
+        @Test
+        fun `should cancel discipline successfully`() {
+            // given
+            val disciplineId = 1L
+            val player = createPlayer(1L, "홍길동")
+            val competition = createCompetition(1L, "2025 춘계대회")
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+
+            every { disciplineRepository.findByIdOrNull(disciplineId) } returns discipline
+
+            // when
+            val result = disciplineService.cancelDiscipline(disciplineId)
+
+            // then
+            assertThat(result.status).isEqualTo(DisciplineStatus.CANCELLED)
+        }
+
+        @Test
+        fun `should throw exception when discipline not found`() {
+            // given
+            val disciplineId = 999L
+            every { disciplineRepository.findByIdOrNull(disciplineId) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                disciplineService.cancelDiscipline(disciplineId)
+            }.isInstanceOf(DisciplineNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when discipline is already served`() {
+            // given
+            val disciplineId = 1L
+            val player = createPlayer(1L, "홍길동")
+            val competition = createCompetition(1L, "2025 춘계대회")
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 1,
+                    issuedBy = "기술위원장",
+                )
+            discipline.markServed()
+
+            every { disciplineRepository.findByIdOrNull(disciplineId) } returns discipline
+
+            // when & then
+            assertThatThrownBy {
+                disciplineService.cancelDiscipline(disciplineId)
+            }.isInstanceOf(InvalidDisciplineStateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getById")
+    inner class GetById {
+        @Test
+        fun `should return discipline when found`() {
+            // given
+            val disciplineId = 1L
+            val player = createPlayer(1L, "홍길동")
+            val competition = createCompetition(1L, "2025 춘계대회")
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+
+            every { disciplineRepository.findByIdOrNull(disciplineId) } returns discipline
+
+            // when
+            val result = disciplineService.getById(disciplineId)
+
+            // then
+            assertThat(result).isEqualTo(discipline)
+        }
+
+        @Test
+        fun `should throw exception when not found`() {
+            // given
+            val disciplineId = 999L
+            every { disciplineRepository.findByIdOrNull(disciplineId) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                disciplineService.getById(disciplineId)
+            }.isInstanceOf(DisciplineNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getActiveDisciplines")
+    inner class GetActiveDisciplines {
+        @Test
+        fun `should return only effective disciplines`() {
+            // given
+            val playerId = 1L
+            val competitionId = 1L
+            val player = createPlayer(playerId, "홍길동")
+            val competition = createCompetition(competitionId, "2025 춘계대회")
+
+            val activeDiscipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+
+            val cancelledDiscipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고2",
+                    issuedBy = "심판장",
+                ).apply { cancel() }
+
+            every {
+                disciplineRepository.findActiveByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns listOf(activeDiscipline, cancelledDiscipline)
+
+            // when
+            val result = disciplineService.getActiveDisciplines(playerId, competitionId)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result.first().isEffective()).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("canPlayerPlay")
+    inner class CanPlayerPlay {
+        @Test
+        fun `should return true when no active disciplines`() {
+            // given
+            val playerId = 1L
+            val competitionId = 1L
+
+            every {
+                disciplineRepository.findActiveByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns emptyList()
+
+            // when
+            val result = disciplineService.canPlayerPlay(playerId, competitionId)
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `should return false when player has active ban`() {
+            // given
+            val playerId = 1L
+            val competitionId = 1L
+            val player = createPlayer(playerId, "홍길동")
+            val competition = createCompetition(competitionId, "2025 춘계대회")
+
+            val ban =
+                Discipline.createBan(
+                    player = player,
+                    competition = competition,
+                    reason = "승부 조작",
+                    issuedBy = "협회장",
+                )
+
+            every {
+                disciplineRepository.findActiveByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns listOf(ban)
+
+            // when
+            val result = disciplineService.canPlayerPlay(playerId, competitionId)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `should return false when player has active suspension`() {
+            // given
+            val playerId = 1L
+            val competitionId = 1L
+            val player = createPlayer(playerId, "홍길동")
+            val competition = createCompetition(competitionId, "2025 춘계대회")
+
+            val suspension =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 3,
+                    issuedBy = "기술위원장",
+                )
+
+            every {
+                disciplineRepository.findActiveByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns listOf(suspension)
+
+            // when
+            val result = disciplineService.canPlayerPlay(playerId, competitionId)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `should return true when only warnings exist`() {
+            // given
+            val playerId = 1L
+            val competitionId = 1L
+            val player = createPlayer(playerId, "홍길동")
+            val competition = createCompetition(competitionId, "2025 춘계대회")
+
+            val warning =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+
+            every {
+                disciplineRepository.findActiveByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns listOf(warning)
+
+            // when
+            val result = disciplineService.canPlayerPlay(playerId, competitionId)
+
+            // then
+            assertThat(result).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("incrementServedGames")
+    inner class IncrementServedGames {
+        @Test
+        fun `should increment served games successfully`() {
+            // given
+            val disciplineId = 1L
+            val player = createPlayer(1L, "홍길동")
+            val competition = createCompetition(1L, "2025 춘계대회")
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 3,
+                    issuedBy = "기술위원장",
+                )
+
+            every { disciplineRepository.findByIdOrNull(disciplineId) } returns discipline
+
+            // when
+            val result = disciplineService.incrementServedGames(disciplineId)
+
+            // then
+            assertThat(result.servedGames).isEqualTo(1)
+            assertThat(result.status).isEqualTo(DisciplineStatus.ACTIVE)
+        }
+
+        @Test
+        fun `should mark as served when all games are completed`() {
+            // given
+            val disciplineId = 1L
+            val player = createPlayer(1L, "홍길동")
+            val competition = createCompetition(1L, "2025 춘계대회")
+            val discipline =
+                Discipline.createSuspension(
+                    player = player,
+                    competition = competition,
+                    reason = "폭력 행위",
+                    suspensionGames = 1,
+                    issuedBy = "기술위원장",
+                )
+
+            every { disciplineRepository.findByIdOrNull(disciplineId) } returns discipline
+
+            // when
+            val result = disciplineService.incrementServedGames(disciplineId)
+
+            // then
+            assertThat(result.servedGames).isEqualTo(1)
+            assertThat(result.status).isEqualTo(DisciplineStatus.SERVED)
+        }
+
+        @Test
+        fun `should throw exception when discipline is not suspension`() {
+            // given
+            val disciplineId = 1L
+            val player = createPlayer(1L, "홍길동")
+            val competition = createCompetition(1L, "2025 춘계대회")
+            val discipline =
+                Discipline.createWarning(
+                    player = player,
+                    competition = competition,
+                    reason = "경고",
+                    issuedBy = "심판장",
+                )
+
+            every { disciplineRepository.findByIdOrNull(disciplineId) } returns discipline
+
+            // when & then
+            assertThatThrownBy {
+                disciplineService.incrementServedGames(disciplineId)
+            }.isInstanceOf(InvalidDisciplineStateException::class.java)
+        }
+    }
+
+    private fun createPlayer(
+        id: Long,
+        name: String,
+    ): Player =
+        Player(
+            name = name,
+            birthDate = LocalDate.of(1995, 5, 15),
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+        ).apply {
+            val idField = Player::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createCompetition(
+        id: Long,
+        name: String,
+    ): Competition {
+        val association =
+            Association(
+                name = "서울시야구협회",
+                abbreviation = "SBA",
+                region = "서울",
+            )
+
+        val league =
+            League(
+                association = association,
+                name = "1부 리그",
+                abbreviation = "1st",
+                foundedYear = 2020,
+                divisionLevel = 1,
+            )
+
+        return Competition(
+            league = league,
+            name = name,
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/lineup/LineupServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/lineup/LineupServiceTest.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.service.lineup
 
 import com.nextup.common.exception.NoCatcherInLineupException
+import com.nextup.common.exception.NonAttendingPlayerInLineupException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.game.Game
@@ -37,6 +38,7 @@ class LineupServiceTest {
     private lateinit var teamRepository: TeamRepositoryPort
     private lateinit var playerRepository: PlayerRepositoryPort
     private lateinit var userRepository: UserRepositoryPort
+    private lateinit var attendanceVoteRepository: com.nextup.core.port.repository.AttendanceVoteRepositoryPort
     private lateinit var lineupService: LineupService
 
     private lateinit var game: Game
@@ -52,6 +54,7 @@ class LineupServiceTest {
         teamRepository = mockk()
         playerRepository = mockk()
         userRepository = mockk()
+        attendanceVoteRepository = mockk()
 
         lineupService =
             LineupService(
@@ -61,6 +64,7 @@ class LineupServiceTest {
                 teamRepository = teamRepository,
                 playerRepository = playerRepository,
                 userRepository = userRepository,
+                attendanceVoteRepository = attendanceVoteRepository,
             )
 
         // Setup test data
@@ -374,8 +378,15 @@ class LineupServiceTest {
         fun `should submit lineup successfully with 9 starters`() {
             // given
             val submission = createSubmissionWithEntries()
+            val attendingVotes = createAttendingVotesForPlayers(listOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L))
 
             every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every {
+                attendanceVoteRepository.findByGameIdAndStatus(
+                    any(),
+                    com.nextup.core.domain.game.AttendanceStatus.ATTENDING
+                )
+            } returns attendingVotes
 
             val submissionSlot = slot<LineupSubmission>()
             every { lineupSubmissionRepository.save(capture(submissionSlot)) } answers { submissionSlot.captured }
@@ -410,13 +421,64 @@ class LineupServiceTest {
         fun `should throw exception when no catcher`() {
             // given
             val submission = createSubmissionWithEntriesNoCatcher()
+            val attendingVotes = createAttendingVotesForPlayers(listOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L))
 
             every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every {
+                attendanceVoteRepository.findByGameIdAndStatus(
+                    any(),
+                    com.nextup.core.domain.game.AttendanceStatus.ATTENDING
+                )
+            } returns attendingVotes
 
             // when & then
             assertThrows<NoCatcherInLineupException> {
                 lineupService.submitLineup(1L)
             }
+        }
+
+        @Test
+        fun `should throw exception when non-attending player in lineup`() {
+            // given
+            val submission = createSubmissionWithEntries()
+            val attendingVotes = createAttendingVotesForPlayers(listOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L))
+
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every {
+                attendanceVoteRepository.findByGameIdAndStatus(
+                    any(),
+                    com.nextup.core.domain.game.AttendanceStatus.ATTENDING
+                )
+            } returns attendingVotes
+
+            // when & then - player 9 is not attending
+            assertThrows<NonAttendingPlayerInLineupException> {
+                lineupService.submitLineup(1L)
+            }
+        }
+
+        @Test
+        fun `should submit successfully when all players are attending`() {
+            // given
+            val submission = createSubmissionWithEntries()
+            val attendingVotes = createAttendingVotesForPlayers(listOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L))
+
+            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
+            every {
+                attendanceVoteRepository.findByGameIdAndStatus(
+                    any(),
+                    com.nextup.core.domain.game.AttendanceStatus.ATTENDING
+                )
+            } returns attendingVotes
+
+            val submissionSlot = slot<LineupSubmission>()
+            every { lineupSubmissionRepository.save(capture(submissionSlot)) } answers { submissionSlot.captured }
+
+            // when
+            val result = lineupService.submitLineup(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(LineupSubmissionStatus.SUBMITTED)
         }
     }
 
@@ -704,4 +766,20 @@ class LineupServiceTest {
             )
         }
     }
+
+    private fun createAttendingVotesForPlayers(
+        playerIds: List<Long>,
+    ): List<com.nextup.core.domain.game.AttendanceVote> =
+        playerIds.map { playerId ->
+            mockk<com.nextup.core.domain.game.AttendanceVote>().apply {
+                every { member } returns
+                    mockk<com.nextup.core.domain.team.TeamMember>().apply {
+                        every { team } returns this@LineupServiceTest.team
+                        every { player } returns
+                            mockk<Player>().apply {
+                                every { id } returns playerId
+                            }
+                    }
+            }
+        }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/lineup/LineupServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/lineup/LineupServiceTest.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.service.lineup
 
+import com.nextup.common.exception.NoCatcherInLineupException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.game.Game
@@ -372,11 +373,9 @@ class LineupServiceTest {
         @Test
         fun `should submit lineup successfully with 9 starters`() {
             // given
-            val submission = LineupSubmission.create(game, team, user)
-            val entries = createMinimalLineup(submission)
+            val submission = createSubmissionWithEntries()
 
             every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
-            every { lineupEntryRepository.findAllBySubmissionId(any()) } returns entries
 
             val submissionSlot = slot<LineupSubmission>()
             every { lineupSubmissionRepository.save(capture(submissionSlot)) } answers { submissionSlot.captured }
@@ -392,14 +391,12 @@ class LineupServiceTest {
         fun `should throw exception when less than 9 starters`() {
             // given
             val submission = LineupSubmission.create(game, team, user)
-            val entries =
-                listOf(
-                    createMockEntry(submission, Position.STARTING_PITCHER, 1),
-                    createMockEntry(submission, Position.CATCHER, 2),
-                )
+            addEntriesToSubmission(
+                submission,
+                listOf(Position.STARTING_PITCHER, Position.CATCHER),
+            )
 
             every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
-            every { lineupEntryRepository.findAllBySubmissionId(any()) } returns entries
 
             // when & then
             val exception =
@@ -410,37 +407,16 @@ class LineupServiceTest {
         }
 
         @Test
-        fun `should throw exception when no pitcher`() {
-            // given
-            val submission = LineupSubmission.create(game, team, user)
-            val entries = createMinimalLineupWithoutPitcher(submission)
-
-            every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
-            every { lineupEntryRepository.findAllBySubmissionId(any()) } returns entries
-
-            // when & then
-            val exception =
-                assertThrows<IllegalArgumentException> {
-                    lineupService.submitLineup(1L)
-                }
-            assertThat(exception.message).contains("투수가 지정되지 않았습니다")
-        }
-
-        @Test
         fun `should throw exception when no catcher`() {
             // given
-            val submission = LineupSubmission.create(game, team, user)
-            val entries = createMinimalLineupWithoutCatcher(submission)
+            val submission = createSubmissionWithEntriesNoCatcher()
 
             every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
-            every { lineupEntryRepository.findAllBySubmissionId(any()) } returns entries
 
             // when & then
-            val exception =
-                assertThrows<IllegalArgumentException> {
-                    lineupService.submitLineup(1L)
-                }
-            assertThat(exception.message).contains("포수가 지정되지 않았습니다")
+            assertThrows<NoCatcherInLineupException> {
+                lineupService.submitLineup(1L)
+            }
         }
     }
 
@@ -449,7 +425,7 @@ class LineupServiceTest {
         @Test
         fun `should confirm lineup successfully`() {
             // given
-            val submission = LineupSubmission.create(game, team, user).apply { submit() }
+            val submission = createSubmissionWithEntries().apply { submit() }
             val scorer = User.createLocalUser(email = "scorer@test.com", encodedPassword = "encoded", nickname = "기록원")
 
             every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
@@ -468,7 +444,7 @@ class LineupServiceTest {
         @Test
         fun `should throw exception when scorer not found`() {
             // given
-            val submission = LineupSubmission.create(game, team, user).apply { submit() }
+            val submission = createSubmissionWithEntries().apply { submit() }
 
             every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
             every { userRepository.findByIdOrNull(any()) } returns null
@@ -487,7 +463,7 @@ class LineupServiceTest {
         @Test
         fun `should reject lineup successfully`() {
             // given
-            val submission = LineupSubmission.create(game, team, user).apply { submit() }
+            val submission = createSubmissionWithEntries().apply { submit() }
             val scorer = User.createLocalUser(email = "scorer@test.com", encodedPassword = "encoded", nickname = "기록원")
 
             every { lineupSubmissionRepository.findByIdOrNull(any()) } returns submission
@@ -548,7 +524,7 @@ class LineupServiceTest {
         @Test
         fun `should get submitted lineups by game`() {
             // given
-            val submission = LineupSubmission.create(game, team, user).apply { submit() }
+            val submission = createSubmissionWithEntries().apply { submit() }
             every {
                 lineupSubmissionRepository.findAllByGameIdAndStatus(any(), LineupSubmissionStatus.SUBMITTED)
             } returns
@@ -667,4 +643,65 @@ class LineupServiceTest {
             createMockEntry(submission, Position.RIGHT_FIELD, 8),
             createMockEntry(submission, Position.DESIGNATED_HITTER, 9),
         )
+
+    private fun createSubmissionWithEntries(): LineupSubmission {
+        val submission = LineupSubmission.create(game, team, user)
+        addEntriesToSubmission(
+            submission,
+            listOf(
+                Position.STARTING_PITCHER,
+                Position.CATCHER,
+                Position.FIRST_BASE,
+                Position.SECOND_BASE,
+                Position.THIRD_BASE,
+                Position.SHORTSTOP,
+                Position.LEFT_FIELD,
+                Position.CENTER_FIELD,
+                Position.RIGHT_FIELD,
+            ),
+        )
+        return submission
+    }
+
+    private fun createSubmissionWithEntriesNoCatcher(): LineupSubmission {
+        val submission = LineupSubmission.create(game, team, user)
+        addEntriesToSubmission(
+            submission,
+            listOf(
+                Position.STARTING_PITCHER,
+                Position.FIRST_BASE,
+                Position.SECOND_BASE,
+                Position.THIRD_BASE,
+                Position.SHORTSTOP,
+                Position.LEFT_FIELD,
+                Position.CENTER_FIELD,
+                Position.RIGHT_FIELD,
+                Position.DESIGNATED_HITTER,
+            ),
+        )
+        return submission
+    }
+
+    private fun addEntriesToSubmission(
+        submission: LineupSubmission,
+        positions: List<Position>,
+    ) {
+        positions.forEachIndexed { index, position ->
+            val mockPlayer =
+                mockk<Player>().apply {
+                    every { id } returns (index + 1).toLong()
+                    every { name } returns "선수${index + 1}"
+                }
+            submission.addEntry(
+                LineupEntry(
+                    submission = submission,
+                    player = mockPlayer,
+                    position = position,
+                    battingOrder = index + 1,
+                    backNumber = index + 1,
+                    isStarter = true,
+                ),
+            )
+        }
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/schedule/LeagueScheduleServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/schedule/LeagueScheduleServiceTest.kt
@@ -385,6 +385,154 @@ class LeagueScheduleServiceTest {
         assertThat(conflicts).isEmpty()
     }
 
+    @Test
+    fun `should generate round robin schedule for 4 teams`() {
+        // given
+        val competition = createCompetition()
+        val teams =
+            listOf(
+                createTeam("팀A", 1L),
+                createTeam("팀B", 2L),
+                createTeam("팀C", 3L),
+                createTeam("팀D", 4L),
+            )
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        teams.forEach { team ->
+            every { teamRepository.findByIdOrNull(team.id) } returns team
+        }
+        every { scheduleRepository.save(any<LeagueSchedule>()) } answers { firstArg() }
+
+        // when
+        val result =
+            service.generateRoundRobinSchedule(
+                competitionId = 1L,
+                teamIds = listOf(1L, 2L, 3L, 4L),
+                doubleRoundRobin = false,
+            )
+
+        // then
+        assertThat(result).hasSize(6) // 4C2 = 6 matches
+        assertThat(result.map { it.round }.distinct()).containsExactlyInAnyOrder(1, 2, 3)
+
+        // 각 팀이 정확히 3번씩 경기
+        val teamMatchCounts = mutableMapOf<Long, Int>()
+        result.forEach { schedule ->
+            teamMatchCounts[schedule.homeTeam.id] =
+                teamMatchCounts.getOrDefault(schedule.homeTeam.id, 0) + 1
+            teamMatchCounts[schedule.awayTeam.id] =
+                teamMatchCounts.getOrDefault(schedule.awayTeam.id, 0) + 1
+        }
+        assertThat(teamMatchCounts.values).allMatch { it == 3 }
+
+        verify(exactly = 6) { scheduleRepository.save(any<LeagueSchedule>()) }
+    }
+
+    @Test
+    fun `should generate double round robin schedule`() {
+        // given
+        val competition = createCompetition()
+        val teams =
+            listOf(
+                createTeam("팀A", 1L),
+                createTeam("팀B", 2L),
+                createTeam("팀C", 3L),
+            )
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        teams.forEach { team ->
+            every { teamRepository.findByIdOrNull(team.id) } returns team
+        }
+        every { scheduleRepository.save(any<LeagueSchedule>()) } answers { firstArg() }
+
+        // when
+        val result =
+            service.generateRoundRobinSchedule(
+                competitionId = 1L,
+                teamIds = listOf(1L, 2L, 3L),
+                doubleRoundRobin = true,
+            )
+
+        // then
+        assertThat(result).hasSize(6) // 3C2 * 2 = 6 matches
+
+        // 각 팀이 정확히 4번씩 경기 (모든 상대와 2번씩)
+        val teamMatchCounts = mutableMapOf<Long, Int>()
+        result.forEach { schedule ->
+            teamMatchCounts[schedule.homeTeam.id] =
+                teamMatchCounts.getOrDefault(schedule.homeTeam.id, 0) + 1
+            teamMatchCounts[schedule.awayTeam.id] =
+                teamMatchCounts.getOrDefault(schedule.awayTeam.id, 0) + 1
+        }
+        assertThat(teamMatchCounts.values).allMatch { it == 4 }
+
+        verify(exactly = 6) { scheduleRepository.save(any<LeagueSchedule>()) }
+    }
+
+    @Test
+    fun `should throw CompetitionNotFoundException when generating schedule for non-existent competition`() {
+        // given
+        every { competitionRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<CompetitionNotFoundException> {
+            service.generateRoundRobinSchedule(
+                competitionId = 999L,
+                teamIds = listOf(1L, 2L, 3L),
+            )
+        }
+    }
+
+    @Test
+    fun `should throw TeamNotFoundException when generating schedule with non-existent team`() {
+        // given
+        val competition = createCompetition()
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(1L) } returns createTeam("팀A", 1L)
+        every { teamRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<TeamNotFoundException> {
+            service.generateRoundRobinSchedule(
+                competitionId = 1L,
+                teamIds = listOf(1L, 999L),
+            )
+        }
+    }
+
+    @Test
+    fun `should assign temporary dates with weekly intervals`() {
+        // given
+        val competition = createCompetition()
+        val teams =
+            listOf(
+                createTeam("팀A", 1L),
+                createTeam("팀B", 2L),
+                createTeam("팀C", 3L),
+            )
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        teams.forEach { team ->
+            every { teamRepository.findByIdOrNull(team.id) } returns team
+        }
+        every { scheduleRepository.save(any<LeagueSchedule>()) } answers { firstArg() }
+
+        // when
+        val result =
+            service.generateRoundRobinSchedule(
+                competitionId = 1L,
+                teamIds = listOf(1L, 2L, 3L),
+            )
+
+        // then
+        val round1Date = result.first { it.round == 1 }.scheduledDate
+        val round2Date = result.first { it.round == 2 }.scheduledDate
+        val round3Date = result.first { it.round == 3 }.scheduledDate
+
+        assertThat(round2Date).isEqualTo(round1Date.plusWeeks(1))
+        assertThat(round3Date).isEqualTo(round1Date.plusWeeks(2))
+    }
+
     // ========== Helper Methods ==========
 
     private fun createCompetition(): Competition {

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/schedule/LeagueScheduleServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/schedule/LeagueScheduleServiceTest.kt
@@ -1,0 +1,228 @@
+package com.nextup.core.service.schedule
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidScheduleStateException
+import com.nextup.common.exception.ScheduleNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.schedule.LeagueSchedule
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.LeagueScheduleRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalTime
+
+class LeagueScheduleServiceTest {
+    private lateinit var scheduleRepository: LeagueScheduleRepositoryPort
+    private lateinit var competitionRepository: CompetitionRepositoryPort
+    private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var service: LeagueScheduleService
+
+    @BeforeEach
+    fun setUp() {
+        scheduleRepository = mockk()
+        competitionRepository = mockk()
+        teamRepository = mockk()
+        service = LeagueScheduleService(scheduleRepository, competitionRepository, teamRepository)
+    }
+
+    @Test
+    fun `should create schedule successfully`() {
+        // given
+        val competition = createCompetition()
+        val homeTeam = createTeam("홈팀", 1L)
+        val awayTeam = createTeam("원정팀", 2L)
+        val scheduledDate = LocalDate.now().plusDays(7)
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(1L) } returns homeTeam
+        every { teamRepository.findByIdOrNull(2L) } returns awayTeam
+        every {
+            scheduleRepository.existsByCompetitionIdAndRoundAndMatchNumber(any(), any(), any())
+        } returns false
+        every { scheduleRepository.save(any<LeagueSchedule>()) } answers { firstArg() }
+
+        // when
+        val result =
+            service.createSchedule(
+                competitionId = 1L,
+                round = 1,
+                matchNumber = 1,
+                homeTeamId = 1L,
+                awayTeamId = 2L,
+                scheduledDate = scheduledDate,
+                scheduledTime = LocalTime.of(14, 0),
+                venue = "서울야구장",
+            )
+
+        // then
+        assertThat(result.round).isEqualTo(1)
+        assertThat(result.matchNumber).isEqualTo(1)
+        assertThat(result.scheduledDate).isEqualTo(scheduledDate)
+    }
+
+    @Test
+    fun `should throw CompetitionNotFoundException when competition not found`() {
+        // given
+        every { competitionRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<CompetitionNotFoundException> {
+            service.createSchedule(
+                competitionId = 999L,
+                round = 1,
+                matchNumber = 1,
+                homeTeamId = 1L,
+                awayTeamId = 2L,
+                scheduledDate = LocalDate.now().plusDays(7),
+            )
+        }
+    }
+
+    @Test
+    fun `should throw when home team not found`() {
+        // given
+        every { competitionRepository.findByIdOrNull(1L) } returns createCompetition()
+        every { teamRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            service.createSchedule(
+                competitionId = 1L,
+                round = 1,
+                matchNumber = 1,
+                homeTeamId = 999L,
+                awayTeamId = 2L,
+                scheduledDate = LocalDate.now().plusDays(7),
+            )
+        }
+    }
+
+    @Test
+    fun `should throw InvalidScheduleStateException when duplicate schedule exists`() {
+        // given
+        val competition = createCompetition()
+        val homeTeam = createTeam("홈팀", 1L)
+        val awayTeam = createTeam("원정팀", 2L)
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(1L) } returns homeTeam
+        every { teamRepository.findByIdOrNull(2L) } returns awayTeam
+        every {
+            scheduleRepository.existsByCompetitionIdAndRoundAndMatchNumber(1L, 1, 1)
+        } returns true
+
+        // when & then
+        assertThrows<InvalidScheduleStateException> {
+            service.createSchedule(
+                competitionId = 1L,
+                round = 1,
+                matchNumber = 1,
+                homeTeamId = 1L,
+                awayTeamId = 2L,
+                scheduledDate = LocalDate.now().plusDays(7),
+            )
+        }
+    }
+
+    @Test
+    fun `should throw ScheduleNotFoundException when schedule not found`() {
+        // given
+        every { scheduleRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<ScheduleNotFoundException> {
+            service.getById(999L)
+        }
+    }
+
+    @Test
+    fun `should delete schedule successfully`() {
+        // given
+        val schedule = createLeagueSchedule()
+        every { scheduleRepository.findByIdOrNull(1L) } returns schedule
+        every { scheduleRepository.delete(schedule) } returns Unit
+
+        // when
+        service.deleteSchedule(1L)
+
+        // then
+        verify { scheduleRepository.delete(schedule) }
+    }
+
+    @Test
+    fun `should get schedules by competition`() {
+        // given
+        val schedules = listOf(createLeagueSchedule())
+        every { scheduleRepository.findByCompetitionId(1L) } returns schedules
+
+        // when
+        val result = service.getSchedulesByCompetition(1L)
+
+        // then
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun `should get schedules by round`() {
+        // given
+        val schedules = listOf(createLeagueSchedule())
+        every { scheduleRepository.findByCompetitionIdAndRound(1L, 1) } returns schedules
+
+        // when
+        val result = service.getSchedulesByRound(1L, 1)
+
+        // then
+        assertThat(result).hasSize(1)
+    }
+
+    // ========== Helper Methods ==========
+
+    private fun createCompetition(): Competition {
+        val association = Association(name = "서울시야구협회", abbreviation = "서야협", region = "서울")
+        val league = League(association = association, name = "서울시 리그", foundedYear = 2020)
+        return Competition(
+            league = league,
+            name = "2024 시즌",
+            year = 2024,
+            startDate = LocalDate.now().minusDays(30),
+            id = 1L,
+        )
+    }
+
+    private fun createTeam(
+        name: String,
+        id: Long,
+    ): Team {
+        val association = Association(name = "서울시야구협회", abbreviation = "서야협", region = "서울")
+        val league = League(association = association, name = "서울시 리그", foundedYear = 2020)
+        return Team(
+            league = league,
+            name = name,
+            city = "서울",
+            foundedYear = 2020,
+            id = id,
+        )
+    }
+
+    private fun createLeagueSchedule(): LeagueSchedule =
+        LeagueSchedule.create(
+            competition = createCompetition(),
+            round = 1,
+            matchNumber = 1,
+            homeTeam = createTeam("홈팀", 1L),
+            awayTeam = createTeam("원정팀", 2L),
+            scheduledDate = LocalDate.now().plusDays(7),
+            scheduledTime = LocalTime.of(14, 0),
+            venue = "서울야구장",
+        )
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/schedule/LeagueScheduleServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/schedule/LeagueScheduleServiceTest.kt
@@ -3,6 +3,7 @@ package com.nextup.core.service.schedule
 import com.nextup.common.exception.CompetitionNotFoundException
 import com.nextup.common.exception.InvalidScheduleStateException
 import com.nextup.common.exception.ScheduleNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.league.League
@@ -95,7 +96,7 @@ class LeagueScheduleServiceTest {
         every { teamRepository.findByIdOrNull(999L) } returns null
 
         // when & then
-        assertThrows<IllegalArgumentException> {
+        assertThrows<TeamNotFoundException> {
             service.createSchedule(
                 competitionId = 1L,
                 round = 1,

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/schedule/LeagueScheduleServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/schedule/LeagueScheduleServiceTest.kt
@@ -50,6 +50,9 @@ class LeagueScheduleServiceTest {
         every {
             scheduleRepository.existsByCompetitionIdAndRoundAndMatchNumber(any(), any(), any())
         } returns false
+        every {
+            scheduleRepository.findByCompetitionIdAndScheduledDate(any(), any())
+        } returns emptyList()
         every { scheduleRepository.save(any<LeagueSchedule>()) } answers { firstArg() }
 
         // when
@@ -184,6 +187,202 @@ class LeagueScheduleServiceTest {
 
         // then
         assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun `should throw InvalidScheduleStateException when team time conflict detected`() {
+        // given
+        val competition = createCompetition()
+        val homeTeam = createTeam("팀A", 1L)
+        val awayTeam = createTeam("팀B", 2L)
+        val teamC = createTeam("팀C", 3L)
+        val scheduledDate = LocalDate.now().plusDays(7)
+        val scheduledTime = LocalTime.of(14, 0)
+
+        val existingSchedule =
+            LeagueSchedule.create(
+                competition = competition,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledDate = scheduledDate,
+                scheduledTime = scheduledTime,
+                venue = "구장A",
+            ).apply {
+                val idField = LeagueSchedule::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 100L)
+            }
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(1L) } returns homeTeam
+        every { teamRepository.findByIdOrNull(3L) } returns teamC
+        every {
+            scheduleRepository.existsByCompetitionIdAndRoundAndMatchNumber(any(), any(), any())
+        } returns false
+        every {
+            scheduleRepository.findByCompetitionIdAndScheduledDate(1L, scheduledDate)
+        } returns listOf(existingSchedule)
+
+        // when & then
+        val exception =
+            assertThrows<InvalidScheduleStateException> {
+                service.createSchedule(
+                    competitionId = 1L,
+                    round = 1,
+                    matchNumber = 2,
+                    homeTeamId = 1L,
+                    awayTeamId = 3L,
+                    scheduledDate = scheduledDate,
+                    scheduledTime = scheduledTime,
+                    venue = "구장B",
+                )
+            }
+
+        assertThat(exception.message).contains("충돌이 감지되었습니다")
+        assertThat(exception.message).contains("팀A")
+    }
+
+    @Test
+    fun `should throw InvalidScheduleStateException when venue time conflict detected`() {
+        // given
+        val competition = createCompetition()
+        val homeTeam = createTeam("팀A", 1L)
+        val awayTeam = createTeam("팀B", 2L)
+        val teamC = createTeam("팀C", 3L)
+        val teamD = createTeam("팀D", 4L)
+        val scheduledDate = LocalDate.now().plusDays(7)
+        val scheduledTime = LocalTime.of(14, 0)
+
+        val existingSchedule =
+            LeagueSchedule.create(
+                competition = competition,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledDate = scheduledDate,
+                scheduledTime = scheduledTime,
+                venue = "구장A",
+            ).apply {
+                val idField = LeagueSchedule::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 100L)
+            }
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(3L) } returns teamC
+        every { teamRepository.findByIdOrNull(4L) } returns teamD
+        every {
+            scheduleRepository.existsByCompetitionIdAndRoundAndMatchNumber(any(), any(), any())
+        } returns false
+        every {
+            scheduleRepository.findByCompetitionIdAndScheduledDate(1L, scheduledDate)
+        } returns listOf(existingSchedule)
+
+        // when & then
+        val exception =
+            assertThrows<InvalidScheduleStateException> {
+                service.createSchedule(
+                    competitionId = 1L,
+                    round = 1,
+                    matchNumber = 2,
+                    homeTeamId = 3L,
+                    awayTeamId = 4L,
+                    scheduledDate = scheduledDate,
+                    scheduledTime = scheduledTime,
+                    venue = "구장A",
+                )
+            }
+
+        assertThat(exception.message).contains("충돌이 감지되었습니다")
+        assertThat(exception.message).contains("구장A")
+    }
+
+    @Test
+    fun `should validate schedule and return conflicts without saving`() {
+        // given
+        val competition = createCompetition()
+        val homeTeam = createTeam("팀A", 1L)
+        val awayTeam = createTeam("팀B", 2L)
+        val teamC = createTeam("팀C", 3L)
+        val scheduledDate = LocalDate.now().plusDays(7)
+        val scheduledTime = LocalTime.of(14, 0)
+
+        val existingSchedule =
+            LeagueSchedule.create(
+                competition = competition,
+                round = 1,
+                matchNumber = 1,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledDate = scheduledDate,
+                scheduledTime = scheduledTime,
+                venue = "구장A",
+            ).apply {
+                val idField = LeagueSchedule::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 100L)
+            }
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(1L) } returns homeTeam
+        every { teamRepository.findByIdOrNull(3L) } returns teamC
+        every {
+            scheduleRepository.findByCompetitionIdAndScheduledDate(1L, scheduledDate)
+        } returns listOf(existingSchedule)
+
+        // when
+        val conflicts =
+            service.validateSchedule(
+                competitionId = 1L,
+                round = 1,
+                matchNumber = 2,
+                homeTeamId = 1L,
+                awayTeamId = 3L,
+                scheduledDate = scheduledDate,
+                scheduledTime = scheduledTime,
+                venue = "구장B",
+            )
+
+        // then
+        assertThat(conflicts).hasSize(1)
+        assertThat(conflicts[0].description).contains("팀A")
+        verify(exactly = 0) { scheduleRepository.save(any()) }
+    }
+
+    @Test
+    fun `should validate schedule and return no conflicts when valid`() {
+        // given
+        val competition = createCompetition()
+        val homeTeam = createTeam("팀A", 1L)
+        val awayTeam = createTeam("팀B", 2L)
+        val scheduledDate = LocalDate.now().plusDays(7)
+        val scheduledTime = LocalTime.of(14, 0)
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(1L) } returns homeTeam
+        every { teamRepository.findByIdOrNull(2L) } returns awayTeam
+        every {
+            scheduleRepository.findByCompetitionIdAndScheduledDate(1L, scheduledDate)
+        } returns emptyList()
+
+        // when
+        val conflicts =
+            service.validateSchedule(
+                competitionId = 1L,
+                round = 1,
+                matchNumber = 1,
+                homeTeamId = 1L,
+                awayTeamId = 2L,
+                scheduledDate = scheduledDate,
+                scheduledTime = scheduledTime,
+                venue = "구장A",
+            )
+
+        // then
+        assertThat(conflicts).isEmpty()
     }
 
     // ========== Helper Methods ==========

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumAdminServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumAdminServiceTest.kt
@@ -1,0 +1,208 @@
+package com.nextup.core.service.stadium
+
+import com.nextup.common.exception.StadiumNotFoundException
+import com.nextup.core.domain.stadium.Stadium
+import com.nextup.core.port.repository.StadiumRepositoryPort
+import com.nextup.core.port.repository.StadiumSlotRepositoryPort
+import com.nextup.core.service.stadium.dto.CreateSlotRequest
+import com.nextup.core.service.stadium.dto.CreateStadiumRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalTime
+
+@DisplayName("StadiumAdminService")
+class StadiumAdminServiceTest {
+    private lateinit var stadiumRepository: StadiumRepositoryPort
+    private lateinit var slotRepository: StadiumSlotRepositoryPort
+    private lateinit var stadiumAdminService: StadiumAdminService
+
+    @BeforeEach
+    fun setUp() {
+        stadiumRepository = mockk()
+        slotRepository = mockk()
+        stadiumAdminService = StadiumAdminService(stadiumRepository, slotRepository)
+    }
+
+    @Nested
+    @DisplayName("createStadium")
+    inner class CreateStadium {
+        @Test
+        fun `should create stadium successfully`() {
+            // given
+            val request =
+                CreateStadiumRequest(
+                    name = "잠실 야구장",
+                    address = "서울특별시 송파구 올림픽로 25",
+                    latitude = 37.5121,
+                    longitude = 127.0717,
+                    capacity = 25000,
+                    facilities = "주차장, 샤워실",
+                    contactInfo = "02-1234-5678",
+                )
+            every { stadiumRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = stadiumAdminService.createStadium(request)
+
+            // then
+            assertThat(result.name).isEqualTo("잠실 야구장")
+            assertThat(result.latitude).isEqualTo(37.5121)
+            assertThat(result.isActive).isTrue()
+            verify { stadiumRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStadium")
+    inner class UpdateStadium {
+        @Test
+        fun `should update stadium successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            every { stadiumRepository.findByIdOrNull(1L) } returns stadium
+
+            // when
+            val result =
+                stadiumAdminService.updateStadium(
+                    id = 1L,
+                    address = "서울특별시 송파구 올림픽로 25",
+                    capacity = 26000,
+                    facilities = "주차장, 샤워실, 식당",
+                )
+
+            // then
+            assertThat(result.address).isEqualTo("서울특별시 송파구 올림픽로 25")
+            assertThat(result.capacity).isEqualTo(26000)
+            assertThat(result.facilities).isEqualTo("주차장, 샤워실, 식당")
+        }
+
+        @Test
+        fun `should throw exception when stadium not found`() {
+            // given
+            every { stadiumRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                stadiumAdminService.updateStadium(999L)
+            }.isInstanceOf(StadiumNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("createSlots")
+    inner class CreateSlots {
+        @Test
+        fun `should create multiple slots successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val requests =
+                listOf(
+                    CreateSlotRequest(
+                        stadiumId = 1L,
+                        date = LocalDate.of(2024, 12, 25),
+                        startTime = LocalTime.of(10, 0),
+                        endTime = LocalTime.of(12, 0),
+                        price = BigDecimal("50000"),
+                    ),
+                    CreateSlotRequest(
+                        stadiumId = 1L,
+                        date = LocalDate.of(2024, 12, 25),
+                        startTime = LocalTime.of(14, 0),
+                        endTime = LocalTime.of(16, 0),
+                        price = BigDecimal("50000"),
+                    ),
+                )
+            every { stadiumRepository.findByIdOrNull(1L) } returns stadium
+            every { slotRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = stadiumAdminService.createSlots(requests)
+
+            // then
+            assertThat(result).hasSize(2)
+            verify(exactly = 2) { slotRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when stadium not found`() {
+            // given
+            val requests =
+                listOf(
+                    CreateSlotRequest(
+                        stadiumId = 999L,
+                        date = LocalDate.of(2024, 12, 25),
+                        startTime = LocalTime.of(10, 0),
+                        endTime = LocalTime.of(12, 0),
+                    ),
+                )
+            every { stadiumRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                stadiumAdminService.createSlots(requests)
+            }.isInstanceOf(StadiumNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("deactivateStadium")
+    inner class DeactivateStadium {
+        @Test
+        fun `should deactivate stadium successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            every { stadiumRepository.findByIdOrNull(1L) } returns stadium
+
+            // when
+            val result = stadiumAdminService.deactivateStadium(1L)
+
+            // then
+            assertThat(result.isActive).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("activateStadium")
+    inner class ActivateStadium {
+        @Test
+        fun `should activate stadium successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717).apply { deactivate() }
+            every { stadiumRepository.findByIdOrNull(1L) } returns stadium
+
+            // when
+            val result = stadiumAdminService.activateStadium(1L)
+
+            // then
+            assertThat(result.isActive).isTrue()
+        }
+    }
+
+    private fun createStadium(
+        id: Long,
+        name: String,
+        latitude: Double,
+        longitude: Double,
+    ): Stadium {
+        val stadium =
+            Stadium.create(
+                name = name,
+                address = "서울특별시",
+                latitude = latitude,
+                longitude = longitude,
+            )
+        val idField = Stadium::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(stadium, id)
+        return stadium
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumServiceTest.kt
@@ -1,0 +1,298 @@
+package com.nextup.core.service.stadium
+
+import com.nextup.common.exception.BookingNotFoundException
+import com.nextup.common.exception.SlotNotFoundException
+import com.nextup.common.exception.StadiumNotFoundException
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.domain.stadium.SlotStatus
+import com.nextup.core.domain.stadium.Stadium
+import com.nextup.core.domain.stadium.StadiumBooking
+import com.nextup.core.domain.stadium.StadiumSlot
+import com.nextup.core.port.repository.StadiumBookingRepositoryPort
+import com.nextup.core.port.repository.StadiumRepositoryPort
+import com.nextup.core.port.repository.StadiumSlotRepositoryPort
+import com.nextup.core.service.stadium.dto.BookSlotRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+@DisplayName("StadiumService")
+class StadiumServiceTest {
+    private lateinit var stadiumRepository: StadiumRepositoryPort
+    private lateinit var slotRepository: StadiumSlotRepositoryPort
+    private lateinit var bookingRepository: StadiumBookingRepositoryPort
+    private lateinit var stadiumService: StadiumService
+
+    @BeforeEach
+    fun setUp() {
+        stadiumRepository = mockk()
+        slotRepository = mockk()
+        bookingRepository = mockk()
+        stadiumService = StadiumService(stadiumRepository, slotRepository, bookingRepository)
+    }
+
+    @Nested
+    @DisplayName("searchStadiums")
+    inner class SearchStadiums {
+        @Test
+        fun `should search nearby stadiums`() {
+            // given
+            val stadiums =
+                listOf(
+                    createStadium(1L, "잠실 야구장", 37.5121, 127.0717),
+                    createStadium(2L, "고척 야구장", 37.4981, 126.8671),
+                )
+            every { stadiumRepository.findNearby(37.5, 127.0, 10.0) } returns stadiums
+
+            // when
+            val result = stadiumService.searchStadiums(37.5, 127.0, 10.0)
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result[0].name).isEqualTo("잠실 야구장")
+        }
+    }
+
+    @Nested
+    @DisplayName("getById")
+    inner class GetById {
+        @Test
+        fun `should return stadium when found`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            every { stadiumRepository.findByIdOrNull(1L) } returns stadium
+
+            // when
+            val result = stadiumService.getById(1L)
+
+            // then
+            assertThat(result.id).isEqualTo(1L)
+            assertThat(result.name).isEqualTo("잠실 야구장")
+        }
+
+        @Test
+        fun `should throw exception when not found`() {
+            // given
+            every { stadiumRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                stadiumService.getById(999L)
+            }.isInstanceOf(StadiumNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getAvailableSlots")
+    inner class GetAvailableSlots {
+        @Test
+        fun `should return only available slots`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val availableSlot = createSlot(1L, stadium, LocalDate.of(2024, 12, 25))
+            val bookedSlot = createSlot(2L, stadium, LocalDate.of(2024, 12, 25)).apply { book() }
+            every { stadiumRepository.findByIdOrNull(1L) } returns stadium
+            every { slotRepository.findByStadiumIdAndDate(1L, LocalDate.of(2024, 12, 25)) } returns
+                listOf(availableSlot, bookedSlot)
+
+            // when
+            val result = stadiumService.getAvailableSlots(1L, LocalDate.of(2024, 12, 25))
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].status).isEqualTo(SlotStatus.AVAILABLE)
+        }
+
+        @Test
+        fun `should throw exception when stadium not found`() {
+            // given
+            every { stadiumRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                stadiumService.getAvailableSlots(999L, LocalDate.of(2024, 12, 25))
+            }.isInstanceOf(StadiumNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("bookSlot")
+    inner class BookSlot {
+        @Test
+        fun `should book slot successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val slot = createSlot(1L, stadium, LocalDate.of(2024, 12, 25))
+            val request = BookSlotRequest(slotId = 1L, teamId = 100L, bookedBy = 200L)
+            every { slotRepository.findByIdOrNull(1L) } returns slot
+            every { bookingRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = stadiumService.bookSlot(request)
+
+            // then
+            assertThat(slot.status).isEqualTo(SlotStatus.BOOKED)
+            assertThat(result.teamId).isEqualTo(100L)
+            verify { bookingRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when slot not found`() {
+            // given
+            val request = BookSlotRequest(slotId = 999L, teamId = 100L, bookedBy = 200L)
+            every { slotRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                stadiumService.bookSlot(request)
+            }.isInstanceOf(SlotNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelBooking")
+    inner class CancelBooking {
+        @Test
+        fun `should cancel booking and restore slot status`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val slot = createSlot(1L, stadium, LocalDate.of(2024, 12, 25)).apply { book() }
+            val booking = createBooking(1L, slot, 100L, 200L)
+            every { bookingRepository.findByIdOrNull(1L) } returns booking
+
+            // when
+            val result = stadiumService.cancelBooking(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(BookingStatus.CANCELLED)
+            assertThat(slot.status).isEqualTo(SlotStatus.AVAILABLE)
+        }
+
+        @Test
+        fun `should throw exception when booking not found`() {
+            // given
+            every { bookingRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                stadiumService.cancelBooking(999L)
+            }.isInstanceOf(BookingNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("completeBooking")
+    inner class CompleteBooking {
+        @Test
+        fun `should complete booking successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val slot = createSlot(1L, stadium, LocalDate.of(2024, 12, 25))
+            val booking = createBooking(1L, slot, 100L, 200L)
+            every { bookingRepository.findByIdOrNull(1L) } returns booking
+
+            // when
+            val result = stadiumService.completeBooking(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(BookingStatus.COMPLETED)
+        }
+    }
+
+    @Nested
+    @DisplayName("getTeamBookings")
+    inner class GetTeamBookings {
+        @Test
+        fun `should return all team bookings when status is null`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val slot = createSlot(1L, stadium, LocalDate.of(2024, 12, 25))
+            val bookings =
+                listOf(
+                    createBooking(1L, slot, 100L, 200L),
+                    createBooking(2L, slot, 100L, 200L),
+                )
+            every { bookingRepository.findByTeamId(100L) } returns bookings
+
+            // when
+            val result = stadiumService.getTeamBookings(100L, null)
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+
+        @Test
+        fun `should filter by status when provided`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val slot = createSlot(1L, stadium, LocalDate.of(2024, 12, 25))
+            val bookings = listOf(createBooking(1L, slot, 100L, 200L))
+            every { bookingRepository.findByTeamIdAndStatus(100L, BookingStatus.CONFIRMED) } returns bookings
+
+            // when
+            val result = stadiumService.getTeamBookings(100L, BookingStatus.CONFIRMED)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].status).isEqualTo(BookingStatus.CONFIRMED)
+        }
+    }
+
+    private fun createStadium(
+        id: Long,
+        name: String,
+        latitude: Double,
+        longitude: Double,
+    ): Stadium {
+        val stadium =
+            Stadium.create(
+                name = name,
+                address = "서울특별시",
+                latitude = latitude,
+                longitude = longitude,
+            )
+        val idField = Stadium::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(stadium, id)
+        return stadium
+    }
+
+    private fun createSlot(
+        id: Long,
+        stadium: Stadium,
+        date: LocalDate,
+    ): StadiumSlot {
+        val slot =
+            StadiumSlot.create(
+                stadium = stadium,
+                date = date,
+                startTime = LocalTime.of(10, 0),
+                endTime = LocalTime.of(12, 0),
+            )
+        val idField = StadiumSlot::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(slot, id)
+        return slot
+    }
+
+    private fun createBooking(
+        id: Long,
+        slot: StadiumSlot,
+        teamId: Long,
+        bookedBy: Long,
+    ): StadiumBooking {
+        val booking = StadiumBooking.create(slot = slot, teamId = teamId, bookedBy = bookedBy)
+        val idField = StadiumBooking::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(booking, id)
+        return booking
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/adapter/output/persistence/PitchEventRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/adapter/output/persistence/PitchEventRepositoryAdapter.kt
@@ -1,0 +1,58 @@
+package com.nextup.infrastructure.adapter.output.persistence
+
+import com.nextup.core.domain.game.PitchEvent
+import com.nextup.core.port.repository.PitchEventRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PitchEventJpaRepository : JpaRepository<PitchEvent, Long> {
+    fun findByGameIdOrderByPitchNumberAsc(gameId: Long): List<PitchEvent>
+
+    fun findByGameIdAndInningAndIsTopInningOrderByPitchNumberAsc(
+        gameId: Long,
+        inning: Int,
+        isTopInning: Boolean,
+    ): List<PitchEvent>
+
+    fun findByPitcherIdOrderByCreatedAtAsc(pitcherId: Long): List<PitchEvent>
+
+    fun findByBatterIdOrderByCreatedAtAsc(batterId: Long): List<PitchEvent>
+
+    @Query("SELECT COALESCE(MAX(pe.pitchNumber), 0) FROM PitchEvent pe WHERE pe.game.id = :gameId")
+    fun findMaxPitchNumberByGameId(
+        @Param("gameId") gameId: Long,
+    ): Int
+}
+
+@Repository
+class PitchEventRepositoryAdapter(
+    private val jpaRepository: PitchEventJpaRepository,
+) : PitchEventRepositoryPort {
+    override fun save(pitchEvent: PitchEvent): PitchEvent = jpaRepository.save(pitchEvent)
+
+    override fun findByIdOrNull(id: Long): PitchEvent? = jpaRepository.findById(id).orElse(null)
+
+    override fun findByGameId(gameId: Long): List<PitchEvent> = jpaRepository.findByGameIdOrderByPitchNumberAsc(gameId)
+
+    override fun findByGameIdAndInning(
+        gameId: Long,
+        inning: Int,
+        isTopInning: Boolean,
+    ): List<PitchEvent> =
+        jpaRepository.findByGameIdAndInningAndIsTopInningOrderByPitchNumberAsc(
+            gameId,
+            inning,
+            isTopInning,
+        )
+
+    override fun findByPitcherId(pitcherId: Long): List<PitchEvent> =
+        jpaRepository.findByPitcherIdOrderByCreatedAtAsc(pitcherId)
+
+    override fun findByBatterId(batterId: Long): List<PitchEvent> =
+        jpaRepository.findByBatterIdOrderByCreatedAtAsc(batterId)
+
+    override fun getNextPitchNumber(gameId: Long): Int = jpaRepository.findMaxPitchNumberByGameId(gameId) + 1
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/adapter/pdf/StubPdfGeneratorAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/adapter/pdf/StubPdfGeneratorAdapter.kt
@@ -1,0 +1,202 @@
+package com.nextup.infrastructure.adapter.pdf
+
+import com.nextup.core.port.PdfGeneratorPort
+import com.nextup.core.service.game.dto.ScoresheetDto
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+
+/**
+ * PDF 생성 어댑터 Stub 구현
+ *
+ * 실제 PDF 라이브러리 연동 전까지 사용하는 임시 구현체입니다.
+ * 향후 iText, PDFBox 등의 라이브러리로 교체 예정입니다.
+ */
+@Component
+class StubPdfGeneratorAdapter : PdfGeneratorPort {
+    override fun generateScoresheetPdf(scoresheet: ScoresheetDto): ByteArray {
+        val content = buildScoresheetText(scoresheet)
+        return content.toByteArray(StandardCharsets.UTF_8)
+    }
+
+    private fun buildScoresheetText(scoresheet: ScoresheetDto): String =
+        buildString {
+            appendLine("=".repeat(80))
+            appendLine("공식 기록지 (Official Scoresheet)")
+            appendLine("=".repeat(80))
+            appendLine()
+
+            // 경기 정보
+            with(scoresheet.gameInfo) {
+                appendLine("경기 정보")
+                appendLine("-".repeat(80))
+                appendLine("대회: $competitionName")
+                appendLine("일시: $scheduledAt")
+                appendLine("장소: ${location ?: "미정"} ${fieldName?.let { "($it)" } ?: ""}")
+                appendLine("상태: $status")
+                appendLine()
+            }
+
+            // 팀 정보
+            appendLine("경기 결과")
+            appendLine("-".repeat(80))
+            appendLine(
+                String.format(
+                    "%-20s %3d점 %3d안타 %3d실책 (%s)",
+                    scoresheet.teams.away.teamName,
+                    scoresheet.teams.away.totalScore,
+                    scoresheet.teams.away.totalHits,
+                    scoresheet.teams.away.totalErrors,
+                    scoresheet.teams.away.result,
+                ),
+            )
+            appendLine(
+                String.format(
+                    "%-20s %3d점 %3d안타 %3d실책 (%s)",
+                    scoresheet.teams.home.teamName,
+                    scoresheet.teams.home.totalScore,
+                    scoresheet.teams.home.totalHits,
+                    scoresheet.teams.home.totalErrors,
+                    scoresheet.teams.home.result,
+                ),
+            )
+            appendLine()
+
+            // 이닝별 점수
+            appendLine("이닝별 점수")
+            appendLine("-".repeat(80))
+            append("이닝   ")
+            (1..scoresheet.inningScores.innings).forEach { append(String.format("%3d ", it)) }
+            appendLine("  R   H   E")
+
+            append("원정   ")
+            scoresheet.inningScores.awayScores.forEach { append(String.format("%3d ", it)) }
+            appendLine(
+                String.format(
+                    " %3d %3d %3d",
+                    scoresheet.teams.away.totalScore,
+                    scoresheet.teams.away.totalHits,
+                    scoresheet.teams.away.totalErrors,
+                ),
+            )
+
+            append("홈     ")
+            scoresheet.inningScores.homeScores.forEach { append(String.format("%3d ", it)) }
+            appendLine(
+                String.format(
+                    " %3d %3d %3d",
+                    scoresheet.teams.home.totalScore,
+                    scoresheet.teams.home.totalHits,
+                    scoresheet.teams.home.totalErrors,
+                ),
+            )
+            appendLine()
+
+            // 타격 기록
+            appendLine("타격 기록 - ${scoresheet.teams.away.teamName}")
+            appendLine("-".repeat(80))
+            appendLine("선수명            포지션  타석  타수  득점  안타  2루  3루  홈런  타점  볼넷  삼진  타율")
+            scoresheet.battingRecords.away.forEach { batter ->
+                appendLine(
+                    String.format(
+                        "%-15s %4s %4d %4d %4d %4d %3d %3d %4d %4d %4d %4d %5s",
+                        batter.name,
+                        batter.position,
+                        batter.plateAppearances,
+                        batter.atBats,
+                        batter.runs,
+                        batter.hits,
+                        batter.doubles,
+                        batter.triples,
+                        batter.homeRuns,
+                        batter.rbis,
+                        batter.walks,
+                        batter.strikeouts,
+                        batter.avg,
+                    ),
+                )
+            }
+            appendLine()
+
+            appendLine("타격 기록 - ${scoresheet.teams.home.teamName}")
+            appendLine("-".repeat(80))
+            appendLine("선수명            포지션  타석  타수  득점  안타  2루  3루  홈런  타점  볼넷  삼진  타율")
+            scoresheet.battingRecords.home.forEach { batter ->
+                appendLine(
+                    String.format(
+                        "%-15s %4s %4d %4d %4d %4d %3d %3d %4d %4d %4d %4d %5s",
+                        batter.name,
+                        batter.position,
+                        batter.plateAppearances,
+                        batter.atBats,
+                        batter.runs,
+                        batter.hits,
+                        batter.doubles,
+                        batter.triples,
+                        batter.homeRuns,
+                        batter.rbis,
+                        batter.walks,
+                        batter.strikeouts,
+                        batter.avg,
+                    ),
+                )
+            }
+            appendLine()
+
+            // 투수 기록
+            appendLine("투수 기록 - ${scoresheet.teams.away.teamName}")
+            appendLine("-".repeat(80))
+            appendLine("선수명            이닝  피안타  실점  자책  볼넷  삼진  홈런  결정  평균자책")
+            scoresheet.pitchingRecords.away.forEach { pitcher ->
+                appendLine(
+                    String.format(
+                        "%-15s %5s %6d %4d %4d %4d %4d %4d %4s %8s",
+                        pitcher.name,
+                        pitcher.inningsPitched,
+                        pitcher.hitsAllowed,
+                        pitcher.runsAllowed,
+                        pitcher.earnedRuns,
+                        pitcher.walks,
+                        pitcher.strikeouts,
+                        pitcher.homeRunsAllowed,
+                        pitcher.decision ?: "-",
+                        pitcher.era,
+                    ),
+                )
+            }
+            appendLine()
+
+            appendLine("투수 기록 - ${scoresheet.teams.home.teamName}")
+            appendLine("-".repeat(80))
+            appendLine("선수명            이닝  피안타  실점  자책  볼넷  삼진  홈런  결정  평균자책")
+            scoresheet.pitchingRecords.home.forEach { pitcher ->
+                appendLine(
+                    String.format(
+                        "%-15s %5s %6d %4d %4d %4d %4d %4d %4s %8s",
+                        pitcher.name,
+                        pitcher.inningsPitched,
+                        pitcher.hitsAllowed,
+                        pitcher.runsAllowed,
+                        pitcher.earnedRuns,
+                        pitcher.walks,
+                        pitcher.strikeouts,
+                        pitcher.homeRunsAllowed,
+                        pitcher.decision ?: "-",
+                        pitcher.era,
+                    ),
+                )
+            }
+            appendLine()
+
+            // 주요 이벤트
+            if (scoresheet.keyEvents.isNotEmpty()) {
+                appendLine("주요 이벤트")
+                appendLine("-".repeat(80))
+                scoresheet.keyEvents.take(20).forEach { event ->
+                    appendLine("[${event.inning}] ${event.timestamp} - ${event.description}")
+                }
+            }
+
+            appendLine()
+            appendLine("=".repeat(80))
+        }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/ActivityScoreJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/ActivityScoreJpaRepository.kt
@@ -1,0 +1,20 @@
+package com.nextup.infrastructure.persistence.attendance
+
+import com.nextup.core.domain.attendance.ActivityScore
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ActivityScoreJpaRepository : JpaRepository<ActivityScore, Long> {
+    fun findByTeamId(teamId: Long): List<ActivityScore>
+
+    fun findByTeamIdAndMemberId(
+        teamId: Long,
+        memberId: Long,
+    ): ActivityScore?
+
+    fun existsByTeamIdAndMemberId(
+        teamId: Long,
+        memberId: Long,
+    ): Boolean
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/ActivityScoreRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/ActivityScoreRepositoryAdapter.kt
@@ -1,0 +1,40 @@
+package com.nextup.infrastructure.persistence.attendance
+
+import com.nextup.core.domain.attendance.ActivityScore
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.port.attendance.ActivityScoreRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class ActivityScoreRepositoryAdapter(
+    private val jpaRepository: ActivityScoreJpaRepository,
+) : ActivityScoreRepositoryPort {
+    override fun save(activityScore: ActivityScore): ActivityScore = jpaRepository.save(activityScore)
+
+    override fun findById(id: Long): ActivityScore? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByTeamAndMember(
+        team: Team,
+        member: TeamMember,
+    ): ActivityScore? = jpaRepository.findByTeamIdAndMemberId(team.id, member.id)
+
+    override fun findByTeamIdAndMemberId(
+        teamId: Long,
+        memberId: Long,
+    ): ActivityScore? = jpaRepository.findByTeamIdAndMemberId(teamId, memberId)
+
+    override fun findByTeam(team: Team): List<ActivityScore> = jpaRepository.findByTeamId(team.id)
+
+    override fun findByTeamId(teamId: Long): List<ActivityScore> = jpaRepository.findByTeamId(teamId)
+
+    override fun delete(activityScore: ActivityScore) {
+        jpaRepository.delete(activityScore)
+    }
+
+    override fun existsByTeamAndMember(
+        team: Team,
+        member: TeamMember,
+    ): Boolean = jpaRepository.existsByTeamIdAndMemberId(team.id, member.id)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/AttendancePollJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/AttendancePollJpaRepository.kt
@@ -1,0 +1,16 @@
+package com.nextup.infrastructure.persistence.attendance
+
+import com.nextup.core.domain.attendance.AttendancePoll
+import com.nextup.core.domain.attendance.PollStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AttendancePollJpaRepository : JpaRepository<AttendancePoll, Long> {
+    fun findByTeamId(teamId: Long): List<AttendancePoll>
+
+    fun findByTeamIdAndStatus(
+        teamId: Long,
+        status: PollStatus,
+    ): List<AttendancePoll>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/AttendancePollRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/AttendancePollRepositoryAdapter.kt
@@ -1,0 +1,43 @@
+package com.nextup.infrastructure.persistence.attendance
+
+import com.nextup.core.domain.attendance.AttendancePoll
+import com.nextup.core.domain.attendance.PollStatus
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.attendance.AttendancePollRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class AttendancePollRepositoryAdapter(
+    private val jpaRepository: AttendancePollJpaRepository,
+) : AttendancePollRepositoryPort {
+    override fun save(attendancePoll: AttendancePoll): AttendancePoll = jpaRepository.save(attendancePoll)
+
+    override fun findById(id: Long): AttendancePoll? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByTeam(
+        team: Team,
+        status: PollStatus?,
+    ): List<AttendancePoll> =
+        if (status == null) {
+            jpaRepository.findByTeamId(team.id)
+        } else {
+            jpaRepository.findByTeamIdAndStatus(team.id, status)
+        }
+
+    override fun findByTeamId(
+        teamId: Long,
+        status: PollStatus?,
+    ): List<AttendancePoll> =
+        if (status == null) {
+            jpaRepository.findByTeamId(teamId)
+        } else {
+            jpaRepository.findByTeamIdAndStatus(teamId, status)
+        }
+
+    override fun delete(attendancePoll: AttendancePoll) {
+        jpaRepository.delete(attendancePoll)
+    }
+
+    override fun existsById(id: Long): Boolean = jpaRepository.existsById(id)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/AttendanceVoteJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/AttendanceVoteJpaRepository.kt
@@ -1,0 +1,22 @@
+package com.nextup.infrastructure.persistence.attendance
+
+import com.nextup.core.domain.attendance.AttendanceVote
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AttendanceVoteJpaRepository : JpaRepository<AttendanceVote, Long> {
+    fun findByPollId(pollId: Long): List<AttendanceVote>
+
+    fun findByPlayerId(playerId: Long): List<AttendanceVote>
+
+    fun findByPollIdAndPlayerId(
+        pollId: Long,
+        playerId: Long,
+    ): AttendanceVote?
+
+    fun existsByPollIdAndPlayerId(
+        pollId: Long,
+        playerId: Long,
+    ): Boolean
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/AttendanceVoteRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/attendance/AttendanceVoteRepositoryAdapter.kt
@@ -1,0 +1,42 @@
+package com.nextup.infrastructure.persistence.attendance
+
+import com.nextup.core.domain.attendance.AttendancePoll
+import com.nextup.core.domain.attendance.AttendanceVote
+import com.nextup.core.domain.player.Player
+import com.nextup.core.port.attendance.AttendanceVoteRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class AttendanceVoteRepositoryAdapter(
+    private val jpaRepository: AttendanceVoteJpaRepository,
+) : AttendanceVoteRepositoryPort {
+    override fun save(attendanceVote: AttendanceVote): AttendanceVote = jpaRepository.save(attendanceVote)
+
+    override fun findById(id: Long): AttendanceVote? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByPollAndPlayer(
+        poll: AttendancePoll,
+        player: Player,
+    ): AttendanceVote? = jpaRepository.findByPollIdAndPlayerId(poll.id, player.id)
+
+    override fun findByPollIdAndPlayerId(
+        pollId: Long,
+        playerId: Long,
+    ): AttendanceVote? = jpaRepository.findByPollIdAndPlayerId(pollId, playerId)
+
+    override fun findByPoll(poll: AttendancePoll): List<AttendanceVote> = jpaRepository.findByPollId(poll.id)
+
+    override fun findByPollId(pollId: Long): List<AttendanceVote> = jpaRepository.findByPollId(pollId)
+
+    override fun findByPlayer(player: Player): List<AttendanceVote> = jpaRepository.findByPlayerId(player.id)
+
+    override fun delete(attendanceVote: AttendanceVote) {
+        jpaRepository.delete(attendanceVote)
+    }
+
+    override fun existsByPollAndPlayer(
+        poll: AttendancePoll,
+        player: Player,
+    ): Boolean = jpaRepository.existsByPollIdAndPlayerId(poll.id, player.id)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/bracket/BracketEntryJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/bracket/BracketEntryJpaRepository.kt
@@ -1,0 +1,10 @@
+package com.nextup.infrastructure.persistence.bracket
+
+import com.nextup.core.domain.competition.BracketEntry
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BracketEntryJpaRepository : JpaRepository<BracketEntry, Long> {
+    fun findByCompetitionId(competitionId: Long): List<BracketEntry>
+
+    fun deleteByCompetitionId(competitionId: Long)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/bracket/BracketEntryRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/bracket/BracketEntryRepositoryAdapter.kt
@@ -1,0 +1,21 @@
+package com.nextup.infrastructure.persistence.bracket
+
+import com.nextup.core.domain.competition.BracketEntry
+import com.nextup.core.port.repository.BracketEntryRepositoryPort
+import org.springframework.stereotype.Repository
+
+@Repository
+class BracketEntryRepositoryAdapter(
+    private val jpaRepository: BracketEntryJpaRepository,
+) : BracketEntryRepositoryPort {
+    override fun save(bracketEntry: BracketEntry): BracketEntry = jpaRepository.save(bracketEntry)
+
+    override fun saveAll(entries: List<BracketEntry>): List<BracketEntry> = jpaRepository.saveAll(entries)
+
+    override fun findByCompetitionId(competitionId: Long): List<BracketEntry> =
+        jpaRepository.findByCompetitionId(competitionId)
+
+    override fun findByIdOrNull(id: Long): BracketEntry? = jpaRepository.findById(id).orElse(null)
+
+    override fun deleteByCompetitionId(competitionId: Long) = jpaRepository.deleteByCompetitionId(competitionId)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/CandidateJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/CandidateJpaRepository.kt
@@ -1,0 +1,22 @@
+package com.nextup.infrastructure.persistence.election
+
+import com.nextup.core.domain.election.Candidate
+import org.springframework.data.jpa.repository.JpaRepository
+
+/**
+ * Candidate JPA Repository
+ */
+interface CandidateJpaRepository : JpaRepository<Candidate, Long> {
+    /**
+     * 선거 ID로 모든 Candidate를 조회합니다.
+     */
+    fun findAllByElectionId(electionId: Long): List<Candidate>
+
+    /**
+     * 선거 ID와 회원 ID로 Candidate를 조회합니다.
+     */
+    fun findByElectionIdAndMemberId(
+        electionId: Long,
+        memberId: Long,
+    ): Candidate?
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/CandidateRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/CandidateRepositoryAdapter.kt
@@ -1,0 +1,29 @@
+package com.nextup.infrastructure.persistence.election
+
+import com.nextup.core.domain.election.Candidate
+import com.nextup.core.port.repository.CandidateRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+/**
+ * Candidate Repository Adapter
+ */
+@Repository
+class CandidateRepositoryAdapter(
+    private val jpaRepository: CandidateJpaRepository,
+) : CandidateRepositoryPort {
+    override fun save(candidate: Candidate): Candidate = jpaRepository.save(candidate)
+
+    override fun findById(id: Long): Candidate? = jpaRepository.findByIdOrNull(id)
+
+    override fun findAllByElectionId(electionId: Long): List<Candidate> = jpaRepository.findAllByElectionId(electionId)
+
+    override fun findByElectionIdAndMemberId(
+        electionId: Long,
+        memberId: Long,
+    ): Candidate? = jpaRepository.findByElectionIdAndMemberId(electionId, memberId)
+
+    override fun delete(candidate: Candidate) {
+        jpaRepository.delete(candidate)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/ElectionJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/ElectionJpaRepository.kt
@@ -1,0 +1,14 @@
+package com.nextup.infrastructure.persistence.election
+
+import com.nextup.core.domain.election.Election
+import org.springframework.data.jpa.repository.JpaRepository
+
+/**
+ * Election JPA Repository
+ */
+interface ElectionJpaRepository : JpaRepository<Election, Long> {
+    /**
+     * 팀 ID로 모든 Election을 조회합니다.
+     */
+    fun findAllByTeamId(teamId: Long): List<Election>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/ElectionRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/ElectionRepositoryAdapter.kt
@@ -1,0 +1,24 @@
+package com.nextup.infrastructure.persistence.election
+
+import com.nextup.core.domain.election.Election
+import com.nextup.core.port.repository.ElectionRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+/**
+ * Election Repository Adapter
+ */
+@Repository
+class ElectionRepositoryAdapter(
+    private val jpaRepository: ElectionJpaRepository,
+) : ElectionRepositoryPort {
+    override fun save(election: Election): Election = jpaRepository.save(election)
+
+    override fun findById(id: Long): Election? = jpaRepository.findByIdOrNull(id)
+
+    override fun findAllByTeamId(teamId: Long): List<Election> = jpaRepository.findAllByTeamId(teamId)
+
+    override fun delete(election: Election) {
+        jpaRepository.delete(election)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/ElectionVoteJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/ElectionVoteJpaRepository.kt
@@ -1,0 +1,44 @@
+package com.nextup.infrastructure.persistence.election
+
+import com.nextup.core.domain.election.ElectionVote
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+/**
+ * ElectionVote JPA Repository
+ */
+interface ElectionVoteJpaRepository : JpaRepository<ElectionVote, Long> {
+    /**
+     * 선거 ID로 모든 ElectionVote를 조회합니다.
+     */
+    fun findAllByElectionId(electionId: Long): List<ElectionVote>
+
+    /**
+     * 선거 ID와 투표자 ID로 ElectionVote를 조회합니다.
+     */
+    fun findByElectionIdAndVoterId(
+        electionId: Long,
+        voterId: Long,
+    ): ElectionVote?
+
+    /**
+     * 선거 ID로 투표 수를 집계합니다 (후보자별).
+     */
+    @Query(
+        """
+        SELECT v.candidateId as candidateId, COUNT(v) as voteCount
+        FROM ElectionVote v
+        WHERE v.electionId = :electionId
+        GROUP BY v.candidateId
+    """,
+    )
+    fun countByElectionIdGroupByCandidateId(electionId: Long): List<VoteCountProjection>
+}
+
+/**
+ * 투표 집계 결과 Projection
+ */
+interface VoteCountProjection {
+    val candidateId: Long
+    val voteCount: Long
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/ElectionVoteRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/election/ElectionVoteRepositoryAdapter.kt
@@ -1,0 +1,27 @@
+package com.nextup.infrastructure.persistence.election
+
+import com.nextup.core.domain.election.ElectionVote
+import com.nextup.core.port.repository.ElectionVoteRepositoryPort
+import org.springframework.stereotype.Repository
+
+/**
+ * ElectionVote Repository Adapter
+ */
+@Repository
+class ElectionVoteRepositoryAdapter(
+    private val jpaRepository: ElectionVoteJpaRepository,
+) : ElectionVoteRepositoryPort {
+    override fun save(electionVote: ElectionVote): ElectionVote = jpaRepository.save(electionVote)
+
+    override fun findAllByElectionId(electionId: Long): List<ElectionVote> =
+        jpaRepository.findAllByElectionId(electionId)
+
+    override fun findByElectionIdAndVoterId(
+        electionId: Long,
+        voterId: Long,
+    ): ElectionVote? = jpaRepository.findByElectionIdAndVoterId(electionId, voterId)
+
+    override fun countByElectionIdGroupByCandidateId(electionId: Long): Map<Long, Long> =
+        jpaRepository.countByElectionIdGroupByCandidateId(electionId)
+            .associate { it.candidateId to it.voteCount }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchRequestJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchRequestJpaRepository.kt
@@ -1,0 +1,16 @@
+package com.nextup.infrastructure.persistence.match
+
+import com.nextup.core.domain.match.MatchRequest
+import com.nextup.core.domain.match.MatchRequestStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface MatchRequestJpaRepository : JpaRepository<MatchRequest, Long> {
+    @Query("SELECT mr FROM MatchRequest mr WHERE mr.team.id = :teamId")
+    fun findByTeamId(teamId: Long): List<MatchRequest>
+
+    @Query("SELECT mr FROM MatchRequest mr WHERE mr.status = 'OPEN'")
+    fun findAllOpen(): List<MatchRequest>
+
+    fun findByStatus(status: MatchRequestStatus): List<MatchRequest>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchRequestRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchRequestRepositoryAdapter.kt
@@ -1,0 +1,22 @@
+package com.nextup.infrastructure.persistence.match
+
+import com.nextup.core.domain.match.MatchRequest
+import com.nextup.core.domain.match.MatchRequestStatus
+import com.nextup.core.port.repository.MatchRequestRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class MatchRequestRepositoryAdapter(
+    private val jpaRepository: MatchRequestJpaRepository,
+) : MatchRequestRepositoryPort {
+    override fun save(matchRequest: MatchRequest): MatchRequest = jpaRepository.save(matchRequest)
+
+    override fun findByIdOrNull(id: Long): MatchRequest? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByTeamId(teamId: Long): List<MatchRequest> = jpaRepository.findByTeamId(teamId)
+
+    override fun findAllOpen(): List<MatchRequest> = jpaRepository.findAllOpen()
+
+    override fun findByStatus(status: MatchRequestStatus): List<MatchRequest> = jpaRepository.findByStatus(status)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchResponseJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchResponseJpaRepository.kt
@@ -1,0 +1,13 @@
+package com.nextup.infrastructure.persistence.match
+
+import com.nextup.core.domain.match.MatchResponse
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface MatchResponseJpaRepository : JpaRepository<MatchResponse, Long> {
+    @Query("SELECT mr FROM MatchResponse mr WHERE mr.matchRequest.id = :matchRequestId")
+    fun findByMatchRequestId(matchRequestId: Long): List<MatchResponse>
+
+    @Query("SELECT mr FROM MatchResponse mr WHERE mr.respondTeam.id = :respondTeamId")
+    fun findByRespondTeamId(respondTeamId: Long): List<MatchResponse>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchResponseRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchResponseRepositoryAdapter.kt
@@ -1,0 +1,21 @@
+package com.nextup.infrastructure.persistence.match
+
+import com.nextup.core.domain.match.MatchResponse
+import com.nextup.core.port.repository.MatchResponseRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class MatchResponseRepositoryAdapter(
+    private val jpaRepository: MatchResponseJpaRepository,
+) : MatchResponseRepositoryPort {
+    override fun save(matchResponse: MatchResponse): MatchResponse = jpaRepository.save(matchResponse)
+
+    override fun findByIdOrNull(id: Long): MatchResponse? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByMatchRequestId(matchRequestId: Long): List<MatchResponse> =
+        jpaRepository.findByMatchRequestId(matchRequestId)
+
+    override fun findByRespondTeamId(respondTeamId: Long): List<MatchResponse> =
+        jpaRepository.findByRespondTeamId(respondTeamId)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumBookingJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumBookingJpaRepository.kt
@@ -1,0 +1,28 @@
+package com.nextup.infrastructure.persistence.stadium
+
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.domain.stadium.StadiumBooking
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface StadiumBookingJpaRepository : JpaRepository<StadiumBooking, Long> {
+    @Query("SELECT b FROM StadiumBooking b WHERE b.slot.id = :slotId")
+    fun findBySlotId(slotId: Long): List<StadiumBooking>
+
+    @Query("SELECT b FROM StadiumBooking b WHERE b.teamId = :teamId")
+    fun findByTeamId(teamId: Long): List<StadiumBooking>
+
+    @Query("SELECT b FROM StadiumBooking b WHERE b.teamId = :teamId AND b.status = :status")
+    fun findByTeamIdAndStatus(
+        teamId: Long,
+        status: BookingStatus,
+    ): List<StadiumBooking>
+
+    @Query(
+        "SELECT CASE WHEN COUNT(b) > 0 THEN true ELSE false END FROM StadiumBooking b WHERE b.slot.id = :slotId AND b.status = :status"
+    )
+    fun existsBySlotIdAndStatus(
+        slotId: Long,
+        status: BookingStatus,
+    ): Boolean
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumBookingRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumBookingRepositoryAdapter.kt
@@ -1,0 +1,30 @@
+package com.nextup.infrastructure.persistence.stadium
+
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.domain.stadium.StadiumBooking
+import com.nextup.core.port.repository.StadiumBookingRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class StadiumBookingRepositoryAdapter(
+    private val jpaRepository: StadiumBookingJpaRepository,
+) : StadiumBookingRepositoryPort {
+    override fun save(booking: StadiumBooking): StadiumBooking = jpaRepository.save(booking)
+
+    override fun findByIdOrNull(id: Long): StadiumBooking? = jpaRepository.findByIdOrNull(id)
+
+    override fun findBySlotId(slotId: Long): List<StadiumBooking> = jpaRepository.findBySlotId(slotId)
+
+    override fun findByTeamId(teamId: Long): List<StadiumBooking> = jpaRepository.findByTeamId(teamId)
+
+    override fun findByTeamIdAndStatus(
+        teamId: Long,
+        status: BookingStatus,
+    ): List<StadiumBooking> = jpaRepository.findByTeamIdAndStatus(teamId, status)
+
+    override fun existsBySlotIdAndStatus(
+        slotId: Long,
+        status: BookingStatus,
+    ): Boolean = jpaRepository.existsBySlotIdAndStatus(slotId, status)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumJpaRepository.kt
@@ -1,0 +1,27 @@
+package com.nextup.infrastructure.persistence.stadium
+
+import com.nextup.core.domain.stadium.Stadium
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface StadiumJpaRepository : JpaRepository<Stadium, Long> {
+    fun findByIsActiveTrue(): List<Stadium>
+
+    @Query(
+        """
+        SELECT * FROM stadiums s
+        WHERE ST_DWithin(
+            ST_SetSRID(ST_MakePoint(s.longitude, s.latitude), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
+            :radiusMeters
+        ) = true
+        AND s.is_active = true
+        """,
+        nativeQuery = true,
+    )
+    fun findNearby(
+        latitude: Double,
+        longitude: Double,
+        radiusMeters: Double,
+    ): List<Stadium>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumRepositoryAdapter.kt
@@ -1,0 +1,28 @@
+package com.nextup.infrastructure.persistence.stadium
+
+import com.nextup.core.domain.stadium.Stadium
+import com.nextup.core.port.repository.StadiumRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class StadiumRepositoryAdapter(
+    private val jpaRepository: StadiumJpaRepository,
+) : StadiumRepositoryPort {
+    override fun save(stadium: Stadium): Stadium = jpaRepository.save(stadium)
+
+    override fun findByIdOrNull(id: Long): Stadium? = jpaRepository.findByIdOrNull(id)
+
+    override fun findAll(): List<Stadium> = jpaRepository.findAll()
+
+    override fun findAllActive(): List<Stadium> = jpaRepository.findByIsActiveTrue()
+
+    override fun findNearby(
+        latitude: Double,
+        longitude: Double,
+        radiusKm: Double,
+    ): List<Stadium> {
+        val radiusMeters = radiusKm * 1000.0
+        return jpaRepository.findNearby(latitude, longitude, radiusMeters)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumSlotJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumSlotJpaRepository.kt
@@ -1,0 +1,28 @@
+package com.nextup.infrastructure.persistence.stadium
+
+import com.nextup.core.domain.stadium.SlotStatus
+import com.nextup.core.domain.stadium.StadiumSlot
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
+
+interface StadiumSlotJpaRepository : JpaRepository<StadiumSlot, Long> {
+    @Query("SELECT s FROM StadiumSlot s WHERE s.stadium.id = :stadiumId AND s.date = :date")
+    fun findByStadiumIdAndDate(
+        stadiumId: Long,
+        date: LocalDate,
+    ): List<StadiumSlot>
+
+    @Query("SELECT s FROM StadiumSlot s WHERE s.stadium.id = :stadiumId AND s.date BETWEEN :startDate AND :endDate")
+    fun findByStadiumIdAndDateBetween(
+        stadiumId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<StadiumSlot>
+
+    @Query("SELECT s FROM StadiumSlot s WHERE s.stadium.id = :stadiumId AND s.status = :status")
+    fun findByStadiumIdAndStatus(
+        stadiumId: Long,
+        status: SlotStatus,
+    ): List<StadiumSlot>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumSlotRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumSlotRepositoryAdapter.kt
@@ -1,0 +1,33 @@
+package com.nextup.infrastructure.persistence.stadium
+
+import com.nextup.core.domain.stadium.SlotStatus
+import com.nextup.core.domain.stadium.StadiumSlot
+import com.nextup.core.port.repository.StadiumSlotRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class StadiumSlotRepositoryAdapter(
+    private val jpaRepository: StadiumSlotJpaRepository,
+) : StadiumSlotRepositoryPort {
+    override fun save(slot: StadiumSlot): StadiumSlot = jpaRepository.save(slot)
+
+    override fun findByIdOrNull(id: Long): StadiumSlot? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByStadiumIdAndDate(
+        stadiumId: Long,
+        date: LocalDate,
+    ): List<StadiumSlot> = jpaRepository.findByStadiumIdAndDate(stadiumId, date)
+
+    override fun findByStadiumIdAndDateBetween(
+        stadiumId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<StadiumSlot> = jpaRepository.findByStadiumIdAndDateBetween(stadiumId, startDate, endDate)
+
+    override fun findByStadiumIdAndStatus(
+        stadiumId: Long,
+        status: SlotStatus,
+    ): List<StadiumSlot> = jpaRepository.findByStadiumIdAndStatus(stadiumId, status)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/LeagueScheduleRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/LeagueScheduleRepository.kt
@@ -1,0 +1,40 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.schedule.LeagueSchedule
+import com.nextup.core.domain.schedule.ScheduleStatus
+import com.nextup.core.port.repository.LeagueScheduleRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
+
+interface LeagueScheduleRepository :
+    JpaRepository<LeagueSchedule, Long>,
+    LeagueScheduleRepositoryPort {
+    override fun findByIdOrNull(id: Long): LeagueSchedule? = findById(id).orElse(null)
+
+    override fun findByCompetitionId(competitionId: Long): List<LeagueSchedule>
+
+    override fun findByCompetitionIdAndRound(
+        competitionId: Long,
+        round: Int
+    ): List<LeagueSchedule>
+
+    override fun findByCompetitionIdAndStatus(
+        competitionId: Long,
+        status: ScheduleStatus
+    ): List<LeagueSchedule>
+
+    @Query(
+        "SELECT s FROM LeagueSchedule s WHERE s.scheduledDate BETWEEN :startDate AND :endDate ORDER BY s.scheduledDate",
+    )
+    override fun findByScheduledDateBetween(
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<LeagueSchedule>
+
+    override fun existsByCompetitionIdAndRoundAndMatchNumber(
+        competitionId: Long,
+        round: Int,
+        matchNumber: Int,
+    ): Boolean
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/LeagueScheduleRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/LeagueScheduleRepository.kt
@@ -37,4 +37,9 @@ interface LeagueScheduleRepository :
         round: Int,
         matchNumber: Int,
     ): Boolean
+
+    override fun findByCompetitionIdAndScheduledDate(
+        competitionId: Long,
+        scheduledDate: LocalDate,
+    ): List<LeagueSchedule>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepository.kt
@@ -76,4 +76,13 @@ interface TeamMemberRepository :
 
     @Query("SELECT COUNT(tm) FROM TeamMember tm WHERE tm.team.id = :teamId AND tm.role = 'OWNER'")
     override fun countOwnersByTeamId(teamId: Long): Long
+
+    @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.player.id = :playerId AND tm.status = 'ACTIVE'")
+    override fun findByPlayerIdActive(playerId: Long): List<TeamMember>
+
+    @Query("SELECT COUNT(tm) FROM TeamMember tm WHERE tm.team.id = :teamId AND tm.status = :status")
+    override fun countByTeamIdAndStatus(
+        teamId: Long,
+        status: TeamMemberStatus,
+    ): Long
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/appeal/AppealRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/appeal/AppealRepository.kt
@@ -1,0 +1,16 @@
+package com.nextup.infrastructure.repository.appeal
+
+import com.nextup.core.domain.appeal.Appeal
+import com.nextup.core.domain.appeal.AppealStatus
+import com.nextup.core.port.repository.AppealRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AppealRepository :
+    JpaRepository<Appeal, Long>,
+    AppealRepositoryPort {
+    override fun findByGameId(gameId: Long): List<Appeal>
+
+    override fun findByAppealerId(appealerId: Long): List<Appeal>
+
+    override fun findByStatus(status: AppealStatus): List<Appeal>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/certificate/CertificateJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/certificate/CertificateJpaRepository.kt
@@ -1,0 +1,28 @@
+package com.nextup.infrastructure.repository.certificate
+
+import com.nextup.core.domain.certificate.Certificate
+import com.nextup.core.domain.certificate.CertificateStatus
+import org.springframework.data.jpa.repository.JpaRepository
+
+/**
+ * Certificate JPA Repository
+ */
+interface CertificateJpaRepository : JpaRepository<Certificate, Long> {
+    /**
+     * 발급 번호로 증명서를 조회합니다.
+     */
+    fun findByIssueNumber(issueNumber: String): Certificate?
+
+    /**
+     * 선수 ID로 모든 증명서를 조회합니다.
+     */
+    fun findAllByPlayerId(playerId: Long): List<Certificate>
+
+    /**
+     * 선수 ID와 상태로 증명서를 조회합니다.
+     */
+    fun findAllByPlayerIdAndStatus(
+        playerId: Long,
+        status: CertificateStatus,
+    ): List<Certificate>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/certificate/CertificateRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/certificate/CertificateRepositoryAdapter.kt
@@ -1,0 +1,32 @@
+package com.nextup.infrastructure.repository.certificate
+
+import com.nextup.core.domain.certificate.Certificate
+import com.nextup.core.domain.certificate.CertificateStatus
+import com.nextup.core.port.repository.CertificateRepositoryPort
+import org.springframework.stereotype.Repository
+
+/**
+ * Certificate Repository Adapter
+ * Core의 CertificateRepositoryPort를 Infrastructure의 JPA Repository로 구현
+ */
+@Repository
+class CertificateRepositoryAdapter(
+    private val jpaRepository: CertificateJpaRepository,
+) : CertificateRepositoryPort {
+    override fun save(certificate: Certificate): Certificate = jpaRepository.save(certificate)
+
+    override fun findById(id: Long): Certificate? = jpaRepository.findById(id).orElse(null)
+
+    override fun findByIssueNumber(issueNumber: String): Certificate? = jpaRepository.findByIssueNumber(issueNumber)
+
+    override fun findAllByPlayerId(playerId: Long): List<Certificate> = jpaRepository.findAllByPlayerId(playerId)
+
+    override fun findAllByPlayerIdAndStatus(
+        playerId: Long,
+        status: CertificateStatus,
+    ): List<Certificate> = jpaRepository.findAllByPlayerIdAndStatus(playerId, status)
+
+    override fun delete(certificate: Certificate) {
+        jpaRepository.delete(certificate)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/discipline/DisciplineRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/discipline/DisciplineRepository.kt
@@ -1,0 +1,46 @@
+package com.nextup.infrastructure.repository.discipline
+
+import com.nextup.core.domain.discipline.Discipline
+import com.nextup.core.domain.discipline.DisciplineStatus
+import com.nextup.core.port.repository.DisciplineRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface DisciplineRepository :
+    JpaRepository<Discipline, Long>,
+    DisciplineRepositoryPort {
+    override fun findByPlayerId(playerId: Long): List<Discipline>
+
+    override fun findByPlayerIdAndCompetitionId(
+        playerId: Long,
+        competitionId: Long,
+    ): List<Discipline>
+
+    override fun findByCompetitionId(competitionId: Long): List<Discipline>
+
+    override fun findByStatus(status: DisciplineStatus): List<Discipline>
+
+    @Query(
+        """
+        SELECT d FROM Discipline d
+        WHERE d.player.id = :playerId
+        AND d.status = 'ACTIVE'
+        ORDER BY d.issuedAt DESC
+        """
+    )
+    override fun findActiveByPlayerId(playerId: Long): List<Discipline>
+
+    @Query(
+        """
+        SELECT d FROM Discipline d
+        WHERE d.player.id = :playerId
+        AND d.competition.id = :competitionId
+        AND d.status = 'ACTIVE'
+        ORDER BY d.issuedAt DESC
+        """
+    )
+    override fun findActiveByPlayerIdAndCompetitionId(
+        playerId: Long,
+        competitionId: Long,
+    ): List<Discipline>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameEventRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameEventRepository.kt
@@ -14,6 +14,18 @@ interface GameEventRepository :
         """
         SELECT ge FROM GameEvent ge
         JOIN FETCH ge.game g
+        WHERE g.id = :gameId
+          AND ge.undone = false
+        ORDER BY ge.eventTimestamp DESC
+        LIMIT 1
+        """,
+    )
+    override fun findLastActiveEvent(gameId: Long): GameEvent?
+
+    @Query(
+        """
+        SELECT ge FROM GameEvent ge
+        JOIN FETCH ge.game g
         WHERE ge.pitcher.player.id = :pitcherId
           AND ge.batter.player.id = :batterId
           AND ge.eventType = 'PLATE_APPEARANCE'

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
@@ -3,6 +3,9 @@ package com.nextup.infrastructure.repository.game
 import com.nextup.core.domain.game.Game
 import com.nextup.core.port.repository.GameRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 
 interface GameRepository :
     JpaRepository<Game, Long>,
@@ -10,4 +13,24 @@ interface GameRepository :
     override fun findByIdOrNull(id: Long): Game? = findById(id).orElse(null)
 
     override fun findAllByIds(ids: List<Long>): List<Game> = findAllById(ids)
+
+    @Query("SELECT g FROM Game g WHERE g.competition.id = :competitionId ORDER BY g.scheduledAt ASC")
+    override fun findByCompetitionId(
+        @Param("competitionId") competitionId: Long,
+    ): List<Game>
+
+    @Query("SELECT g FROM Game g WHERE g.scheduledAt BETWEEN :start AND :end ORDER BY g.scheduledAt ASC")
+    override fun findByScheduledAtBetween(
+        @Param("start") start: LocalDateTime,
+        @Param("end") end: LocalDateTime,
+    ): List<Game>
+
+    @Query(
+        "SELECT g FROM Game g " +
+            "LEFT JOIN FETCH g.competition " +
+            "WHERE g.id = :id",
+    )
+    override fun findByIdWithTeams(
+        @Param("id") id: Long,
+    ): Game?
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameTeamRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameTeamRepository.kt
@@ -77,4 +77,26 @@ interface GameTeamRepository :
         """,
     )
     override fun findAllByCompetitionId(competitionId: Long): List<GameTeam>
+
+    @Query(
+        """
+        SELECT gt FROM GameTeam gt
+        JOIN FETCH gt.game g
+        JOIN FETCH gt.team t
+        WHERE gt.team.id = :teamId
+        AND g.status IN ('FINISHED', 'CALLED', 'FORFEITED')
+        AND EXISTS (
+            SELECT 1 FROM GameTeam gt2
+            WHERE gt2.game.id = gt.game.id
+            AND gt2.team.id = :opponentId
+        )
+        AND (:competitionId IS NULL OR g.competition.id = :competitionId)
+        ORDER BY g.scheduledAt DESC
+        """,
+    )
+    override fun findCompletedGamesBetweenTeams(
+        teamId: Long,
+        opponentId: Long,
+        competitionId: Long?,
+    ): List<GameTeam>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/DeviceTokenRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/DeviceTokenRepository.kt
@@ -1,0 +1,15 @@
+package com.nextup.infrastructure.repository.notification
+
+import com.nextup.core.domain.notification.DeviceToken
+import com.nextup.core.port.repository.DeviceTokenRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DeviceTokenRepository :
+    JpaRepository<DeviceToken, Long>,
+    DeviceTokenRepositoryPort {
+    override fun findByUserId(userId: Long): List<DeviceToken>
+
+    override fun deleteByToken(token: String)
+
+    override fun findByToken(token: String): DeviceToken?
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationPreferenceRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationPreferenceRepository.kt
@@ -1,0 +1,17 @@
+package com.nextup.infrastructure.repository.notification
+
+import com.nextup.core.domain.notification.NotificationPreference
+import com.nextup.core.domain.notification.NotificationType
+import com.nextup.core.port.repository.NotificationPreferenceRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NotificationPreferenceRepository :
+    JpaRepository<NotificationPreference, Long>,
+    NotificationPreferenceRepositoryPort {
+    override fun findByUserId(userId: Long): List<NotificationPreference>
+
+    override fun findByUserIdAndType(
+        userId: Long,
+        type: NotificationType,
+    ): NotificationPreference?
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
@@ -1,0 +1,18 @@
+package com.nextup.infrastructure.repository.notification
+
+import com.nextup.core.domain.notification.Notification
+import com.nextup.core.port.repository.NotificationRepositoryPort
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NotificationRepository :
+    JpaRepository<Notification, Long>,
+    NotificationRepositoryPort {
+    override fun findByUserId(
+        userId: Long,
+        pageable: Pageable,
+    ): Page<Notification>
+
+    override fun findByUserId(userId: Long): List<Notification>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/recruitment/TeamRecruitmentRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/recruitment/TeamRecruitmentRepository.kt
@@ -1,0 +1,18 @@
+package com.nextup.infrastructure.repository.recruitment
+
+import com.nextup.core.domain.recruitment.RecruitmentStatus
+import com.nextup.core.domain.recruitment.TeamRecruitment
+import com.nextup.core.port.repository.TeamRecruitmentRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface TeamRecruitmentRepository :
+    JpaRepository<TeamRecruitment, Long>,
+    TeamRecruitmentRepositoryPort {
+    override fun findByTeamId(teamId: Long): List<TeamRecruitment>
+
+    @Query("SELECT r FROM TeamRecruitment r WHERE r.status = 'OPEN' ORDER BY r.deadline ASC")
+    override fun findAllOpen(): List<TeamRecruitment>
+
+    override fun findByStatus(status: RecruitmentStatus): List<TeamRecruitment>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonBattingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonBattingStatsRepository.kt
@@ -107,4 +107,68 @@ interface SeasonBattingStatsRepository :
         @Param("minPlateAppearances") minPlateAppearances: Int,
         @Param("limit") limit: Int,
     ): List<SeasonBattingStats>
+
+    @Query(
+        """
+        SELECT s FROM SeasonBattingStats s
+        WHERE s.year = :year
+        ORDER BY s.hits DESC
+        LIMIT :limit
+    """,
+    )
+    override fun findTopByHits(
+        @Param("year") year: Int,
+        @Param("limit") limit: Int,
+    ): List<SeasonBattingStats>
+
+    @Query(
+        """
+        SELECT s FROM SeasonBattingStats s
+        WHERE s.year = :year
+        ORDER BY s.stolenBases DESC
+        LIMIT :limit
+    """,
+    )
+    override fun findTopByStolenBases(
+        @Param("year") year: Int,
+        @Param("limit") limit: Int,
+    ): List<SeasonBattingStats>
+
+    @Query(
+        """
+        SELECT s FROM SeasonBattingStats s
+        WHERE s.year = :year
+        AND s.plateAppearances >= :minPlateAppearances
+        ORDER BY (
+            CAST(s.hits + s.walks + s.intentionalWalks + s.hitByPitch AS double) /
+            CAST(s.atBats + s.walks + s.intentionalWalks + s.hitByPitch + s.sacrificeFlies AS double)
+        ) DESC
+        LIMIT :limit
+    """,
+    )
+    override fun findTopByOnBasePercentage(
+        @Param("year") year: Int,
+        @Param("minPlateAppearances") minPlateAppearances: Int,
+        @Param("limit") limit: Int,
+    ): List<SeasonBattingStats>
+
+    @Query(
+        """
+        SELECT s FROM SeasonBattingStats s
+        WHERE s.year = :year
+        AND s.plateAppearances >= :minPlateAppearances
+        AND s.atBats > 0
+        ORDER BY (
+            CAST(s.hits - s.doubles - s.triples - s.homeRuns +
+                 (2 * s.doubles) + (3 * s.triples) + (4 * s.homeRuns) AS double) /
+            CAST(s.atBats AS double)
+        ) DESC
+        LIMIT :limit
+    """,
+    )
+    override fun findTopBySlugging(
+        @Param("year") year: Int,
+        @Param("minPlateAppearances") minPlateAppearances: Int,
+        @Param("limit") limit: Int,
+    ): List<SeasonBattingStats>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/PitchEventServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/PitchEventServiceImpl.kt
@@ -1,0 +1,195 @@
+package com.nextup.infrastructure.service
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.common.exception.PitchEventNotFoundException
+import com.nextup.core.domain.game.PitchEvent
+import com.nextup.core.domain.game.PitchResult
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchEventRepositoryPort
+import com.nextup.core.service.BatterPitchStats
+import com.nextup.core.service.PitchEventService
+import com.nextup.core.service.PitcherPitchStats
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class PitchEventServiceImpl(
+    private val pitchEventRepository: PitchEventRepositoryPort,
+    private val gameRepository: GameRepositoryPort,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
+) : PitchEventService {
+    @Transactional
+    override fun recordPitch(
+        gameId: Long,
+        pitcherId: Long,
+        batterId: Long,
+        result: PitchResult,
+        description: String?,
+    ): PitchEvent {
+        val game = gameRepository.findByIdOrNull(gameId) ?: throw GameNotFoundException(gameId)
+        require(game.status.isOngoing()) { throw InvalidGameStateException("진행 중인 경기에서만 투구를 기록할 수 있습니다.") }
+
+        val pitcher = gamePlayerRepository.findByIdOrNull(pitcherId) ?: throw GamePlayerNotFoundException(pitcherId)
+        val batter = gamePlayerRepository.findByIdOrNull(batterId) ?: throw GamePlayerNotFoundException(batterId)
+
+        // 현재 볼카운트 조회
+        val currentBalls = game.gameState.balls
+        val currentStrikes = game.gameState.strikes
+
+        // 투구 결과에 따른 새로운 볼카운트 계산
+        val newBalls =
+            if (result.incrementsBall) {
+                (currentBalls + 1).coerceAtMost(4)
+            } else {
+                currentBalls
+            }
+
+        val newStrikes =
+            when {
+                result.incrementsStrike -> (currentStrikes + 1).coerceAtMost(3)
+                result.isFoul && currentStrikes < 2 -> currentStrikes + 1
+                else -> currentStrikes
+            }
+
+        // 다음 투구 번호 조회
+        val pitchNumber = pitchEventRepository.getNextPitchNumber(gameId)
+
+        // 투구 이벤트 생성
+        val pitchEvent =
+            PitchEvent.create(
+                game = game,
+                pitcher = pitcher,
+                batter = batter,
+                pitchNumber = pitchNumber,
+                result = result,
+                ballCount = newBalls,
+                strikeCount = newStrikes,
+                description = description,
+            )
+
+        return pitchEventRepository.save(pitchEvent)
+    }
+
+    override fun getPitchEvent(pitchEventId: Long): PitchEvent =
+        pitchEventRepository.findByIdOrNull(pitchEventId) ?: throw PitchEventNotFoundException(pitchEventId)
+
+    override fun getGamePitchEvents(gameId: Long): List<PitchEvent> {
+        // 경기 존재 확인
+        gameRepository.findByIdOrNull(gameId) ?: throw GameNotFoundException(gameId)
+        return pitchEventRepository.findByGameId(gameId)
+    }
+
+    override fun getInningPitchEvents(
+        gameId: Long,
+        inning: Int,
+        isTopInning: Boolean,
+    ): List<PitchEvent> {
+        // 경기 존재 확인
+        gameRepository.findByIdOrNull(gameId) ?: throw GameNotFoundException(gameId)
+        return pitchEventRepository.findByGameIdAndInning(gameId, inning, isTopInning)
+    }
+
+    override fun getCurrentBallCount(gameId: Long): Pair<Int, Int> {
+        val game = gameRepository.findByIdOrNull(gameId) ?: throw GameNotFoundException(gameId)
+        return Pair(game.gameState.balls, game.gameState.strikes)
+    }
+
+    override fun calculatePitcherStats(pitcherId: Long): PitcherPitchStats {
+        // 투수 존재 확인
+        gamePlayerRepository.findByIdOrNull(pitcherId) ?: throw GamePlayerNotFoundException(pitcherId)
+
+        val pitchEvents = pitchEventRepository.findByPitcherId(pitcherId)
+
+        if (pitchEvents.isEmpty()) {
+            return PitcherPitchStats(
+                totalPitches = 0,
+                strikes = 0,
+                balls = 0,
+                fouls = 0,
+                inPlayPitches = 0,
+                strikePercentage = 0.0,
+                avgPitchesPerAtBat = 0.0,
+            )
+        }
+
+        val totalPitches = pitchEvents.size
+        val strikes = pitchEvents.count { it.result == PitchResult.STRIKE || it.result == PitchResult.SWING_MISS }
+        val balls = pitchEvents.count { it.result == PitchResult.BALL }
+        val fouls = pitchEvents.count { it.result == PitchResult.FOUL }
+        val inPlayPitches = pitchEvents.count { it.result == PitchResult.IN_PLAY }
+
+        // 스트라이크 비율 계산 (스트라이크 + 헛스윙 + 파울)
+        val totalStrikes = strikes + fouls
+        val strikePercentage =
+            if (totalPitches > 0) {
+                (totalStrikes.toDouble() / totalPitches.toDouble()) * 100.0
+            } else {
+                0.0
+            }
+
+        // 타석당 평균 투구 수 계산 (인플레이로 종료된 타석 기준)
+        val atBats = inPlayPitches
+        val avgPitchesPerAtBat =
+            if (atBats > 0) {
+                totalPitches.toDouble() / atBats.toDouble()
+            } else {
+                0.0
+            }
+
+        return PitcherPitchStats(
+            totalPitches = totalPitches,
+            strikes = strikes,
+            balls = balls,
+            fouls = fouls,
+            inPlayPitches = inPlayPitches,
+            strikePercentage = strikePercentage,
+            avgPitchesPerAtBat = avgPitchesPerAtBat,
+        )
+    }
+
+    override fun calculateBatterPitchStats(batterId: Long): BatterPitchStats {
+        // 타자 존재 확인
+        gamePlayerRepository.findByIdOrNull(batterId) ?: throw GamePlayerNotFoundException(batterId)
+
+        val pitchEvents = pitchEventRepository.findByBatterId(batterId)
+
+        if (pitchEvents.isEmpty()) {
+            return BatterPitchStats(
+                totalPitches = 0,
+                strikes = 0,
+                balls = 0,
+                fouls = 0,
+                swingAndMiss = 0,
+                avgPitchesPerAtBat = 0.0,
+            )
+        }
+
+        val totalPitches = pitchEvents.size
+        val strikes = pitchEvents.count { it.result == PitchResult.STRIKE }
+        val balls = pitchEvents.count { it.result == PitchResult.BALL }
+        val fouls = pitchEvents.count { it.result == PitchResult.FOUL }
+        val swingAndMiss = pitchEvents.count { it.result == PitchResult.SWING_MISS }
+
+        // 타석당 평균 투구 수 계산 (인플레이로 종료된 타석 기준)
+        val atBats = pitchEvents.count { it.result == PitchResult.IN_PLAY }
+        val avgPitchesPerAtBat =
+            if (atBats > 0) {
+                totalPitches.toDouble() / atBats.toDouble()
+            } else {
+                0.0
+            }
+
+        return BatterPitchStats(
+            totalPitches = totalPitches,
+            strikes = strikes,
+            balls = balls,
+            fouls = fouls,
+            swingAndMiss = swingAndMiss,
+            avgPitchesPerAtBat = avgPitchesPerAtBat,
+        )
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/attendance/ActivityServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/attendance/ActivityServiceImpl.kt
@@ -1,0 +1,92 @@
+package com.nextup.infrastructure.service.attendance
+
+import com.nextup.common.exception.TeamMemberNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.attendance.ActivityScore
+import com.nextup.core.port.attendance.ActivityScoreRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.attendance.ActivityService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+/**
+ * 활동 점수 관리 서비스 구현
+ */
+@Service
+@Transactional(readOnly = true)
+class ActivityServiceImpl(
+    private val activityScoreRepository: ActivityScoreRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+    private val teamMemberRepository: TeamMemberRepositoryPort,
+) : ActivityService {
+    @Transactional
+    override fun getActivityScore(
+        teamId: Long,
+        memberId: Long,
+    ): ActivityScore {
+        val team =
+            teamRepository.findByIdOrNull(teamId)
+                ?: throw TeamNotFoundException(teamId)
+
+        val member =
+            teamMemberRepository.findByIdOrNull(memberId)
+                ?: throw TeamMemberNotFoundException(memberId)
+
+        // Get or create activity score
+        val existingScore = activityScoreRepository.findByTeamIdAndMemberId(teamId, memberId)
+        if (existingScore != null) {
+            return existingScore
+        }
+
+        val newScore =
+            ActivityScore.create(
+                team = team,
+                member = member,
+            )
+
+        return activityScoreRepository.save(newScore)
+    }
+
+    override fun listActivityScores(teamId: Long): List<ActivityScore> {
+        if (!teamRepository.existsById(teamId)) {
+            throw TeamNotFoundException(teamId)
+        }
+
+        return activityScoreRepository.findByTeamId(teamId)
+    }
+
+    @Transactional
+    override fun updateGameParticipationRate(
+        teamId: Long,
+        memberId: Long,
+        rate: BigDecimal,
+    ): ActivityScore {
+        val activityScore = getActivityScore(teamId, memberId)
+        activityScore.updateGameParticipationRate(rate)
+        return activityScoreRepository.save(activityScore)
+    }
+
+    @Transactional
+    override fun updatePracticeAttendanceRate(
+        teamId: Long,
+        memberId: Long,
+        rate: BigDecimal,
+    ): ActivityScore {
+        val activityScore = getActivityScore(teamId, memberId)
+        activityScore.updatePracticeAttendanceRate(rate)
+        return activityScoreRepository.save(activityScore)
+    }
+
+    @Transactional
+    override fun updateContributionScore(
+        teamId: Long,
+        memberId: Long,
+        score: BigDecimal,
+    ): ActivityScore {
+        val activityScore = getActivityScore(teamId, memberId)
+        activityScore.updateContributionScore(score)
+        return activityScoreRepository.save(activityScore)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/attendance/AttendanceServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/attendance/AttendanceServiceImpl.kt
@@ -1,0 +1,125 @@
+package com.nextup.infrastructure.service.attendance
+
+import com.nextup.common.exception.AttendancePollClosedException
+import com.nextup.common.exception.AttendancePollNotFoundException
+import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.attendance.AttendancePoll
+import com.nextup.core.domain.attendance.AttendanceVote
+import com.nextup.core.domain.attendance.PollStatus
+import com.nextup.core.domain.attendance.VoteType
+import com.nextup.core.port.attendance.AttendancePollRepositoryPort
+import com.nextup.core.port.attendance.AttendanceVoteRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.attendance.AttendanceService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * 출석 관리 서비스 구현
+ */
+@Service
+@Transactional(readOnly = true)
+class AttendanceServiceImpl(
+    private val attendancePollRepository: AttendancePollRepositoryPort,
+    private val attendanceVoteRepository: AttendanceVoteRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+    private val playerRepository: PlayerRepositoryPort,
+) : AttendanceService {
+    @Transactional
+    override fun createPoll(
+        teamId: Long,
+        title: String,
+        eventDate: String,
+        deadline: String,
+    ): AttendancePoll {
+        val team =
+            teamRepository.findByIdOrNull(teamId)
+                ?: throw TeamNotFoundException(teamId)
+
+        val eventDateTime = LocalDateTime.parse(eventDate, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        val deadlineDateTime = LocalDateTime.parse(deadline, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+
+        val poll =
+            AttendancePoll.create(
+                team = team,
+                title = title,
+                eventDate = eventDateTime,
+                deadline = deadlineDateTime,
+            )
+
+        return attendancePollRepository.save(poll)
+    }
+
+    @Transactional
+    override fun submitVote(
+        pollId: Long,
+        playerId: Long,
+        voteType: VoteType,
+    ): AttendanceVote {
+        val poll =
+            attendancePollRepository.findById(pollId)
+                ?: throw AttendancePollNotFoundException(pollId)
+
+        if (!poll.canVote()) {
+            throw AttendancePollClosedException(pollId)
+        }
+
+        val player =
+            playerRepository.findByIdOrNull(playerId)
+                ?: throw PlayerNotFoundException(playerId)
+
+        // Check if already voted
+        val existingVote = attendanceVoteRepository.findByPollIdAndPlayerId(pollId, playerId)
+        if (existingVote != null) {
+            // Update existing vote
+            existingVote.changeVote(voteType)
+            return attendanceVoteRepository.save(existingVote)
+        }
+
+        val vote =
+            AttendanceVote.create(
+                poll = poll,
+                player = player,
+                voteType = voteType,
+            )
+
+        return attendanceVoteRepository.save(vote)
+    }
+
+    override fun getPoll(pollId: Long): AttendancePoll =
+        attendancePollRepository.findById(pollId)
+            ?: throw AttendancePollNotFoundException(pollId)
+
+    override fun listPolls(
+        teamId: Long,
+        status: PollStatus?,
+    ): List<AttendancePoll> {
+        if (!teamRepository.existsById(teamId)) {
+            throw TeamNotFoundException(teamId)
+        }
+
+        return attendancePollRepository.findByTeamId(teamId, status)
+    }
+
+    @Transactional
+    override fun closePoll(pollId: Long): AttendancePoll {
+        val poll =
+            attendancePollRepository.findById(pollId)
+                ?: throw AttendancePollNotFoundException(pollId)
+
+        poll.close()
+        return attendancePollRepository.save(poll)
+    }
+
+    override fun listVotes(pollId: Long): List<AttendanceVote> {
+        if (!attendancePollRepository.existsById(pollId)) {
+            throw AttendancePollNotFoundException(pollId)
+        }
+
+        return attendanceVoteRepository.findByPollId(pollId)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/bracket/BracketGeneratorServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/bracket/BracketGeneratorServiceImpl.kt
@@ -1,0 +1,241 @@
+package com.nextup.infrastructure.service.bracket
+
+import com.nextup.common.exception.BracketEntryNotFoundException
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.core.domain.competition.BracketEntry
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.port.repository.BracketEntryRepositoryPort
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.bracket.BracketGeneratorService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.math.log2
+import kotlin.math.pow
+
+@Service
+@Transactional(readOnly = true)
+class BracketGeneratorServiceImpl(
+    private val bracketEntryRepository: BracketEntryRepositoryPort,
+    private val competitionRepository: CompetitionRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+) : BracketGeneratorService {
+    @Transactional
+    override fun generateSingleElimination(
+        competitionId: Long,
+        seededTeamIds: List<Long>,
+    ): List<BracketEntry> {
+        val competition = findCompetition(competitionId)
+        validateTeamIds(seededTeamIds)
+
+        // 기존 대진표 삭제
+        bracketEntryRepository.deleteByCompetitionId(competitionId)
+
+        val teamCount = seededTeamIds.size
+        require(teamCount >= 2) { "최소 2개 팀이 필요합니다" }
+
+        // 다음 2의 거듭제곱 계산
+        val totalSlots = nextPowerOfTwo(teamCount)
+        val byeCount = totalSlots - teamCount
+
+        // 라운드 수 계산
+        val totalRounds = log2(totalSlots.toDouble()).toInt()
+
+        // 팀 매칭 생성 (seeding algorithm)
+        val bracketEntries = mutableListOf<BracketEntry>()
+        val firstRoundMatchCount = totalSlots / 2
+
+        // 첫 라운드 매치 생성
+        for (matchNumber in 1..firstRoundMatchCount) {
+            val seed1 = matchNumber
+            val seed2 = totalSlots - matchNumber + 1
+
+            val team1Id = if (seed1 <= teamCount) seededTeamIds[seed1 - 1] else null
+            val team2Id = if (seed2 <= teamCount) seededTeamIds[seed2 - 1] else null
+
+            val team1 = team1Id?.let { teamRepository.findByIdOrNull(it) }
+            val team2 = team2Id?.let { teamRepository.findByIdOrNull(it) }
+
+            bracketEntries.add(
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = matchNumber,
+                    team1 = team1,
+                    team2 = team2,
+                    bracketType = "WINNERS",
+                    seed1 = seed1,
+                    seed2 = seed2,
+                ),
+            )
+        }
+
+        // 이후 라운드 빈 엔트리 생성
+        for (round in 2..totalRounds) {
+            val matchCount = totalSlots / (2.0.pow(round).toInt())
+            for (matchNumber in 1..matchCount) {
+                bracketEntries.add(
+                    BracketEntry(
+                        competition = competition,
+                        roundNumber = round,
+                        matchNumber = matchNumber,
+                        team1 = null,
+                        team2 = null,
+                        bracketType = "WINNERS",
+                    ),
+                )
+            }
+        }
+
+        return bracketEntryRepository.saveAll(bracketEntries)
+    }
+
+    @Transactional
+    override fun generateDoubleElimination(
+        competitionId: Long,
+        seededTeamIds: List<Long>,
+    ): List<BracketEntry> {
+        val competition = findCompetition(competitionId)
+        validateTeamIds(seededTeamIds)
+
+        // 기존 대진표 삭제
+        bracketEntryRepository.deleteByCompetitionId(competitionId)
+
+        val teamCount = seededTeamIds.size
+        require(teamCount >= 2) { "최소 2개 팀이 필요합니다" }
+
+        val totalSlots = nextPowerOfTwo(teamCount)
+        val totalRounds = log2(totalSlots.toDouble()).toInt()
+
+        val bracketEntries = mutableListOf<BracketEntry>()
+
+        // Winners Bracket 생성 (Single Elimination과 동일)
+        val firstRoundMatchCount = totalSlots / 2
+
+        for (matchNumber in 1..firstRoundMatchCount) {
+            val seed1 = matchNumber
+            val seed2 = totalSlots - matchNumber + 1
+
+            val team1Id = if (seed1 <= teamCount) seededTeamIds[seed1 - 1] else null
+            val team2Id = if (seed2 <= teamCount) seededTeamIds[seed2 - 1] else null
+
+            val team1 = team1Id?.let { teamRepository.findByIdOrNull(it) }
+            val team2 = team2Id?.let { teamRepository.findByIdOrNull(it) }
+
+            bracketEntries.add(
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = matchNumber,
+                    team1 = team1,
+                    team2 = team2,
+                    bracketType = "WINNERS",
+                    seed1 = seed1,
+                    seed2 = seed2,
+                ),
+            )
+        }
+
+        // Winners Bracket 이후 라운드
+        for (round in 2..totalRounds) {
+            val matchCount = totalSlots / (2.0.pow(round).toInt())
+            for (matchNumber in 1..matchCount) {
+                bracketEntries.add(
+                    BracketEntry(
+                        competition = competition,
+                        roundNumber = round,
+                        matchNumber = matchNumber,
+                        team1 = null,
+                        team2 = null,
+                        bracketType = "WINNERS",
+                    ),
+                )
+            }
+        }
+
+        // Losers Bracket 생성 (간소화 버전: Winners Bracket과 동일한 구조)
+        for (round in 1..totalRounds) {
+            val matchCount = totalSlots / (2.0.pow(round).toInt())
+            for (matchNumber in 1..matchCount) {
+                bracketEntries.add(
+                    BracketEntry(
+                        competition = competition,
+                        roundNumber = round,
+                        matchNumber = matchNumber,
+                        team1 = null,
+                        team2 = null,
+                        bracketType = "LOSERS",
+                    ),
+                )
+            }
+        }
+
+        // Grand Final 추가
+        bracketEntries.add(
+            BracketEntry(
+                competition = competition,
+                roundNumber = totalRounds + 1,
+                matchNumber = 1,
+                team1 = null,
+                team2 = null,
+                bracketType = "FINAL",
+            ),
+        )
+
+        return bracketEntryRepository.saveAll(bracketEntries)
+    }
+
+    override fun getBracket(competitionId: Long): List<BracketEntry> {
+        findCompetition(competitionId)
+        return bracketEntryRepository.findByCompetitionId(competitionId)
+    }
+
+    @Transactional
+    override fun advanceWinner(
+        bracketEntryId: Long,
+        winnerTeamId: Long,
+    ): BracketEntry {
+        val bracketEntry =
+            bracketEntryRepository.findByIdOrNull(bracketEntryId)
+                ?: throw BracketEntryNotFoundException(bracketEntryId)
+
+        val winnerTeam =
+            teamRepository.findByIdOrNull(winnerTeamId)
+                ?: throw InvalidInputException(
+                    code = "TEAM_NOT_FOUND",
+                    message = "팀을 찾을 수 없습니다: $winnerTeamId",
+                )
+
+        bracketEntry.recordWinner(winnerTeam)
+        return bracketEntryRepository.save(bracketEntry)
+    }
+
+    private fun findCompetition(competitionId: Long): Competition =
+        competitionRepository.findByIdOrNull(competitionId)
+            ?: throw CompetitionNotFoundException(competitionId)
+
+    private fun validateTeamIds(teamIds: List<Long>) {
+        if (teamIds.isEmpty()) {
+            throw InvalidInputException(
+                code = "EMPTY_TEAM_LIST",
+                message = "팀 목록이 비어있습니다",
+            )
+        }
+
+        if (teamIds.distinct().size != teamIds.size) {
+            throw InvalidInputException(
+                code = "DUPLICATE_TEAMS",
+                message = "중복된 팀이 존재합니다",
+            )
+        }
+    }
+
+    private fun nextPowerOfTwo(n: Int): Int {
+        var power = 1
+        while (power < n) {
+            power *= 2
+        }
+        return power
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/CertificateServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/CertificateServiceImpl.kt
@@ -1,0 +1,304 @@
+package com.nextup.infrastructure.service.certificate
+
+import com.nextup.common.exception.CertificateNotFoundByIssueNumberException
+import com.nextup.common.exception.CertificateNotFoundException
+import com.nextup.core.domain.certificate.Certificate
+import com.nextup.core.dto.certificate.*
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.CertificateRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.service.QrCodeGeneratorPort
+import com.nextup.core.service.certificate.CertificateService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 증명서 서비스 구현
+ *
+ * 선수의 경기 기록을 기반으로 증명서를 발급하고 관리합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class CertificateServiceImpl(
+    private val certificateRepository: CertificateRepositoryPort,
+    private val playerRepository: PlayerRepositoryPort,
+    private val battingRecordRepository: BattingRecordRepositoryPort,
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
+    private val qrCodeGenerator: QrCodeGeneratorPort,
+) : CertificateService {
+    @Transactional
+    override fun issueCertificate(
+        playerId: Long,
+        validityDays: Long,
+    ): CertificateDto {
+        val player =
+            playerRepository.findByIdOrNull(playerId)
+                ?: throw IllegalArgumentException("선수를 찾을 수 없습니다: $playerId")
+
+        // 증명서 발급
+        val certificate = Certificate.issue(player, validityDays)
+        val savedCertificate = certificateRepository.save(certificate)
+
+        // 선수 경력 정보 수집
+        val playerCareer = buildPlayerCareer(playerId)
+
+        // QR 코드 생성
+        val qrCodeData = qrCodeGenerator.generate(savedCertificate.issueNumber)
+
+        return savedCertificate.toDto(player.name, playerCareer, qrCodeData)
+    }
+
+    override fun getCertificate(certificateId: Long): CertificateDto {
+        val certificate =
+            certificateRepository.findById(certificateId)
+                ?: throw CertificateNotFoundException(certificateId)
+
+        val playerCareer = buildPlayerCareer(certificate.player.id)
+        val qrCodeData = qrCodeGenerator.generate(certificate.issueNumber)
+
+        return certificate.toDto(certificate.player.name, playerCareer, qrCodeData)
+    }
+
+    override fun getCertificateByIssueNumber(issueNumber: String): CertificateDto {
+        val certificate =
+            certificateRepository.findByIssueNumber(issueNumber)
+                ?: throw CertificateNotFoundByIssueNumberException(issueNumber)
+
+        val playerCareer = buildPlayerCareer(certificate.player.id)
+        val qrCodeData = qrCodeGenerator.generate(certificate.issueNumber)
+
+        return certificate.toDto(certificate.player.name, playerCareer, qrCodeData)
+    }
+
+    override fun verifyCertificate(issueNumber: String): CertificateVerificationDto {
+        val certificate =
+            certificateRepository.findByIssueNumber(issueNumber)
+                ?: throw CertificateNotFoundByIssueNumberException(issueNumber)
+
+        return CertificateVerificationDto(
+            valid = certificate.isValid(),
+            issueNumber = certificate.issueNumber,
+            playerName = certificate.player.name,
+            issuedAt = certificate.issuedAt,
+            expiresAt = certificate.expiresAt,
+            status = certificate.status,
+        )
+    }
+
+    override fun getPlayerCertificates(playerId: Long): List<CertificateDto> {
+        val certificates = certificateRepository.findAllByPlayerId(playerId)
+        val playerCareer = buildPlayerCareer(playerId)
+
+        return certificates.map { certificate ->
+            val player = certificate.player
+            val qrCodeData = qrCodeGenerator.generate(certificate.issueNumber)
+            certificate.toDto(player.name, playerCareer, qrCodeData)
+        }
+    }
+
+    @Transactional
+    override fun revokeCertificate(certificateId: Long) {
+        val certificate =
+            certificateRepository.findById(certificateId)
+                ?: throw CertificateNotFoundException(certificateId)
+
+        certificate.revoke()
+        certificateRepository.save(certificate)
+    }
+
+    /**
+     * 선수의 경력 정보를 수집합니다.
+     */
+    private fun buildPlayerCareer(playerId: Long): PlayerCareerDto {
+        // 출전한 모든 경기 조회
+        val gamePlayers = gamePlayerRepository.findAllByPlayerId(playerId)
+        val totalGames = gamePlayers.size
+
+        // 타격 기록 수집
+        val battingRecords = battingRecordRepository.findAllByPlayerId(playerId)
+        val battingStats =
+            if (battingRecords.isNotEmpty()) {
+                buildCareerBattingStats(battingRecords)
+            } else {
+                null
+            }
+
+        // 투수 기록 수집
+        val pitchingRecords = pitchingRecordRepository.findAllByPlayerId(playerId)
+        val pitchingStats =
+            if (pitchingRecords.isNotEmpty()) {
+                buildCareerPitchingStats(pitchingRecords)
+            } else {
+                null
+            }
+
+        // 대회 이력 수집
+        val competitionHistory = buildCompetitionHistory(gamePlayers)
+
+        return PlayerCareerDto(
+            totalGames = totalGames,
+            battingStats = battingStats,
+            pitchingStats = pitchingStats,
+            competitionHistory = competitionHistory,
+        )
+    }
+
+    /**
+     * 통산 타격 기록을 계산합니다.
+     */
+    private fun buildCareerBattingStats(
+        battingRecords: List<com.nextup.core.domain.game.BattingRecord>
+    ): CareerBattingStatsDto {
+        var games = 0
+        var plateAppearances = 0
+        var atBats = 0
+        var hits = 0
+        var doubles = 0
+        var triples = 0
+        var homeRuns = 0
+        var runsBattedIn = 0
+        var stolenBases = 0
+
+        battingRecords.forEach { record ->
+            games++
+            plateAppearances += record.plateAppearances
+            atBats += record.atBats
+            hits += record.hits
+            doubles += record.doubles
+            triples += record.triples
+            homeRuns += record.homeRuns
+            runsBattedIn += record.runsBattedIn
+            stolenBases += record.stolenBases
+        }
+
+        val battingAverage = if (atBats > 0) hits.toDouble() / atBats else 0.0
+        val onBasePercentage = if (plateAppearances > 0) hits.toDouble() / plateAppearances else 0.0
+        val sluggingPercentage =
+            if (atBats > 0) {
+                (hits + doubles + (triples * 2) + (homeRuns * 3)).toDouble() / atBats
+            } else {
+                0.0
+            }
+
+        return CareerBattingStatsDto(
+            games = games,
+            plateAppearances = plateAppearances,
+            atBats = atBats,
+            hits = hits,
+            doubles = doubles,
+            triples = triples,
+            homeRuns = homeRuns,
+            runsBattedIn = runsBattedIn,
+            stolenBases = stolenBases,
+            battingAverage = battingAverage,
+            onBasePercentage = onBasePercentage,
+            sluggingPercentage = sluggingPercentage,
+        )
+    }
+
+    /**
+     * 통산 투수 기록을 계산합니다.
+     */
+    private fun buildCareerPitchingStats(
+        pitchingRecords: List<com.nextup.core.domain.game.PitchingRecord>,
+    ): CareerPitchingStatsDto {
+        var games = 0
+        var wins = 0
+        var losses = 0
+        var saves = 0
+        var holds = 0
+        var inningsPitchedOuts = 0
+        var strikeouts = 0
+        var walks = 0
+        var earnedRuns = 0
+
+        pitchingRecords.forEach { record ->
+            games++
+            wins += if (record.decision?.name == "WIN") 1 else 0
+            losses += if (record.decision?.name == "LOSS") 1 else 0
+            saves += if (record.decision?.name == "SAVE") 1 else 0
+            holds += if (record.decision?.name == "HOLD") 1 else 0
+            inningsPitchedOuts += record.inningsPitchedOuts
+            strikeouts += record.strikeouts
+            walks += record.walksAllowed
+            earnedRuns += record.earnedRuns
+        }
+
+        val inningsPitched = inningsPitchedOuts / 3.0
+        val earnedRunAverage =
+            if (inningsPitched > 0) {
+                (earnedRuns * 9.0) / inningsPitched
+            } else {
+                0.0
+            }
+        val walksAndHitsPerInningPitched =
+            if (inningsPitched > 0) {
+                (walks + earnedRuns) / inningsPitched
+            } else {
+                0.0
+            }
+
+        return CareerPitchingStatsDto(
+            games = games,
+            wins = wins,
+            losses = losses,
+            saves = saves,
+            holds = holds,
+            inningsPitched = inningsPitched,
+            strikeouts = strikeouts,
+            walks = walks,
+            earnedRuns = earnedRuns,
+            earnedRunAverage = earnedRunAverage,
+            walksAndHitsPerInningPitched = walksAndHitsPerInningPitched,
+        )
+    }
+
+    /**
+     * 대회 이력을 수집합니다.
+     */
+    private fun buildCompetitionHistory(
+        gamePlayers: List<com.nextup.core.domain.game.GamePlayer>,
+    ): List<CompetitionHistoryDto> {
+        return gamePlayers
+            .groupBy { gamePlayer ->
+                val game = gamePlayer.gameTeam.game
+                val year = game.scheduledAt.year
+                val competition = game.competition
+                val team = gamePlayer.gameTeam.team
+                Triple(year, competition?.name ?: "연습 경기", team.name)
+            }
+            .map { (key, players) ->
+                val (year, competitionName, teamName) = key
+                CompetitionHistoryDto(
+                    year = year,
+                    competitionName = competitionName,
+                    teamName = teamName,
+                    games = players.size,
+                )
+            }
+            .sortedByDescending { it.year }
+    }
+
+    /**
+     * Certificate를 DTO로 변환합니다.
+     */
+    private fun Certificate.toDto(
+        playerName: String,
+        playerCareer: PlayerCareerDto,
+        qrCodeData: String,
+    ): CertificateDto =
+        CertificateDto(
+            id = this.id,
+            issueNumber = this.issueNumber,
+            playerId = this.player.id,
+            playerName = playerName,
+            issuedAt = this.issuedAt,
+            expiresAt = this.expiresAt,
+            status = this.status,
+            playerCareer = playerCareer,
+            qrCodeData = qrCodeData,
+        )
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/StubQrCodeGenerator.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/StubQrCodeGenerator.kt
@@ -1,0 +1,23 @@
+package com.nextup.infrastructure.service.certificate
+
+import com.nextup.core.port.service.QrCodeGeneratorPort
+import org.springframework.stereotype.Component
+import java.util.*
+
+/**
+ * QR 코드 생성기 스텁 구현
+ *
+ * 실제 QR 코드 생성 라이브러리는 추가하지 않고,
+ * Base64로 인코딩된 더미 데이터를 반환합니다.
+ */
+@Component
+class StubQrCodeGenerator : QrCodeGeneratorPort {
+    override fun generate(
+        content: String,
+        size: Int,
+    ): String {
+        // TODO: 실제 QR 코드 생성 라이브러리 (예: ZXing) 추가 시 구현
+        val dummyData = "QR:$content:SIZE:$size"
+        return Base64.getEncoder().encodeToString(dummyData.toByteArray())
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImpl.kt
@@ -1,0 +1,159 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.service.game.GameScheduleService
+import com.nextup.core.service.game.dto.GameDetailDto
+import com.nextup.core.service.game.dto.GameSummaryDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+/**
+ * 경기 일정 조회 서비스 구현
+ */
+@Service
+@Transactional(readOnly = true)
+class GameScheduleServiceImpl(
+    private val gameRepository: GameRepositoryPort,
+    private val gameTeamRepository: GameTeamRepositoryPort,
+) : GameScheduleService {
+    override fun getGames(
+        date: LocalDate?,
+        teamId: Long?,
+        competitionId: Long?,
+        page: Int,
+        size: Int,
+    ): List<GameSummaryDto> {
+        val games =
+            when {
+                competitionId != null -> gameRepository.findByCompetitionId(competitionId)
+                date != null -> {
+                    val start = date.atStartOfDay()
+                    val end = date.atTime(LocalTime.MAX)
+                    gameRepository.findByScheduledAtBetween(start, end)
+                }
+                else -> gameRepository.findAll()
+            }
+
+        val filteredGames =
+            if (teamId != null) {
+                val teamGameIds =
+                    gameTeamRepository.findAllByTeamId(teamId)
+                        .map { it.game.id }
+                        .toSet()
+                games.filter { it.id in teamGameIds }
+            } else {
+                games
+            }
+
+        // 페이징
+        val start = page * size
+        val paged = filteredGames.drop(start).take(size)
+
+        return toSummaryDtos(paged)
+    }
+
+    override fun getGameDetail(gameId: Long): GameDetailDto {
+        val game =
+            gameRepository.findByIdWithTeams(gameId)
+                ?: throw GameNotFoundException(gameId)
+
+        val gameTeams = gameTeamRepository.findAllByGameId(gameId)
+        val homeTeam = gameTeams.firstOrNull { it.homeAway == HomeAway.HOME }
+        val awayTeam = gameTeams.firstOrNull { it.homeAway == HomeAway.AWAY }
+
+        return GameDetailDto(
+            gameId = game.id,
+            competitionId = game.competition.id,
+            competitionName = game.competition.name,
+            homeTeamId = homeTeam?.team?.id ?: 0L,
+            homeTeamName = homeTeam?.team?.name ?: "",
+            awayTeamId = awayTeam?.team?.id ?: 0L,
+            awayTeamName = awayTeam?.team?.name ?: "",
+            scheduledAt = game.scheduledAt,
+            status = game.status,
+            homeScore = homeTeam?.totalScore ?: 0,
+            awayScore = awayTeam?.totalScore ?: 0,
+            location = game.location,
+            fieldName = game.fieldName,
+            gameNumber = game.gameNumber,
+            currentInning = game.currentInningDisplay,
+            totalInnings = game.totalInnings,
+            startedAt = game.startedAt,
+            endedAt = game.endedAt,
+            note = game.note,
+            forfeitReason = game.forfeitReason,
+        )
+    }
+
+    override fun getGamesByTeam(teamId: Long): List<GameSummaryDto> {
+        val gameTeams = gameTeamRepository.findAllByTeamId(teamId)
+        val gameIds = gameTeams.map { it.game.id }.distinct()
+        val games =
+            gameRepository.findAllByIds(gameIds)
+                .sortedBy { it.scheduledAt }
+
+        return toSummaryDtos(games)
+    }
+
+    override fun getUpcomingGamesByTeam(
+        teamId: Long,
+        limit: Int,
+    ): List<GameSummaryDto> {
+        val now = LocalDateTime.now()
+        val gameTeams = gameTeamRepository.findAllByTeamId(teamId)
+        val gameIds = gameTeams.map { it.game.id }.distinct()
+        val games =
+            gameRepository.findAllByIds(gameIds)
+                .filter { it.scheduledAt.isAfter(now) && it.status == GameStatus.SCHEDULED }
+                .sortedBy { it.scheduledAt }
+                .take(limit)
+
+        return toSummaryDtos(games)
+    }
+
+    private fun toSummaryDtos(games: List<Game>): List<GameSummaryDto> {
+        if (games.isEmpty()) return emptyList()
+
+        val gameIds = games.map { it.id }
+        val allGameTeams = gameTeamRepository.findAllByGameIds(gameIds)
+        val gameTeamsByGameId = allGameTeams.groupBy { it.game.id }
+
+        return games.map { game ->
+            val teams = gameTeamsByGameId[game.id] ?: emptyList()
+            toSummaryDto(game, teams)
+        }
+    }
+
+    private fun toSummaryDto(
+        game: Game,
+        gameTeams: List<GameTeam>,
+    ): GameSummaryDto {
+        val homeTeam = gameTeams.firstOrNull { it.homeAway == HomeAway.HOME }
+        val awayTeam = gameTeams.firstOrNull { it.homeAway == HomeAway.AWAY }
+
+        return GameSummaryDto(
+            gameId = game.id,
+            competitionId = game.competition.id,
+            competitionName = game.competition.name,
+            homeTeamId = homeTeam?.team?.id ?: 0L,
+            homeTeamName = homeTeam?.team?.name ?: "",
+            awayTeamId = awayTeam?.team?.id ?: 0L,
+            awayTeamName = awayTeam?.team?.name ?: "",
+            scheduledAt = game.scheduledAt,
+            status = game.status,
+            homeScore = homeTeam?.totalScore ?: 0,
+            awayScore = awayTeam?.totalScore ?: 0,
+            location = game.location,
+            fieldName = game.fieldName,
+        )
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -15,6 +15,7 @@ import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.BoxScoreService
 import com.nextup.core.service.game.GameScorerService
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional
 class GameScorerServiceImpl(
     private val gameRepository: GameRepositoryPort,
     private val gamePlayerRepository: GamePlayerRepositoryPort,
+    private val gameTeamRepository: GameTeamRepositoryPort,
     private val boxScoreService: BoxScoreService,
     private val gameEventRepository: GameEventRepositoryPort,
     private val battingRecordRepository: BattingRecordRepositoryPort,
@@ -270,6 +272,40 @@ class GameScorerServiceImpl(
             outs = event.outCountBefore,
         )
         game.gameState.restoreRunners(event.runnersBeforeJson)
+    }
+
+    @Transactional
+    override fun forfeitGame(
+        gameId: Long,
+        winnerTeamId: Long,
+        reason: String,
+    ): Game {
+        val game = findGame(gameId)
+
+        // 경기 상태 확인 (예정 또는 진행 중인 경기만 몰수 처리 가능)
+        if (game.status != GameStatus.SCHEDULED && game.status != GameStatus.IN_PROGRESS) {
+            throw InvalidGameStateException(
+                "예정 또는 진행 중인 경기만 몰수 처리할 수 있습니다. 현재 상태: ${game.status.displayName}",
+            )
+        }
+
+        // 해당 경기에 참여하는 GameTeam 조회
+        val gameTeams = gameTeamRepository.findAllByGameId(gameId)
+
+        if (gameTeams.size != 2) {
+            throw InvalidGameStateException(
+                "몰수 처리를 위해서는 정확히 2개의 팀이 필요합니다. 현재 팀 수: ${gameTeams.size}",
+            )
+        }
+
+        // 몰수 처리 (7:0 점수 자동 반영)
+        game.forfeit(
+            winnerTeamId = winnerTeamId,
+            reason = reason,
+            gameTeams = gameTeams,
+        )
+
+        return gameRepository.save(game)
     }
 
     private fun findGame(id: Long): Game =

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -1,12 +1,21 @@
 package com.nextup.infrastructure.service.game
 
+import com.nextup.common.exception.BattingRecordNotFoundException
 import com.nextup.common.exception.GameNotFoundException
 import com.nextup.common.exception.GamePlayerNotFoundException
 import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.common.exception.NoEventToUndoException
+import com.nextup.common.exception.PitchingRecordNotFoundException
+import com.nextup.common.exception.UndoNotAvailableException
 import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
 import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.BoxScoreService
 import com.nextup.core.service.game.GameScorerService
 import com.nextup.core.service.game.dto.GameEndReason
@@ -23,6 +32,9 @@ class GameScorerServiceImpl(
     private val gameRepository: GameRepositoryPort,
     private val gamePlayerRepository: GamePlayerRepositoryPort,
     private val boxScoreService: BoxScoreService,
+    private val gameEventRepository: GameEventRepositoryPort,
+    private val battingRecordRepository: BattingRecordRepositoryPort,
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
 ) : GameScorerService {
     @Transactional
     override fun startGame(gameId: Long): Game {
@@ -139,11 +151,125 @@ class GameScorerServiceImpl(
             GameEndReason.REGULATION -> game.finish()
             GameEndReason.MERCY_RULE -> game.callGame("콜드게임 (점수차)")
             GameEndReason.WEATHER -> game.callGame("콜드게임 (기상 조건)")
-            GameEndReason.FORFEIT -> game.forfeit("몰수 처리")
+            GameEndReason.FORFEIT -> throw InvalidGameStateException(
+                "몰수 처리는 전용 API를 사용해주세요.",
+            )
             GameEndReason.OTHER -> game.callGame("기타 사유")
         }
 
         return gameRepository.save(game)
+    }
+
+    @Transactional
+    override fun undoLastEvent(gameId: Long): GameEvent {
+        val game = findGame(gameId)
+
+        // 경기가 진행 중인지 확인
+        if (!game.canUndo()) {
+            throw UndoNotAvailableException(
+                "진행 중인 경기만 Undo할 수 있습니다. 현재 상태: ${game.status.displayName}",
+            )
+        }
+
+        // 마지막 활성 이벤트 조회
+        val lastEvent =
+            gameEventRepository.findLastActiveEvent(gameId)
+                ?: throw NoEventToUndoException()
+
+        // 이벤트 타입에 따른 롤백 처리
+        when (lastEvent.eventType) {
+            GameEventType.PLATE_APPEARANCE -> undoPlateAppearance(game, lastEvent)
+            GameEventType.INNING_CHANGE -> undoInningChange(game, lastEvent)
+            else -> {
+                // GAME_STATUS, BASE_RUNNING 등은 단순 마킹만 처리
+            }
+        }
+
+        // 이벤트를 undone으로 마킹
+        lastEvent.markUndone()
+        gameEventRepository.save(lastEvent)
+
+        // 게임 상태 저장
+        gameRepository.save(game)
+
+        return lastEvent
+    }
+
+    private fun undoPlateAppearance(
+        game: Game,
+        event: GameEvent,
+    ) {
+        val result = event.plateAppearanceResult ?: return
+
+        // 1. GameState 복원 - 아웃 카운트와 주자 상태
+        game.restoreInningState(
+            inning = event.inning,
+            isTop = event.isTopInning,
+            outs = event.outCountBefore,
+        )
+        game.gameState.restoreRunners(event.runnersBeforeJson)
+        game.gameState.resetCount()
+
+        // 2. 타순 롤백
+        game.revertBatter()
+
+        // 3. 타격 기록 롤백
+        event.batter?.let { batter ->
+            val battingRecord =
+                battingRecordRepository.findByGamePlayer(batter)
+                    ?: throw BattingRecordNotFoundException(batter.id)
+
+            battingRecord.revertPlateAppearanceResult(result, event.rbis)
+        }
+
+        // 4. 득점한 주자들의 득점 기록 롤백
+        if (event.runsScored > 0) {
+            // 홈런인 경우 타자 자신의 득점도 롤백 (revertPlateAppearanceResult에서 처리됨)
+            // 다른 주자들의 득점 롤백은 runnersBeforeJson/runnersAfterJson 비교로 처리
+            // runsScored 수만큼 팀 점수 차감
+            event.batter?.let { batter ->
+                batter.gameTeam.subtractRunInInning(event.inning, event.runsScored)
+            }
+        }
+
+        // 5. 투수 기록 롤백
+        event.pitcher?.let { pitcher ->
+            val pitchingRecord =
+                pitchingRecordRepository.findByGamePlayer(pitcher)
+                    ?: throw PitchingRecordNotFoundException(pitcher.id)
+
+            pitchingRecord.revertBatterFaced(result)
+
+            // 아웃이었으면 아웃 카운트도 롤백
+            if (!result.isOnBase) {
+                pitchingRecord.revertOut()
+            }
+
+            // 득점이 있었으면 투수 실점도 롤백
+            if (event.runsScored > 0) {
+                pitchingRecord.revertEarnedRun(event.runsScored)
+            }
+        }
+
+        // 6. 안타였으면 팀 안타 수 차감
+        if (result.isHit) {
+            event.batter?.let { batter ->
+                batter.gameTeam.subtractHit()
+            }
+        }
+    }
+
+    private fun undoInningChange(
+        game: Game,
+        event: GameEvent,
+    ) {
+        // 이닝 전환 이벤트 롤백: 이전 이닝/상태로 복원
+        game.restoreInningState(
+            inning = event.inning,
+            isTop = event.isTopInning,
+            outs = event.outCountBefore,
+        )
+        game.gameState.restoreRunners(event.runnersBeforeJson)
     }
 
     private fun findGame(id: Long): Game =

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/ScoresheetServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/ScoresheetServiceImpl.kt
@@ -1,0 +1,195 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.service.game.ScoresheetService
+import com.nextup.core.service.game.dto.*
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.RoundingMode
+import java.time.format.DateTimeFormatter
+
+/**
+ * 공식 기록지 서비스 구현
+ */
+@Service
+@Transactional(readOnly = true)
+class ScoresheetServiceImpl(
+    private val gameRepository: GameRepositoryPort,
+    private val gameTeamRepository: GameTeamRepositoryPort,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
+    private val battingRecordRepository: BattingRecordRepositoryPort,
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+    private val gameEventRepository: GameEventRepositoryPort,
+) : ScoresheetService {
+    override fun getScoresheet(gameId: Long): ScoresheetDto {
+        val game =
+            gameRepository.findByIdOrNull(gameId)
+                ?: throw GameNotFoundException(gameId)
+
+        val gameTeams = gameTeamRepository.findAllByGameId(gameId)
+        if (gameTeams.size != 2) {
+            throw InvalidStateException(
+                "INVALID_GAME_TEAMS",
+                "경기에 정확히 2개의 팀이 필요합니다.",
+            )
+        }
+
+        val homeTeam =
+            gameTeams.firstOrNull { it.isHome }
+                ?: throw InvalidStateException("MISSING_HOME_TEAM", "홈팀을 찾을 수 없습니다.")
+        val awayTeam =
+            gameTeams.firstOrNull { it.isAway }
+                ?: throw InvalidStateException("MISSING_AWAY_TEAM", "원정팀을 찾을 수 없습니다.")
+
+        val gamePlayers = gamePlayerRepository.findAllByGameId(gameId)
+        val homePlayers = gamePlayers.filter { it.gameTeam.isHome }
+        val awayPlayers = gamePlayers.filter { it.gameTeam.isAway }
+
+        val gameEvents = gameEventRepository.findAllByGameIdOrderByEventTimestamp(gameId)
+        val keyEvents = gameEvents.filter { !it.undone }.map { buildKeyEvent(it) }
+
+        return ScoresheetDto(
+            gameInfo = buildGameInfo(game),
+            teams =
+                TeamsScoresheetDto(
+                    home = buildTeamInfo(homeTeam),
+                    away = buildTeamInfo(awayTeam),
+                ),
+            inningScores = buildInningScores(game, homeTeam, awayTeam),
+            battingRecords =
+                BattingRecordsDto(
+                    home = buildBattingRecords(homePlayers),
+                    away = buildBattingRecords(awayPlayers),
+                ),
+            pitchingRecords =
+                PitchingRecordsDto(
+                    home = buildPitchingRecords(homePlayers),
+                    away = buildPitchingRecords(awayPlayers),
+                ),
+            keyEvents = keyEvents,
+        )
+    }
+
+    private fun buildGameInfo(game: com.nextup.core.domain.game.Game): GameInfoDto =
+        GameInfoDto(
+            gameId = game.id,
+            competitionName = game.competition.name,
+            gameNumber = game.gameNumber,
+            scheduledAt = game.scheduledAt,
+            startedAt = game.startedAt,
+            endedAt = game.endedAt,
+            location = game.location,
+            fieldName = game.fieldName,
+            status = game.status.displayName,
+            currentInning = game.currentInningDisplay,
+            totalInnings = game.totalInnings,
+        )
+
+    private fun buildTeamInfo(gameTeam: com.nextup.core.domain.game.GameTeam): TeamScoresheetInfoDto =
+        TeamScoresheetInfoDto(
+            teamId = gameTeam.team.id,
+            teamName = gameTeam.team.name,
+            totalScore = gameTeam.totalScore,
+            totalHits = gameTeam.totalHits,
+            totalErrors = gameTeam.totalErrors,
+            result = gameTeam.result.displayName,
+        )
+
+    private fun buildInningScores(
+        game: com.nextup.core.domain.game.Game,
+        homeTeam: com.nextup.core.domain.game.GameTeam,
+        awayTeam: com.nextup.core.domain.game.GameTeam,
+    ): InningScoresDto {
+        val maxInning = maxOf(game.currentInning, game.totalInnings)
+        val homeScores = (1..maxInning).map { homeTeam.getInningScore(it) }
+        val awayScores = (1..maxInning).map { awayTeam.getInningScore(it) }
+
+        return InningScoresDto(
+            innings = maxInning,
+            homeScores = homeScores,
+            awayScores = awayScores,
+        )
+    }
+
+    private fun buildBattingRecords(players: List<com.nextup.core.domain.game.GamePlayer>,): List<BatterScoresheetDto> =
+        players
+            .filter { it.battingOrder != null || it.isStarter }
+            .mapNotNull { player ->
+                val battingRecord = battingRecordRepository.findByGamePlayer(player)
+                if (battingRecord != null) {
+                    BatterScoresheetDto(
+                        playerId = player.player.id,
+                        name = player.player.name,
+                        backNumber = player.backNumber,
+                        position = player.position.abbreviation,
+                        battingOrder = player.battingOrder,
+                        plateAppearances = battingRecord.plateAppearances,
+                        atBats = battingRecord.atBats,
+                        runs = battingRecord.runs,
+                        hits = battingRecord.hits,
+                        doubles = battingRecord.doubles,
+                        triples = battingRecord.triples,
+                        homeRuns = battingRecord.homeRuns,
+                        rbis = battingRecord.runsBattedIn,
+                        walks = battingRecord.walks,
+                        strikeouts = battingRecord.strikeouts,
+                        stolenBases = battingRecord.stolenBases,
+                        avg = formatAverage(battingRecord.battingAverage),
+                    )
+                } else {
+                    null
+                }
+            }.sortedBy { it.battingOrder ?: 999 }
+
+    private fun buildPitchingRecords(
+        players: List<com.nextup.core.domain.game.GamePlayer>,
+    ): List<PitcherScoresheetDto> =
+        players
+            .filter { it.isPitcher }
+            .mapNotNull { player ->
+                val pitchingRecord = pitchingRecordRepository.findByGamePlayer(player)
+                if (pitchingRecord != null) {
+                    PitcherScoresheetDto(
+                        playerId = player.player.id,
+                        name = player.player.name,
+                        backNumber = player.backNumber,
+                        isStartingPitcher = pitchingRecord.isStartingPitcher,
+                        inningsPitched = pitchingRecord.inningsPitchedDisplay,
+                        hitsAllowed = pitchingRecord.hitsAllowed,
+                        runsAllowed = pitchingRecord.runsAllowed,
+                        earnedRuns = pitchingRecord.earnedRuns,
+                        walks = pitchingRecord.walksAllowed,
+                        strikeouts = pitchingRecord.strikeouts,
+                        homeRunsAllowed = pitchingRecord.homeRunsAllowed,
+                        decision = pitchingRecord.decision.abbreviation,
+                        era = formatERA(pitchingRecord.earnedRunAverage),
+                    )
+                } else {
+                    null
+                }
+            }.sortedByDescending { it.isStartingPitcher }
+
+    private fun buildKeyEvent(event: com.nextup.core.domain.game.GameEvent): KeyEventDto {
+        val inningDisplay = "${event.inning}회${if (event.isTopInning) "초" else "말"}"
+        val timestamp =
+            event.eventTimestamp.atZone(java.time.ZoneId.systemDefault())
+                .format(DateTimeFormatter.ofPattern("HH:mm:ss"))
+
+        return KeyEventDto(
+            inning = inningDisplay,
+            description = event.description,
+            timestamp = timestamp,
+        )
+    }
+
+    private fun formatAverage(avg: java.math.BigDecimal): String = avg.setScale(3, RoundingMode.HALF_UP).toString()
+
+    private fun formatERA(era: java.math.BigDecimal): String = era.setScale(2, RoundingMode.HALF_UP).toString()
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/report/CompetitionReportServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/report/CompetitionReportServiceImpl.kt
@@ -1,0 +1,205 @@
+package com.nextup.infrastructure.service.report
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.service.report.CompetitionReportService
+import com.nextup.core.service.report.dto.CompetitionReportDto
+import com.nextup.core.service.report.dto.CompetitionSummaryDto
+import com.nextup.core.service.report.dto.HighScoringGameDto
+import com.nextup.core.service.report.dto.WinStreakDto
+import com.nextup.core.service.standings.StandingsService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * 대회 리포트 서비스 구현
+ */
+@Service
+@Transactional(readOnly = true)
+class CompetitionReportServiceImpl(
+    private val competitionRepository: CompetitionRepositoryPort,
+    private val standingsService: StandingsService,
+    private val gameRepository: GameRepositoryPort,
+    private val gameTeamRepository: GameTeamRepositoryPort,
+    private val battingRecordRepository: BattingRecordRepositoryPort,
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+) : CompetitionReportService {
+    override fun getReport(competitionId: Long): CompetitionReportDto {
+        // 1. 대회 조회
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        // 2. 순위표 조회 (기존 StandingsService 재사용)
+        val standings = standingsService.getStandings(competitionId)
+
+        // 3. 요약 통계 조회
+        val summary = getReportSummary(competitionId)
+
+        return CompetitionReportDto(
+            competitionId = competition.id,
+            competitionName = competition.name,
+            season = competition.season,
+            standings = standings.standings,
+            summary = summary,
+        )
+    }
+
+    override fun getReportSummary(competitionId: Long): CompetitionSummaryDto {
+        // 1. 대회 존재 확인
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        // 2. 대회의 모든 경기 조회
+        val allGames = gameRepository.findByCompetitionId(competitionId)
+        val completedGames = allGames.filter { it.status.isCompleted() }
+
+        // 3. 완료된 경기의 GameTeam 조회
+        val completedGameIds = completedGames.map { it.id }
+        val gameTeams =
+            if (completedGameIds.isEmpty()) {
+                emptyList()
+            } else {
+                gameTeamRepository.findAllByGameIds(completedGameIds)
+            }
+
+        // 4. 통계 계산
+        val totalRuns = gameTeams.sumOf { it.totalScore }
+        val totalHits = gameTeams.sumOf { it.totalHits }
+        val averageRunsPerGame =
+            if (completedGames.isNotEmpty()) {
+                BigDecimal(totalRuns)
+                    .divide(BigDecimal(completedGames.size), 2, RoundingMode.HALF_UP)
+                    .toDouble()
+            } else {
+                0.0
+            }
+
+        // 5. 타격/투구 통계 조회
+        val battingRecords =
+            if (completedGameIds.isEmpty()) {
+                emptyList()
+            } else {
+                completedGameIds.flatMap { battingRecordRepository.findAllByGameId(it) }
+            }
+
+        val pitchingRecords =
+            if (completedGameIds.isEmpty()) {
+                emptyList()
+            } else {
+                completedGameIds.flatMap { pitchingRecordRepository.findAllByGameId(it) }
+            }
+
+        val totalHomeRuns = battingRecords.sumOf { it.homeRuns }
+        val totalStrikeouts = pitchingRecords.sumOf { it.strikeouts }
+
+        // 6. 최다 득점 경기 계산
+        val highestScoringGame = calculateHighestScoringGame(completedGames, gameTeams)
+
+        // 7. 최장 연승 팀 계산
+        val longestWinStreak = calculateLongestWinStreak(competitionId)
+
+        return CompetitionSummaryDto(
+            competitionId = competition.id,
+            totalGames = allGames.size,
+            completedGames = completedGames.size,
+            totalRuns = totalRuns,
+            averageRunsPerGame = averageRunsPerGame,
+            totalHits = totalHits,
+            totalHomeRuns = totalHomeRuns,
+            totalStrikeouts = totalStrikeouts,
+            highestScoringGame = highestScoringGame,
+            longestWinStreak = longestWinStreak,
+        )
+    }
+
+    /**
+     * 최다 득점 경기 계산
+     */
+    private fun calculateHighestScoringGame(
+        completedGames: List<com.nextup.core.domain.game.Game>,
+        gameTeams: List<com.nextup.core.domain.game.GameTeam>,
+    ): HighScoringGameDto? {
+        if (completedGames.isEmpty()) return null
+
+        // 경기별 총 득점 계산
+        val gameScores =
+            completedGames.map { game ->
+                val teams = gameTeams.filter { it.game.id == game.id }
+                val totalScore = teams.sumOf { it.totalScore }
+                Triple(game, teams, totalScore)
+            }
+
+        // 최다 득점 경기 찾기
+        val highestScoring = gameScores.maxByOrNull { it.third } ?: return null
+        val (game, teams) = highestScoring
+
+        if (teams.size < 2) return null
+
+        val homeTeam = teams.find { it.isHome }
+        val awayTeam = teams.find { it.isAway }
+
+        return HighScoringGameDto(
+            gameId = game.id,
+            homeTeamName = homeTeam?.team?.name ?: "Unknown",
+            awayTeamName = awayTeam?.team?.name ?: "Unknown",
+            totalRuns = highestScoring.third,
+            date = game.scheduledAt.toLocalDate(),
+        )
+    }
+
+    /**
+     * 최장 연승 팀 계산
+     */
+    private fun calculateLongestWinStreak(competitionId: Long): WinStreakDto? {
+        val decidedGameTeams =
+            gameTeamRepository
+                .findAllByCompetitionIdWithDecidedResult(competitionId)
+                .filter { it.game.status.isCompleted() }
+                .sortedBy { it.game.scheduledAt }
+
+        if (decidedGameTeams.isEmpty()) return null
+
+        // 팀별 경기 그룹화
+        val teamGames = decidedGameTeams.groupBy { it.team.id }
+
+        // 각 팀의 최장 연승 계산
+        val teamStreaks =
+            teamGames.mapValues { (_, games) ->
+                var maxStreak = 0
+                var currentStreak = 0
+
+                games.forEach { gameTeam ->
+                    if (gameTeam.result == com.nextup.core.domain.game.GameResult.WIN) {
+                        currentStreak++
+                        maxStreak = maxOf(maxStreak, currentStreak)
+                    } else {
+                        currentStreak = 0
+                    }
+                }
+
+                maxStreak
+            }
+
+        // 최장 연승 팀 찾기
+        val longestStreak = teamStreaks.maxByOrNull { it.value } ?: return null
+        if (longestStreak.value == 0) return null
+
+        val teamName =
+            decidedGameTeams
+                .find { it.team.id == longestStreak.key }
+                ?.team?.name ?: "Unknown"
+
+        return WinStreakDto(
+            teamName = teamName,
+            streakLength = longestStreak.value,
+        )
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/IndividualRankingServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/IndividualRankingServiceImpl.kt
@@ -1,0 +1,160 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import com.nextup.core.service.stats.IndividualRankingService
+import com.nextup.core.service.stats.dto.BattingCategory
+import com.nextup.core.service.stats.dto.BattingLeaderDto
+import com.nextup.core.service.stats.dto.PitchingCategory
+import com.nextup.core.service.stats.dto.PitchingLeaderDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class IndividualRankingServiceImpl(
+    private val competitionRepository: CompetitionRepositoryPort,
+    private val seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort,
+    private val seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort,
+    private val teamMemberRepository: TeamMemberRepositoryPort,
+) : IndividualRankingService {
+    companion object {
+        // 사회인 야구 규정 타석 계수 (팀 경기 수 * 3.1)
+        const val QUALIFYING_PA_FACTOR = 3.1
+
+        // 사회인 야구 규정 이닝 계수 (팀 경기 수 * 1.0)
+        const val QUALIFYING_IP_FACTOR = 1.0
+
+        // 기본 팀 경기 수 (규정 타석/이닝 산출 기본값)
+        const val DEFAULT_TEAM_GAMES = 10
+    }
+
+    override fun getBattingLeaders(
+        competitionId: Long,
+        category: BattingCategory,
+        limit: Int,
+    ): List<BattingLeaderDto> {
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+        val year = competition.year
+
+        val qualifyingPA = (DEFAULT_TEAM_GAMES * QUALIFYING_PA_FACTOR).toInt()
+
+        val stats =
+            when (category) {
+                BattingCategory.BATTING_AVG ->
+                    seasonBattingStatsRepository.findTopByBattingAverage(year, qualifyingPA, limit)
+                BattingCategory.OBP ->
+                    seasonBattingStatsRepository.findTopByOnBasePercentage(year, qualifyingPA, limit)
+                BattingCategory.SLG ->
+                    seasonBattingStatsRepository.findTopBySlugging(year, qualifyingPA, limit)
+                BattingCategory.OPS ->
+                    seasonBattingStatsRepository.findTopByOps(year, qualifyingPA, limit)
+                BattingCategory.HOME_RUNS ->
+                    seasonBattingStatsRepository.findTopByHomeRuns(year, limit)
+                BattingCategory.RBI ->
+                    seasonBattingStatsRepository.findTopByRunsBattedIn(year, limit)
+                BattingCategory.HITS ->
+                    seasonBattingStatsRepository.findTopByHits(year, limit)
+                BattingCategory.STOLEN_BASES ->
+                    seasonBattingStatsRepository.findTopByStolenBases(year, limit)
+            }
+
+        return stats.mapIndexed { index, stat ->
+            stat.toBattingLeaderDto(index + 1, category)
+        }
+    }
+
+    override fun getPitchingLeaders(
+        competitionId: Long,
+        category: PitchingCategory,
+        limit: Int,
+    ): List<PitchingLeaderDto> {
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+        val year = competition.year
+
+        val qualifyingIPOuts = (DEFAULT_TEAM_GAMES * QUALIFYING_IP_FACTOR * 3).toInt()
+
+        val stats =
+            when (category) {
+                PitchingCategory.ERA ->
+                    seasonPitchingStatsRepository.findTopByEra(year, qualifyingIPOuts, limit)
+                PitchingCategory.WHIP ->
+                    seasonPitchingStatsRepository.findTopByWhip(year, qualifyingIPOuts, limit)
+                PitchingCategory.WINS ->
+                    seasonPitchingStatsRepository.findTopByWins(year, limit)
+                PitchingCategory.SAVES ->
+                    seasonPitchingStatsRepository.findTopBySaves(year, limit)
+                PitchingCategory.STRIKEOUTS ->
+                    seasonPitchingStatsRepository.findTopByStrikeouts(year, limit)
+            }
+
+        return stats.mapIndexed { index, stat ->
+            stat.toPitchingLeaderDto(index + 1, category)
+        }
+    }
+
+    private fun SeasonBattingStats.toBattingLeaderDto(
+        rank: Int,
+        category: BattingCategory,
+    ): BattingLeaderDto {
+        val teamName = resolveTeamName(this.player.id)
+        val value =
+            when (category) {
+                BattingCategory.BATTING_AVG -> this.battingAverage.toDouble()
+                BattingCategory.OBP -> this.onBasePercentage.toDouble()
+                BattingCategory.SLG -> this.sluggingPercentage.toDouble()
+                BattingCategory.OPS -> this.ops.toDouble()
+                BattingCategory.HOME_RUNS -> this.homeRuns.toDouble()
+                BattingCategory.RBI -> this.runsBattedIn.toDouble()
+                BattingCategory.HITS -> this.hits.toDouble()
+                BattingCategory.STOLEN_BASES -> this.stolenBases.toDouble()
+            }
+        return BattingLeaderDto(
+            rank = rank,
+            playerId = this.player.id,
+            playerName = this.player.name,
+            teamName = teamName,
+            value = value,
+            games = this.gamesPlayed,
+            plateAppearances = this.plateAppearances,
+        )
+    }
+
+    private fun SeasonPitchingStats.toPitchingLeaderDto(
+        rank: Int,
+        category: PitchingCategory,
+    ): PitchingLeaderDto {
+        val teamName = resolveTeamName(this.player.id)
+        val value =
+            when (category) {
+                PitchingCategory.ERA -> this.earnedRunAverage.toDouble()
+                PitchingCategory.WHIP -> this.whip.toDouble()
+                PitchingCategory.WINS -> this.wins.toDouble()
+                PitchingCategory.SAVES -> this.saves.toDouble()
+                PitchingCategory.STRIKEOUTS -> this.strikeouts.toDouble()
+            }
+        return PitchingLeaderDto(
+            rank = rank,
+            playerId = this.player.id,
+            playerName = this.player.name,
+            teamName = teamName,
+            value = value,
+            games = this.gamesPlayed,
+            inningsPitched = this.inningsPitched.toDouble(),
+        )
+    }
+
+    private fun resolveTeamName(playerId: Long): String {
+        val members = teamMemberRepository.findByPlayerIdActive(playerId)
+        return members.firstOrNull()?.team?.name ?: "-"
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMatchupServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMatchupServiceImpl.kt
@@ -1,0 +1,152 @@
+package com.nextup.infrastructure.service.team
+
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.game.GameResult
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.team.TeamMatchupService
+import com.nextup.core.service.team.dto.TeamMatchupDto
+import com.nextup.core.service.team.dto.TeamMatchupGameDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Service
+@Transactional(readOnly = true)
+class TeamMatchupServiceImpl(
+    private val gameTeamRepositoryPort: GameTeamRepositoryPort,
+    private val teamRepositoryPort: TeamRepositoryPort,
+) : TeamMatchupService {
+    override fun getTeamMatchup(
+        teamId: Long,
+        opponentId: Long,
+        competitionId: Long?,
+    ): TeamMatchupDto {
+        // 팀 존재 여부 확인
+        val team =
+            teamRepositoryPort.findByIdOrNull(teamId)
+                ?: throw TeamNotFoundException(teamId)
+        val opponent =
+            teamRepositoryPort.findByIdOrNull(opponentId)
+                ?: throw TeamNotFoundException(opponentId)
+
+        // 두 팀 간의 완료된 경기 조회
+        val teamGameTeams =
+            gameTeamRepositoryPort.findCompletedGamesBetweenTeams(
+                teamId,
+                opponentId,
+                competitionId,
+            )
+
+        // 통계 계산
+        var wins = 0
+        var losses = 0
+        var draws = 0
+        var runsScored = 0
+        var runsAllowed = 0
+
+        teamGameTeams.forEach { teamGameTeam ->
+            when (teamGameTeam.result) {
+                GameResult.WIN -> wins++
+                GameResult.LOSS -> losses++
+                GameResult.DRAW -> draws++
+                GameResult.UNDECIDED -> {} // 완료된 경기만 조회했으므로 발생하지 않음
+            }
+
+            runsScored += teamGameTeam.totalScore
+
+            // 상대팀의 점수 찾기
+            val opponentGameTeam =
+                gameTeamRepositoryPort
+                    .findAllByGameId(teamGameTeam.game.id)
+                    .firstOrNull { it.team.id == opponentId }
+
+            if (opponentGameTeam != null) {
+                runsAllowed += opponentGameTeam.totalScore
+            }
+        }
+
+        val totalGames = wins + losses + draws
+
+        // 평균 득실점 계산
+        val avgRunsScored =
+            if (totalGames > 0) {
+                BigDecimal(runsScored)
+                    .divide(BigDecimal(totalGames), 2, RoundingMode.HALF_UP)
+                    .toDouble()
+            } else {
+                0.0
+            }
+
+        val avgRunsAllowed =
+            if (totalGames > 0) {
+                BigDecimal(runsAllowed)
+                    .divide(BigDecimal(totalGames), 2, RoundingMode.HALF_UP)
+                    .toDouble()
+            } else {
+                0.0
+            }
+
+        return TeamMatchupDto(
+            teamId = teamId,
+            teamName = team.fullName,
+            opponentId = opponentId,
+            opponentName = opponent.fullName,
+            wins = wins,
+            losses = losses,
+            draws = draws,
+            totalGames = totalGames,
+            runsScored = runsScored,
+            runsAllowed = runsAllowed,
+            avgRunsScored = avgRunsScored,
+            avgRunsAllowed = avgRunsAllowed,
+        )
+    }
+
+    override fun getRecentGames(
+        teamId: Long,
+        opponentId: Long,
+        limit: Int,
+    ): List<TeamMatchupGameDto> {
+        // 팀 존재 여부 확인
+        teamRepositoryPort.findByIdOrNull(teamId)
+            ?: throw TeamNotFoundException(teamId)
+        teamRepositoryPort.findByIdOrNull(opponentId)
+            ?: throw TeamNotFoundException(opponentId)
+
+        // 최근 경기 조회
+        val teamGameTeams =
+            gameTeamRepositoryPort
+                .findCompletedGamesBetweenTeams(teamId, opponentId, null)
+                .take(limit)
+
+        return teamGameTeams.map { teamGameTeam ->
+            val game = teamGameTeam.game
+            val allGameTeams = gameTeamRepositoryPort.findAllByGameId(game.id)
+
+            val homeTeam = allGameTeams.firstOrNull { it.isHome }
+            val awayTeam = allGameTeams.firstOrNull { it.isAway }
+
+            // 결과 결정 (teamId 관점에서)
+            val result =
+                when (teamGameTeam.result) {
+                    GameResult.WIN -> "WIN"
+                    GameResult.LOSS -> "LOSS"
+                    GameResult.DRAW -> "DRAW"
+                    GameResult.UNDECIDED -> "UNDECIDED"
+                }
+
+            TeamMatchupGameDto(
+                gameId = game.id,
+                date = game.scheduledAt.toLocalDate(),
+                homeTeamId = homeTeam?.team?.id ?: 0L,
+                awayTeamId = awayTeam?.team?.id ?: 0L,
+                homeScore = homeTeam?.totalScore ?: 0,
+                awayScore = awayTeam?.totalScore ?: 0,
+                result = result,
+                venue = game.location,
+            )
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
@@ -243,4 +243,87 @@ class TeamMembershipServiceImpl(
     ): TeamMember? {
         return teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
     }
+
+    @Transactional
+    override fun createTeamWithOwner(
+        userId: Long,
+        team: Team,
+        uniformNumber: Int,
+    ): Team {
+        // 등번호 유효성 검증
+        if (uniformNumber !in 1..99) {
+            throw InvalidUniformNumberException(uniformNumber)
+        }
+
+        val user =
+            userRepository.findByIdOrNull(userId)
+                ?: throw UserNotFoundException(userId)
+        val player =
+            user.player
+                ?: throw PlayerNotFoundException(userId)
+
+        // 이미 다른 팀에 소속된 경우 검증
+        val activeMember = teamMemberRepository.findActiveByUserId(userId)
+        if (activeMember != null) {
+            throw AlreadyInTeamException(userId, activeMember.team.id, activeMember.team.name)
+        }
+
+        // 팀 이름 중복 검증
+        val existingTeam = teamRepository.findByName(team.name)
+        if (existingTeam != null) {
+            throw TeamAlreadyExistsException(team.name)
+        }
+
+        // 팀 저장
+        val savedTeam = teamRepository.save(team)
+
+        // OWNER로 멤버 생성
+        val ownerMember =
+            TeamMember.create(
+                team = savedTeam,
+                user = user,
+                player = player,
+                uniformNumber = uniformNumber,
+                role = TeamMemberRole.OWNER,
+            )
+        teamMemberRepository.save(ownerMember)
+
+        return savedTeam
+    }
+
+    @Transactional
+    override fun deleteTeam(
+        teamId: Long,
+        userId: Long,
+    ) {
+        val team =
+            teamRepository.findByIdOrNull(teamId)
+                ?: throw TeamNotFoundException(teamId)
+
+        // OWNER 권한 검증
+        val member =
+            teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+                ?: throw InsufficientTeamRoleException("OWNER", "NONE")
+
+        if (!member.isOwner()) {
+            throw InsufficientTeamRoleException("OWNER", member.role.name)
+        }
+
+        // 활성 멤버 수 검증 (1명일 때만 삭제 가능)
+        val activeMemberCount =
+            teamMemberRepository.countByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE)
+        if (activeMemberCount > 1) {
+            throw InvalidTeamStateException(
+                "팀 멤버가 ${activeMemberCount}명입니다. 멤버가 1명일 때만 삭제할 수 있습니다.",
+            )
+        }
+
+        // 멤버 삭제 후 팀 삭제
+        teamMemberRepository.delete(member)
+        teamRepository.delete(team)
+    }
+
+    override fun getTeamMemberCount(teamId: Long): Int {
+        return teamMemberRepository.countByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE).toInt()
+    }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/title/TitleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/title/TitleServiceImpl.kt
@@ -1,0 +1,286 @@
+package com.nextup.infrastructure.service.title
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import com.nextup.core.service.title.TitleCategory
+import com.nextup.core.service.title.TitleService
+import com.nextup.core.service.title.dto.TitleCandidateDto
+import com.nextup.core.service.title.dto.TitleDto
+import com.nextup.core.service.title.dto.TitleWinnerDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 타이틀 서비스 구현
+ */
+@Service
+@Transactional(readOnly = true)
+class TitleServiceImpl(
+    private val competitionRepository: CompetitionRepositoryPort,
+    private val gameTeamRepository: GameTeamRepositoryPort,
+    private val seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort,
+    private val seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort,
+) : TitleService {
+    companion object {
+        private const val TOP_CANDIDATES_LIMIT = 10
+        private const val QUALIFICATION_PLATE_APPEARANCES_MULTIPLIER = 3.1
+        private const val QUALIFICATION_INNINGS_MULTIPLIER = 1.0
+    }
+
+    override fun getTitles(competitionId: Long): List<TitleDto> {
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        val year = competition.year
+        val teamGamesCount = calculateTeamGamesCount(competitionId)
+
+        return TitleCategory.entries.map { category ->
+            calculateTitle(category, year, teamGamesCount)
+        }
+    }
+
+    override fun getTitleByCategory(
+        competitionId: Long,
+        category: TitleCategory,
+    ): TitleDto {
+        val competition =
+            competitionRepository.findByIdOrNull(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        val year = competition.year
+        val teamGamesCount = calculateTeamGamesCount(competitionId)
+
+        return calculateTitle(category, year, teamGamesCount)
+    }
+
+    /**
+     * 팀당 경기 수를 계산합니다 (규정 타석/이닝 계산용).
+     */
+    private fun calculateTeamGamesCount(competitionId: Long): Int {
+        val allGameTeams = gameTeamRepository.findAllByCompetitionId(competitionId)
+        if (allGameTeams.isEmpty()) {
+            return 0
+        }
+
+        // 팀별 예정된 총 경기 수의 최댓값 반환
+        return allGameTeams.groupBy { it.team.id }
+            .mapValues { (_, gameTeams) -> gameTeams.size }
+            .values
+            .maxOrNull() ?: 0
+    }
+
+    /**
+     * 특정 카테고리의 타이틀을 계산합니다.
+     */
+    private fun calculateTitle(
+        category: TitleCategory,
+        year: Int,
+        teamGamesCount: Int,
+    ): TitleDto {
+        val candidates =
+            when (category) {
+                TitleCategory.BATTING_AVG -> calculateBattingAvgTitle(year, teamGamesCount)
+                TitleCategory.HOME_RUNS -> calculateHomeRunsTitle(year)
+                TitleCategory.RBI -> calculateRbiTitle(year)
+                TitleCategory.STOLEN_BASES -> calculateStolenBasesTitle(year)
+                TitleCategory.HITS -> calculateHitsTitle(year)
+                TitleCategory.WINS -> calculateWinsTitle(year)
+                TitleCategory.ERA -> calculateEraTitle(year, teamGamesCount)
+                TitleCategory.SAVES -> calculateSavesTitle(year)
+                TitleCategory.STRIKEOUTS -> calculateStrikeoutsTitle(year)
+            }
+
+        // 후보자 중 규정 충족자 중에서 1위를 우승자로 선정
+        val winner =
+            candidates
+                .firstOrNull { it.isQualified }
+                ?.let {
+                    TitleWinnerDto(
+                        playerId = it.playerId,
+                        playerName = it.playerName,
+                        teamName = it.teamName,
+                        statValue = it.statValue,
+                    )
+                }
+
+        return TitleDto(
+            category = category,
+            displayName = category.displayName,
+            winner = winner,
+            topCandidates = candidates,
+        )
+    }
+
+    // ========== 타격 타이틀 ==========
+
+    private fun calculateBattingAvgTitle(
+        year: Int,
+        teamGamesCount: Int,
+    ): List<TitleCandidateDto> {
+        val minPlateAppearances = (teamGamesCount * QUALIFICATION_PLATE_APPEARANCES_MULTIPLIER).toInt()
+        val allStats = seasonBattingStatsRepository.findAllByYear(year)
+
+        return allStats
+            .sortedByDescending { it.battingAverage }
+            .take(TOP_CANDIDATES_LIMIT)
+            .mapIndexed { index, stats ->
+                TitleCandidateDto(
+                    rank = index + 1,
+                    playerId = stats.player.id,
+                    playerName = stats.player.name,
+                    teamName = getPlayerTeamName(stats),
+                    statValue = stats.battingAverage.toDouble(),
+                    isQualified = stats.plateAppearances >= minPlateAppearances,
+                )
+            }
+    }
+
+    private fun calculateHomeRunsTitle(year: Int): List<TitleCandidateDto> {
+        val stats = seasonBattingStatsRepository.findTopByHomeRuns(year, TOP_CANDIDATES_LIMIT)
+
+        return stats.mapIndexed { index, stat ->
+            TitleCandidateDto(
+                rank = index + 1,
+                playerId = stat.player.id,
+                playerName = stat.player.name,
+                teamName = getPlayerTeamName(stat),
+                statValue = stat.homeRuns.toDouble(),
+                isQualified = true, // 홈런왕은 규정 타석 불필요
+            )
+        }
+    }
+
+    private fun calculateRbiTitle(year: Int): List<TitleCandidateDto> {
+        val stats = seasonBattingStatsRepository.findTopByRunsBattedIn(year, TOP_CANDIDATES_LIMIT)
+
+        return stats.mapIndexed { index, stat ->
+            TitleCandidateDto(
+                rank = index + 1,
+                playerId = stat.player.id,
+                playerName = stat.player.name,
+                teamName = getPlayerTeamName(stat),
+                statValue = stat.runsBattedIn.toDouble(),
+                isQualified = true, // 타점왕은 규정 타석 불필요
+            )
+        }
+    }
+
+    private fun calculateStolenBasesTitle(year: Int): List<TitleCandidateDto> {
+        val stats = seasonBattingStatsRepository.findTopByStolenBases(year, TOP_CANDIDATES_LIMIT)
+
+        return stats.mapIndexed { index, stat ->
+            TitleCandidateDto(
+                rank = index + 1,
+                playerId = stat.player.id,
+                playerName = stat.player.name,
+                teamName = getPlayerTeamName(stat),
+                statValue = stat.stolenBases.toDouble(),
+                isQualified = true, // 도루왕은 규정 타석 불필요
+            )
+        }
+    }
+
+    private fun calculateHitsTitle(year: Int): List<TitleCandidateDto> {
+        val stats = seasonBattingStatsRepository.findTopByHits(year, TOP_CANDIDATES_LIMIT)
+
+        return stats.mapIndexed { index, stat ->
+            TitleCandidateDto(
+                rank = index + 1,
+                playerId = stat.player.id,
+                playerName = stat.player.name,
+                teamName = getPlayerTeamName(stat),
+                statValue = stat.hits.toDouble(),
+                isQualified = true, // 최다안타는 규정 타석 불필요
+            )
+        }
+    }
+
+    // ========== 투수 타이틀 ==========
+
+    private fun calculateWinsTitle(year: Int): List<TitleCandidateDto> {
+        val stats = seasonPitchingStatsRepository.findTopByWins(year, TOP_CANDIDATES_LIMIT)
+
+        return stats.mapIndexed { index, stat ->
+            TitleCandidateDto(
+                rank = index + 1,
+                playerId = stat.player.id,
+                playerName = stat.player.name,
+                teamName = getPlayerTeamName(stat),
+                statValue = stat.wins.toDouble(),
+                isQualified = true, // 다승왕은 규정 이닝 불필요
+            )
+        }
+    }
+
+    private fun calculateEraTitle(
+        year: Int,
+        teamGamesCount: Int,
+    ): List<TitleCandidateDto> {
+        val minInningsPitchedOuts = (teamGamesCount * QUALIFICATION_INNINGS_MULTIPLIER * 3).toInt()
+        val allStats = seasonPitchingStatsRepository.findAllByYear(year)
+
+        return allStats
+            .sortedBy { it.earnedRunAverage } // ERA는 낮을수록 좋음
+            .take(TOP_CANDIDATES_LIMIT)
+            .mapIndexed { index, stats ->
+                TitleCandidateDto(
+                    rank = index + 1,
+                    playerId = stats.player.id,
+                    playerName = stats.player.name,
+                    teamName = getPlayerTeamName(stats),
+                    statValue = stats.earnedRunAverage.toDouble(),
+                    isQualified = stats.inningsPitchedOuts >= minInningsPitchedOuts,
+                )
+            }
+    }
+
+    private fun calculateSavesTitle(year: Int): List<TitleCandidateDto> {
+        val stats = seasonPitchingStatsRepository.findTopBySaves(year, TOP_CANDIDATES_LIMIT)
+
+        return stats.mapIndexed { index, stat ->
+            TitleCandidateDto(
+                rank = index + 1,
+                playerId = stat.player.id,
+                playerName = stat.player.name,
+                teamName = getPlayerTeamName(stat),
+                statValue = stat.saves.toDouble(),
+                isQualified = true, // 세이브왕은 규정 이닝 불필요
+            )
+        }
+    }
+
+    private fun calculateStrikeoutsTitle(year: Int): List<TitleCandidateDto> {
+        val stats = seasonPitchingStatsRepository.findTopByStrikeouts(year, TOP_CANDIDATES_LIMIT)
+
+        return stats.mapIndexed { index, stat ->
+            TitleCandidateDto(
+                rank = index + 1,
+                playerId = stat.player.id,
+                playerName = stat.player.name,
+                teamName = getPlayerTeamName(stat),
+                statValue = stat.strikeouts.toDouble(),
+                isQualified = true, // 탈삼진왕은 규정 이닝 불필요
+            )
+        }
+    }
+
+    // ========== 헬퍼 메서드 ==========
+
+    private fun getPlayerTeamName(stats: SeasonBattingStats): String {
+        // TODO: PlayerTeamHistory에서 해당 시즌의 팀 정보를 조회
+        // 현재는 임시로 "알 수 없음" 반환
+        return "알 수 없음"
+    }
+
+    private fun getPlayerTeamName(stats: SeasonPitchingStats): String {
+        // TODO: PlayerTeamHistory에서 해당 시즌의 팀 정보를 조회
+        // 현재는 임시로 "알 수 없음" 반환
+        return "알 수 없음"
+    }
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V002__create_league_schedule_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V002__create_league_schedule_table.sql
@@ -1,0 +1,32 @@
+-- V002: Create league_schedules table
+-- Description: 대진표 관리 시스템 (LeagueSchedule)
+
+CREATE TABLE league_schedules (
+    id BIGSERIAL PRIMARY KEY,
+    competition_id BIGINT NOT NULL REFERENCES competitions(id),
+    round INT NOT NULL,
+    match_number INT NOT NULL,
+    home_team_id BIGINT NOT NULL REFERENCES teams(id),
+    away_team_id BIGINT NOT NULL REFERENCES teams(id),
+    scheduled_date DATE NOT NULL,
+    scheduled_time TIME,
+    venue VARCHAR(255),
+    status VARCHAR(20) NOT NULL DEFAULT 'SCHEDULED',
+    game_id BIGINT REFERENCES games(id),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    -- Unique Constraints
+    CONSTRAINT uk_league_schedules_competition_round_match UNIQUE (competition_id, round, match_number)
+);
+
+-- Indexes for performance
+CREATE INDEX idx_league_schedules_competition ON league_schedules(competition_id);
+CREATE INDEX idx_league_schedules_date ON league_schedules(scheduled_date);
+CREATE INDEX idx_league_schedules_status ON league_schedules(status);
+CREATE INDEX idx_league_schedules_game ON league_schedules(game_id);
+
+COMMENT ON TABLE league_schedules IS '대진표 - 대회 내 라운드별 경기 일정 관리';
+COMMENT ON COLUMN league_schedules.round IS '라운드 (1차전, 2차전 등)';
+COMMENT ON COLUMN league_schedules.match_number IS '라운드 내 경기 번호';
+COMMENT ON COLUMN league_schedules.status IS 'SCHEDULED(예정), GAME_CREATED(경기생성), POSTPONED(연기), CANCELLED(취소), COMPLETED(완료)';

--- a/nextup-infrastructure/src/main/resources/db/migration/V003__add_game_event_undone_column.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V003__add_game_event_undone_column.sql
@@ -1,0 +1,5 @@
+-- V003: game_events 테이블에 undone 컬럼 추가 (기록원 Undo 시스템)
+ALTER TABLE game_events ADD COLUMN undone BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- undone=false인 이벤트만 빠르게 조회하기 위한 인덱스
+CREATE INDEX idx_game_events_game_undone ON game_events (game_id, undone, event_timestamp DESC);

--- a/nextup-infrastructure/src/main/resources/db/migration/V004__add_forfeit_reason_and_playoff_teams.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V004__add_forfeit_reason_and_playoff_teams.sql
@@ -1,0 +1,5 @@
+-- #75: 몰수패 자동 처리 - 몰수 사유 필드 추가
+ALTER TABLE games ADD COLUMN forfeit_reason VARCHAR(500);
+
+-- #69: 플레이오프 라인 하이라이트 - 플레이오프 진출 팀 수 필드 추가
+ALTER TABLE competitions ADD COLUMN playoff_teams INTEGER;

--- a/nextup-infrastructure/src/main/resources/db/migration/V005__create_disciplines_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V005__create_disciplines_table.sql
@@ -1,0 +1,33 @@
+-- 징계 관리 테이블 생성
+CREATE TABLE disciplines (
+    id BIGSERIAL PRIMARY KEY,
+    player_id BIGINT NOT NULL REFERENCES players(id),
+    competition_id BIGINT NOT NULL REFERENCES competitions(id),
+    type VARCHAR(20) NOT NULL CHECK (type IN ('WARNING', 'SUSPENSION', 'BAN')),
+    reason TEXT NOT NULL,
+    suspension_games INTEGER,
+    issued_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMP,
+    issued_by VARCHAR(255) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE' CHECK (status IN ('ACTIVE', 'SERVED', 'CANCELLED')),
+    served_games INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- 인덱스 생성
+CREATE INDEX idx_disciplines_player_id ON disciplines(player_id);
+CREATE INDEX idx_disciplines_competition_id ON disciplines(competition_id);
+CREATE INDEX idx_disciplines_status ON disciplines(status);
+CREATE INDEX idx_disciplines_player_competition_status ON disciplines(player_id, competition_id, status);
+
+-- 코멘트 추가
+COMMENT ON TABLE disciplines IS '선수 징계 정보';
+COMMENT ON COLUMN disciplines.type IS '징계 유형: WARNING(경고), SUSPENSION(출장정지), BAN(영구제재)';
+COMMENT ON COLUMN disciplines.reason IS '징계 사유';
+COMMENT ON COLUMN disciplines.suspension_games IS '출장 정지 경기 수 (SUSPENSION 타입인 경우)';
+COMMENT ON COLUMN disciplines.issued_at IS '징계 발급일시';
+COMMENT ON COLUMN disciplines.expires_at IS '징계 만료일시 (선택사항)';
+COMMENT ON COLUMN disciplines.issued_by IS '징계 발급자 (관리자 이름 또는 ID)';
+COMMENT ON COLUMN disciplines.status IS '징계 상태: ACTIVE(활성), SERVED(이행완료), CANCELLED(취소)';
+COMMENT ON COLUMN disciplines.served_games IS '소화한 경기 수 (SUSPENSION 타입인 경우)';

--- a/nextup-infrastructure/src/main/resources/db/migration/V006__create_appeals_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V006__create_appeals_table.sql
@@ -1,0 +1,35 @@
+-- 이의 제기/정정 신청 테이블 생성
+CREATE TABLE appeals (
+    id BIGSERIAL PRIMARY KEY,
+    game_id BIGINT NOT NULL REFERENCES games(id),
+    appealer_id BIGINT NOT NULL,
+    appealer_name VARCHAR(100) NOT NULL,
+    type VARCHAR(30) NOT NULL CHECK (type IN ('SCORING_ERROR', 'RECORD_CORRECTION', 'RULE_VIOLATION', 'OTHER')),
+    title VARCHAR(200) NOT NULL,
+    description TEXT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING' CHECK (status IN ('PENDING', 'APPROVED', 'REJECTED')),
+    reviewer_id BIGINT,
+    reviewer_comment TEXT,
+    reviewed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- 인덱스 생성
+CREATE INDEX idx_appeals_game_id ON appeals(game_id);
+CREATE INDEX idx_appeals_appealer_id ON appeals(appealer_id);
+CREATE INDEX idx_appeals_status ON appeals(status);
+CREATE INDEX idx_appeals_game_status ON appeals(game_id, status);
+
+-- 코멘트 추가
+COMMENT ON TABLE appeals IS '경기 기록 이의 제기/정정 신청';
+COMMENT ON COLUMN appeals.game_id IS '경기 ID';
+COMMENT ON COLUMN appeals.appealer_id IS '신청자 ID (선수 또는 감독)';
+COMMENT ON COLUMN appeals.appealer_name IS '신청자 이름';
+COMMENT ON COLUMN appeals.type IS '이의 제기 유형: SCORING_ERROR(득점 오류), RECORD_CORRECTION(기록 정정), RULE_VIOLATION(규칙 위반), OTHER(기타)';
+COMMENT ON COLUMN appeals.title IS '제목';
+COMMENT ON COLUMN appeals.description IS '상세 설명';
+COMMENT ON COLUMN appeals.status IS '처리 상태: PENDING(대기), APPROVED(승인), REJECTED(반려)';
+COMMENT ON COLUMN appeals.reviewer_id IS '검토자 ID (관리자)';
+COMMENT ON COLUMN appeals.reviewer_comment IS '검토 의견';
+COMMENT ON COLUMN appeals.reviewed_at IS '검토 일시';

--- a/nextup-infrastructure/src/main/resources/db/migration/V007__add_postpone_fields_to_league_schedule.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V007__add_postpone_fields_to_league_schedule.sql
@@ -1,0 +1,3 @@
+-- 우천 순연 필드 추가
+ALTER TABLE league_schedules ADD COLUMN IF NOT EXISTS postponed_reason VARCHAR(500);
+ALTER TABLE league_schedules ADD COLUMN IF NOT EXISTS original_date DATE;

--- a/nextup-infrastructure/src/main/resources/db/migration/V008__create_notification_tables.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V008__create_notification_tables.sql
@@ -1,0 +1,70 @@
+-- 알림 테이블
+CREATE TABLE notifications (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    type VARCHAR(30) NOT NULL,
+    title VARCHAR(200) NOT NULL,
+    body TEXT NOT NULL,
+    data TEXT,
+    read_at TIMESTAMP,
+    sent_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- 알림 인덱스
+CREATE INDEX idx_notifications_user_id ON notifications(user_id);
+CREATE INDEX idx_notifications_type ON notifications(type);
+CREATE INDEX idx_notifications_user_type ON notifications(user_id, type);
+CREATE INDEX idx_notifications_sent_at ON notifications(sent_at);
+
+-- 알림 테이블 코멘트
+COMMENT ON TABLE notifications IS '푸시 알림';
+COMMENT ON COLUMN notifications.user_id IS '사용자 ID';
+COMMENT ON COLUMN notifications.type IS '알림 타입 (GAME_START, TEAM_NOTICE, ATTENDANCE_NUDGE, RECORD_ALERT)';
+COMMENT ON COLUMN notifications.title IS '알림 제목';
+COMMENT ON COLUMN notifications.body IS '알림 내용';
+COMMENT ON COLUMN notifications.data IS '추가 데이터 (JSON)';
+COMMENT ON COLUMN notifications.read_at IS '읽은 시각';
+COMMENT ON COLUMN notifications.sent_at IS '전송 시각';
+
+-- 디바이스 토큰 테이블
+CREATE TABLE device_tokens (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    token VARCHAR(500) NOT NULL,
+    platform VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- 디바이스 토큰 인덱스
+CREATE INDEX idx_device_tokens_user_id ON device_tokens(user_id);
+CREATE UNIQUE INDEX idx_device_tokens_token ON device_tokens(token);
+CREATE INDEX idx_device_tokens_user_platform ON device_tokens(user_id, platform);
+
+-- 디바이스 토큰 테이블 코멘트
+COMMENT ON TABLE device_tokens IS 'FCM 디바이스 토큰';
+COMMENT ON COLUMN device_tokens.user_id IS '사용자 ID';
+COMMENT ON COLUMN device_tokens.token IS 'FCM 토큰';
+COMMENT ON COLUMN device_tokens.platform IS '플랫폼 (IOS, ANDROID, WEB)';
+
+-- 알림 설정 테이블
+CREATE TABLE notification_preferences (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    type VARCHAR(30) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- 알림 설정 인덱스
+CREATE INDEX idx_notification_preferences_user_id ON notification_preferences(user_id);
+CREATE UNIQUE INDEX idx_notification_preferences_user_type ON notification_preferences(user_id, type);
+
+-- 알림 설정 테이블 코멘트
+COMMENT ON TABLE notification_preferences IS '알림 수신 설정';
+COMMENT ON COLUMN notification_preferences.user_id IS '사용자 ID';
+COMMENT ON COLUMN notification_preferences.type IS '알림 타입';
+COMMENT ON COLUMN notification_preferences.enabled IS '수신 활성화 여부';

--- a/nextup-infrastructure/src/main/resources/db/migration/V009__create_team_recruitments_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V009__create_team_recruitments_table.sql
@@ -1,0 +1,38 @@
+-- 팀 모집 공고 테이블
+CREATE TABLE team_recruitments
+(
+    id               BIGSERIAL PRIMARY KEY,
+    team_id          BIGINT       NOT NULL REFERENCES teams (id) ON DELETE CASCADE,
+    title            VARCHAR(200) NOT NULL,
+    description      TEXT         NOT NULL,
+    positions_needed VARCHAR(255) NOT NULL,
+    age_range        VARCHAR(50),
+    skill_level      VARCHAR(50),
+    location         VARCHAR(255),
+    deadline         DATE         NOT NULL,
+    status           VARCHAR(20)  NOT NULL DEFAULT 'OPEN',
+    created_at       TIMESTAMP    NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMP    NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_recruitment_status CHECK (status IN ('OPEN', 'CLOSED', 'EXPIRED'))
+);
+
+-- 인덱스 생성
+CREATE INDEX idx_team_recruitments_team_id ON team_recruitments (team_id);
+CREATE INDEX idx_team_recruitments_status ON team_recruitments (status);
+CREATE INDEX idx_team_recruitments_deadline ON team_recruitments (deadline);
+CREATE INDEX idx_team_recruitments_team_status ON team_recruitments (team_id, status);
+
+-- 테이블 코멘트
+COMMENT ON TABLE team_recruitments IS '팀 선수 모집 공고';
+COMMENT ON COLUMN team_recruitments.id IS '모집 공고 ID';
+COMMENT ON COLUMN team_recruitments.team_id IS '팀 ID';
+COMMENT ON COLUMN team_recruitments.title IS '모집 공고 제목';
+COMMENT ON COLUMN team_recruitments.description IS '모집 공고 상세 설명';
+COMMENT ON COLUMN team_recruitments.positions_needed IS '모집 포지션 (쉼표로 구분)';
+COMMENT ON COLUMN team_recruitments.age_range IS '나이 범위 (예: 20-35)';
+COMMENT ON COLUMN team_recruitments.skill_level IS '실력 수준 (예: 초급, 중급, 고급)';
+COMMENT ON COLUMN team_recruitments.location IS '활동 지역';
+COMMENT ON COLUMN team_recruitments.deadline IS '모집 마감일';
+COMMENT ON COLUMN team_recruitments.status IS '모집 상태 (OPEN, CLOSED, EXPIRED)';
+COMMENT ON COLUMN team_recruitments.created_at IS '생성 일시';
+COMMENT ON COLUMN team_recruitments.updated_at IS '수정 일시';

--- a/nextup-infrastructure/src/main/resources/db/migration/V010__create_match_request_tables.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V010__create_match_request_tables.sql
@@ -1,0 +1,37 @@
+-- 매칭 요청 테이블
+CREATE TABLE match_requests (
+    id BIGSERIAL PRIMARY KEY,
+    team_id BIGINT NOT NULL,
+    preferred_date DATE NOT NULL,
+    preferred_time VARCHAR(50),
+    preferred_location VARCHAR(500),
+    message TEXT,
+    skill_level VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_match_requests_team FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE
+);
+
+-- 매칭 응답 테이블
+CREATE TABLE match_responses (
+    id BIGSERIAL PRIMARY KEY,
+    match_request_id BIGINT NOT NULL,
+    respond_team_id BIGINT NOT NULL,
+    message TEXT,
+    status VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_match_responses_match_request FOREIGN KEY (match_request_id) REFERENCES match_requests(id) ON DELETE CASCADE,
+    CONSTRAINT fk_match_responses_respond_team FOREIGN KEY (respond_team_id) REFERENCES teams(id) ON DELETE CASCADE
+);
+
+-- 인덱스 생성
+CREATE INDEX idx_match_requests_team_id ON match_requests(team_id);
+CREATE INDEX idx_match_requests_status ON match_requests(status);
+CREATE INDEX idx_match_requests_preferred_date ON match_requests(preferred_date);
+CREATE INDEX idx_match_requests_skill_level ON match_requests(skill_level);
+
+CREATE INDEX idx_match_responses_match_request_id ON match_responses(match_request_id);
+CREATE INDEX idx_match_responses_respond_team_id ON match_responses(respond_team_id);
+CREATE INDEX idx_match_responses_status ON match_responses(status);

--- a/nextup-infrastructure/src/main/resources/db/migration/V011__create_election_tables.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V011__create_election_tables.sql
@@ -1,0 +1,76 @@
+-- 선거 테이블
+CREATE TABLE elections
+(
+    id            BIGSERIAL PRIMARY KEY,
+    team_id       BIGINT                   NOT NULL,
+    title         VARCHAR(200)             NOT NULL,
+    description   VARCHAR(1000),
+    election_type VARCHAR(50)              NOT NULL,
+    start_at      TIMESTAMP WITH TIME ZONE NOT NULL,
+    end_at        TIMESTAMP WITH TIME ZONE NOT NULL,
+    status        VARCHAR(50)              NOT NULL DEFAULT 'SCHEDULED',
+    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_elections_team ON elections (team_id);
+CREATE INDEX idx_elections_status ON elections (status);
+CREATE INDEX idx_elections_start_at ON elections (start_at);
+CREATE INDEX idx_elections_end_at ON elections (end_at);
+
+COMMENT ON TABLE elections IS '팀 내 선거/투표';
+COMMENT ON COLUMN elections.id IS '선거 ID';
+COMMENT ON COLUMN elections.team_id IS '팀 ID';
+COMMENT ON COLUMN elections.title IS '선거 제목';
+COMMENT ON COLUMN elections.description IS '선거 설명';
+COMMENT ON COLUMN elections.election_type IS '선거 유형 (OWNER_ELECTION, CAPTAIN_ELECTION, GENERAL)';
+COMMENT ON COLUMN elections.start_at IS '시작 시간';
+COMMENT ON COLUMN elections.end_at IS '종료 시간';
+COMMENT ON COLUMN elections.status IS '선거 상태 (SCHEDULED, IN_PROGRESS, COMPLETED, CANCELLED)';
+
+-- 후보자 테이블
+CREATE TABLE candidates
+(
+    id          BIGSERIAL PRIMARY KEY,
+    election_id BIGINT                   NOT NULL,
+    member_id   BIGINT                   NOT NULL,
+    member_name VARCHAR(100)             NOT NULL,
+    statement   VARCHAR(1000),
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_candidates_election_member UNIQUE (election_id, member_id)
+);
+
+CREATE INDEX idx_candidates_election ON candidates (election_id);
+CREATE INDEX idx_candidates_member ON candidates (member_id);
+
+COMMENT ON TABLE candidates IS '선거 후보자';
+COMMENT ON COLUMN candidates.id IS '후보자 ID';
+COMMENT ON COLUMN candidates.election_id IS '선거 ID';
+COMMENT ON COLUMN candidates.member_id IS '회원 ID';
+COMMENT ON COLUMN candidates.member_name IS '회원 이름';
+COMMENT ON COLUMN candidates.statement IS '공약/소견';
+
+-- 투표 테이블
+CREATE TABLE election_votes
+(
+    id           BIGSERIAL PRIMARY KEY,
+    election_id  BIGINT                   NOT NULL,
+    voter_id     BIGINT                   NOT NULL,
+    candidate_id BIGINT                   NOT NULL,
+    voted_at     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_election_votes_election_voter UNIQUE (election_id, voter_id)
+);
+
+CREATE INDEX idx_election_votes_election ON election_votes (election_id);
+CREATE INDEX idx_election_votes_candidate ON election_votes (candidate_id);
+CREATE INDEX idx_election_votes_voter ON election_votes (voter_id);
+
+COMMENT ON TABLE election_votes IS '선거 투표 기록';
+COMMENT ON COLUMN election_votes.id IS '투표 ID';
+COMMENT ON COLUMN election_votes.election_id IS '선거 ID';
+COMMENT ON COLUMN election_votes.voter_id IS '투표자 ID';
+COMMENT ON COLUMN election_votes.candidate_id IS '후보자 ID';
+COMMENT ON COLUMN election_votes.voted_at IS '투표 시간';

--- a/nextup-infrastructure/src/main/resources/db/migration/V012__create_stadium_tables.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V012__create_stadium_tables.sql
@@ -1,0 +1,55 @@
+-- 구장 테이블
+CREATE TABLE stadiums (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    address VARCHAR(255) NOT NULL,
+    latitude DOUBLE PRECISION NOT NULL,
+    longitude DOUBLE PRECISION NOT NULL,
+    capacity INTEGER,
+    facilities VARCHAR(500),
+    contact_info VARCHAR(255),
+    image_urls VARCHAR(1000),
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 구장 인덱스
+CREATE INDEX idx_stadiums_is_active ON stadiums(is_active);
+CREATE INDEX idx_stadiums_location ON stadiums(latitude, longitude);
+
+-- 구장 슬롯 테이블
+CREATE TABLE stadium_slots (
+    id BIGSERIAL PRIMARY KEY,
+    stadium_id BIGINT NOT NULL REFERENCES stadiums(id),
+    date DATE NOT NULL,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    price DECIMAL(10, 2),
+    status VARCHAR(20) NOT NULL DEFAULT 'AVAILABLE',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_slot_status CHECK (status IN ('AVAILABLE', 'BOOKED', 'MAINTENANCE'))
+);
+
+-- 구장 슬롯 인덱스
+CREATE INDEX idx_stadium_slots_stadium_date ON stadium_slots(stadium_id, date);
+CREATE INDEX idx_stadium_slots_status ON stadium_slots(status);
+
+-- 구장 예약 테이블
+CREATE TABLE stadium_bookings (
+    id BIGSERIAL PRIMARY KEY,
+    slot_id BIGINT NOT NULL REFERENCES stadium_slots(id),
+    team_id BIGINT NOT NULL,
+    booked_by BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'CONFIRMED',
+    booked_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_booking_status CHECK (status IN ('CONFIRMED', 'CANCELLED', 'COMPLETED'))
+);
+
+-- 구장 예약 인덱스
+CREATE INDEX idx_stadium_bookings_slot ON stadium_bookings(slot_id);
+CREATE INDEX idx_stadium_bookings_team ON stadium_bookings(team_id);
+CREATE INDEX idx_stadium_bookings_status ON stadium_bookings(status);

--- a/nextup-infrastructure/src/main/resources/db/migration/V013__create_bracket_entries.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V013__create_bracket_entries.sql
@@ -1,0 +1,16 @@
+CREATE TABLE bracket_entries (
+    id BIGSERIAL PRIMARY KEY,
+    competition_id BIGINT NOT NULL REFERENCES competitions(id),
+    round_number INT NOT NULL,
+    match_number INT NOT NULL,
+    team1_id BIGINT REFERENCES teams(id),
+    team2_id BIGINT REFERENCES teams(id),
+    winner_id BIGINT REFERENCES teams(id),
+    bracket_type VARCHAR(20) NOT NULL DEFAULT 'WINNERS',
+    seed1 INT,
+    seed2 INT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_bracket_entries_competition ON bracket_entries(competition_id);

--- a/nextup-infrastructure/src/main/resources/db/migration/V014__create_pitch_events_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V014__create_pitch_events_table.sql
@@ -1,0 +1,42 @@
+-- 투구 이벤트 테이블 생성
+CREATE TABLE pitch_events
+(
+    id              BIGSERIAL PRIMARY KEY,
+    game_id         BIGINT       NOT NULL,
+    pitcher_id      BIGINT       NOT NULL,
+    batter_id       BIGINT       NOT NULL,
+    inning          INTEGER      NOT NULL CHECK (inning >= 1),
+    is_top_inning   BOOLEAN      NOT NULL,
+    pitch_number    INTEGER      NOT NULL CHECK (pitch_number >= 1),
+    result          VARCHAR(20)  NOT NULL,
+    ball_count      INTEGER      NOT NULL CHECK (ball_count >= 0 AND ball_count <= 4),
+    strike_count    INTEGER      NOT NULL CHECK (strike_count >= 0 AND strike_count <= 3),
+    description     VARCHAR(500),
+    created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_pitch_events_game FOREIGN KEY (game_id) REFERENCES games (id) ON DELETE CASCADE,
+    CONSTRAINT fk_pitch_events_pitcher FOREIGN KEY (pitcher_id) REFERENCES game_players (id) ON DELETE CASCADE,
+    CONSTRAINT fk_pitch_events_batter FOREIGN KEY (batter_id) REFERENCES game_players (id) ON DELETE CASCADE
+);
+
+-- 인덱스 생성
+CREATE INDEX idx_pitch_events_game ON pitch_events (game_id);
+CREATE INDEX idx_pitch_events_game_inning ON pitch_events (game_id, inning, is_top_inning);
+CREATE INDEX idx_pitch_events_pitcher ON pitch_events (pitcher_id);
+CREATE INDEX idx_pitch_events_batter ON pitch_events (batter_id);
+CREATE INDEX idx_pitch_events_game_pitch_number ON pitch_events (game_id, pitch_number);
+
+-- 코멘트 추가
+COMMENT ON TABLE pitch_events IS '투구 이벤트 테이블 - 경기 중 발생하는 개별 투구를 기록';
+COMMENT ON COLUMN pitch_events.id IS '투구 이벤트 ID';
+COMMENT ON COLUMN pitch_events.game_id IS '경기 ID';
+COMMENT ON COLUMN pitch_events.pitcher_id IS '투수 ID (game_players)';
+COMMENT ON COLUMN pitch_events.batter_id IS '타자 ID (game_players)';
+COMMENT ON COLUMN pitch_events.inning IS '이닝';
+COMMENT ON COLUMN pitch_events.is_top_inning IS '초/말 여부 (true: 초, false: 말)';
+COMMENT ON COLUMN pitch_events.pitch_number IS '투구 번호 (경기 내 순서)';
+COMMENT ON COLUMN pitch_events.result IS '투구 결과 (BALL, STRIKE, FOUL, SWING_MISS, IN_PLAY)';
+COMMENT ON COLUMN pitch_events.ball_count IS '투구 후 볼카운트 (0-4)';
+COMMENT ON COLUMN pitch_events.strike_count IS '투구 후 스트라이크 카운트 (0-3)';
+COMMENT ON COLUMN pitch_events.description IS '투구 설명 (선택)';

--- a/nextup-infrastructure/src/main/resources/db/migration/V015__create_certificates_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V015__create_certificates_table.sql
@@ -1,0 +1,35 @@
+-- V015: Create certificates table
+-- Description: 기록 증명서 관리 시스템
+
+-- ===========================================================================
+-- certificates 테이블
+-- ===========================================================================
+CREATE TABLE certificates (
+    id BIGSERIAL PRIMARY KEY,
+    issue_number VARCHAR(36) NOT NULL UNIQUE,
+    player_id BIGINT NOT NULL,
+    issued_at TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'VALID',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    -- Foreign Keys
+    CONSTRAINT fk_cert_player FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE,
+
+    -- Constraints
+    CONSTRAINT chk_cert_status CHECK (status IN ('VALID', 'EXPIRED', 'REVOKED'))
+);
+
+-- Indexes for performance
+CREATE UNIQUE INDEX idx_cert_issue_number ON certificates(issue_number);
+CREATE INDEX idx_cert_player_id ON certificates(player_id);
+CREATE INDEX idx_cert_status ON certificates(status);
+CREATE INDEX idx_cert_expires_at ON certificates(expires_at);
+CREATE INDEX idx_cert_player_status ON certificates(player_id, status);
+
+COMMENT ON TABLE certificates IS '기록 증명서 - 선수의 경기 기록을 증명하는 공식 문서';
+COMMENT ON COLUMN certificates.issue_number IS '발급 번호 (UUID)';
+COMMENT ON COLUMN certificates.status IS 'VALID(유효), EXPIRED(만료), REVOKED(취소)';
+COMMENT ON COLUMN certificates.issued_at IS '발급 일시';
+COMMENT ON COLUMN certificates.expires_at IS '만료 일시';

--- a/nextup-infrastructure/src/main/resources/db/migration/V016__create_attendance_tables.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V016__create_attendance_tables.sql
@@ -1,0 +1,75 @@
+-- V016: 출석 투표 및 활동 점수 테이블 생성
+
+-- 출석 투표 테이블
+CREATE TABLE attendance_polls
+(
+    id         BIGSERIAL PRIMARY KEY,
+    team_id    BIGINT                   NOT NULL,
+    title      VARCHAR(200)             NOT NULL,
+    event_date TIMESTAMP                NOT NULL,
+    deadline   TIMESTAMP                NOT NULL,
+    status     VARCHAR(20)              NOT NULL DEFAULT 'OPEN',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_attendance_polls_team FOREIGN KEY (team_id) REFERENCES teams (id) ON DELETE CASCADE,
+    CONSTRAINT chk_attendance_polls_status CHECK (status IN ('OPEN', 'CLOSED'))
+);
+
+-- 출석 투표 인덱스
+CREATE INDEX idx_ap_team_id ON attendance_polls (team_id);
+CREATE INDEX idx_ap_status ON attendance_polls (status);
+CREATE INDEX idx_ap_event_date ON attendance_polls (event_date);
+
+-- 출석 투표 응답 테이블
+CREATE TABLE poll_votes
+(
+    id         BIGSERIAL PRIMARY KEY,
+    poll_id    BIGINT                   NOT NULL,
+    player_id  BIGINT                   NOT NULL,
+    vote_type  VARCHAR(20)              NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_poll_votes_poll FOREIGN KEY (poll_id) REFERENCES attendance_polls (id) ON DELETE CASCADE,
+    CONSTRAINT fk_poll_votes_player FOREIGN KEY (player_id) REFERENCES players (id) ON DELETE CASCADE,
+    CONSTRAINT uk_pv_poll_player UNIQUE (poll_id, player_id),
+    CONSTRAINT chk_poll_votes_type CHECK (vote_type IN ('ATTEND', 'ABSENT', 'UNDECIDED'))
+);
+
+-- 출석 투표 응답 인덱스
+CREATE INDEX idx_pv_poll_id ON poll_votes (poll_id);
+CREATE INDEX idx_pv_player_id ON poll_votes (player_id);
+CREATE INDEX idx_pv_vote_type ON poll_votes (vote_type);
+
+-- 활동 점수 테이블
+CREATE TABLE activity_scores
+(
+    id                        BIGSERIAL PRIMARY KEY,
+    team_id                   BIGINT                   NOT NULL,
+    member_id                 BIGINT                   NOT NULL,
+    game_participation_rate   DECIMAL(5, 2)            NOT NULL DEFAULT 0.00,
+    practice_attendance_rate  DECIMAL(5, 2)            NOT NULL DEFAULT 0.00,
+    contribution_score        DECIMAL(5, 2)            NOT NULL DEFAULT 0.00,
+    created_at                TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at                TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_activity_scores_team FOREIGN KEY (team_id) REFERENCES teams (id) ON DELETE CASCADE,
+    CONSTRAINT fk_activity_scores_member FOREIGN KEY (member_id) REFERENCES team_members (id) ON DELETE CASCADE,
+    CONSTRAINT uk_as_team_member UNIQUE (team_id, member_id),
+    CONSTRAINT chk_activity_scores_game_rate CHECK (game_participation_rate >= 0.00 AND game_participation_rate <= 100.00),
+    CONSTRAINT chk_activity_scores_practice_rate CHECK (practice_attendance_rate >= 0.00 AND practice_attendance_rate <= 100.00),
+    CONSTRAINT chk_activity_scores_contribution CHECK (contribution_score >= 0.00 AND contribution_score <= 100.00)
+);
+
+-- 활동 점수 인덱스
+CREATE INDEX idx_as_team_id ON activity_scores (team_id);
+CREATE INDEX idx_as_member_id ON activity_scores (member_id);
+
+-- 코멘트 추가
+COMMENT ON TABLE attendance_polls IS '팀 이벤트 출석 투표';
+COMMENT ON TABLE poll_votes IS '출석 투표 응답';
+COMMENT ON TABLE activity_scores IS '팀원 활동 점수';
+
+COMMENT ON COLUMN attendance_polls.status IS '투표 상태: OPEN(진행중), CLOSED(마감)';
+COMMENT ON COLUMN poll_votes.vote_type IS '투표 유형: ATTEND(참석), ABSENT(불참), UNDECIDED(미정)';
+COMMENT ON COLUMN activity_scores.game_participation_rate IS '경기 참여율 (0~100)';
+COMMENT ON COLUMN activity_scores.practice_attendance_rate IS '연습 참석률 (0~100)';
+COMMENT ON COLUMN activity_scores.contribution_score IS '기여도 점수 (0~100)';

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/PitchEventServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/PitchEventServiceImplTest.kt
@@ -1,0 +1,419 @@
+package com.nextup.infrastructure.service
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.common.exception.PitchEventNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.*
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchEventRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class PitchEventServiceImplTest {
+    private lateinit var pitchEventRepository: PitchEventRepositoryPort
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var pitchEventService: PitchEventServiceImpl
+
+    private lateinit var game: Game
+    private lateinit var pitcher: GamePlayer
+    private lateinit var batter: GamePlayer
+
+    @BeforeEach
+    fun setUp() {
+        pitchEventRepository = mockk()
+        gameRepository = mockk()
+        gamePlayerRepository = mockk()
+        pitchEventService =
+            PitchEventServiceImpl(
+                pitchEventRepository,
+                gameRepository,
+                gamePlayerRepository,
+            )
+
+        // Test fixtures
+        game = createGame()
+        pitcher = createPitcher(game)
+        batter = createBatter(game)
+    }
+
+    @Test
+    fun `투구를 기록할 수 있다`() {
+        // given
+        val gameId = 1L
+        val pitcherId = 2L
+        val batterId = 3L
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { gamePlayerRepository.findByIdOrNull(pitcherId) } returns pitcher
+        every { gamePlayerRepository.findByIdOrNull(batterId) } returns batter
+        every { pitchEventRepository.getNextPitchNumber(gameId) } returns 1
+        every { pitchEventRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result =
+            pitchEventService.recordPitch(
+                gameId = gameId,
+                pitcherId = pitcherId,
+                batterId = batterId,
+                result = PitchResult.STRIKE,
+                description = "스트라이크",
+            )
+
+        // then
+        assertThat(result.result).isEqualTo(PitchResult.STRIKE)
+        assertThat(result.ballCount).isEqualTo(0)
+        assertThat(result.strikeCount).isEqualTo(1)
+        verify { pitchEventRepository.save(any()) }
+    }
+
+    @Test
+    fun `경기가 진행 중이 아니면 투구를 기록할 수 없다`() {
+        // given
+        val gameId = 1L
+        val finishedGame = createGame().apply { status = GameStatus.FINISHED }
+
+        every { gameRepository.findByIdOrNull(gameId) } returns finishedGame
+
+        // when & then
+        assertThrows<InvalidGameStateException> {
+            pitchEventService.recordPitch(
+                gameId = gameId,
+                pitcherId = 2L,
+                batterId = 3L,
+                result = PitchResult.STRIKE,
+            )
+        }
+    }
+
+    @Test
+    fun `존재하지 않는 경기에 투구를 기록할 수 없다`() {
+        // given
+        val gameId = 999L
+        every { gameRepository.findByIdOrNull(gameId) } returns null
+
+        // when & then
+        assertThrows<GameNotFoundException> {
+            pitchEventService.recordPitch(
+                gameId = gameId,
+                pitcherId = 2L,
+                batterId = 3L,
+                result = PitchResult.STRIKE,
+            )
+        }
+    }
+
+    @Test
+    fun `존재하지 않는 투수로 투구를 기록할 수 없다`() {
+        // given
+        val gameId = 1L
+        val pitcherId = 999L
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { gamePlayerRepository.findByIdOrNull(pitcherId) } returns null
+
+        // when & then
+        assertThrows<GamePlayerNotFoundException> {
+            pitchEventService.recordPitch(
+                gameId = gameId,
+                pitcherId = pitcherId,
+                batterId = 3L,
+                result = PitchResult.STRIKE,
+            )
+        }
+    }
+
+    @Test
+    fun `볼 투구 시 볼카운트가 증가한다`() {
+        // given
+        val gameId = 1L
+        val pitcherId = 2L
+        val batterId = 3L
+
+        game.gameState.balls = 2
+        game.gameState.strikes = 1
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { gamePlayerRepository.findByIdOrNull(pitcherId) } returns pitcher
+        every { gamePlayerRepository.findByIdOrNull(batterId) } returns batter
+        every { pitchEventRepository.getNextPitchNumber(gameId) } returns 1
+        every { pitchEventRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result =
+            pitchEventService.recordPitch(
+                gameId = gameId,
+                pitcherId = pitcherId,
+                batterId = batterId,
+                result = PitchResult.BALL,
+            )
+
+        // then
+        assertThat(result.ballCount).isEqualTo(3)
+        assertThat(result.strikeCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `스트라이크 투구 시 스트라이크 카운트가 증가한다`() {
+        // given
+        val gameId = 1L
+        val pitcherId = 2L
+        val batterId = 3L
+
+        game.gameState.balls = 1
+        game.gameState.strikes = 1
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { gamePlayerRepository.findByIdOrNull(pitcherId) } returns pitcher
+        every { gamePlayerRepository.findByIdOrNull(batterId) } returns batter
+        every { pitchEventRepository.getNextPitchNumber(gameId) } returns 1
+        every { pitchEventRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result =
+            pitchEventService.recordPitch(
+                gameId = gameId,
+                pitcherId = pitcherId,
+                batterId = batterId,
+                result = PitchResult.STRIKE,
+            )
+
+        // then
+        assertThat(result.ballCount).isEqualTo(1)
+        assertThat(result.strikeCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `파울은 2스트라이크 미만에서만 카운트가 증가한다`() {
+        // given
+        val gameId = 1L
+        val pitcherId = 2L
+        val batterId = 3L
+
+        // Case 1: 1스트라이크 상태에서 파울
+        game.gameState.balls = 1
+        game.gameState.strikes = 1
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { gamePlayerRepository.findByIdOrNull(pitcherId) } returns pitcher
+        every { gamePlayerRepository.findByIdOrNull(batterId) } returns batter
+        every { pitchEventRepository.getNextPitchNumber(gameId) } returns 1
+        every { pitchEventRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result1 =
+            pitchEventService.recordPitch(
+                gameId = gameId,
+                pitcherId = pitcherId,
+                batterId = batterId,
+                result = PitchResult.FOUL,
+            )
+
+        // then
+        assertThat(result1.strikeCount).isEqualTo(2)
+
+        // Case 2: 2스트라이크 상태에서 파울
+        game.gameState.balls = 1
+        game.gameState.strikes = 2
+
+        every { pitchEventRepository.getNextPitchNumber(gameId) } returns 2
+        every { pitchEventRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result2 =
+            pitchEventService.recordPitch(
+                gameId = gameId,
+                pitcherId = pitcherId,
+                batterId = batterId,
+                result = PitchResult.FOUL,
+            )
+
+        // then
+        assertThat(result2.strikeCount).isEqualTo(2) // 증가하지 않음
+    }
+
+    @Test
+    fun `투구 이벤트를 조회할 수 있다`() {
+        // given
+        val pitchEventId = 1L
+        val pitchEvent = createPitchEvent()
+
+        every { pitchEventRepository.findByIdOrNull(pitchEventId) } returns pitchEvent
+
+        // when
+        val result = pitchEventService.getPitchEvent(pitchEventId)
+
+        // then
+        assertThat(result).isEqualTo(pitchEvent)
+    }
+
+    @Test
+    fun `존재하지 않는 투구 이벤트를 조회하면 예외가 발생한다`() {
+        // given
+        val pitchEventId = 999L
+        every { pitchEventRepository.findByIdOrNull(pitchEventId) } returns null
+
+        // when & then
+        assertThrows<PitchEventNotFoundException> {
+            pitchEventService.getPitchEvent(pitchEventId)
+        }
+    }
+
+    @Test
+    fun `경기의 투구 이벤트 목록을 조회할 수 있다`() {
+        // given
+        val gameId = 1L
+        val pitchEvents = listOf(createPitchEvent(), createPitchEvent())
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+        every { pitchEventRepository.findByGameId(gameId) } returns pitchEvents
+
+        // when
+        val result = pitchEventService.getGamePitchEvents(gameId)
+
+        // then
+        assertThat(result).hasSize(2)
+    }
+
+    @Test
+    fun `현재 볼카운트를 조회할 수 있다`() {
+        // given
+        val gameId = 1L
+        game.gameState.balls = 2
+        game.gameState.strikes = 1
+
+        every { gameRepository.findByIdOrNull(gameId) } returns game
+
+        // when
+        val (balls, strikes) = pitchEventService.getCurrentBallCount(gameId)
+
+        // then
+        assertThat(balls).isEqualTo(2)
+        assertThat(strikes).isEqualTo(1)
+    }
+
+    @Test
+    fun `투수의 투구 통계를 계산할 수 있다`() {
+        // given
+        val pitcherId = 2L
+        val pitchEvents =
+            listOf(
+                createPitchEvent(result = PitchResult.STRIKE),
+                createPitchEvent(result = PitchResult.BALL),
+                createPitchEvent(result = PitchResult.FOUL),
+                createPitchEvent(result = PitchResult.SWING_MISS),
+                createPitchEvent(result = PitchResult.IN_PLAY),
+            )
+
+        every { gamePlayerRepository.findByIdOrNull(pitcherId) } returns pitcher
+        every { pitchEventRepository.findByPitcherId(pitcherId) } returns pitchEvents
+
+        // when
+        val stats = pitchEventService.calculatePitcherStats(pitcherId)
+
+        // then
+        assertThat(stats.totalPitches).isEqualTo(5)
+        assertThat(stats.strikes).isEqualTo(2) // STRIKE + SWING_MISS
+        assertThat(stats.balls).isEqualTo(1)
+        assertThat(stats.fouls).isEqualTo(1)
+        assertThat(stats.inPlayPitches).isEqualTo(1)
+        assertThat(stats.strikePercentage).isEqualTo(60.0) // (2 + 1) / 5 * 100
+    }
+
+    // Helper methods
+    private fun createGame(): Game {
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
+        val competition =
+            Competition(
+                league = league,
+                name = "테스트 대회",
+                year = 2024,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2024, 3, 1),
+                id = 1L,
+            )
+
+        return Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2024, 6, 1, 14, 0),
+            status = GameStatus.IN_PROGRESS,
+            currentInning = 1,
+            id = 1L,
+        )
+    }
+
+    private fun createHomeTeam(game: Game): GameTeam {
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
+        val team = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        return GameTeam(game = game, team = team, homeAway = HomeAway.HOME, id = 1L)
+    }
+
+    private fun createAwayTeam(game: Game): GameTeam {
+        val association = Association(name = "테스트 협회", id = 2L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 2L)
+        val team = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        return GameTeam(game = game, team = team, homeAway = HomeAway.AWAY, id = 2L)
+    }
+
+    private fun createPitcher(game: Game): GamePlayer {
+        val awayTeam = createAwayTeam(game)
+        val player =
+            Player(
+                name = "투수",
+                birthDate = LocalDate.of(1995, 1, 1),
+                primaryPosition = Position.STARTING_PITCHER,
+            )
+        return GamePlayer(
+            gameTeam = awayTeam,
+            player = player,
+            position = Position.STARTING_PITCHER,
+            battingOrder = null,
+        )
+    }
+
+    private fun createBatter(game: Game): GamePlayer {
+        val homeTeam = createHomeTeam(game)
+        val player =
+            Player(
+                name = "타자",
+                birthDate = LocalDate.of(1995, 1, 1),
+                primaryPosition = Position.FIRST_BASE,
+            )
+        return GamePlayer(
+            gameTeam = homeTeam,
+            player = player,
+            position = Position.FIRST_BASE,
+            battingOrder = 1,
+        )
+    }
+
+    private fun createPitchEvent(result: PitchResult = PitchResult.STRIKE): PitchEvent =
+        PitchEvent.create(
+            game = game,
+            pitcher = pitcher,
+            batter = batter,
+            pitchNumber = 1,
+            result = result,
+            ballCount = 0,
+            strikeCount = 1,
+        )
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/attendance/ActivityServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/attendance/ActivityServiceImplTest.kt
@@ -1,0 +1,206 @@
+package com.nextup.infrastructure.service.attendance
+
+import com.nextup.common.exception.TeamMemberNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.attendance.ActivityScore
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.user.User
+import com.nextup.core.port.attendance.ActivityScoreRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+
+@DisplayName("ActivityServiceImpl")
+class ActivityServiceImplTest {
+    private lateinit var activityScoreRepository: ActivityScoreRepositoryPort
+    private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
+    private lateinit var activityService: ActivityServiceImpl
+
+    private lateinit var team: Team
+    private lateinit var member: TeamMember
+    private lateinit var activityScore: ActivityScore
+
+    @BeforeEach
+    fun setUp() {
+        activityScoreRepository = mockk()
+        teamRepository = mockk()
+        teamMemberRepository = mockk()
+        activityService =
+            ActivityServiceImpl(
+                activityScoreRepository,
+                teamRepository,
+                teamMemberRepository,
+            )
+
+        val association = Association(name = "테스트협회", region = "서울")
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2024)
+        team = Team(league = league, name = "테스트 팀", city = "서울", foundedYear = 2024)
+        val user = User.createLocalUser(email = "test@test.com", encodedPassword = "encoded123", nickname = "테스트")
+        val player = Player(name = "홍길동", primaryPosition = Position.STARTING_PITCHER)
+        member = TeamMember.create(team = team, user = user, player = player, uniformNumber = 10)
+        activityScore = ActivityScore.create(team = team, member = member)
+    }
+
+    @Nested
+    @DisplayName("getActivityScore")
+    inner class GetActivityScore {
+        @Test
+        fun `활동 점수를 조회할 수 있다`() {
+            // given
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamMemberRepository.findByIdOrNull(1L) } returns member
+            every { activityScoreRepository.findByTeamIdAndMemberId(1L, 1L) } returns activityScore
+
+            // when
+            val result = activityService.getActivityScore(1L, 1L)
+
+            // then
+            assertThat(result).isNotNull
+            assertThat(result.team).isEqualTo(team)
+            assertThat(result.member).isEqualTo(member)
+        }
+
+        @Test
+        fun `활동 점수가 없으면 새로 생성한다`() {
+            // given
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamMemberRepository.findByIdOrNull(1L) } returns member
+            every { activityScoreRepository.findByTeamIdAndMemberId(1L, 1L) } returns null
+            every { activityScoreRepository.save(any()) } returnsArgument 0
+
+            // when
+            val result = activityService.getActivityScore(1L, 1L)
+
+            // then
+            assertThat(result).isNotNull
+            verify { activityScoreRepository.save(any()) }
+        }
+
+        @Test
+        fun `팀이 존재하지 않으면 TeamNotFoundException 발생`() {
+            // given
+            every { teamRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                activityService.getActivityScore(999L, 1L)
+            }
+        }
+
+        @Test
+        fun `멤버가 존재하지 않으면 TeamMemberNotFoundException 발생`() {
+            // given
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamMemberRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThrows<TeamMemberNotFoundException> {
+                activityService.getActivityScore(1L, 999L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateGameParticipationRate")
+    inner class UpdateGameParticipationRate {
+        @Test
+        fun `경기 참여율을 업데이트할 수 있다`() {
+            // given
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamMemberRepository.findByIdOrNull(1L) } returns member
+            every { activityScoreRepository.findByTeamIdAndMemberId(1L, 1L) } returns activityScore
+            every { activityScoreRepository.save(any()) } returnsArgument 0
+
+            // when
+            val result = activityService.updateGameParticipationRate(1L, 1L, BigDecimal("85.50"))
+
+            // then
+            assertThat(result.gameParticipationRate).isEqualByComparingTo(BigDecimal("85.50"))
+            verify { activityScoreRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("updatePracticeAttendanceRate")
+    inner class UpdatePracticeAttendanceRate {
+        @Test
+        fun `연습 참석률을 업데이트할 수 있다`() {
+            // given
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamMemberRepository.findByIdOrNull(1L) } returns member
+            every { activityScoreRepository.findByTeamIdAndMemberId(1L, 1L) } returns activityScore
+            every { activityScoreRepository.save(any()) } returnsArgument 0
+
+            // when
+            val result = activityService.updatePracticeAttendanceRate(1L, 1L, BigDecimal("90.00"))
+
+            // then
+            assertThat(result.practiceAttendanceRate).isEqualByComparingTo(BigDecimal("90.00"))
+            verify { activityScoreRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateContributionScore")
+    inner class UpdateContributionScore {
+        @Test
+        fun `기여도 점수를 업데이트할 수 있다`() {
+            // given
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamMemberRepository.findByIdOrNull(1L) } returns member
+            every { activityScoreRepository.findByTeamIdAndMemberId(1L, 1L) } returns activityScore
+            every { activityScoreRepository.save(any()) } returnsArgument 0
+
+            // when
+            val result = activityService.updateContributionScore(1L, 1L, BigDecimal("75.00"))
+
+            // then
+            assertThat(result.contributionScore).isEqualByComparingTo(BigDecimal("75.00"))
+            verify { activityScoreRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("listActivityScores")
+    inner class ListActivityScores {
+        @Test
+        fun `팀의 모든 활동 점수를 조회할 수 있다`() {
+            // given
+            every { teamRepository.existsById(1L) } returns true
+            every { activityScoreRepository.findByTeamId(1L) } returns listOf(activityScore)
+
+            // when
+            val result = activityService.listActivityScores(1L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].team).isEqualTo(team)
+        }
+
+        @Test
+        fun `팀이 존재하지 않으면 TeamNotFoundException 발생`() {
+            // given
+            every { teamRepository.existsById(999L) } returns false
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                activityService.listActivityScores(999L)
+            }
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/attendance/AttendanceServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/attendance/AttendanceServiceImplTest.kt
@@ -1,0 +1,285 @@
+package com.nextup.infrastructure.service.attendance
+
+import com.nextup.common.exception.AttendancePollClosedException
+import com.nextup.common.exception.AttendancePollNotFoundException
+import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.attendance.AttendancePoll
+import com.nextup.core.domain.attendance.AttendanceVote
+import com.nextup.core.domain.attendance.PollStatus
+import com.nextup.core.domain.attendance.VoteType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.attendance.AttendancePollRepositoryPort
+import com.nextup.core.port.attendance.AttendanceVoteRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@DisplayName("AttendanceServiceImpl")
+class AttendanceServiceImplTest {
+    private lateinit var attendancePollRepository: AttendancePollRepositoryPort
+    private lateinit var attendanceVoteRepository: AttendanceVoteRepositoryPort
+    private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var playerRepository: PlayerRepositoryPort
+    private lateinit var attendanceService: AttendanceServiceImpl
+
+    private lateinit var team: Team
+    private lateinit var player: Player
+    private lateinit var poll: AttendancePoll
+
+    @BeforeEach
+    fun setUp() {
+        attendancePollRepository = mockk()
+        attendanceVoteRepository = mockk()
+        teamRepository = mockk()
+        playerRepository = mockk()
+        attendanceService =
+            AttendanceServiceImpl(
+                attendancePollRepository,
+                attendanceVoteRepository,
+                teamRepository,
+                playerRepository,
+            )
+
+        val association = Association(name = "테스트협회", region = "서울")
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2024)
+        team = Team(league = league, name = "테스트 팀", city = "서울", foundedYear = 2024)
+        player = Player(name = "홍길동", primaryPosition = Position.STARTING_PITCHER)
+        poll =
+            AttendancePoll.create(
+                team = team,
+                title = "테스트 투표",
+                eventDate = LocalDateTime.now().plusDays(7),
+                deadline = LocalDateTime.now().plusDays(5),
+            )
+    }
+
+    @Nested
+    @DisplayName("createPoll")
+    inner class CreatePoll {
+        @Test
+        fun `출석 투표를 생성할 수 있다`() {
+            // given
+            val eventDate = LocalDateTime.now().plusDays(7)
+            val deadline = LocalDateTime.now().plusDays(5)
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { attendancePollRepository.save(any()) } returnsArgument 0
+
+            // when
+            val result =
+                attendanceService.createPoll(
+                    teamId = 1L,
+                    title = "이번 주 일요일 경기",
+                    eventDate = eventDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                    deadline = deadline.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                )
+
+            // then
+            assertThat(result.title).isEqualTo("이번 주 일요일 경기")
+            assertThat(result.status).isEqualTo(PollStatus.OPEN)
+            verify { attendancePollRepository.save(any()) }
+        }
+
+        @Test
+        fun `팀이 존재하지 않으면 TeamNotFoundException 발생`() {
+            // given
+            val eventDate = LocalDateTime.now().plusDays(7)
+            val deadline = LocalDateTime.now().plusDays(5)
+            every { teamRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                attendanceService.createPoll(
+                    teamId = 999L,
+                    title = "테스트",
+                    eventDate = eventDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                    deadline = deadline.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("submitVote")
+    inner class SubmitVote {
+        @Test
+        fun `출석 투표에 응답할 수 있다`() {
+            // given
+            every { attendancePollRepository.findById(1L) } returns poll
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every { attendanceVoteRepository.findByPollIdAndPlayerId(1L, 1L) } returns null
+            every { attendanceVoteRepository.save(any()) } returnsArgument 0
+
+            // when
+            val result =
+                attendanceService.submitVote(
+                    pollId = 1L,
+                    playerId = 1L,
+                    voteType = VoteType.ATTEND,
+                )
+
+            // then
+            assertThat(result.voteType).isEqualTo(VoteType.ATTEND)
+            verify { attendanceVoteRepository.save(any()) }
+        }
+
+        @Test
+        fun `이미 투표한 경우 투표를 변경할 수 있다`() {
+            // given
+            val existingVote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.UNDECIDED,
+                )
+            every { attendancePollRepository.findById(1L) } returns poll
+            every { playerRepository.findByIdOrNull(1L) } returns player
+            every { attendanceVoteRepository.findByPollIdAndPlayerId(1L, 1L) } returns existingVote
+            every { attendanceVoteRepository.save(any()) } returnsArgument 0
+
+            // when
+            val result =
+                attendanceService.submitVote(
+                    pollId = 1L,
+                    playerId = 1L,
+                    voteType = VoteType.ATTEND,
+                )
+
+            // then
+            assertThat(result.voteType).isEqualTo(VoteType.ATTEND)
+        }
+
+        @Test
+        fun `투표가 마감되면 AttendancePollClosedException 발생`() {
+            // given
+            poll.close()
+            every { attendancePollRepository.findById(1L) } returns poll
+
+            // when & then
+            assertThrows<AttendancePollClosedException> {
+                attendanceService.submitVote(
+                    pollId = 1L,
+                    playerId = 1L,
+                    voteType = VoteType.ATTEND,
+                )
+            }
+        }
+
+        @Test
+        fun `투표가 존재하지 않으면 AttendancePollNotFoundException 발생`() {
+            // given
+            every { attendancePollRepository.findById(999L) } returns null
+
+            // when & then
+            assertThrows<AttendancePollNotFoundException> {
+                attendanceService.submitVote(
+                    pollId = 999L,
+                    playerId = 1L,
+                    voteType = VoteType.ATTEND,
+                )
+            }
+        }
+
+        @Test
+        fun `선수가 존재하지 않으면 PlayerNotFoundException 발생`() {
+            // given
+            every { attendancePollRepository.findById(1L) } returns poll
+            every { playerRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThrows<PlayerNotFoundException> {
+                attendanceService.submitVote(
+                    pollId = 1L,
+                    playerId = 999L,
+                    voteType = VoteType.ATTEND,
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("listPolls")
+    inner class ListPolls {
+        @Test
+        fun `팀의 모든 투표를 조회할 수 있다`() {
+            // given
+            every { teamRepository.existsById(1L) } returns true
+            every { attendancePollRepository.findByTeamId(1L, null) } returns listOf(poll)
+
+            // when
+            val result = attendanceService.listPolls(1L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].title).isEqualTo("테스트 투표")
+        }
+
+        @Test
+        fun `상태별로 투표를 조회할 수 있다`() {
+            // given
+            every { teamRepository.existsById(1L) } returns true
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns listOf(poll)
+
+            // when
+            val result = attendanceService.listPolls(1L, PollStatus.OPEN)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].status).isEqualTo(PollStatus.OPEN)
+        }
+
+        @Test
+        fun `팀이 존재하지 않으면 TeamNotFoundException 발생`() {
+            // given
+            every { teamRepository.existsById(999L) } returns false
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                attendanceService.listPolls(999L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("closePoll")
+    inner class ClosePoll {
+        @Test
+        fun `투표를 마감할 수 있다`() {
+            // given
+            every { attendancePollRepository.findById(1L) } returns poll
+            every { attendancePollRepository.save(any()) } returnsArgument 0
+
+            // when
+            val result = attendanceService.closePoll(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(PollStatus.CLOSED)
+            verify { attendancePollRepository.save(any()) }
+        }
+
+        @Test
+        fun `투표가 존재하지 않으면 AttendancePollNotFoundException 발생`() {
+            // given
+            every { attendancePollRepository.findById(999L) } returns null
+
+            // when & then
+            assertThrows<AttendancePollNotFoundException> {
+                attendanceService.closePoll(999L)
+            }
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/bracket/BracketGeneratorServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/bracket/BracketGeneratorServiceImplTest.kt
@@ -1,0 +1,337 @@
+package com.nextup.infrastructure.service.bracket
+
+import com.nextup.common.exception.BracketEntryNotFoundException
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.BracketEntry
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.BracketEntryRepositoryPort
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+@DisplayName("BracketGeneratorServiceImpl")
+class BracketGeneratorServiceImplTest {
+    private lateinit var bracketEntryRepository: BracketEntryRepositoryPort
+    private lateinit var competitionRepository: CompetitionRepositoryPort
+    private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var bracketGeneratorService: BracketGeneratorServiceImpl
+
+    private lateinit var competition: Competition
+    private lateinit var league: League
+    private lateinit var association: Association
+    private lateinit var teams: List<Team>
+
+    @BeforeEach
+    fun setUp() {
+        bracketEntryRepository = mockk()
+        competitionRepository = mockk()
+        teamRepository = mockk()
+        bracketGeneratorService =
+            BracketGeneratorServiceImpl(
+                bracketEntryRepository,
+                competitionRepository,
+                teamRepository,
+            )
+
+        // Test data setup
+        association = Association(name = "서울시야구협회", id = 1L)
+        league = League(association = association, name = "1부 리그", foundedYear = 2020, id = 1L)
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계 토너먼트",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.TOURNAMENT,
+                startDate = LocalDate.of(2025, 3, 1),
+                id = 1L,
+            )
+
+        teams =
+            listOf(
+                Team(league = league, name = "팀1", city = "서울", foundedYear = 2020, id = 1L),
+                Team(league = league, name = "팀2", city = "서울", foundedYear = 2020, id = 2L),
+                Team(league = league, name = "팀3", city = "서울", foundedYear = 2020, id = 3L),
+                Team(league = league, name = "팀4", city = "서울", foundedYear = 2020, id = 4L),
+            )
+    }
+
+    @Nested
+    @DisplayName("generateSingleElimination")
+    inner class GenerateSingleElimination {
+        @Test
+        fun `대회가 존재하지 않으면 CompetitionNotFoundException 발생`() {
+            // given
+            val competitionId = 999L
+            every { competitionRepository.findByIdOrNull(competitionId) } returns null
+
+            // when & then
+            assertThrows<CompetitionNotFoundException> {
+                bracketGeneratorService.generateSingleElimination(competitionId, listOf(1L, 2L))
+            }
+        }
+
+        @Test
+        fun `팀 목록이 비어있으면 InvalidInputException 발생`() {
+            // given
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+
+            // when & then
+            val exception =
+                assertThrows<InvalidInputException> {
+                    bracketGeneratorService.generateSingleElimination(1L, emptyList())
+                }
+            assertThat(exception.code).isEqualTo("EMPTY_TEAM_LIST")
+        }
+
+        @Test
+        fun `중복된 팀이 있으면 InvalidInputException 발생`() {
+            // given
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+
+            // when & then
+            val exception =
+                assertThrows<InvalidInputException> {
+                    bracketGeneratorService.generateSingleElimination(1L, listOf(1L, 1L, 2L))
+                }
+            assertThat(exception.code).isEqualTo("DUPLICATE_TEAMS")
+        }
+
+        @Test
+        fun `2개 팀으로 단일 토너먼트 생성 시 결승전만 생성`() {
+            // given
+            val teamIds = listOf(1L, 2L)
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { bracketEntryRepository.deleteByCompetitionId(1L) } returns Unit
+            every { teamRepository.findByIdOrNull(1L) } returns teams[0]
+            every { teamRepository.findByIdOrNull(2L) } returns teams[1]
+
+            val savedEntries = mutableListOf<BracketEntry>()
+            every { bracketEntryRepository.saveAll(any<List<BracketEntry>>()) } answers {
+                savedEntries.addAll(firstArg<List<BracketEntry>>())
+                savedEntries
+            }
+
+            // when
+            val result = bracketGeneratorService.generateSingleElimination(1L, teamIds)
+
+            // then
+            verify { bracketEntryRepository.deleteByCompetitionId(1L) }
+            assertThat(result).hasSize(1)
+            assertThat(result[0].roundNumber).isEqualTo(1)
+            assertThat(result[0].team1).isEqualTo(teams[0])
+            assertThat(result[0].team2).isEqualTo(teams[1])
+        }
+
+        @Test
+        fun `4개 팀으로 단일 토너먼트 생성 시 준결승 2경기와 결승전 생성`() {
+            // given
+            val teamIds = listOf(1L, 2L, 3L, 4L)
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { bracketEntryRepository.deleteByCompetitionId(1L) } returns Unit
+            teams.forEachIndexed { index, team ->
+                every { teamRepository.findByIdOrNull(team.id) } returns teams[index]
+            }
+
+            val savedEntries = mutableListOf<BracketEntry>()
+            every { bracketEntryRepository.saveAll(any<List<BracketEntry>>()) } answers {
+                savedEntries.addAll(firstArg<List<BracketEntry>>())
+                savedEntries
+            }
+
+            // when
+            val result = bracketGeneratorService.generateSingleElimination(1L, teamIds)
+
+            // then
+            assertThat(result).hasSize(3) // 준결승 2경기 + 결승 1경기
+
+            // 1라운드 (준결승)
+            val round1 = result.filter { it.roundNumber == 1 }
+            assertThat(round1).hasSize(2)
+
+            // 2라운드 (결승)
+            val round2 = result.filter { it.roundNumber == 2 }
+            assertThat(round2).hasSize(1)
+            assertThat(round2[0].team1).isNull()
+            assertThat(round2[0].team2).isNull()
+        }
+
+        @Test
+        fun `3개 팀으로 단일 토너먼트 생성 시 부전승 포함`() {
+            // given
+            val teamIds = listOf(1L, 2L, 3L)
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { bracketEntryRepository.deleteByCompetitionId(1L) } returns Unit
+            every { teamRepository.findByIdOrNull(1L) } returns teams[0]
+            every { teamRepository.findByIdOrNull(2L) } returns teams[1]
+            every { teamRepository.findByIdOrNull(3L) } returns teams[2]
+
+            val savedEntries = mutableListOf<BracketEntry>()
+            every { bracketEntryRepository.saveAll(any<List<BracketEntry>>()) } answers {
+                savedEntries.addAll(firstArg<List<BracketEntry>>())
+                savedEntries
+            }
+
+            // when
+            val result = bracketGeneratorService.generateSingleElimination(1L, teamIds)
+
+            // then
+            assertThat(result).hasSize(3)
+
+            val round1 = result.filter { it.roundNumber == 1 }
+            val byeMatches = round1.filter { it.team1 == null || it.team2 == null }
+            assertThat(byeMatches).hasSize(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("generateDoubleElimination")
+    inner class GenerateDoubleElimination {
+        @Test
+        fun `4개 팀으로 더블 토너먼트 생성 시 Winners와 Losers 브라켓 모두 생성`() {
+            // given
+            val teamIds = listOf(1L, 2L, 3L, 4L)
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { bracketEntryRepository.deleteByCompetitionId(1L) } returns Unit
+            teams.forEachIndexed { index, team ->
+                every { teamRepository.findByIdOrNull(team.id) } returns teams[index]
+            }
+
+            val savedEntries = mutableListOf<BracketEntry>()
+            every { bracketEntryRepository.saveAll(any<List<BracketEntry>>()) } answers {
+                savedEntries.addAll(firstArg<List<BracketEntry>>())
+                savedEntries
+            }
+
+            // when
+            val result = bracketGeneratorService.generateDoubleElimination(1L, teamIds)
+
+            // then
+            val winnersBracket = result.filter { it.bracketType == "WINNERS" }
+            val losersBracket = result.filter { it.bracketType == "LOSERS" }
+            val finalBracket = result.filter { it.bracketType == "FINAL" }
+
+            assertThat(winnersBracket).isNotEmpty
+            assertThat(losersBracket).isNotEmpty
+            assertThat(finalBracket).hasSize(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("getBracket")
+    inner class GetBracket {
+        @Test
+        fun `대회가 존재하지 않으면 CompetitionNotFoundException 발생`() {
+            // given
+            val competitionId = 999L
+            every { competitionRepository.findByIdOrNull(competitionId) } returns null
+
+            // when & then
+            assertThrows<CompetitionNotFoundException> {
+                bracketGeneratorService.getBracket(competitionId)
+            }
+        }
+
+        @Test
+        fun `대진표를 정상적으로 조회`() {
+            // given
+            val mockEntries =
+                listOf(
+                    BracketEntry(
+                        competition = competition,
+                        roundNumber = 1,
+                        matchNumber = 1,
+                        team1 = teams[0],
+                        team2 = teams[1],
+                        id = 1L,
+                    ),
+                )
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { bracketEntryRepository.findByCompetitionId(1L) } returns mockEntries
+
+            // when
+            val result = bracketGeneratorService.getBracket(1L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].competition).isEqualTo(competition)
+        }
+    }
+
+    @Nested
+    @DisplayName("advanceWinner")
+    inner class AdvanceWinner {
+        @Test
+        fun `대진표 엔트리가 존재하지 않으면 BracketEntryNotFoundException 발생`() {
+            // given
+            val bracketEntryId = 999L
+            every { bracketEntryRepository.findByIdOrNull(bracketEntryId) } returns null
+
+            // when & then
+            assertThrows<BracketEntryNotFoundException> {
+                bracketGeneratorService.advanceWinner(bracketEntryId, 1L)
+            }
+        }
+
+        @Test
+        fun `팀이 존재하지 않으면 InvalidInputException 발생`() {
+            // given
+            val bracketEntry =
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = 1,
+                    team1 = teams[0],
+                    team2 = teams[1],
+                    id = 1L,
+                )
+            every { bracketEntryRepository.findByIdOrNull(1L) } returns bracketEntry
+            every { teamRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            val exception =
+                assertThrows<InvalidInputException> {
+                    bracketGeneratorService.advanceWinner(1L, 999L)
+                }
+            assertThat(exception.code).isEqualTo("TEAM_NOT_FOUND")
+        }
+
+        @Test
+        fun `승자를 정상적으로 기록`() {
+            // given
+            val bracketEntry =
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = 1,
+                    team1 = teams[0],
+                    team2 = teams[1],
+                    id = 1L,
+                )
+            every { bracketEntryRepository.findByIdOrNull(1L) } returns bracketEntry
+            every { teamRepository.findByIdOrNull(1L) } returns teams[0]
+            every { bracketEntryRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = bracketGeneratorService.advanceWinner(1L, 1L)
+
+            // then
+            assertThat(result.winner).isEqualTo(teams[0])
+            verify { bracketEntryRepository.save(any()) }
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/certificate/CertificateServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/certificate/CertificateServiceImplTest.kt
@@ -1,0 +1,211 @@
+package com.nextup.infrastructure.service.certificate
+
+import com.nextup.common.exception.CertificateNotFoundByIssueNumberException
+import com.nextup.common.exception.CertificateNotFoundException
+import com.nextup.core.domain.certificate.Certificate
+import com.nextup.core.domain.certificate.CertificateStatus
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.CertificateRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.service.QrCodeGeneratorPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class CertificateServiceImplTest {
+    private lateinit var certificateRepository: CertificateRepositoryPort
+    private lateinit var playerRepository: PlayerRepositoryPort
+    private lateinit var battingRecordRepository: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var qrCodeGenerator: QrCodeGeneratorPort
+    private lateinit var certificateService: CertificateServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        certificateRepository = mockk()
+        playerRepository = mockk()
+        battingRecordRepository = mockk()
+        pitchingRecordRepository = mockk()
+        gamePlayerRepository = mockk()
+        qrCodeGenerator = mockk()
+
+        certificateService =
+            CertificateServiceImpl(
+                certificateRepository,
+                playerRepository,
+                battingRecordRepository,
+                pitchingRecordRepository,
+                gamePlayerRepository,
+                qrCodeGenerator,
+            )
+    }
+
+    @Test
+    fun `should issue certificate for player`() {
+        // given
+        val playerId = 1L
+        val player = createPlayer(playerId)
+        val certificateSlot = slot<Certificate>()
+
+        every { playerRepository.findByIdOrNull(playerId) } returns player
+        every { certificateRepository.save(capture(certificateSlot)) } answers { certificateSlot.captured }
+        every { gamePlayerRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { battingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { pitchingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { qrCodeGenerator.generate(any(), any()) } returns "QR_CODE_DATA"
+
+        // when
+        val result = certificateService.issueCertificate(playerId, validityDays = 365)
+
+        // then
+        assertThat(result.playerId).isEqualTo(playerId)
+        assertThat(result.playerName).isEqualTo(player.name)
+        assertThat(result.status).isEqualTo(CertificateStatus.VALID)
+        assertThat(result.qrCodeData).isEqualTo("QR_CODE_DATA")
+        assertThat(result.playerCareer.totalGames).isEqualTo(0)
+
+        verify { certificateRepository.save(any()) }
+        verify { qrCodeGenerator.generate(any(), any()) }
+    }
+
+    @Test
+    fun `should throw exception when issuing certificate for non-existent player`() {
+        // given
+        val playerId = 999L
+        every { playerRepository.findByIdOrNull(playerId) } returns null
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            certificateService.issueCertificate(playerId)
+        }
+    }
+
+    @Test
+    fun `should get certificate by id`() {
+        // given
+        val certificateId = 1L
+        val player = createPlayer(1L)
+        val certificate = Certificate.issue(player, validityDays = 365)
+
+        every { certificateRepository.findById(certificateId) } returns certificate
+        every { gamePlayerRepository.findAllByPlayerId(player.id) } returns emptyList()
+        every { battingRecordRepository.findAllByPlayerId(player.id) } returns emptyList()
+        every { pitchingRecordRepository.findAllByPlayerId(player.id) } returns emptyList()
+        every { qrCodeGenerator.generate(any(), any()) } returns "QR_CODE_DATA"
+
+        // when
+        val result = certificateService.getCertificate(certificateId)
+
+        // then
+        assertThat(result.playerId).isEqualTo(player.id)
+        assertThat(result.playerName).isEqualTo(player.name)
+        assertThat(result.status).isEqualTo(CertificateStatus.VALID)
+    }
+
+    @Test
+    fun `should throw exception when getting non-existent certificate`() {
+        // given
+        val certificateId = 999L
+        every { certificateRepository.findById(certificateId) } returns null
+
+        // when & then
+        assertThrows<CertificateNotFoundException> {
+            certificateService.getCertificate(certificateId)
+        }
+    }
+
+    @Test
+    fun `should verify certificate by issue number`() {
+        // given
+        val issueNumber = "test-uuid-123"
+        val player = createPlayer(1L)
+        val certificate = Certificate.issue(player, validityDays = 365)
+
+        every { certificateRepository.findByIssueNumber(issueNumber) } returns certificate
+
+        // when
+        val result = certificateService.verifyCertificate(issueNumber)
+
+        // then
+        assertThat(result.valid).isTrue()
+        assertThat(result.issueNumber).isEqualTo(certificate.issueNumber)
+        assertThat(result.playerName).isEqualTo(player.name)
+        assertThat(result.status).isEqualTo(CertificateStatus.VALID)
+    }
+
+    @Test
+    fun `should throw exception when verifying non-existent certificate`() {
+        // given
+        val issueNumber = "non-existent-uuid"
+        every { certificateRepository.findByIssueNumber(issueNumber) } returns null
+
+        // when & then
+        assertThrows<CertificateNotFoundByIssueNumberException> {
+            certificateService.verifyCertificate(issueNumber)
+        }
+    }
+
+    @Test
+    fun `should revoke certificate`() {
+        // given
+        val certificateId = 1L
+        val player = createPlayer(1L)
+        val certificate = Certificate.issue(player, validityDays = 365)
+
+        every { certificateRepository.findById(certificateId) } returns certificate
+        every { certificateRepository.save(any()) } returns certificate
+
+        // when
+        certificateService.revokeCertificate(certificateId)
+
+        // then
+        assertThat(certificate.status).isEqualTo(CertificateStatus.REVOKED)
+        verify { certificateRepository.save(certificate) }
+    }
+
+    @Test
+    fun `should get all player certificates`() {
+        // given
+        val playerId = 1L
+        val player = createPlayer(playerId)
+        val certificate1 = Certificate.issue(player, validityDays = 365)
+        val certificate2 = Certificate.issue(player, validityDays = 365)
+
+        every { certificateRepository.findAllByPlayerId(playerId) } returns listOf(certificate1, certificate2)
+        every { gamePlayerRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { battingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { pitchingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { qrCodeGenerator.generate(any(), any()) } returns "QR_CODE_DATA"
+
+        // when
+        val result = certificateService.getPlayerCertificates(playerId)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result[0].playerId).isEqualTo(playerId)
+        assertThat(result[1].playerId).isEqualTo(playerId)
+    }
+
+    private fun createPlayer(id: Long): Player =
+        Player(
+            name = "홍길동",
+            birthDate = LocalDate.of(1990, 1, 1),
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            primaryPosition = Position.STARTING_PITCHER,
+            id = id,
+        )
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -18,6 +18,7 @@ import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.BoxScoreService
 import com.nextup.core.service.game.dto.GameEndReason
@@ -39,6 +40,7 @@ import java.time.LocalDateTime
 class GameScorerServiceImplTest {
     private lateinit var gameRepository: GameRepositoryPort
     private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
     private lateinit var boxScoreService: BoxScoreService
     private lateinit var gameEventRepository: GameEventRepositoryPort
     private lateinit var battingRecordRepository: BattingRecordRepositoryPort
@@ -49,6 +51,7 @@ class GameScorerServiceImplTest {
     fun setUp() {
         gameRepository = mockk()
         gamePlayerRepository = mockk()
+        gameTeamRepository = mockk()
         boxScoreService = mockk(relaxed = true)
         gameEventRepository = mockk()
         battingRecordRepository = mockk()
@@ -57,6 +60,7 @@ class GameScorerServiceImplTest {
             GameScorerServiceImpl(
                 gameRepository,
                 gamePlayerRepository,
+                gameTeamRepository,
                 boxScoreService,
                 gameEventRepository,
                 battingRecordRepository,
@@ -606,10 +610,169 @@ class GameScorerServiceImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("forfeitGame")
+    inner class ForfeitGame {
+        @Test
+        fun `should forfeit game when status is SCHEDULED`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            val homeTeam = createMockTeam(10L, "홈팀")
+            val awayTeam = createMockTeam(20L, "원정팀")
+            val homeGameTeam = createMockGameTeam(1L, game, homeTeam)
+            val awayGameTeam = createMockGameTeam(2L, game, awayTeam)
+            val gameTeams = listOf(homeGameTeam, awayGameTeam)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameTeamRepository.findAllByGameId(1L) } returns gameTeams
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result =
+                gameScorerService.forfeitGame(
+                    gameId = 1L,
+                    winnerTeamId = 10L,
+                    reason = "상대팀 불참",
+                )
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.FORFEITED)
+            assertThat(result.forfeitReason).isEqualTo("상대팀 불참")
+            assertThat(result.endedAt).isNotNull()
+            verify { gameRepository.save(any()) }
+            verify { homeGameTeam.updateScore(7, 0, 0) }
+            verify { homeGameTeam.updateResult(any()) }
+            verify { awayGameTeam.updateScore(0, 0, 0) }
+            verify { awayGameTeam.updateResult(any()) }
+        }
+
+        @Test
+        fun `should forfeit game when status is IN_PROGRESS`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val homeTeam = createMockTeam(10L, "홈팀")
+            val awayTeam = createMockTeam(20L, "원정팀")
+            val homeGameTeam = createMockGameTeam(1L, game, homeTeam)
+            val awayGameTeam = createMockGameTeam(2L, game, awayTeam)
+            val gameTeams = listOf(homeGameTeam, awayGameTeam)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameTeamRepository.findAllByGameId(1L) } returns gameTeams
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result =
+                gameScorerService.forfeitGame(
+                    gameId = 1L,
+                    winnerTeamId = 20L,
+                    reason = "홈팀 규정 위반",
+                )
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.FORFEITED)
+            assertThat(result.forfeitReason).isEqualTo("홈팀 규정 위반")
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when game is already finished`() {
+            // given
+            val game = createGame(1L, GameStatus.FINISHED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.forfeitGame(
+                    gameId = 1L,
+                    winnerTeamId = 10L,
+                    reason = "사유",
+                )
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("예정 또는 진행 중인 경기만 몰수 처리할 수 있습니다")
+        }
+
+        @Test
+        fun `should throw exception when game is cancelled`() {
+            // given
+            val game = createGame(1L, GameStatus.CANCELLED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.forfeitGame(
+                    gameId = 1L,
+                    winnerTeamId = 10L,
+                    reason = "사유",
+                )
+            }.isInstanceOf(InvalidGameStateException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when game not found`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.forfeitGame(
+                    gameId = 999L,
+                    winnerTeamId = 10L,
+                    reason = "사유",
+                )
+            }.isInstanceOf(GameNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when GameTeams count is not 2`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            val homeTeam = createMockTeam(10L, "홈팀")
+            val homeGameTeam = createMockGameTeam(1L, game, homeTeam)
+            val gameTeams = listOf(homeGameTeam) // Only 1 team
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameTeamRepository.findAllByGameId(1L) } returns gameTeams
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.forfeitGame(
+                    gameId = 1L,
+                    winnerTeamId = 10L,
+                    reason = "사유",
+                )
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("정확히 2개의 팀이 필요합니다")
+        }
+    }
+
     private fun createGamePlayer(id: Long): GamePlayer {
         val gamePlayer = mockk<GamePlayer>(relaxed = true)
         every { gamePlayer.id } returns id
         return gamePlayer
+    }
+
+    private fun createMockTeam(
+        id: Long,
+        name: String,
+    ): com.nextup.core.domain.team.Team {
+        val team = mockk<com.nextup.core.domain.team.Team>(relaxed = true)
+        every { team.id } returns id
+        every { team.name } returns name
+        return team
+    }
+
+    private fun createMockGameTeam(
+        id: Long,
+        game: Game,
+        team: com.nextup.core.domain.team.Team,
+    ): com.nextup.core.domain.game.GameTeam {
+        val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+        every { gameTeam.id } returns id
+        every { gameTeam.game } returns game
+        every { gameTeam.team } returns team
+        every { gameTeam.updateScore(any(), any(), any()) } returns Unit
+        every { gameTeam.updateResult(any()) } returns Unit
+        return gameTeam
     }
 
     private fun createAssociation(id: Long): Association =

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -14,8 +14,11 @@ import com.nextup.core.domain.game.GameState
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.BoxScoreService
 import com.nextup.core.service.game.dto.GameEndReason
 import com.nextup.core.service.game.dto.PlateAppearanceRequest
@@ -37,6 +40,9 @@ class GameScorerServiceImplTest {
     private lateinit var gameRepository: GameRepositoryPort
     private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var boxScoreService: BoxScoreService
+    private lateinit var gameEventRepository: GameEventRepositoryPort
+    private lateinit var battingRecordRepository: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
     private lateinit var gameScorerService: GameScorerServiceImpl
 
     @BeforeEach
@@ -44,11 +50,17 @@ class GameScorerServiceImplTest {
         gameRepository = mockk()
         gamePlayerRepository = mockk()
         boxScoreService = mockk(relaxed = true)
+        gameEventRepository = mockk()
+        battingRecordRepository = mockk()
+        pitchingRecordRepository = mockk()
         gameScorerService =
             GameScorerServiceImpl(
                 gameRepository,
                 gamePlayerRepository,
                 boxScoreService,
+                gameEventRepository,
+                battingRecordRepository,
+                pitchingRecordRepository,
             )
     }
 
@@ -165,17 +177,15 @@ class GameScorerServiceImplTest {
         }
 
         @Test
-        fun `should end game with FORFEIT reason`() {
+        fun `should throw exception for FORFEIT reason requiring dedicated API`() {
             // given
             val game = createGame(1L, GameStatus.IN_PROGRESS)
             every { gameRepository.findByIdOrNull(1L) } returns game
-            every { gameRepository.save(any()) } answers { firstArg() }
 
-            // when
-            val result = gameScorerService.endGame(1L, GameEndReason.FORFEIT)
-
-            // then
-            assertThat(result.status).isEqualTo(GameStatus.FORFEITED)
+            // when & then
+            assertThatThrownBy { gameScorerService.endGame(1L, GameEndReason.FORFEIT) }
+                .isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("몰수 처리는 전용 API를 사용해주세요")
         }
 
         @Test

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceUndoTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceUndoTest.kt
@@ -20,6 +20,7 @@ import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.BoxScoreService
 import io.mockk.every
@@ -38,6 +39,7 @@ import java.time.LocalDateTime
 class GameScorerServiceUndoTest {
     private lateinit var gameRepository: GameRepositoryPort
     private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
     private lateinit var boxScoreService: BoxScoreService
     private lateinit var gameEventRepository: GameEventRepositoryPort
     private lateinit var battingRecordRepository: BattingRecordRepositoryPort
@@ -48,6 +50,7 @@ class GameScorerServiceUndoTest {
     fun setUp() {
         gameRepository = mockk()
         gamePlayerRepository = mockk()
+        gameTeamRepository = mockk()
         boxScoreService = mockk(relaxed = true)
         gameEventRepository = mockk()
         battingRecordRepository = mockk()
@@ -56,6 +59,7 @@ class GameScorerServiceUndoTest {
             GameScorerServiceImpl(
                 gameRepository,
                 gamePlayerRepository,
+                gameTeamRepository,
                 boxScoreService,
                 gameEventRepository,
                 battingRecordRepository,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceUndoTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceUndoTest.kt
@@ -1,0 +1,449 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.NoEventToUndoException
+import com.nextup.common.exception.UndoNotAvailableException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameState
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.game.PlateAppearanceResult
+import com.nextup.core.domain.league.League
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.service.game.BoxScoreService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameScorerServiceImpl - Undo")
+class GameScorerServiceUndoTest {
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var boxScoreService: BoxScoreService
+    private lateinit var gameEventRepository: GameEventRepositoryPort
+    private lateinit var battingRecordRepository: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var gameScorerService: GameScorerServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        gamePlayerRepository = mockk()
+        boxScoreService = mockk(relaxed = true)
+        gameEventRepository = mockk()
+        battingRecordRepository = mockk()
+        pitchingRecordRepository = mockk()
+        gameScorerService =
+            GameScorerServiceImpl(
+                gameRepository,
+                gamePlayerRepository,
+                boxScoreService,
+                gameEventRepository,
+                battingRecordRepository,
+                pitchingRecordRepository,
+            )
+    }
+
+    @Nested
+    @DisplayName("undoLastEvent")
+    inner class UndoLastEvent {
+        @Test
+        fun `should undo single hit event and revert batting record`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            game.gameState.runnerOnFirstId = 10L // 타자가 1루에 있음
+
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.SINGLE, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.SINGLE)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.SINGLE,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(result.undone).isTrue()
+            assertThat(battingRecord.plateAppearances).isEqualTo(0)
+            assertThat(battingRecord.atBats).isEqualTo(0)
+            assertThat(battingRecord.hits).isEqualTo(0)
+            verify { gameEventRepository.save(any()) }
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should undo home run and revert score and batting record`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.HOME_RUN, 1)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.HOME_RUN)
+                    recordEarnedRun(1)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.HOME_RUN,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runsScored = 1,
+                    rbis = 1,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(result.undone).isTrue()
+            assertThat(battingRecord.homeRuns).isEqualTo(0)
+            assertThat(battingRecord.hits).isEqualTo(0)
+            assertThat(battingRecord.runs).isEqualTo(0)
+            assertThat(battingRecord.runsBattedIn).isEqualTo(0)
+            verify { gameTeam.subtractRunInInning(any(), eq(1)) }
+        }
+
+        @Test
+        fun `should undo strikeout and restore out count and pitching record`() {
+            // given
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.outs = 1 // 이미 1아웃
+                }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.STRIKEOUT)
+                    recordOut()
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    outCountBefore = 0,
+                    outCountAfter = 1,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(game.gameState.outs).isEqualTo(0) // 아웃 카운트 복원
+            assertThat(battingRecord.strikeouts).isEqualTo(0)
+            assertThat(pitchingRecord.strikeouts).isEqualTo(0)
+            assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(0)
+        }
+
+        @Test
+        fun `should throw exception when game is not in progress`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { gameScorerService.undoLastEvent(1L) }
+                .isInstanceOf(UndoNotAvailableException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when no event to undo`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns null
+
+            // when & then
+            assertThatThrownBy { gameScorerService.undoLastEvent(1L) }
+                .isInstanceOf(NoEventToUndoException::class.java)
+        }
+
+        @Test
+        fun `should undo consecutive events correctly`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter1 = createGamePlayer(10L)
+            val batter2 = createGamePlayer(11L)
+            val pitcher = createGamePlayer(20L)
+
+            val battingRecord2 =
+                createBattingRecord(batter2).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.SINGLE)
+                    applyBatterFaced(PlateAppearanceResult.DOUBLE)
+                }
+
+            // 두 번째 이벤트 (나중에 기록된 것)
+            val event2 =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter2,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.DOUBLE,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = "1루:10",
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event2
+            every { battingRecordRepository.findByGamePlayer(batter2) } returns battingRecord2
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when - 첫 번째 Undo
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event2.undone).isTrue()
+            assertThat(battingRecord2.doubles).isEqualTo(0)
+            assertThat(battingRecord2.hits).isEqualTo(0)
+            // 주자가 이전 상태로 복원되었는지 확인
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should undo inning change event`() {
+            // given - 이닝 전환 후 상태
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 1
+                    isTopInning = false // 1회말로 전환된 상태
+                    gameState.outs = 0
+                }
+
+            val event =
+                GameEvent(
+                    game = game,
+                    inning = 1,
+                    isTopInning = true, // 이벤트는 1회초에서 발생
+                    outCountBefore = 3,
+                    outCountAfter = 0,
+                    eventType = GameEventType.INNING_CHANGE,
+                    description = "1회초 종료, 1회말 시작",
+                )
+            setEntityId(event, 100L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(game.currentInning).isEqualTo(1)
+            assertThat(game.isTopInning).isTrue() // 1회초로 복원
+            assertThat(game.gameState.outs).isEqualTo(3) // 3아웃 상태로 복원
+        }
+    }
+
+    // Helper methods
+
+    private fun createGamePlayer(id: Long): GamePlayer {
+        val gamePlayer = mockk<GamePlayer>(relaxed = true)
+        every { gamePlayer.id } returns id
+        return gamePlayer
+    }
+
+    private fun createBattingRecord(gamePlayer: GamePlayer): BattingRecord = BattingRecord.create(gamePlayer)
+
+    private fun createPitchingRecord(gamePlayer: GamePlayer): PitchingRecord = PitchingRecord.create(gamePlayer)
+
+    private fun createPlateAppearanceEvent(
+        game: Game,
+        batter: GamePlayer,
+        pitcher: GamePlayer,
+        result: PlateAppearanceResult,
+        outCountBefore: Int,
+        outCountAfter: Int,
+        runnersBeforeJson: String?,
+        runsScored: Int,
+        rbis: Int = 0,
+    ): GameEvent {
+        val event =
+            GameEvent(
+                game = game,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                outCountBefore = outCountBefore,
+                outCountAfter = outCountAfter,
+                eventType = GameEventType.PLATE_APPEARANCE,
+                description = "${result.displayName}",
+                batter = batter,
+                pitcher = pitcher,
+                runnersBeforeJson = runnersBeforeJson,
+                plateAppearanceResult = result,
+                runsScored = runsScored,
+                rbis = rbis,
+            )
+        setEntityId(event, 1L)
+        return event
+    }
+
+    private fun setEntityId(
+        entity: Any,
+        id: Long
+    ) {
+        val idField = entity::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(entity, id)
+    }
+
+    private fun createAssociation(id: Long): Association =
+        Association(
+            name = "서울시야구협회",
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null,
+        ).apply {
+            setEntityId(this, id)
+        }
+
+    private fun createLeague(
+        id: Long,
+        association: Association,
+    ): League =
+        League(
+            association = association,
+            name = "1부 리그",
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null,
+        ).apply {
+            setEntityId(this, id)
+        }
+
+    private fun createCompetition(
+        id: Long,
+        league: League,
+    ): Competition =
+        Competition(
+            league = league,
+            name = "2025 춘계대회",
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            endDate = LocalDate.of(2025, 6, 30),
+            status = CompetitionStatus.IN_PROGRESS,
+            description = null,
+            maxTeams = null,
+        ).apply {
+            setEntityId(this, id)
+        }
+
+    private fun createGame(
+        id: Long,
+        status: GameStatus,
+    ): Game {
+        val association = createAssociation(1L)
+        val league = createLeague(1L, association)
+        val competition = createCompetition(1L, league)
+
+        return Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실구장",
+            fieldName = "1구장",
+            gameNumber = 1,
+            status = status,
+            currentInning = 1,
+            isTopInning = true,
+            totalInnings = 9,
+            gameState = GameState(),
+        ).apply {
+            setEntityId(this, id)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/ScoresheetServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/ScoresheetServiceImplTest.kt
@@ -1,0 +1,279 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.*
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.*
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class ScoresheetServiceImplTest {
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var battingRecordRepository: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var gameEventRepository: GameEventRepositoryPort
+    private lateinit var scoresheetService: ScoresheetServiceImpl
+
+    private lateinit var game: Game
+    private lateinit var homeTeam: Team
+    private lateinit var awayTeam: Team
+    private lateinit var homeGameTeam: GameTeam
+    private lateinit var awayGameTeam: GameTeam
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        gameTeamRepository = mockk()
+        gamePlayerRepository = mockk()
+        battingRecordRepository = mockk()
+        pitchingRecordRepository = mockk()
+        gameEventRepository = mockk()
+
+        scoresheetService =
+            ScoresheetServiceImpl(
+                gameRepository,
+                gameTeamRepository,
+                gamePlayerRepository,
+                battingRecordRepository,
+                pitchingRecordRepository,
+                gameEventRepository,
+            )
+
+        val association = Association(name = "테스트협회", id = 1L)
+        val league =
+            League(
+                association = association,
+                name = "테스트리그",
+                foundedYear = 2020,
+                id = 1L,
+            )
+        val competition =
+            Competition(
+                league = league,
+                name = "2024 시즌",
+                year = 2024,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2024, 3, 1),
+                id = 1L,
+            )
+
+        homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+
+        game =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.of(2024, 3, 15, 14, 0),
+                location = "서울",
+                fieldName = "잠실구장",
+                gameNumber = 1,
+                status = GameStatus.FINISHED,
+                currentInning = 9,
+                isTopInning = false,
+                totalInnings = 9,
+                startedAt = LocalDateTime.of(2024, 3, 15, 14, 10),
+                endedAt = LocalDateTime.of(2024, 3, 15, 17, 0),
+                id = 100L,
+            )
+
+        homeGameTeam =
+            GameTeam(
+                game = game,
+                team = homeTeam,
+                homeAway = HomeAway.HOME,
+                id = 1L,
+            )
+        homeGameTeam.updateScore(totalScore = 5, totalHits = 10, totalErrors = 1)
+        homeGameTeam.updateResult(GameResult.WIN)
+        for (i in 1..9) {
+            homeGameTeam.recordInningScore(i, listOf(0, 2, 0, 1, 0, 0, 2, 0, 0)[i - 1])
+        }
+
+        awayGameTeam =
+            GameTeam(
+                game = game,
+                team = awayTeam,
+                homeAway = HomeAway.AWAY,
+                id = 2L,
+            )
+        awayGameTeam.updateScore(totalScore = 3, totalHits = 8, totalErrors = 2)
+        awayGameTeam.updateResult(GameResult.LOSS)
+        for (i in 1..9) {
+            awayGameTeam.recordInningScore(i, listOf(1, 0, 2, 0, 0, 0, 0, 0, 0)[i - 1])
+        }
+    }
+
+    @Test
+    fun `should get scoresheet successfully`() {
+        // given
+        val homePlayer = Player(name = "홈타자1", primaryPosition = Position.FIRST_BASE, id = 1L)
+        val awayPlayer = Player(name = "원정타자1", primaryPosition = Position.SHORTSTOP, id = 2L)
+
+        val homeGamePlayer =
+            GamePlayer.createStarter(
+                gameTeam = homeGameTeam,
+                player = homePlayer,
+                position = Position.FIRST_BASE,
+                battingOrder = 1,
+                backNumber = 10,
+            )
+
+        val awayGamePlayer =
+            GamePlayer.createStarter(
+                gameTeam = awayGameTeam,
+                player = awayPlayer,
+                position = Position.SHORTSTOP,
+                battingOrder = 1,
+                backNumber = 5,
+            )
+
+        val homeBattingRecord =
+            mockk<BattingRecord> {
+                every { plateAppearances } returns 4
+                every { atBats } returns 3
+                every { runs } returns 2
+                every { hits } returns 2
+                every { doubles } returns 1
+                every { triples } returns 0
+                every { homeRuns } returns 0
+                every { runsBattedIn } returns 1
+                every { walks } returns 1
+                every { strikeouts } returns 1
+                every { stolenBases } returns 0
+                every { battingAverage } returns BigDecimal("0.667")
+            }
+
+        val awayBattingRecord =
+            mockk<BattingRecord> {
+                every { plateAppearances } returns 4
+                every { atBats } returns 4
+                every { runs } returns 1
+                every { hits } returns 1
+                every { doubles } returns 0
+                every { triples } returns 0
+                every { homeRuns } returns 0
+                every { runsBattedIn } returns 0
+                every { walks } returns 0
+                every { strikeouts } returns 2
+                every { stolenBases } returns 1
+                every { battingAverage } returns BigDecimal("0.250")
+            }
+
+        every { gameRepository.findByIdOrNull(100L) } returns game
+        every { gameTeamRepository.findAllByGameId(100L) } returns listOf(homeGameTeam, awayGameTeam)
+        every { gamePlayerRepository.findAllByGameId(100L) } returns listOf(homeGamePlayer, awayGamePlayer)
+        every { battingRecordRepository.findByGamePlayer(homeGamePlayer) } returns homeBattingRecord
+        every { battingRecordRepository.findByGamePlayer(awayGamePlayer) } returns awayBattingRecord
+        every { pitchingRecordRepository.findByGamePlayer(any()) } returns null
+        every { gameEventRepository.findAllByGameIdOrderByEventTimestamp(100L) } returns emptyList()
+
+        // when
+        val result = scoresheetService.getScoresheet(100L)
+
+        // then
+        assertThat(result.gameInfo.gameId).isEqualTo(100L)
+        assertThat(result.gameInfo.competitionName).isEqualTo("2024 시즌")
+        assertThat(result.teams.home.teamName).isEqualTo("홈팀")
+        assertThat(result.teams.away.teamName).isEqualTo("원정팀")
+        assertThat(result.teams.home.totalScore).isEqualTo(5)
+        assertThat(result.teams.away.totalScore).isEqualTo(3)
+        assertThat(result.inningScores.innings).isEqualTo(9)
+        assertThat(result.battingRecords.home).hasSize(1)
+        assertThat(result.battingRecords.away).hasSize(1)
+        assertThat(result.battingRecords.home[0].name).isEqualTo("홈타자1")
+        assertThat(result.battingRecords.home[0].hits).isEqualTo(2)
+    }
+
+    @Test
+    fun `should throw GameNotFoundException when game not found`() {
+        // given
+        every { gameRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows(GameNotFoundException::class.java) {
+            scoresheetService.getScoresheet(999L)
+        }
+    }
+
+    @Test
+    fun `should throw InvalidStateException when game teams size is not 2`() {
+        // given
+        every { gameRepository.findByIdOrNull(100L) } returns game
+        every { gameTeamRepository.findAllByGameId(100L) } returns listOf(homeGameTeam)
+
+        // when & then
+        val exception =
+            assertThrows(InvalidStateException::class.java) {
+                scoresheetService.getScoresheet(100L)
+            }
+        assertThat(exception.code).isEqualTo("INVALID_GAME_TEAMS")
+    }
+
+    @Test
+    fun `should throw InvalidStateException when home team is missing`() {
+        // given
+        val anotherAwayTeam =
+            GameTeam(
+                game = game,
+                team = awayTeam,
+                homeAway = HomeAway.AWAY,
+                id = 3L,
+            )
+
+        every { gameRepository.findByIdOrNull(100L) } returns game
+        every { gameTeamRepository.findAllByGameId(100L) } returns listOf(awayGameTeam, anotherAwayTeam)
+
+        // when & then
+        val exception =
+            assertThrows(InvalidStateException::class.java) {
+                scoresheetService.getScoresheet(100L)
+            }
+        assertThat(exception.code).isEqualTo("MISSING_HOME_TEAM")
+    }
+
+    @Test
+    fun `should handle players without batting records`() {
+        // given
+        val player = Player(name = "선수1", primaryPosition = Position.STARTING_PITCHER, id = 1L)
+
+        val gamePlayer =
+            GamePlayer.createStarter(
+                gameTeam = homeGameTeam,
+                player = player,
+                position = Position.STARTING_PITCHER,
+                battingOrder = null,
+                backNumber = 1,
+            )
+
+        every { gameRepository.findByIdOrNull(100L) } returns game
+        every { gameTeamRepository.findAllByGameId(100L) } returns listOf(homeGameTeam, awayGameTeam)
+        every { gamePlayerRepository.findAllByGameId(100L) } returns listOf(gamePlayer)
+        every { battingRecordRepository.findByGamePlayer(any()) } returns null
+        every { pitchingRecordRepository.findByGamePlayer(any()) } returns null
+        every { gameEventRepository.findAllByGameIdOrderByEventTimestamp(100L) } returns emptyList()
+
+        // when
+        val result = scoresheetService.getScoresheet(100L)
+
+        // then
+        assertThat(result.battingRecords.home).isEmpty()
+        assertThat(result.battingRecords.away).isEmpty()
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/report/CompetitionReportServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/report/CompetitionReportServiceImplTest.kt
@@ -1,0 +1,323 @@
+package com.nextup.infrastructure.service.report
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameResult
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.service.standings.StandingsService
+import com.nextup.core.service.standings.dto.StandingsDto
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class CompetitionReportServiceImplTest {
+    private val competitionRepository: CompetitionRepositoryPort = mockk()
+    private val standingsService: StandingsService = mockk()
+    private val gameRepository: GameRepositoryPort = mockk()
+    private val gameTeamRepository: GameTeamRepositoryPort = mockk()
+    private val battingRecordRepository: BattingRecordRepositoryPort = mockk()
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort = mockk()
+
+    private val service =
+        CompetitionReportServiceImpl(
+            competitionRepository = competitionRepository,
+            standingsService = standingsService,
+            gameRepository = gameRepository,
+            gameTeamRepository = gameTeamRepository,
+            battingRecordRepository = battingRecordRepository,
+            pitchingRecordRepository = pitchingRecordRepository,
+        )
+
+    @Test
+    fun `should throw exception when competition not found`() {
+        // given
+        val competitionId = 1L
+        every { competitionRepository.findByIdOrNull(competitionId) } returns null
+
+        // when & then
+        assertThrows<CompetitionNotFoundException> {
+            service.getReport(competitionId)
+        }
+    }
+
+    @Test
+    fun `should return report with standings and summary`() {
+        // given
+        val competitionId = 1L
+        val league = mockk<League>(relaxed = true)
+        val competition =
+            Competition(
+                league = league,
+                name = "2024 춘계대회",
+                year = 2024,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2024, 3, 1),
+                endDate = LocalDate.of(2024, 5, 31),
+                status = CompetitionStatus.IN_PROGRESS,
+                id = competitionId,
+            )
+
+        val standingsDto =
+            StandingsDto(
+                competitionId = competitionId,
+                competitionName = "2024 춘계대회",
+                totalGamesPerTeam = 10,
+                standings = emptyList(),
+                lastUpdated = LocalDateTime.now(),
+            )
+
+        every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+        every { standingsService.getStandings(competitionId) } returns standingsDto
+        every { gameRepository.findByCompetitionId(competitionId) } returns emptyList()
+        every { battingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { pitchingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId) } returns emptyList()
+
+        // when
+        val result = service.getReport(competitionId)
+
+        // then
+        assertThat(result.competitionId).isEqualTo(competitionId)
+        assertThat(result.competitionName).isEqualTo("2024 춘계대회")
+        assertThat(result.season).isEqualTo(1)
+        assertThat(result.standings).isEmpty()
+        assertThat(result.summary.totalGames).isEqualTo(0)
+    }
+
+    @Test
+    fun `should calculate summary statistics correctly`() {
+        // given
+        val competitionId = 1L
+        val league = mockk<League>(relaxed = true)
+        val competition =
+            Competition(
+                league = league,
+                name = "2024 춘계대회",
+                year = 2024,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2024, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+                id = competitionId,
+            )
+
+        val team1 =
+            mockk<Team>(relaxed = true) {
+                every { id } returns 1L
+                every { name } returns "팀A"
+            }
+        val team2 =
+            mockk<Team>(relaxed = true) {
+                every { id } returns 2L
+                every { name } returns "팀B"
+            }
+
+        val game1 =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.of(2024, 3, 15, 14, 0),
+                status = GameStatus.FINISHED,
+                id = 1L,
+            )
+
+        val game2 =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.of(2024, 3, 20, 14, 0),
+                status = GameStatus.FINISHED,
+                id = 2L,
+            )
+
+        val gameTeam1 =
+            GameTeam(game = game1, team = team1, homeAway = HomeAway.HOME, id = 1L).apply {
+                updateScore(totalScore = 5, totalHits = 8, totalErrors = 1)
+                updateResult(GameResult.WIN)
+            }
+
+        val gameTeam2 =
+            GameTeam(game = game1, team = team2, homeAway = HomeAway.AWAY, id = 2L).apply {
+                updateScore(totalScore = 3, totalHits = 6, totalErrors = 2)
+                updateResult(GameResult.LOSS)
+            }
+
+        val gameTeam3 =
+            GameTeam(game = game2, team = team1, homeAway = HomeAway.AWAY, id = 3L).apply {
+                updateScore(totalScore = 7, totalHits = 10, totalErrors = 0)
+                updateResult(GameResult.WIN)
+            }
+
+        val gameTeam4 =
+            GameTeam(game = game2, team = team2, homeAway = HomeAway.HOME, id = 4L).apply {
+                updateScore(totalScore = 2, totalHits = 4, totalErrors = 1)
+                updateResult(GameResult.LOSS)
+            }
+
+        every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+        every { gameRepository.findByCompetitionId(competitionId) } returns listOf(game1, game2)
+        every { gameTeamRepository.findAllByGameIds(listOf(1L, 2L)) } returns
+            listOf(gameTeam1, gameTeam2, gameTeam3, gameTeam4)
+        every { battingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { pitchingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId) } returns
+            listOf(gameTeam1, gameTeam2, gameTeam3, gameTeam4)
+
+        // when
+        val result = service.getReportSummary(competitionId)
+
+        // then
+        assertThat(result.competitionId).isEqualTo(competitionId)
+        assertThat(result.totalGames).isEqualTo(2)
+        assertThat(result.completedGames).isEqualTo(2)
+        assertThat(result.totalRuns).isEqualTo(17) // 5 + 3 + 7 + 2
+        assertThat(result.totalHits).isEqualTo(28) // 8 + 6 + 10 + 4
+        assertThat(result.averageRunsPerGame).isEqualTo(8.5) // 17 / 2
+        assertThat(result.highestScoringGame).isNotNull
+        assertThat(result.highestScoringGame?.totalRuns).isEqualTo(9) // game2: 7 + 2
+        assertThat(result.longestWinStreak).isNotNull
+        assertThat(result.longestWinStreak?.teamName).isEqualTo("팀A")
+        assertThat(result.longestWinStreak?.streakLength).isEqualTo(2)
+    }
+
+    @Test
+    fun `should return null for highest scoring game when no completed games`() {
+        // given
+        val competitionId = 1L
+        val league = mockk<League>(relaxed = true)
+        val competition =
+            Competition(
+                league = league,
+                name = "2024 춘계대회",
+                year = 2024,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2024, 3, 1),
+                status = CompetitionStatus.SCHEDULED,
+                id = competitionId,
+            )
+
+        every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+        every { gameRepository.findByCompetitionId(competitionId) } returns emptyList()
+        every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId) } returns emptyList()
+
+        // when
+        val result = service.getReportSummary(competitionId)
+
+        // then
+        assertThat(result.totalGames).isEqualTo(0)
+        assertThat(result.completedGames).isEqualTo(0)
+        assertThat(result.highestScoringGame).isNull()
+        assertThat(result.longestWinStreak).isNull()
+    }
+
+    @Test
+    fun `should calculate longest win streak correctly with loss interruption`() {
+        // given
+        val competitionId = 1L
+        val league = mockk<League>(relaxed = true)
+        val competition =
+            Competition(
+                league = league,
+                name = "2024 춘계대회",
+                year = 2024,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2024, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+                id = competitionId,
+            )
+        val team =
+            Team(league = league, name = "팀A", city = "서울", foundedYear = 2020, id = 1L)
+
+        val game1 =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.now().minusDays(5),
+                status = GameStatus.FINISHED,
+                id = 1L,
+            )
+        val game2 =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.now().minusDays(4),
+                status = GameStatus.FINISHED,
+                id = 2L,
+            )
+        val game3 =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.now().minusDays(3),
+                status = GameStatus.FINISHED,
+                id = 3L,
+            )
+        val game4 =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.now().minusDays(2),
+                status = GameStatus.FINISHED,
+                id = 4L,
+            )
+        val game5 =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.now().minusDays(1),
+                status = GameStatus.FINISHED,
+                id = 5L,
+            )
+
+        val gameTeam1 =
+            GameTeam(game = game1, team = team, homeAway = HomeAway.HOME, id = 1L).apply {
+                updateResult(GameResult.WIN)
+            }
+        val gameTeam2 =
+            GameTeam(game = game2, team = team, homeAway = HomeAway.HOME, id = 2L).apply {
+                updateResult(GameResult.WIN)
+            }
+        val gameTeam3 =
+            GameTeam(game = game3, team = team, homeAway = HomeAway.HOME, id = 3L).apply {
+                updateResult(GameResult.LOSS)
+            }
+        val gameTeam4 =
+            GameTeam(game = game4, team = team, homeAway = HomeAway.HOME, id = 4L).apply {
+                updateResult(GameResult.WIN)
+            }
+        val gameTeam5 =
+            GameTeam(game = game5, team = team, homeAway = HomeAway.HOME, id = 5L).apply {
+                updateResult(GameResult.WIN)
+            }
+
+        every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+        every { gameRepository.findByCompetitionId(competitionId) } returns
+            listOf(game1, game2, game3, game4, game5)
+        every { gameTeamRepository.findAllByGameIds(any()) } returns emptyList()
+        every { battingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { pitchingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId) } returns
+            listOf(gameTeam1, gameTeam2, gameTeam3, gameTeam4, gameTeam5)
+
+        // when
+        val result = service.getReportSummary(competitionId)
+
+        // then
+        // 2연승 -> 패배 -> 2연승, 최장은 2연승
+        assertThat(result.longestWinStreak).isNotNull
+        assertThat(result.longestWinStreak?.teamName).isEqualTo("팀A")
+        assertThat(result.longestWinStreak?.streakLength).isEqualTo(2)
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/IndividualRankingServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/IndividualRankingServiceImplTest.kt
@@ -1,0 +1,518 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import com.nextup.core.service.stats.dto.BattingCategory
+import com.nextup.core.service.stats.dto.PitchingCategory
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+@DisplayName("IndividualRankingServiceImpl")
+class IndividualRankingServiceImplTest {
+    private lateinit var competitionRepository: CompetitionRepositoryPort
+    private lateinit var seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort
+    private lateinit var seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort
+    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
+    private lateinit var service: IndividualRankingServiceImpl
+
+    private lateinit var competition: Competition
+    private lateinit var player1: Player
+    private lateinit var player2: Player
+    private lateinit var team: Team
+
+    @BeforeEach
+    fun setUp() {
+        competitionRepository = mockk()
+        seasonBattingStatsRepository = mockk()
+        seasonPitchingStatsRepository = mockk()
+        teamMemberRepository = mockk()
+
+        service =
+            IndividualRankingServiceImpl(
+                competitionRepository,
+                seasonBattingStatsRepository,
+                seasonPitchingStatsRepository,
+                teamMemberRepository,
+            )
+
+        val league =
+            mockk<League> {
+                every { id } returns 1L
+                every { name } returns "1부 리그"
+            }
+
+        competition =
+            Competition(
+                league = league,
+                name = "2026 춘계대회",
+                year = 2026,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2026, 3, 1),
+            )
+        setId(competition, Competition::class.java, 1L)
+
+        player1 = Player(name = "홍길동", primaryPosition = Position.SHORTSTOP)
+        setId(player1, Player::class.java, 10L)
+
+        player2 = Player(name = "김철수", primaryPosition = Position.CENTER_FIELD)
+        setId(player2, Player::class.java, 20L)
+
+        team =
+            mockk<Team> {
+                every { id } returns 100L
+                every { name } returns "타이거즈"
+            }
+    }
+
+    @Nested
+    @DisplayName("getBattingLeaders")
+    inner class GetBattingLeaders {
+        @Test
+        fun `should throw when competition not found`() {
+            // given
+            every { competitionRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                service.getBattingLeaders(999L, BattingCategory.BATTING_AVG)
+            }.isInstanceOf(CompetitionNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should return batting average leaders`() {
+            // given
+            val stats1 = createBattingStats(player1, 2026, atBats = 50, hits = 18, pa = 55, games = 12)
+            val stats2 = createBattingStats(player2, 2026, atBats = 45, hits = 14, pa = 50, games = 10)
+            val qualifyingPA =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, qualifyingPA, 10) } returns
+                listOf(stats1, stats2)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdActive(20L) } returns listOf(createTeamMember(player2))
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.BATTING_AVG)
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result[0].rank).isEqualTo(1)
+            assertThat(result[0].playerName).isEqualTo("홍길동")
+            assertThat(result[0].teamName).isEqualTo("타이거즈")
+            assertThat(result[1].rank).isEqualTo(2)
+            assertThat(result[1].playerName).isEqualTo("김철수")
+        }
+
+        @Test
+        fun `should return home run leaders`() {
+            // given
+            val stats1 = createBattingStats(player1, 2026, atBats = 50, hits = 15, pa = 55, games = 12, homeRuns = 5)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 10) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.HOME_RUNS)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].value).isEqualTo(5.0)
+        }
+
+        @Test
+        fun `should return RBI leaders`() {
+            // given
+            val stats1 = createBattingStats(player1, 2026, atBats = 50, hits = 15, pa = 55, games = 12, rbi = 20)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 10) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.RBI)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].value).isEqualTo(20.0)
+        }
+
+        @Test
+        fun `should return hits leaders`() {
+            // given
+            val stats1 = createBattingStats(player1, 2026, atBats = 50, hits = 25, pa = 55, games = 12)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopByHits(2026, 10) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.HITS)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].value).isEqualTo(25.0)
+        }
+
+        @Test
+        fun `should return stolen bases leaders`() {
+            // given
+            val stats1 =
+                createBattingStats(player1, 2026, atBats = 50, hits = 15, pa = 55, games = 12, stolenBases = 10)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 10) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.STOLEN_BASES)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].value).isEqualTo(10.0)
+        }
+
+        @Test
+        fun `should return OBP leaders`() {
+            // given
+            val stats1 = createBattingStats(player1, 2026, atBats = 50, hits = 15, pa = 55, games = 12)
+            val qualifyingPA =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopByOnBasePercentage(2026, qualifyingPA, 10) } returns
+                listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.OBP)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
+
+        @Test
+        fun `should return SLG leaders`() {
+            // given
+            val stats1 = createBattingStats(player1, 2026, atBats = 50, hits = 15, pa = 55, games = 12)
+            val qualifyingPA =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopBySlugging(2026, qualifyingPA, 10) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.SLG)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
+
+        @Test
+        fun `should return OPS leaders`() {
+            // given
+            val stats1 = createBattingStats(player1, 2026, atBats = 50, hits = 15, pa = 55, games = 12)
+            val qualifyingPA =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopByOps(2026, qualifyingPA, 10) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.OPS)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
+
+        @Test
+        fun `should return empty list when no stats`() {
+            // given
+            val qualifyingPA =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, qualifyingPA, 10) } returns emptyList()
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.BATTING_AVG)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `should return dash for team name when player has no active team`() {
+            // given
+            val stats1 = createBattingStats(player1, 2026, atBats = 50, hits = 18, pa = 55, games = 12)
+            val qualifyingPA =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, qualifyingPA, 10) } returns
+                listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns emptyList()
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.BATTING_AVG)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].teamName).isEqualTo("-")
+        }
+
+        @Test
+        fun `should support custom limit`() {
+            // given
+            val stats1 = createBattingStats(player1, 2026, atBats = 50, hits = 18, pa = 55, games = 12)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 5) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getBattingLeaders(1L, BattingCategory.HOME_RUNS, limit = 5)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("getPitchingLeaders")
+    inner class GetPitchingLeaders {
+        @Test
+        fun `should throw when competition not found`() {
+            // given
+            every { competitionRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                service.getPitchingLeaders(999L, PitchingCategory.ERA)
+            }.isInstanceOf(CompetitionNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should return ERA leaders`() {
+            // given
+            val stats1 = createPitchingStats(player1, 2026, ipOuts = 36, earnedRuns = 3, games = 10)
+            val stats2 = createPitchingStats(player2, 2026, ipOuts = 30, earnedRuns = 5, games = 8)
+            val qualifyingIPOuts =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_IP_FACTOR *
+                    3).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonPitchingStatsRepository.findTopByEra(2026, qualifyingIPOuts, 10) } returns
+                listOf(stats1, stats2)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdActive(20L) } returns listOf(createTeamMember(player2))
+
+            // when
+            val result = service.getPitchingLeaders(1L, PitchingCategory.ERA)
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result[0].rank).isEqualTo(1)
+            assertThat(result[0].playerName).isEqualTo("홍길동")
+            assertThat(result[0].teamName).isEqualTo("타이거즈")
+            assertThat(result[1].rank).isEqualTo(2)
+        }
+
+        @Test
+        fun `should return wins leaders`() {
+            // given
+            val stats1 = createPitchingStats(player1, 2026, ipOuts = 50, earnedRuns = 10, games = 12, wins = 8)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 10) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getPitchingLeaders(1L, PitchingCategory.WINS)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].value).isEqualTo(8.0)
+        }
+
+        @Test
+        fun `should return saves leaders`() {
+            // given
+            val stats1 = createPitchingStats(player1, 2026, ipOuts = 30, earnedRuns = 2, games = 15, saves = 10)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 10) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getPitchingLeaders(1L, PitchingCategory.SAVES)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].value).isEqualTo(10.0)
+        }
+
+        @Test
+        fun `should return strikeout leaders`() {
+            // given
+            val stats1 = createPitchingStats(player1, 2026, ipOuts = 50, earnedRuns = 10, games = 12, strikeouts = 45)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 10) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getPitchingLeaders(1L, PitchingCategory.STRIKEOUTS)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].value).isEqualTo(45.0)
+        }
+
+        @Test
+        fun `should return WHIP leaders`() {
+            // given
+            val stats1 = createPitchingStats(player1, 2026, ipOuts = 36, earnedRuns = 3, games = 10)
+            val qualifyingIPOuts =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_IP_FACTOR *
+                    3).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonPitchingStatsRepository.findTopByWhip(2026, qualifyingIPOuts, 10) } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+
+            // when
+            val result = service.getPitchingLeaders(1L, PitchingCategory.WHIP)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
+
+        @Test
+        fun `should return empty list when no pitching stats`() {
+            // given
+            val qualifyingIPOuts =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_IP_FACTOR *
+                    3).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { seasonPitchingStatsRepository.findTopByEra(2026, qualifyingIPOuts, 10) } returns emptyList()
+
+            // when
+            val result = service.getPitchingLeaders(1L, PitchingCategory.ERA)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    // Helper methods
+
+    private fun createBattingStats(
+        player: Player,
+        year: Int,
+        atBats: Int = 0,
+        hits: Int = 0,
+        pa: Int = 0,
+        games: Int = 0,
+        homeRuns: Int = 0,
+        rbi: Int = 0,
+        stolenBases: Int = 0,
+    ): SeasonBattingStats {
+        val stats = SeasonBattingStats(player = player, year = year)
+        setField(stats, "gamesPlayed", games)
+        setField(stats, "plateAppearances", pa)
+        setField(stats, "atBats", atBats)
+        setField(stats, "hits", hits)
+        setField(stats, "homeRuns", homeRuns)
+        setField(stats, "runsBattedIn", rbi)
+        setField(stats, "stolenBases", stolenBases)
+        return stats
+    }
+
+    private fun createPitchingStats(
+        player: Player,
+        year: Int,
+        ipOuts: Int = 0,
+        earnedRuns: Int = 0,
+        games: Int = 0,
+        wins: Int = 0,
+        saves: Int = 0,
+        strikeouts: Int = 0,
+    ): SeasonPitchingStats {
+        val stats = SeasonPitchingStats(player = player, year = year)
+        setField(stats, "gamesPlayed", games)
+        setField(stats, "inningsPitchedOuts", ipOuts)
+        setField(stats, "earnedRuns", earnedRuns)
+        setField(stats, "runsAllowed", earnedRuns)
+        setField(stats, "wins", wins)
+        setField(stats, "saves", saves)
+        setField(stats, "strikeouts", strikeouts)
+        setField(stats, "hitsAllowed", 0)
+        setField(stats, "walksAllowed", 0)
+        setField(stats, "battersFaced", 0)
+        return stats
+    }
+
+    private fun createTeamMember(player: Player): TeamMember {
+        val member =
+            mockk<TeamMember> {
+                every { this@mockk.team } returns this@IndividualRankingServiceImplTest.team
+                every { role } returns TeamMemberRole.MEMBER
+            }
+        return member
+    }
+
+    private fun setField(
+        target: Any,
+        fieldName: String,
+        value: Any
+    ) {
+        val field = target::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+
+    private fun <T> setId(
+        target: T,
+        clazz: Class<T>,
+        id: Long
+    ) {
+        val idField = clazz.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(target, id)
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMatchupServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMatchupServiceImplTest.kt
@@ -1,0 +1,381 @@
+package com.nextup.infrastructure.service.team
+
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameResult
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class TeamMatchupServiceImplTest {
+    private val gameTeamRepositoryPort: GameTeamRepositoryPort = mockk()
+    private val teamRepositoryPort: TeamRepositoryPort = mockk()
+    private val service = TeamMatchupServiceImpl(gameTeamRepositoryPort, teamRepositoryPort)
+
+    private val association =
+        Association(
+            name = "테스트 협회",
+            abbreviation = "TA",
+            region = "서울",
+            id = 1L,
+        )
+
+    private val league =
+        League(
+            association = association,
+            name = "테스트 리그",
+            abbreviation = "TL",
+            foundedYear = 2020,
+            id = 1L,
+        )
+
+    private val competition =
+        Competition(
+            league = league,
+            name = "2024 시즌",
+            year = 2024,
+            season = 1,
+            startDate = LocalDate.now().minusMonths(3),
+            endDate = LocalDate.now().plusMonths(3),
+            id = 1L,
+        )
+
+    private val teamA =
+        Team(
+            league = league,
+            name = "타이거즈",
+            city = "서울",
+            foundedYear = 2020,
+            id = 1L,
+        )
+
+    private val teamB =
+        Team(
+            league = league,
+            name = "라이온즈",
+            city = "부산",
+            foundedYear = 2020,
+            id = 2L,
+        )
+
+    @Test
+    fun `should return team matchup with correct win-loss record`() {
+        // given
+        val game1 = createGame(1L, GameStatus.FINISHED)
+        val game2 = createGame(2L, GameStatus.FINISHED)
+        val game3 = createGame(3L, GameStatus.FINISHED)
+
+        val teamAGameTeams =
+            listOf(
+                createGameTeam(game1, teamA, HomeAway.HOME, GameResult.WIN, 5, 3),
+                createGameTeam(game2, teamA, HomeAway.AWAY, GameResult.LOSS, 2, 4),
+                createGameTeam(game3, teamA, HomeAway.HOME, GameResult.WIN, 7, 1),
+            )
+
+        every { teamRepositoryPort.findByIdOrNull(teamA.id) } returns teamA
+        every { teamRepositoryPort.findByIdOrNull(teamB.id) } returns teamB
+        every {
+            gameTeamRepositoryPort.findCompletedGamesBetweenTeams(
+                teamA.id,
+                teamB.id,
+                null,
+            )
+        } returns teamAGameTeams
+
+        every { gameTeamRepositoryPort.findAllByGameId(game1.id) } returns
+            listOf(
+                teamAGameTeams[0],
+                createGameTeam(game1, teamB, HomeAway.AWAY, GameResult.LOSS, 3, 5),
+            )
+        every { gameTeamRepositoryPort.findAllByGameId(game2.id) } returns
+            listOf(
+                teamAGameTeams[1],
+                createGameTeam(game2, teamB, HomeAway.HOME, GameResult.WIN, 4, 2),
+            )
+        every { gameTeamRepositoryPort.findAllByGameId(game3.id) } returns
+            listOf(
+                teamAGameTeams[2],
+                createGameTeam(game3, teamB, HomeAway.AWAY, GameResult.LOSS, 1, 7),
+            )
+
+        // when
+        val result = service.getTeamMatchup(teamA.id, teamB.id, null)
+
+        // then
+        assertThat(result.teamId).isEqualTo(teamA.id)
+        assertThat(result.teamName).isEqualTo("서울 타이거즈")
+        assertThat(result.opponentId).isEqualTo(teamB.id)
+        assertThat(result.opponentName).isEqualTo("부산 라이온즈")
+        assertThat(result.wins).isEqualTo(2)
+        assertThat(result.losses).isEqualTo(1)
+        assertThat(result.draws).isEqualTo(0)
+        assertThat(result.totalGames).isEqualTo(3)
+        assertThat(result.runsScored).isEqualTo(14) // 5 + 2 + 7
+        assertThat(result.runsAllowed).isEqualTo(8) // 3 + 4 + 1
+        assertThat(result.avgRunsScored).isEqualTo(4.67)
+        assertThat(result.avgRunsAllowed).isEqualTo(2.67)
+    }
+
+    @Test
+    fun `should return empty matchup when no games played`() {
+        // given
+        every { teamRepositoryPort.findByIdOrNull(teamA.id) } returns teamA
+        every { teamRepositoryPort.findByIdOrNull(teamB.id) } returns teamB
+        every {
+            gameTeamRepositoryPort.findCompletedGamesBetweenTeams(
+                teamA.id,
+                teamB.id,
+                null,
+            )
+        } returns emptyList()
+
+        // when
+        val result = service.getTeamMatchup(teamA.id, teamB.id, null)
+
+        // then
+        assertThat(result.totalGames).isEqualTo(0)
+        assertThat(result.wins).isEqualTo(0)
+        assertThat(result.losses).isEqualTo(0)
+        assertThat(result.draws).isEqualTo(0)
+        assertThat(result.runsScored).isEqualTo(0)
+        assertThat(result.runsAllowed).isEqualTo(0)
+        assertThat(result.avgRunsScored).isEqualTo(0.0)
+        assertThat(result.avgRunsAllowed).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `should handle draw games correctly`() {
+        // given
+        val game1 = createGame(1L, GameStatus.FINISHED)
+
+        val teamAGameTeams =
+            listOf(
+                createGameTeam(game1, teamA, HomeAway.HOME, GameResult.DRAW, 3, 3),
+            )
+
+        every { teamRepositoryPort.findByIdOrNull(teamA.id) } returns teamA
+        every { teamRepositoryPort.findByIdOrNull(teamB.id) } returns teamB
+        every {
+            gameTeamRepositoryPort.findCompletedGamesBetweenTeams(
+                teamA.id,
+                teamB.id,
+                null,
+            )
+        } returns teamAGameTeams
+
+        every { gameTeamRepositoryPort.findAllByGameId(game1.id) } returns
+            listOf(
+                teamAGameTeams[0],
+                createGameTeam(game1, teamB, HomeAway.AWAY, GameResult.DRAW, 3, 3),
+            )
+
+        // when
+        val result = service.getTeamMatchup(teamA.id, teamB.id, null)
+
+        // then
+        assertThat(result.wins).isEqualTo(0)
+        assertThat(result.losses).isEqualTo(0)
+        assertThat(result.draws).isEqualTo(1)
+        assertThat(result.totalGames).isEqualTo(1)
+    }
+
+    @Test
+    fun `should throw TeamNotFoundException when team does not exist`() {
+        // given
+        every { teamRepositoryPort.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<TeamNotFoundException> {
+            service.getTeamMatchup(999L, teamB.id, null)
+        }
+    }
+
+    @Test
+    fun `should throw TeamNotFoundException when opponent does not exist`() {
+        // given
+        every { teamRepositoryPort.findByIdOrNull(teamA.id) } returns teamA
+        every { teamRepositoryPort.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<TeamNotFoundException> {
+            service.getTeamMatchup(teamA.id, 999L, null)
+        }
+    }
+
+    @Test
+    fun `should return recent games in descending order`() {
+        // given
+        val game1 = createGame(1L, GameStatus.FINISHED, LocalDateTime.now().minusDays(10))
+        val game2 = createGame(2L, GameStatus.FINISHED, LocalDateTime.now().minusDays(5))
+        val game3 = createGame(3L, GameStatus.FINISHED, LocalDateTime.now().minusDays(1))
+
+        val teamAGameTeams =
+            listOf(
+                createGameTeam(game3, teamA, HomeAway.HOME, GameResult.WIN, 5, 3),
+                createGameTeam(game2, teamA, HomeAway.AWAY, GameResult.LOSS, 2, 4),
+                createGameTeam(game1, teamA, HomeAway.HOME, GameResult.WIN, 7, 1),
+            )
+
+        every { teamRepositoryPort.findByIdOrNull(teamA.id) } returns teamA
+        every { teamRepositoryPort.findByIdOrNull(teamB.id) } returns teamB
+        every {
+            gameTeamRepositoryPort.findCompletedGamesBetweenTeams(
+                teamA.id,
+                teamB.id,
+                null,
+            )
+        } returns teamAGameTeams
+
+        every { gameTeamRepositoryPort.findAllByGameId(game3.id) } returns
+            listOf(
+                teamAGameTeams[0],
+                createGameTeam(game3, teamB, HomeAway.AWAY, GameResult.LOSS, 3, 5),
+            )
+        every { gameTeamRepositoryPort.findAllByGameId(game2.id) } returns
+            listOf(
+                teamAGameTeams[1],
+                createGameTeam(game2, teamB, HomeAway.HOME, GameResult.WIN, 4, 2),
+            )
+        every { gameTeamRepositoryPort.findAllByGameId(game1.id) } returns
+            listOf(
+                teamAGameTeams[2],
+                createGameTeam(game1, teamB, HomeAway.AWAY, GameResult.LOSS, 1, 7),
+            )
+
+        // when
+        val result = service.getRecentGames(teamA.id, teamB.id, 10)
+
+        // then
+        assertThat(result).hasSize(3)
+        assertThat(result[0].gameId).isEqualTo(game3.id)
+        assertThat(result[1].gameId).isEqualTo(game2.id)
+        assertThat(result[2].gameId).isEqualTo(game1.id)
+    }
+
+    @Test
+    fun `should limit recent games to specified limit`() {
+        // given
+        val game1 = createGame(1L, GameStatus.FINISHED, LocalDateTime.now().minusDays(10))
+        val game2 = createGame(2L, GameStatus.FINISHED, LocalDateTime.now().minusDays(5))
+        val game3 = createGame(3L, GameStatus.FINISHED, LocalDateTime.now().minusDays(1))
+
+        val teamAGameTeams =
+            listOf(
+                createGameTeam(game3, teamA, HomeAway.HOME, GameResult.WIN, 5, 3),
+                createGameTeam(game2, teamA, HomeAway.AWAY, GameResult.LOSS, 2, 4),
+                createGameTeam(game1, teamA, HomeAway.HOME, GameResult.WIN, 7, 1),
+            )
+
+        every { teamRepositoryPort.findByIdOrNull(teamA.id) } returns teamA
+        every { teamRepositoryPort.findByIdOrNull(teamB.id) } returns teamB
+        every {
+            gameTeamRepositoryPort.findCompletedGamesBetweenTeams(
+                teamA.id,
+                teamB.id,
+                null,
+            )
+        } returns teamAGameTeams
+
+        every { gameTeamRepositoryPort.findAllByGameId(game3.id) } returns
+            listOf(
+                teamAGameTeams[0],
+                createGameTeam(game3, teamB, HomeAway.AWAY, GameResult.LOSS, 3, 5),
+            )
+        every { gameTeamRepositoryPort.findAllByGameId(game2.id) } returns
+            listOf(
+                teamAGameTeams[1],
+                createGameTeam(game2, teamB, HomeAway.HOME, GameResult.WIN, 4, 2),
+            )
+
+        // when
+        val result = service.getRecentGames(teamA.id, teamB.id, 2)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result[0].gameId).isEqualTo(game3.id)
+        assertThat(result[1].gameId).isEqualTo(game2.id)
+    }
+
+    @Test
+    fun `should return correct result from team perspective`() {
+        // given
+        val game1 = createGame(1L, GameStatus.FINISHED)
+
+        val teamAGameTeams =
+            listOf(
+                createGameTeam(game1, teamA, HomeAway.HOME, GameResult.WIN, 5, 3),
+            )
+
+        every { teamRepositoryPort.findByIdOrNull(teamA.id) } returns teamA
+        every { teamRepositoryPort.findByIdOrNull(teamB.id) } returns teamB
+        every {
+            gameTeamRepositoryPort.findCompletedGamesBetweenTeams(
+                teamA.id,
+                teamB.id,
+                null,
+            )
+        } returns teamAGameTeams
+
+        every { gameTeamRepositoryPort.findAllByGameId(game1.id) } returns
+            listOf(
+                teamAGameTeams[0],
+                createGameTeam(game1, teamB, HomeAway.AWAY, GameResult.LOSS, 3, 5),
+            )
+
+        // when
+        val result = service.getRecentGames(teamA.id, teamB.id, 10)
+
+        // then
+        assertThat(result).hasSize(1)
+        assertThat(result[0].result).isEqualTo("WIN")
+        assertThat(result[0].homeTeamId).isEqualTo(teamA.id)
+        assertThat(result[0].awayTeamId).isEqualTo(teamB.id)
+        assertThat(result[0].homeScore).isEqualTo(5)
+        assertThat(result[0].awayScore).isEqualTo(3)
+    }
+
+    private fun createGame(
+        id: Long,
+        status: GameStatus,
+        scheduledAt: LocalDateTime = LocalDateTime.now(),
+    ): Game =
+        Game(
+            competition = competition,
+            scheduledAt = scheduledAt,
+            status = status,
+            id = id,
+        )
+
+    private fun createGameTeam(
+        game: Game,
+        team: Team,
+        homeAway: HomeAway,
+        result: GameResult,
+        totalScore: Int,
+        opponentScore: Int,
+    ): GameTeam {
+        val gameTeam =
+            GameTeam(
+                game = game,
+                team = team,
+                homeAway = homeAway,
+                id = 0L,
+            )
+        gameTeam.updateScore(totalScore, 0, 0)
+        gameTeam.updateResult(result)
+        return gameTeam
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
@@ -630,6 +630,195 @@ class TeamMembershipServiceImplTest {
     }
 
     @Nested
+    @DisplayName("createTeamWithOwner")
+    inner class CreateTeamWithOwner {
+        @Test
+        fun `should create team and register owner`() {
+            // given
+            every { userRepository.findByIdOrNull(2L) } returns user
+            every { teamMemberRepository.findActiveByUserId(2L) } returns null
+            every { teamRepository.findByName("뉴팀") } returns null
+            every { teamRepository.save(any()) } answers { firstArg() }
+            every { teamMemberRepository.save(any()) } answers { firstArg() }
+
+            val association = Association(name = "서울시야구협회", region = "서울")
+            val league = League(association = association, name = "1부 리그", foundedYear = 2020)
+            val newTeam = Team(league = league, name = "뉴팀", city = "서울", foundedYear = 2026)
+
+            // when
+            val result = service.createTeamWithOwner(2L, newTeam, 7)
+
+            // then
+            assertThat(result.name).isEqualTo("뉴팀")
+            verify { teamRepository.save(any()) }
+            verify { teamMemberRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw when uniform number is invalid`() {
+            // when & then
+            assertThatThrownBy {
+                service.createTeamWithOwner(2L, team, 0)
+            }.isInstanceOf(InvalidUniformNumberException::class.java)
+
+            assertThatThrownBy {
+                service.createTeamWithOwner(2L, team, 100)
+            }.isInstanceOf(InvalidUniformNumberException::class.java)
+        }
+
+        @Test
+        fun `should throw when user not found`() {
+            // given
+            every { userRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                service.createTeamWithOwner(999L, team, 7)
+            }.isInstanceOf(UserNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw when user has no player`() {
+            // given
+            val userWithoutPlayer = User.createLocalUser("noplayer@example.com", "password", "없음")
+            setUserId(userWithoutPlayer, 50L)
+
+            every { userRepository.findByIdOrNull(50L) } returns userWithoutPlayer
+
+            // when & then
+            assertThatThrownBy {
+                service.createTeamWithOwner(50L, team, 7)
+            }.isInstanceOf(PlayerNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw when user already in team`() {
+            // given
+            val existingMember = TeamMember.create(team, user, player, 10)
+            every { userRepository.findByIdOrNull(2L) } returns user
+            every { teamMemberRepository.findActiveByUserId(2L) } returns existingMember
+
+            // when & then
+            assertThatThrownBy {
+                service.createTeamWithOwner(2L, team, 7)
+            }.isInstanceOf(AlreadyInTeamException::class.java)
+        }
+
+        @Test
+        fun `should throw when team name already exists`() {
+            // given
+            every { userRepository.findByIdOrNull(2L) } returns user
+            every { teamMemberRepository.findActiveByUserId(2L) } returns null
+            every { teamRepository.findByName("타이거즈") } returns team
+
+            // when & then
+            assertThatThrownBy {
+                service.createTeamWithOwner(2L, team, 7)
+            }.isInstanceOf(TeamAlreadyExistsException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteTeam")
+    inner class DeleteTeam {
+        @Test
+        fun `should delete team when owner and single member`() {
+            // given
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns ownerMember
+            every { teamMemberRepository.countByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE) } returns 1L
+            every { teamMemberRepository.delete(ownerMember) } returns Unit
+            every { teamRepository.delete(team) } returns Unit
+
+            // when
+            service.deleteTeam(1L, 10L)
+
+            // then
+            verify { teamMemberRepository.delete(ownerMember) }
+            verify { teamRepository.delete(team) }
+        }
+
+        @Test
+        fun `should throw when team not found`() {
+            // given
+            every { teamRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                service.deleteTeam(999L, 10L)
+            }.isInstanceOf(TeamNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw when user is not a member`() {
+            // given
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                service.deleteTeam(1L, 999L)
+            }.isInstanceOf(InsufficientTeamRoleException::class.java)
+        }
+
+        @Test
+        fun `should throw when user is not owner`() {
+            // given
+            val memberOnly = TeamMember.create(team, user, player, 20, TeamMemberRole.MEMBER)
+            setTeamMemberId(memberOnly, 200L)
+
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 2L) } returns memberOnly
+
+            // when & then
+            assertThatThrownBy {
+                service.deleteTeam(1L, 2L)
+            }.isInstanceOf(InsufficientTeamRoleException::class.java)
+        }
+
+        @Test
+        fun `should throw when team has multiple active members`() {
+            // given
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns ownerMember
+            every { teamMemberRepository.countByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE) } returns 3L
+
+            // when & then
+            assertThatThrownBy {
+                service.deleteTeam(1L, 10L)
+            }.isInstanceOf(InvalidTeamStateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getTeamMemberCount")
+    inner class GetTeamMemberCount {
+        @Test
+        fun `should return active member count`() {
+            // given
+            every { teamMemberRepository.countByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE) } returns 5L
+
+            // when
+            val result = service.getTeamMemberCount(1L)
+
+            // then
+            assertThat(result).isEqualTo(5)
+        }
+
+        @Test
+        fun `should return zero when no active members`() {
+            // given
+            every { teamMemberRepository.countByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE) } returns 0L
+
+            // when
+            val result = service.getTeamMemberCount(1L)
+
+            // then
+            assertThat(result).isEqualTo(0)
+        }
+    }
+
+    @Nested
     @DisplayName("getMember")
     inner class GetMember {
         @Test

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/title/TitleServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/title/TitleServiceImplTest.kt
@@ -1,0 +1,428 @@
+package com.nextup.infrastructure.service.title
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import com.nextup.core.service.title.TitleCategory
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("TitleServiceImpl")
+class TitleServiceImplTest {
+    private lateinit var competitionRepository: CompetitionRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
+    private lateinit var seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort
+    private lateinit var seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort
+    private lateinit var titleService: TitleServiceImpl
+
+    private lateinit var competition: Competition
+    private lateinit var league: League
+    private lateinit var association: Association
+
+    @BeforeEach
+    fun setUp() {
+        competitionRepository = mockk()
+        gameTeamRepository = mockk()
+        seasonBattingStatsRepository = mockk()
+        seasonPitchingStatsRepository = mockk()
+        titleService =
+            TitleServiceImpl(
+                competitionRepository,
+                gameTeamRepository,
+                seasonBattingStatsRepository,
+                seasonPitchingStatsRepository,
+            )
+
+        // Test data setup
+        association = createAssociation(1L, "서울시야구협회")
+        league = createLeague(1L, "1부 리그", association)
+        competition = createCompetition(1L, league, "2025 춘계대회", 2025, 1)
+    }
+
+    @Nested
+    @DisplayName("getTitles")
+    inner class GetTitles {
+        @Test
+        fun `대회가 존재하지 않으면 CompetitionNotFoundException 발생`() {
+            // given
+            val competitionId = 999L
+            every { competitionRepository.findByIdOrNull(competitionId) } returns null
+
+            // when & then
+            assertThrows<CompetitionNotFoundException> {
+                titleService.getTitles(competitionId)
+            }
+        }
+
+        @Test
+        fun `모든 타이틀 카테고리를 반환`() {
+            // given
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns emptyList()
+            every { seasonBattingStatsRepository.findAllByYear(2025) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2025, 10) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2025, 10) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2025, 10) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2025, 10) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2025, 10) } returns emptyList()
+            every { seasonPitchingStatsRepository.findAllByYear(2025) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2025, 10) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2025, 10) } returns emptyList()
+
+            // when
+            val result = titleService.getTitles(1L)
+
+            // then
+            assertThat(result).hasSize(9) // 9개의 타이틀 카테고리
+            assertThat(result.map { it.category }).containsExactlyInAnyOrder(
+                TitleCategory.BATTING_AVG,
+                TitleCategory.HOME_RUNS,
+                TitleCategory.RBI,
+                TitleCategory.STOLEN_BASES,
+                TitleCategory.HITS,
+                TitleCategory.WINS,
+                TitleCategory.ERA,
+                TitleCategory.SAVES,
+                TitleCategory.STRIKEOUTS,
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("getTitleByCategory - 타격왕")
+    inner class GetBattingAvgTitle {
+        @Test
+        fun `규정 타석 충족 선수를 1위로 선정`() {
+            // given
+            val teamA = createTeam(1L, league, "Tigers")
+            val game1 = createGame(1L, competition)
+
+            // 팀당 10경기 (규정 타석 = 10 * 3.1 = 31타석)
+            val gameTeams = (1..10).map { createGameTeam(it.toLong(), game1, teamA, HomeAway.HOME, 0) }
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns gameTeams
+
+            val player1 = createPlayer(1L, "김타격")
+            val player2 = createPlayer(2L, "박안타")
+
+            // player1: 타율 .400 (40타석, 규정 충족)
+            val stats1 = createBattingStats(1L, player1, 2025, plateAppearances = 40, atBats = 35, hits = 14)
+            // player2: 타율 .500 (20타석, 규정 미충족)
+            val stats2 = createBattingStats(2L, player2, 2025, plateAppearances = 20, atBats = 18, hits = 9)
+
+            every { seasonBattingStatsRepository.findAllByYear(2025) } returns listOf(stats2, stats1)
+
+            // when
+            val result = titleService.getTitleByCategory(1L, TitleCategory.BATTING_AVG)
+
+            // then
+            assertThat(result.category).isEqualTo(TitleCategory.BATTING_AVG)
+            assertThat(result.displayName).isEqualTo("타격왕")
+            assertThat(result.winner).isNotNull
+            assertThat(result.winner?.playerId).isEqualTo(1L) // 규정 충족한 player1이 우승
+            assertThat(result.winner?.playerName).isEqualTo("김타격")
+            assertThat(result.topCandidates).hasSize(2)
+            assertThat(result.topCandidates[0].rank).isEqualTo(1)
+            assertThat(result.topCandidates[0].isQualified).isFalse() // 타율 1위지만 규정 미충족
+            assertThat(result.topCandidates[1].rank).isEqualTo(2)
+            assertThat(result.topCandidates[1].isQualified).isTrue() // 규정 충족
+        }
+
+        @Test
+        fun `규정 타석 충족 선수가 없으면 우승자 없음`() {
+            // given
+            val teamA = createTeam(1L, league, "Tigers")
+            val game1 = createGame(1L, competition)
+            val gameTeams = (1..10).map { createGameTeam(it.toLong(), game1, teamA, HomeAway.HOME, 0) }
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns gameTeams
+
+            val player1 = createPlayer(1L, "김타격")
+            // 규정 타석 미충족 (31타석 필요, 20타석만 기록)
+            val stats1 = createBattingStats(1L, player1, 2025, plateAppearances = 20, atBats = 18, hits = 9)
+
+            every { seasonBattingStatsRepository.findAllByYear(2025) } returns listOf(stats1)
+
+            // when
+            val result = titleService.getTitleByCategory(1L, TitleCategory.BATTING_AVG)
+
+            // then
+            assertThat(result.winner).isNull()
+            assertThat(result.topCandidates).hasSize(1)
+            assertThat(result.topCandidates[0].isQualified).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("getTitleByCategory - 홈런왕")
+    inner class GetHomeRunsTitle {
+        @Test
+        fun `홈런 최다 선수를 우승자로 선정`() {
+            // given
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns emptyList()
+
+            val player1 = createPlayer(1L, "김장타")
+            val player2 = createPlayer(2L, "박홈런")
+
+            val stats1 = createBattingStats(1L, player1, 2025, homeRuns = 15)
+            val stats2 = createBattingStats(2L, player2, 2025, homeRuns = 12)
+
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2025, 10) } returns listOf(stats1, stats2)
+
+            // when
+            val result = titleService.getTitleByCategory(1L, TitleCategory.HOME_RUNS)
+
+            // then
+            assertThat(result.category).isEqualTo(TitleCategory.HOME_RUNS)
+            assertThat(result.winner).isNotNull
+            assertThat(result.winner?.playerId).isEqualTo(1L)
+            assertThat(result.winner?.statValue).isEqualTo(15.0)
+            assertThat(result.topCandidates).hasSize(2)
+            assertThat(result.topCandidates[0].isQualified).isTrue() // 홈런왕은 규정 타석 불필요
+        }
+    }
+
+    @Nested
+    @DisplayName("getTitleByCategory - 평균자책점")
+    inner class GetEraTitle {
+        @Test
+        fun `규정 이닝 충족 투수 중 ERA 최저 선수를 우승자로 선정`() {
+            // given
+            val teamA = createTeam(1L, league, "Tigers")
+            val game1 = createGame(1L, competition)
+
+            // 팀당 10경기 (규정 이닝 = 10 * 1.0 = 10이닝 = 30아웃)
+            val gameTeams = (1..10).map { createGameTeam(it.toLong(), game1, teamA, HomeAway.HOME, 0) }
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns gameTeams
+
+            val player1 = createPlayer(1L, "김투수")
+            val player2 = createPlayer(2L, "박마운드")
+
+            // player1: ERA 2.00 (45아웃 = 15이닝, 규정 충족)
+            val stats1 = createPitchingStats(1L, player1, 2025, inningsPitchedOuts = 45, earnedRuns = 10)
+            // player2: ERA 1.50 (18아웃 = 6이닝, 규정 미충족)
+            val stats2 = createPitchingStats(2L, player2, 2025, inningsPitchedOuts = 18, earnedRuns = 3)
+
+            every { seasonPitchingStatsRepository.findAllByYear(2025) } returns listOf(stats2, stats1)
+
+            // when
+            val result = titleService.getTitleByCategory(1L, TitleCategory.ERA)
+
+            // then
+            assertThat(result.category).isEqualTo(TitleCategory.ERA)
+            assertThat(result.winner).isNotNull
+            assertThat(result.winner?.playerId).isEqualTo(1L) // 규정 충족한 player1이 우승
+            assertThat(result.topCandidates).hasSize(2)
+            assertThat(result.topCandidates[0].rank).isEqualTo(1)
+            assertThat(result.topCandidates[0].isQualified).isFalse() // ERA 1위지만 규정 미충족
+            assertThat(result.topCandidates[1].rank).isEqualTo(2)
+            assertThat(result.topCandidates[1].isQualified).isTrue() // 규정 충족
+        }
+    }
+
+    @Nested
+    @DisplayName("getTitleByCategory - 다승왕")
+    inner class GetWinsTitle {
+        @Test
+        fun `승수 최다 투수를 우승자로 선정`() {
+            // given
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns emptyList()
+
+            val player1 = createPlayer(1L, "김에이스")
+            val player2 = createPlayer(2L, "박선발")
+
+            val stats1 = createPitchingStats(1L, player1, 2025, wins = 12)
+            val stats2 = createPitchingStats(2L, player2, 2025, wins = 10)
+
+            every { seasonPitchingStatsRepository.findTopByWins(2025, 10) } returns listOf(stats1, stats2)
+
+            // when
+            val result = titleService.getTitleByCategory(1L, TitleCategory.WINS)
+
+            // then
+            assertThat(result.category).isEqualTo(TitleCategory.WINS)
+            assertThat(result.winner).isNotNull
+            assertThat(result.winner?.playerId).isEqualTo(1L)
+            assertThat(result.winner?.statValue).isEqualTo(12.0)
+            assertThat(result.topCandidates[0].isQualified).isTrue() // 다승왕은 규정 이닝 불필요
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association {
+        val association = mockk<Association>(relaxed = true)
+        every { association.id } returns id
+        every { association.name } returns name
+        return association
+    }
+
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association,
+    ): League {
+        val league = mockk<League>(relaxed = true)
+        every { league.id } returns id
+        every { league.name } returns name
+        every { league.association } returns association
+        return league
+    }
+
+    private fun createCompetition(
+        id: Long,
+        league: League,
+        name: String,
+        year: Int,
+        season: Int,
+    ): Competition {
+        val competition = mockk<Competition>(relaxed = true)
+        every { competition.id } returns id
+        every { competition.league } returns league
+        every { competition.name } returns name
+        every { competition.year } returns year
+        every { competition.season } returns season
+        every { competition.type } returns CompetitionType.LEAGUE
+        every { competition.startDate } returns LocalDate.of(year, 3, 1)
+        return competition
+    }
+
+    private fun createTeam(
+        id: Long,
+        league: League,
+        name: String,
+    ): Team {
+        val team = mockk<Team>(relaxed = true)
+        every { team.id } returns id
+        every { team.league } returns league
+        every { team.name } returns name
+        return team
+    }
+
+    private fun createGame(
+        id: Long,
+        competition: Competition,
+    ): Game {
+        val game = mockk<Game>(relaxed = true)
+        every { game.id } returns id
+        every { game.competition } returns competition
+        every { game.status } returns GameStatus.FINISHED
+        every { game.scheduledAt } returns LocalDateTime.of(2025, 3, 15, 14, 0)
+        return game
+    }
+
+    private fun createGameTeam(
+        id: Long,
+        game: Game,
+        team: Team,
+        homeAway: HomeAway,
+        totalScore: Int,
+    ): GameTeam {
+        val gameTeam = mockk<GameTeam>(relaxed = true)
+        every { gameTeam.id } returns id
+        every { gameTeam.game } returns game
+        every { gameTeam.team } returns team
+        every { gameTeam.homeAway } returns homeAway
+        every { gameTeam.totalScore } returns totalScore
+        return gameTeam
+    }
+
+    private fun createPlayer(
+        id: Long,
+        name: String,
+    ): Player {
+        val player = mockk<Player>(relaxed = true)
+        every { player.id } returns id
+        every { player.name } returns name
+        every { player.primaryPosition } returns Position.STARTING_PITCHER
+        every { player.throwingHand } returns ThrowingHand.RIGHT
+        every { player.battingHand } returns BattingHand.RIGHT
+        return player
+    }
+
+    private fun createBattingStats(
+        id: Long,
+        player: Player,
+        year: Int,
+        plateAppearances: Int = 0,
+        atBats: Int = 0,
+        hits: Int = 0,
+        homeRuns: Int = 0,
+    ): SeasonBattingStats {
+        val stats = mockk<SeasonBattingStats>(relaxed = true)
+        every { stats.id } returns id
+        every { stats.player } returns player
+        every { stats.year } returns year
+        every { stats.plateAppearances } returns plateAppearances
+        every { stats.atBats } returns atBats
+        every { stats.hits } returns hits
+        every { stats.homeRuns } returns homeRuns
+        every { stats.battingAverage } returns
+            if (atBats > 0) {
+                BigDecimal(hits).divide(BigDecimal(atBats), 3, java.math.RoundingMode.HALF_UP)
+            } else {
+                BigDecimal.ZERO
+            }
+        return stats
+    }
+
+    private fun createPitchingStats(
+        id: Long,
+        player: Player,
+        year: Int,
+        inningsPitchedOuts: Int = 0,
+        earnedRuns: Int = 0,
+        wins: Int = 0,
+    ): SeasonPitchingStats {
+        val stats = mockk<SeasonPitchingStats>(relaxed = true)
+        every { stats.id } returns id
+        every { stats.player } returns player
+        every { stats.year } returns year
+        every { stats.inningsPitchedOuts } returns inningsPitchedOuts
+        every { stats.earnedRuns } returns earnedRuns
+        every { stats.wins } returns wins
+        every { stats.earnedRunAverage } returns
+            if (inningsPitchedOuts > 0) {
+                val innings = BigDecimal(inningsPitchedOuts).divide(BigDecimal(3), 10, java.math.RoundingMode.HALF_UP)
+                BigDecimal(earnedRuns)
+                    .multiply(BigDecimal(9))
+                    .divide(innings, 2, java.math.RoundingMode.HALF_UP)
+            } else {
+                BigDecimal.ZERO
+            }
+        return stats
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/PitchEventRecordController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/PitchEventRecordController.kt
@@ -1,0 +1,44 @@
+package com.nextup.scorer.controller
+
+import com.nextup.core.service.PitchEventService
+import com.nextup.scorer.dto.common.ApiResponse
+import com.nextup.scorer.dto.pitch.PitchEventResponse
+import com.nextup.scorer.dto.pitch.RecordPitchRequest
+import com.nextup.scorer.dto.pitch.toResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 투구 이벤트 기록 Controller (Scorer)
+ *
+ * 기록원이 투구를 기록하는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/scorer/v1/games/{gameId}/pitch-events")
+class PitchEventRecordController(
+    private val pitchEventService: PitchEventService,
+) {
+    /**
+     * 투구를 기록합니다.
+     */
+    @PostMapping
+    fun recordPitch(
+        @PathVariable gameId: Long,
+        @RequestBody @Valid request: RecordPitchRequest,
+    ): ResponseEntity<ApiResponse<PitchEventResponse>> {
+        val pitchEvent =
+            pitchEventService.recordPitch(
+                gameId = gameId,
+                pitcherId = request.pitcherId,
+                batterId = request.batterId,
+                result = request.result,
+                description = request.description,
+            )
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(pitchEvent.toResponse()))
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -67,4 +67,24 @@ class GameScorerController(
         val game = gameScorerService.endGame(gameId, request.reason!!)
         return ApiResponse.success(game.toResponse())
     }
+
+    /**
+     * 마지막 이벤트를 되돌립니다 (Undo).
+     */
+    @PostMapping("/{gameId}/undo")
+    @ResponseStatus(HttpStatus.OK)
+    fun undoLastEvent(
+        @PathVariable gameId: Long
+    ): ApiResponse<UndoResponse> {
+        val undoneEvent = gameScorerService.undoLastEvent(gameId)
+        val game = undoneEvent.game
+        return ApiResponse.success(
+            UndoResponse(
+                undoneEventId = undoneEvent.id,
+                eventType = undoneEvent.eventType.displayName,
+                restoredState = game.gameState.toResponse(),
+                message = "${undoneEvent.eventType.displayName} 이벤트가 되돌려졌습니다.",
+            )
+        )
+    }
 }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -87,4 +87,24 @@ class GameScorerController(
             )
         )
     }
+
+    /**
+     * 경기를 몰수 처리합니다.
+     *
+     * 승리팀에 7점, 패배팀에 0점을 자동 반영하고 경기를 종료합니다.
+     */
+    @PostMapping("/{gameId}/forfeit")
+    @ResponseStatus(HttpStatus.OK)
+    fun forfeitGame(
+        @PathVariable gameId: Long,
+        @RequestBody @Valid request: ForfeitRequestDto
+    ): ApiResponse<GameResponse> {
+        val game =
+            gameScorerService.forfeitGame(
+                gameId = gameId,
+                winnerTeamId = request.winnerTeamId!!,
+                reason = request.reason!!,
+            )
+        return ApiResponse.success(game.toResponse())
+    }
 }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/ForfeitRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/ForfeitRequestDto.kt
@@ -1,0 +1,14 @@
+package com.nextup.scorer.dto.game
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 몰수 처리 요청 DTO
+ */
+data class ForfeitRequestDto(
+    @field:NotNull(message = "승리팀 ID는 필수입니다")
+    val winnerTeamId: Long?,
+    @field:NotBlank(message = "몰수 사유는 필수입니다")
+    val reason: String?,
+)

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/UndoResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/UndoResponse.kt
@@ -1,0 +1,11 @@
+package com.nextup.scorer.dto.game
+
+/**
+ * Undo 응답 DTO
+ */
+data class UndoResponse(
+    val undoneEventId: Long,
+    val eventType: String,
+    val restoredState: GameStateResponse,
+    val message: String,
+)

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/pitch/PitchEventResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/pitch/PitchEventResponse.kt
@@ -1,0 +1,49 @@
+package com.nextup.scorer.dto.pitch
+
+import com.nextup.core.domain.game.PitchEvent
+import com.nextup.core.domain.game.PitchResult
+import java.time.Instant
+
+/**
+ * 투구 이벤트 응답 DTO
+ */
+data class PitchEventResponse(
+    val id: Long,
+    val gameId: Long,
+    val pitcherId: Long,
+    val batterId: Long,
+    val inning: Int,
+    val isTopInning: Boolean,
+    val pitchNumber: Int,
+    val result: PitchResult,
+    val ballCount: Int,
+    val strikeCount: Int,
+    val description: String?,
+    val countDisplay: String,
+    val createdAt: Instant,
+)
+
+/**
+ * Entity → Response DTO 변환
+ */
+fun PitchEvent.toResponse(): PitchEventResponse =
+    PitchEventResponse(
+        id = this.id,
+        gameId = this.game.id,
+        pitcherId = this.pitcher.id,
+        batterId = this.batter.id,
+        inning = this.inning,
+        isTopInning = this.isTopInning,
+        pitchNumber = this.pitchNumber,
+        result = this.result,
+        ballCount = this.ballCount,
+        strikeCount = this.strikeCount,
+        description = this.description,
+        countDisplay = this.countDisplay,
+        createdAt = this.createdAt,
+    )
+
+/**
+ * List 변환
+ */
+fun List<PitchEvent>.toResponse(): List<PitchEventResponse> = this.map { it.toResponse() }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/pitch/RecordPitchRequest.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/pitch/RecordPitchRequest.kt
@@ -1,0 +1,20 @@
+package com.nextup.scorer.dto.pitch
+
+import com.nextup.core.domain.game.PitchResult
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+
+/**
+ * 투구 기록 요청 DTO
+ */
+data class RecordPitchRequest(
+    @field:NotNull(message = "투수 ID는 필수입니다")
+    @field:Positive(message = "투수 ID는 양수여야 합니다")
+    val pitcherId: Long,
+    @field:NotNull(message = "타자 ID는 필수입니다")
+    @field:Positive(message = "타자 ID는 양수여야 합니다")
+    val batterId: Long,
+    @field:NotNull(message = "투구 결과는 필수입니다")
+    val result: PitchResult,
+    val description: String? = null,
+)

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
@@ -7,6 +7,7 @@ import com.nextup.common.exception.NotFoundException
 import com.nextup.scorer.dto.common.ApiResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -48,6 +49,15 @@ class GlobalExceptionHandler {
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.error("VALIDATION_ERROR", message))
     }
+
+    /**
+     * JSON 파싱 예외 처리 (잘못된 요청 본문)
+     */
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadable(ex: HttpMessageNotReadableException): ResponseEntity<ApiResponse<Unit>> =
+        ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("INVALID_REQUEST_BODY", "요청 본문이 올바르지 않습니다."))
 
     /**
      * IllegalArgumentException 처리 (도메인 로직 검증 실패)

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/PitchEventRecordControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/PitchEventRecordControllerTest.kt
@@ -1,0 +1,218 @@
+package com.nextup.scorer.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.*
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.service.PitchEventService
+import com.nextup.scorer.dto.pitch.RecordPitchRequest
+import com.nextup.scorer.exception.GlobalExceptionHandler
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class PitchEventRecordControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var pitchEventService: PitchEventService
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var game: Game
+    private lateinit var pitcher: GamePlayer
+    private lateinit var batter: GamePlayer
+
+    @BeforeEach
+    fun setUp() {
+        pitchEventService = mockk()
+        objectMapper = ObjectMapper()
+
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(PitchEventRecordController(pitchEventService))
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        // Test fixtures
+        game = createGame()
+        pitcher = createPitcher(game)
+        batter = createBatter(game)
+    }
+
+    @Test
+    fun `투구를 기록할 수 있다`() {
+        // given
+        val gameId = 1L
+        val request =
+            RecordPitchRequest(
+                pitcherId = 2L,
+                batterId = 3L,
+                result = PitchResult.STRIKE,
+                description = "스트라이크",
+            )
+
+        val pitchEvent = createPitchEvent()
+
+        every {
+            pitchEventService.recordPitch(
+                gameId = gameId,
+                pitcherId = request.pitcherId,
+                batterId = request.batterId,
+                result = request.result,
+                description = request.description,
+            )
+        } returns pitchEvent
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/scorer/v1/games/{gameId}/pitch-events", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.result").value("STRIKE"))
+            .andExpect(jsonPath("$.data.ballCount").value(0))
+            .andExpect(jsonPath("$.data.strikeCount").value(1))
+            .andExpect(jsonPath("$.data.countDisplay").value("0B-1S"))
+    }
+
+    @Test
+    fun `투수 ID가 없으면 400 에러가 발생한다`() {
+        // given
+        val gameId = 1L
+        val invalidRequest = """{"batterId": 3, "result": "STRIKE"}"""
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/scorer/v1/games/{gameId}/pitch-events", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidRequest),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `타자 ID가 없으면 400 에러가 발생한다`() {
+        // given
+        val gameId = 1L
+        val invalidRequest = """{"pitcherId": 2, "result": "STRIKE"}"""
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/scorer/v1/games/{gameId}/pitch-events", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidRequest),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `투구 결과가 없으면 400 에러가 발생한다`() {
+        // given
+        val gameId = 1L
+        val invalidRequest = """{"pitcherId": 2, "batterId": 3}"""
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/scorer/v1/games/{gameId}/pitch-events", gameId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidRequest),
+            ).andExpect(status().isBadRequest)
+    }
+
+    // Helper methods
+    private fun createGame(): Game {
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
+        val competition =
+            Competition(
+                league = league,
+                name = "테스트 대회",
+                year = 2024,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2024, 3, 1),
+                id = 1L,
+            )
+
+        return Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2024, 6, 1, 14, 0),
+            status = GameStatus.IN_PROGRESS,
+            currentInning = 1,
+            id = 1L,
+        )
+    }
+
+    private fun createHomeTeam(game: Game): GameTeam {
+        val association = Association(name = "테스트 협회", id = 1L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
+        val team = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        return GameTeam(game = game, team = team, homeAway = HomeAway.HOME, id = 1L)
+    }
+
+    private fun createAwayTeam(game: Game): GameTeam {
+        val association = Association(name = "테스트 협회", id = 2L)
+        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 2L)
+        val team = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        return GameTeam(game = game, team = team, homeAway = HomeAway.AWAY, id = 2L)
+    }
+
+    private fun createPitcher(game: Game): GamePlayer {
+        val awayTeam = createAwayTeam(game)
+        val player =
+            Player(
+                name = "투수",
+                birthDate = LocalDate.of(1995, 1, 1),
+                primaryPosition = Position.STARTING_PITCHER,
+            )
+        return GamePlayer(
+            gameTeam = awayTeam,
+            player = player,
+            position = Position.STARTING_PITCHER,
+            battingOrder = null,
+        )
+    }
+
+    private fun createBatter(game: Game): GamePlayer {
+        val homeTeam = createHomeTeam(game)
+        val player =
+            Player(
+                name = "타자",
+                birthDate = LocalDate.of(1995, 1, 1),
+                primaryPosition = Position.FIRST_BASE,
+            )
+        return GamePlayer(
+            gameTeam = homeTeam,
+            player = player,
+            position = Position.FIRST_BASE,
+            battingOrder = 1,
+        )
+    }
+
+    private fun createPitchEvent(): PitchEvent =
+        PitchEvent.create(
+            game = game,
+            pitcher = pitcher,
+            batter = batter,
+            pitchNumber = 1,
+            result = PitchResult.STRIKE,
+            ballCount = 0,
+            strikeCount = 1,
+            description = "스트라이크",
+        )
+}


### PR DESCRIPTION
## Summary\n\n> Closes #96, #97, #98, #99\n\nPhase 4: 기록 고도화 및 부가 기능 구현입니다.\n투구 상세 기록, 공식 기록지 PDF, 기록 증명서 발급, 출석/활동 관리 시스템을 구현합니다.\n\n## Tasks\n\n- [x] **#96 투구 상세 기록 API**: PitchEvent 도메인 모델, 기록원(Scorer) 투구 기록 API, 조회 API, V014 마이그레이션\n- [x] **#97 공식 기록지 PDF**: ScoresheetService 기록지 데이터 조합, PdfGeneratorPort, PDF 다운로드 API\n- [x] **#98 기록 증명서 발급**: Certificate 도메인 엔티티, QR 코드 검증, 증명서 발급/조회 API, V015 마이그레이션\n- [x] **#99 출석/활동 관리**: AttendancePoll/AttendanceVote 도메인, 투표 CRUD, 활동 통계, V016 마이그레이션\n\n## To Reviewer\n\n- 4개 이슈를 병렬로 구현 후 빌드 오류를 수정하여 전체 빌드 GREEN 상태입니다 (83 tasks 실행, 모든 테스트 통과)\n- `poll_votes` 테이블명은 기존 `game.AttendanceVote`의 `attendance_votes`와 충돌을 피하기 위해 변경했습니다\n- PdfGeneratorPort, QrCodeGeneratorPort는 Stub 구현체로 제공 (실제 라이브러리 연동은 별도 이슈)\n- GlobalExceptionHandler에 HttpMessageNotReadableException 핸들러 추가 (JSON 파싱 오류 시 400 반환)