### PR TITLE
fix(#111): WebSocket 무인증 접근 차단 및 JWT 인증 추가

### DIFF
--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/SecurityConfig.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/SecurityConfig.kt
@@ -63,7 +63,7 @@ class SecurityConfig(
                         "/swagger-resources/**"
                     ).permitAll()
 
-                    // WebSocket endpoints (for real-time scoreboard)
+                    // WebSocket endpoints - HTTP 핸드셰이크 허용 (STOMP CONNECT에서 JWT 검증)
                     .requestMatchers("/ws/**").permitAll()
 
                     // Scorer API endpoints

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketAuthInterceptor.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketAuthInterceptor.kt
@@ -1,0 +1,58 @@
+package com.nextup.scorer.config
+
+import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.messaging.support.MessageHeaderAccessor
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.stereotype.Component
+
+/**
+ * WebSocket STOMP CONNECT 시 JWT 토큰을 검증하는 인터셉터
+ *
+ * Authorization 헤더에서 Bearer 토큰을 추출하여 인증을 수행합니다.
+ */
+@Component
+class WebSocketAuthInterceptor(
+    private val jwtTokenProvider: JwtTokenProvider,
+) : ChannelInterceptor {
+    companion object {
+        private const val BEARER_PREFIX = "Bearer "
+    }
+
+    override fun preSend(
+        message: Message<*>,
+        channel: MessageChannel,
+    ): Message<*> {
+        val accessor =
+            MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor::class.java)
+                ?: return message
+
+        if (accessor.command == StompCommand.CONNECT) {
+            val token =
+                accessor.getFirstNativeHeader("Authorization")
+                    ?.removePrefix(BEARER_PREFIX)
+                    ?: throw AuthenticationCredentialsNotFoundException(
+                        "WebSocket 연결에 인증 토큰이 필요합니다",
+                    )
+
+            if (!jwtTokenProvider.validateToken(token) || !jwtTokenProvider.isAccessToken(token)) {
+                throw AuthenticationCredentialsNotFoundException("유효하지 않은 토큰입니다")
+            }
+
+            val userId = jwtTokenProvider.getUserId(token)
+            val roles = jwtTokenProvider.getRoles(token)
+            val authorities = roles.map { SimpleGrantedAuthority("ROLE_$it") }
+
+            accessor.user =
+                UsernamePasswordAuthenticationToken(userId, null, authorities)
+        }
+
+        return message
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketConfig.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketConfig.kt
@@ -1,6 +1,8 @@
 package com.nextup.scorer.config
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.ChannelRegistration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry
@@ -10,10 +12,15 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
  * WebSocket 설정
  *
  * 실시간 스코어보드 브로드캐스트를 위한 STOMP over WebSocket 설정
+ * JWT 인증 필수, 허용된 도메인만 접근 가능
  */
 @Configuration
 @EnableWebSocketMessageBroker
-class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+class WebSocketConfig(
+    private val webSocketAuthInterceptor: WebSocketAuthInterceptor,
+    @Value("\${app.websocket.allowed-origins:http://localhost:3000}")
+    private val allowedOrigins: String,
+) : WebSocketMessageBrokerConfigurer {
 
     override fun configureMessageBroker(registry: MessageBrokerRegistry) {
         // 클라이언트가 구독할 수 있는 prefix
@@ -26,13 +33,19 @@ class WebSocketConfig : WebSocketMessageBrokerConfigurer {
     }
 
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
-        // WebSocket 연결 엔드포인트
+        val origins = allowedOrigins.split(",").map { it.trim() }.toTypedArray()
+
+        // WebSocket 연결 엔드포인트 (SockJS 포함)
         registry.addEndpoint("/ws/scoreboard")
-            .setAllowedOriginPatterns("*")
+            .setAllowedOrigins(*origins)
             .withSockJS()
 
         // SockJS 없이 순수 WebSocket 연결
         registry.addEndpoint("/ws/scoreboard")
-            .setAllowedOriginPatterns("*")
+            .setAllowedOrigins(*origins)
+    }
+
+    override fun configureClientInboundChannel(registration: ChannelRegistration) {
+        registration.interceptors(webSocketAuthInterceptor)
     }
 }

--- a/nextup-scorer/src/main/resources/application.yml
+++ b/nextup-scorer/src/main/resources/application.yml
@@ -24,6 +24,10 @@ spring:
     property-naming-strategy: SNAKE_CASE
     default-property-inclusion: non_null
 
+app:
+  websocket:
+    allowed-origins: ${WEBSOCKET_ALLOWED_ORIGINS:http://localhost:3000}
+
 jwt:
   secret: ${JWT_SECRET:dGhpcyBpcyBhIHNhbXBsZSBiYXNlNjQgZW5jb2RlZCBzZWNyZXQga2V5IGZvciBkZXZlbG9wbWVudCBvbmx5}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION:1800000}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/config/WebSocketAuthInterceptorTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/config/WebSocketAuthInterceptorTest.kt
@@ -1,0 +1,135 @@
+package com.nextup.scorer.config
+
+import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.MessageBuilder
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+
+@DisplayName("WebSocketAuthInterceptor")
+class WebSocketAuthInterceptorTest {
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var interceptor: WebSocketAuthInterceptor
+
+    @BeforeEach
+    fun setUp() {
+        jwtTokenProvider = mockk()
+        interceptor = WebSocketAuthInterceptor(jwtTokenProvider)
+    }
+
+    @Nested
+    @DisplayName("STOMP CONNECT")
+    inner class StompConnect {
+        @Test
+        fun `should authenticate with valid token`() {
+            // given
+            val token = "valid-jwt-token"
+            val accessor = StompHeaderAccessor.create(StompCommand.CONNECT)
+            accessor.setLeaveMutable(true)
+            accessor.addNativeHeader("Authorization", "Bearer $token")
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            every { jwtTokenProvider.validateToken(token) } returns true
+            every { jwtTokenProvider.isAccessToken(token) } returns true
+            every { jwtTokenProvider.getUserId(token) } returns 1L
+            every { jwtTokenProvider.getRoles(token) } returns setOf("SCORER")
+
+            // when
+            val result = interceptor.preSend(message, mockk())
+
+            // then
+            assertThat(result).isNotNull
+            assertThat(accessor.user).isInstanceOf(UsernamePasswordAuthenticationToken::class.java)
+            val auth = accessor.user as UsernamePasswordAuthenticationToken
+            assertThat(auth.principal).isEqualTo(1L)
+        }
+
+        @Test
+        fun `should reject when no Authorization header`() {
+            // given
+            val accessor = StompHeaderAccessor.create(StompCommand.CONNECT)
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            // when & then
+            assertThatThrownBy {
+                interceptor.preSend(message, mockk())
+            }.isInstanceOf(AuthenticationCredentialsNotFoundException::class.java)
+                .hasMessageContaining("인증 토큰이 필요합니다")
+        }
+
+        @Test
+        fun `should reject when token is invalid`() {
+            // given
+            val token = "invalid-token"
+            val accessor = StompHeaderAccessor.create(StompCommand.CONNECT)
+            accessor.addNativeHeader("Authorization", "Bearer $token")
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            every { jwtTokenProvider.validateToken(token) } returns false
+
+            // when & then
+            assertThatThrownBy {
+                interceptor.preSend(message, mockk())
+            }.isInstanceOf(AuthenticationCredentialsNotFoundException::class.java)
+                .hasMessageContaining("유효하지 않은 토큰입니다")
+        }
+
+        @Test
+        fun `should reject when token is not access token`() {
+            // given
+            val token = "refresh-token"
+            val accessor = StompHeaderAccessor.create(StompCommand.CONNECT)
+            accessor.addNativeHeader("Authorization", "Bearer $token")
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            every { jwtTokenProvider.validateToken(token) } returns true
+            every { jwtTokenProvider.isAccessToken(token) } returns false
+
+            // when & then
+            assertThatThrownBy {
+                interceptor.preSend(message, mockk())
+            }.isInstanceOf(AuthenticationCredentialsNotFoundException::class.java)
+                .hasMessageContaining("유효하지 않은 토큰입니다")
+        }
+    }
+
+    @Nested
+    @DisplayName("Non-CONNECT commands")
+    inner class NonConnect {
+        @Test
+        fun `should pass through SUBSCRIBE without auth check`() {
+            // given
+            val accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE)
+            accessor.destination = "/topic/games/1/scoreboard"
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            // when
+            val result = interceptor.preSend(message, mockk())
+
+            // then
+            assertThat(result).isNotNull
+        }
+
+        @Test
+        fun `should pass through DISCONNECT without auth check`() {
+            // given
+            val accessor = StompHeaderAccessor.create(StompCommand.DISCONNECT)
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            // when
+            val result = interceptor.preSend(message, mockk())
+
+            // then
+            assertThat(result).isNotNull
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #111

WebSocket 엔드포인트(`/ws/**`)가 `permitAll()`로 설정되고 CORS가 `*`(전체 허용)이어서 인증 없이 실시간 경기 데이터를 수신할 수 있는 취약점을 수정합니다.

## Tasks

- `WebSocketAuthInterceptor` 추가: STOMP CONNECT 시 `Authorization` 헤더에서 Bearer 토큰 추출 및 JWT 검증
- 토큰 없거나 유효하지 않으면 `AuthenticationCredentialsNotFoundException`으로 연결 거부
- CORS `setAllowedOriginPatterns("*")` → 환경변수(`WEBSOCKET_ALLOWED_ORIGINS`) 기반 허용 도메인 목록으로 제한
- `WebSocketConfig`에 인터셉터 등록 (`configureClientInboundChannel`)
- `WebSocketAuthInterceptorTest` 단위 테스트 6건 추가

## To Reviewer

- HTTP 핸드셰이크는 `permitAll()` 유지 (SockJS 호환), 실제 인증은 STOMP CONNECT 단계에서 수행
- Refresh Token으로는 연결 불가 (Access Token만 허용)
- OWASP A01(Broken Access Control), A07(Authentication Failures) 대응