### PR TITLE
feat(#118): 출석 투표 불참 사유 필드 추가

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/TeamAttendancePollController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/TeamAttendancePollController.kt
@@ -79,6 +79,8 @@ class TeamAttendancePollController(
                 pollId = pollId,
                 playerId = request.playerId,
                 voteType = request.voteType,
+                absenceReason = request.absenceReason,
+                reasonDetail = request.reasonDetail,
             )
 
         return ApiResponse.success(vote.toResponse())

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/AttendanceController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/AttendanceController.kt
@@ -34,7 +34,8 @@ class AttendanceController(
                 gameId = gameId,
                 memberId = member.id,
                 status = request.status,
-                reason = request.reason,
+                absenceReason = request.absenceReason,
+                reasonDetail = request.reasonDetail,
             )
 
         return ApiResponse.success(vote.toResponse())

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/AttendanceDto.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/AttendanceDto.kt
@@ -1,5 +1,6 @@
 package com.nextup.api.dto.attendance
 
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.attendance.AttendancePoll
 import com.nextup.core.domain.attendance.AttendanceVote
 import com.nextup.core.domain.attendance.PollStatus
@@ -45,6 +46,8 @@ data class SubmitVoteRequest(
     val playerId: Long,
     @field:NotNull(message = "투표 유형은 필수입니다")
     val voteType: VoteType,
+    val absenceReason: AbsenceReason? = null,
+    val reasonDetail: String? = null,
 )
 
 /**
@@ -56,6 +59,8 @@ data class VoteResponse(
     val playerId: Long,
     val playerName: String,
     val voteType: VoteType,
+    val absenceReason: AbsenceReason?,
+    val reasonDetail: String?,
     val createdAt: String,
     val updatedAt: String,
 )
@@ -94,6 +99,8 @@ fun AttendanceVote.toResponse(): VoteResponse =
         playerId = this.player.id,
         playerName = this.player.name,
         voteType = this.voteType,
+        absenceReason = this.absenceReason,
+        reasonDetail = this.reasonDetail,
         createdAt = this.createdAt.toString(),
         updatedAt = this.updatedAt.toString(),
     )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/AttendanceResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/AttendanceResponse.kt
@@ -1,5 +1,6 @@
 package com.nextup.api.dto.attendance
 
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.game.AttendanceStatus
 import java.time.LocalDateTime
 
@@ -11,7 +12,8 @@ data class AttendanceVoteResponse(
     val gameId: Long,
     val memberId: Long,
     val status: AttendanceStatus,
-    val reason: String?,
+    val absenceReason: AbsenceReason?,
+    val reasonDetail: String?,
     val respondedAt: LocalDateTime?,
 )
 
@@ -34,7 +36,8 @@ data class MemberVoteResponse(
     val voteId: Long,
     val member: MemberSummary,
     val status: AttendanceStatus,
-    val reason: String?,
+    val absenceReason: AbsenceReason?,
+    val reasonDetail: String?,
     val respondedAt: LocalDateTime?,
 )
 

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/AttendanceVoteRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/attendance/AttendanceVoteRequest.kt
@@ -1,5 +1,6 @@
 package com.nextup.api.dto.attendance
 
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.game.AttendanceStatus
 import jakarta.validation.constraints.NotNull
 
@@ -9,5 +10,6 @@ import jakarta.validation.constraints.NotNull
 data class AttendanceVoteRequest(
     @field:NotNull(message = "투표 상태는 필수입니다")
     val status: AttendanceStatus,
-    val reason: String? = null,
+    val absenceReason: AbsenceReason? = null,
+    val reasonDetail: String? = null,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/attendance/AttendanceMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/attendance/AttendanceMapper.kt
@@ -13,7 +13,8 @@ fun AttendanceVote.toResponse(): AttendanceVoteResponse =
         gameId = this.game.id,
         memberId = this.member.id,
         status = this.status,
-        reason = this.reason,
+        absenceReason = this.absenceReason,
+        reasonDetail = this.reasonDetail,
         respondedAt = this.respondedAt,
     )
 
@@ -44,7 +45,8 @@ fun AttendanceVote.toMemberVoteResponse(): MemberVoteResponse =
                 position = this.member.player.primaryPosition.abbreviation,
             ),
         status = this.status,
-        reason = this.reason,
+        absenceReason = this.absenceReason,
+        reasonDetail = this.reasonDetail,
         respondedAt = this.respondedAt,
     )
 

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/attendance/TeamAttendancePollControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/attendance/TeamAttendancePollControllerTest.kt
@@ -154,7 +154,9 @@ class TeamAttendancePollControllerTest {
             val request = SubmitVoteRequest(playerId = 1L, voteType = VoteType.ATTEND)
             val vote =
                 AttendanceVote.create(poll = poll, player = player, voteType = VoteType.ATTEND)
-            every { attendanceService.submitVote(1L, 1L, VoteType.ATTEND) } returns vote
+            every {
+                attendanceService.submitVote(1L, 1L, VoteType.ATTEND, null, null)
+            } returns vote
 
             // when & then
             mockMvc

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/AttendanceControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/AttendanceControllerTest.kt
@@ -70,7 +70,8 @@ class AttendanceControllerTest {
             every { this@mockk.game } returns this@AttendanceControllerTest.game
             every { this@mockk.member } returns this@AttendanceControllerTest.member
             every { this@mockk.status } returns status
-            every { reason } returns null
+            every { absenceReason } returns null
+            every { reasonDetail } returns null
             every { respondedAt } returns LocalDateTime.of(2026, 2, 25, 10, 0)
         }
 
@@ -90,7 +91,8 @@ class AttendanceControllerTest {
                     gameId = 1L,
                     memberId = 50L,
                     status = AttendanceStatus.ATTENDING,
-                    reason = null,
+                    absenceReason = null,
+                    reasonDetail = null,
                 )
             } returns vote
 

--- a/nextup-api/src/test/kotlin/com/nextup/api/mapper/attendance/AttendanceMapperTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/mapper/attendance/AttendanceMapperTest.kt
@@ -1,5 +1,6 @@
 package com.nextup.api.mapper.attendance
 
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.game.AttendanceStatus
 import com.nextup.core.domain.game.AttendanceVote
 import com.nextup.core.domain.game.Game
@@ -46,7 +47,8 @@ class AttendanceMapperTest {
                 every { this@mockk.game } returns this@AttendanceMapperTest.game
                 every { this@mockk.member } returns this@AttendanceMapperTest.member
                 every { status } returns AttendanceStatus.ATTENDING
-                every { reason } returns null
+                every { absenceReason } returns null
+                every { reasonDetail } returns null
                 every { this@mockk.respondedAt } returns respondedAt
             }
 
@@ -58,8 +60,32 @@ class AttendanceMapperTest {
         assertThat(response.gameId).isEqualTo(1L)
         assertThat(response.memberId).isEqualTo(50L)
         assertThat(response.status).isEqualTo(AttendanceStatus.ATTENDING)
-        assertThat(response.reason).isNull()
+        assertThat(response.absenceReason).isNull()
+        assertThat(response.reasonDetail).isNull()
         assertThat(response.respondedAt).isEqualTo(respondedAt)
+    }
+
+    @Test
+    fun `should map AttendanceVote with absence reason to response`() {
+        // given
+        val respondedAt = LocalDateTime.of(2026, 2, 1, 10, 0)
+        val vote =
+            mockk<AttendanceVote> {
+                every { id } returns 2L
+                every { this@mockk.game } returns this@AttendanceMapperTest.game
+                every { this@mockk.member } returns this@AttendanceMapperTest.member
+                every { status } returns AttendanceStatus.ABSENT
+                every { absenceReason } returns AbsenceReason.INJURY
+                every { reasonDetail } returns null
+                every { this@mockk.respondedAt } returns respondedAt
+            }
+
+        // when
+        val response = vote.toResponse()
+
+        // then
+        assertThat(response.absenceReason).isEqualTo(AbsenceReason.INJURY)
+        assertThat(response.reasonDetail).isNull()
     }
 
     @Test
@@ -71,7 +97,8 @@ class AttendanceMapperTest {
                 every { id } returns 2L
                 every { this@mockk.member } returns this@AttendanceMapperTest.member
                 every { status } returns AttendanceStatus.ABSENT
-                every { reason } returns "부상"
+                every { absenceReason } returns AbsenceReason.OTHER
+                every { reasonDetail } returns "부상"
                 every { this@mockk.respondedAt } returns respondedAt
             }
 
@@ -85,7 +112,8 @@ class AttendanceMapperTest {
         assertThat(response.member.uniformNumber).isEqualTo(18)
         assertThat(response.member.position).isEqualTo("P")
         assertThat(response.status).isEqualTo(AttendanceStatus.ABSENT)
-        assertThat(response.reason).isEqualTo("부상")
+        assertThat(response.absenceReason).isEqualTo(AbsenceReason.OTHER)
+        assertThat(response.reasonDetail).isEqualTo("부상")
     }
 
     @Test
@@ -121,7 +149,8 @@ class AttendanceMapperTest {
                 every { this@mockk.game } returns this@AttendanceMapperTest.game
                 every { this@mockk.member } returns this@AttendanceMapperTest.member
                 every { status } returns AttendanceStatus.ATTENDING
-                every { reason } returns null
+                every { absenceReason } returns null
+                every { reasonDetail } returns null
                 every { respondedAt } returns LocalDateTime.now()
             }
         val vote2 =
@@ -130,7 +159,8 @@ class AttendanceMapperTest {
                 every { this@mockk.game } returns this@AttendanceMapperTest.game
                 every { this@mockk.member } returns this@AttendanceMapperTest.member
                 every { status } returns AttendanceStatus.ABSENT
-                every { reason } returns "개인 사유"
+                every { absenceReason } returns AbsenceReason.WORK
+                every { reasonDetail } returns null
                 every { respondedAt } returns LocalDateTime.now()
             }
 
@@ -151,7 +181,8 @@ class AttendanceMapperTest {
                 every { id } returns 1L
                 every { this@mockk.member } returns this@AttendanceMapperTest.member
                 every { status } returns AttendanceStatus.UNDECIDED
-                every { reason } returns null
+                every { absenceReason } returns null
+                every { reasonDetail } returns null
                 every { respondedAt } returns null
             }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/AbsenceReason.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/AbsenceReason.kt
@@ -1,0 +1,28 @@
+package com.nextup.core.domain.attendance
+
+/**
+ * 불참 사유 열거형
+ *
+ * 출석 투표 시 불참/미정 응답에 대한 사유를 분류합니다.
+ */
+enum class AbsenceReason(
+    val displayName: String,
+) {
+    /** 가족 행사 */
+    FAMILY("가족 행사"),
+
+    /** 부상 */
+    INJURY("부상"),
+
+    /** 업무 */
+    WORK("업무"),
+
+    /** 여행 */
+    TRAVEL("여행"),
+
+    /** 날씨 */
+    WEATHER("날씨"),
+
+    /** 기타 (reasonDetail 입력 가능) */
+    OTHER("기타"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/AttendanceVote.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/attendance/AttendanceVote.kt
@@ -34,16 +34,32 @@ class AttendanceVote private constructor(
     @Enumerated(EnumType.STRING)
     @Column(name = "vote_type", nullable = false, length = 20)
     var voteType: VoteType,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "absence_reason", length = 20)
+    var absenceReason: AbsenceReason? = null,
+    @Column(name = "reason_detail", length = 500)
+    var reasonDetail: String? = null,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 ) : BaseTimeEntity() {
     /**
      * 투표를 변경합니다.
+     *
+     * @param newVoteType 새로운 투표 유형
+     * @param absenceReason 불참 사유 (불참/미정 시 선택 가능)
+     * @param reasonDetail 상세 사유 (OTHER 선택 시 입력 가능)
      */
-    fun changeVote(newVoteType: VoteType) {
+    fun changeVote(
+        newVoteType: VoteType,
+        absenceReason: AbsenceReason? = null,
+        reasonDetail: String? = null,
+    ) {
         check(poll.canVote()) { "투표를 변경할 수 없습니다. 마감되었거나 기한이 지났습니다." }
+        validateAbsenceReason(newVoteType, absenceReason, reasonDetail)
         this.voteType = newVoteType
+        this.absenceReason = absenceReason
+        this.reasonDetail = reasonDetail
     }
 
     /**
@@ -63,20 +79,43 @@ class AttendanceVote private constructor(
          * @param poll 출석 투표
          * @param player 선수
          * @param voteType 투표 유형
+         * @param absenceReason 불참 사유 (불참/미정 시 선택 가능)
+         * @param reasonDetail 상세 사유 (OTHER 선택 시 입력 가능)
          * @return 생성된 AttendanceVote
          */
         fun create(
             poll: AttendancePoll,
             player: Player,
             voteType: VoteType,
+            absenceReason: AbsenceReason? = null,
+            reasonDetail: String? = null,
         ): AttendanceVote {
             check(poll.canVote()) { "투표가 마감되었거나 기한이 지났습니다." }
+            validateAbsenceReason(voteType, absenceReason, reasonDetail)
 
             return AttendanceVote(
                 poll = poll,
                 player = player,
                 voteType = voteType,
+                absenceReason = absenceReason,
+                reasonDetail = reasonDetail,
             )
+        }
+
+        private fun validateAbsenceReason(
+            voteType: VoteType,
+            absenceReason: AbsenceReason?,
+            reasonDetail: String?,
+        ) {
+            if (voteType == VoteType.ATTEND) {
+                require(absenceReason == null) { "참석 투표 시 불참 사유를 입력할 수 없습니다." }
+                require(reasonDetail == null) { "참석 투표 시 상세 사유를 입력할 수 없습니다." }
+            }
+            if (reasonDetail != null) {
+                require(absenceReason == AbsenceReason.OTHER) {
+                    "상세 사유는 기타(OTHER) 사유 선택 시에만 입력할 수 있습니다."
+                }
+            }
         }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/AttendanceVote.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/AttendanceVote.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.domain.game
 
 import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.team.TeamMember
 import jakarta.persistence.*
 import java.time.LocalDateTime
@@ -32,8 +33,11 @@ class AttendanceVote private constructor(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     var status: AttendanceStatus = AttendanceStatus.UNDECIDED,
-    @Column(length = 500)
-    var reason: String? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "absence_reason", length = 20)
+    var absenceReason: AbsenceReason? = null,
+    @Column(name = "reason_detail", length = 500)
+    var reasonDetail: String? = null,
     @Column(name = "responded_at")
     var respondedAt: LocalDateTime? = null,
     @Id
@@ -56,18 +60,22 @@ class AttendanceVote private constructor(
      * 투표합니다.
      *
      * @param newStatus 투표 상태
-     * @param reason 사유
+     * @param absenceReason 불참 사유 (불참/미정 시 선택 가능)
+     * @param reasonDetail 상세 사유 (OTHER 선택 시 입력 가능)
      * @throws IllegalStateException 투표 권한이 없는 경우
      */
     fun vote(
         newStatus: AttendanceStatus,
-        reason: String? = null,
+        absenceReason: AbsenceReason? = null,
+        reasonDetail: String? = null,
     ) {
         check(this.member.canVote) {
             "투표 권한이 없는 회원입니다."
         }
+        validateAbsenceReason(newStatus, absenceReason, reasonDetail)
         this.status = newStatus
-        this.reason = reason
+        this.absenceReason = absenceReason
+        this.reasonDetail = reasonDetail
         this.respondedAt = LocalDateTime.now()
     }
 
@@ -75,19 +83,39 @@ class AttendanceVote private constructor(
      * 투표를 변경합니다.
      *
      * @param newStatus 새로운 투표 상태
-     * @param reason 사유
+     * @param absenceReason 불참 사유 (불참/미정 시 선택 가능)
+     * @param reasonDetail 상세 사유 (OTHER 선택 시 입력 가능)
      * @throws IllegalStateException 아직 투표하지 않은 경우
      */
     fun changeVote(
         newStatus: AttendanceStatus,
-        reason: String? = null,
+        absenceReason: AbsenceReason? = null,
+        reasonDetail: String? = null,
     ) {
         check(this.hasResponded) {
             "아직 투표하지 않았습니다."
         }
+        validateAbsenceReason(newStatus, absenceReason, reasonDetail)
         this.status = newStatus
-        this.reason = reason
+        this.absenceReason = absenceReason
+        this.reasonDetail = reasonDetail
         this.respondedAt = LocalDateTime.now()
+    }
+
+    private fun validateAbsenceReason(
+        status: AttendanceStatus,
+        absenceReason: AbsenceReason?,
+        reasonDetail: String?,
+    ) {
+        if (status == AttendanceStatus.ATTENDING) {
+            require(absenceReason == null) { "참석 투표 시 불참 사유를 입력할 수 없습니다." }
+            require(reasonDetail == null) { "참석 투표 시 상세 사유를 입력할 수 없습니다." }
+        }
+        if (reasonDetail != null) {
+            require(absenceReason == AbsenceReason.OTHER) {
+                "상세 사유는 기타(OTHER) 사유 선택 시에만 입력할 수 있습니다."
+            }
+        }
     }
 
     companion object {

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/attendance/AttendanceService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/attendance/AttendanceService.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.service.attendance
 
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.attendance.AttendancePoll
 import com.nextup.core.domain.attendance.AttendanceVote
 import com.nextup.core.domain.attendance.PollStatus
@@ -33,12 +34,16 @@ interface AttendanceService {
      * @param pollId 투표 ID
      * @param playerId 선수 ID
      * @param voteType 투표 유형
+     * @param absenceReason 불참 사유 (불참/미정 시 선택 가능)
+     * @param reasonDetail 상세 사유 (OTHER 선택 시 입력 가능)
      * @return 생성된 AttendanceVote
      */
     fun submitVote(
         pollId: Long,
         playerId: Long,
         voteType: VoteType,
+        absenceReason: AbsenceReason? = null,
+        reasonDetail: String? = null,
     ): AttendanceVote
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/AttendanceService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/AttendanceService.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.service.game
 
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.game.AttendanceStatus
 import com.nextup.core.domain.game.AttendanceVote
 import com.nextup.core.domain.team.TeamMember
@@ -18,7 +19,8 @@ interface AttendanceService {
      * @param gameId 경기 ID
      * @param memberId 회원 ID
      * @param status 투표 상태
-     * @param reason 사유
+     * @param absenceReason 불참 사유 (불참/미정 시 선택 가능)
+     * @param reasonDetail 상세 사유 (OTHER 선택 시 입력 가능)
      * @return 투표 결과
      * @throws AttendanceVoteNotFoundException 투표를 찾을 수 없는 경우
      * @throws VoteClosedException 투표가 마감된 경우
@@ -27,7 +29,8 @@ interface AttendanceService {
         gameId: Long,
         memberId: Long,
         status: AttendanceStatus,
-        reason: String?,
+        absenceReason: AbsenceReason? = null,
+        reasonDetail: String? = null,
     ): AttendanceVote
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/attendance/AttendanceVoteTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/attendance/AttendanceVoteTest.kt
@@ -6,10 +6,13 @@ import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.team.Team
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
 
+@DisplayName("AttendanceVote (Poll) 엔티티 테스트")
 class AttendanceVoteTest {
     private val association =
         Association(
@@ -46,93 +49,236 @@ class AttendanceVoteTest {
             primaryPosition = Position.STARTING_PITCHER,
         )
 
-    @Test
-    fun `출석 투표 응답을 생성할 수 있다`() {
-        // when
-        val vote =
-            AttendanceVote.create(
-                poll = poll,
-                player = player,
-                voteType = VoteType.ATTEND,
-            )
+    @Nested
+    @DisplayName("출석 투표 응답 생성")
+    inner class Create {
+        @Test
+        fun `출석 투표 응답을 생성할 수 있다`() {
+            // when
+            val vote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ATTEND,
+                )
 
-        // then
-        assertThat(vote.poll).isEqualTo(poll)
-        assertThat(vote.player).isEqualTo(player)
-        assertThat(vote.voteType).isEqualTo(VoteType.ATTEND)
-    }
+            // then
+            assertThat(vote.poll).isEqualTo(poll)
+            assertThat(vote.player).isEqualTo(player)
+            assertThat(vote.voteType).isEqualTo(VoteType.ATTEND)
+            assertThat(vote.absenceReason).isNull()
+            assertThat(vote.reasonDetail).isNull()
+        }
 
-    @Test
-    fun `투표를 변경할 수 있다`() {
-        // given
-        val vote =
-            AttendanceVote.create(
-                poll = poll,
-                player = player,
-                voteType = VoteType.UNDECIDED,
-            )
+        @Test
+        fun `불참 투표 시 사유를 입력할 수 있다`() {
+            // when
+            val vote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ABSENT,
+                    absenceReason = AbsenceReason.INJURY,
+                )
 
-        // when
-        vote.changeVote(VoteType.ATTEND)
+            // then
+            assertThat(vote.voteType).isEqualTo(VoteType.ABSENT)
+            assertThat(vote.absenceReason).isEqualTo(AbsenceReason.INJURY)
+            assertThat(vote.reasonDetail).isNull()
+        }
 
-        // then
-        assertThat(vote.voteType).isEqualTo(VoteType.ATTEND)
-    }
+        @Test
+        fun `미정 투표 시 사유를 입력할 수 있다`() {
+            // when
+            val vote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.UNDECIDED,
+                    absenceReason = AbsenceReason.WORK,
+                )
 
-    @Test
-    fun `마감된 투표는 변경할 수 없다`() {
-        // given - 투표를 먼저 생성 후 마감
-        val vote =
-            AttendanceVote.create(
-                poll = poll,
-                player = player,
-                voteType = VoteType.UNDECIDED,
-            )
-        poll.close()
+            // then
+            assertThat(vote.voteType).isEqualTo(VoteType.UNDECIDED)
+            assertThat(vote.absenceReason).isEqualTo(AbsenceReason.WORK)
+        }
 
-        // when & then
-        assertThrows<IllegalStateException> {
-            vote.changeVote(VoteType.ATTEND)
+        @Test
+        fun `기타 사유 선택 시 상세 사유를 입력할 수 있다`() {
+            // when
+            val vote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ABSENT,
+                    absenceReason = AbsenceReason.OTHER,
+                    reasonDetail = "개인 사정으로 불참합니다",
+                )
+
+            // then
+            assertThat(vote.absenceReason).isEqualTo(AbsenceReason.OTHER)
+            assertThat(vote.reasonDetail).isEqualTo("개인 사정으로 불참합니다")
+        }
+
+        @Test
+        fun `참석 투표 시 불참 사유를 입력하면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ATTEND,
+                    absenceReason = AbsenceReason.WORK,
+                )
+            }
+        }
+
+        @Test
+        fun `참석 투표 시 상세 사유를 입력하면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ATTEND,
+                    reasonDetail = "사유",
+                )
+            }
+        }
+
+        @Test
+        fun `기타 외 사유에 상세 사유를 입력하면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ABSENT,
+                    absenceReason = AbsenceReason.INJURY,
+                    reasonDetail = "상세 사유",
+                )
+            }
+        }
+
+        @Test
+        fun `마감된 투표에는 새로운 응답을 생성할 수 없다`() {
+            // given
+            poll.close()
+
+            // when & then
+            assertThrows<IllegalStateException> {
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ATTEND,
+                )
+            }
         }
     }
 
-    @Test
-    fun `참석 의사 확인이 가능하다`() {
-        // given
-        val attendVote =
-            AttendanceVote.create(
-                poll = poll,
-                player = player,
-                voteType = VoteType.ATTEND,
-            )
+    @Nested
+    @DisplayName("투표 변경")
+    inner class ChangeVoteTest {
+        @Test
+        fun `투표를 변경할 수 있다`() {
+            // given
+            val vote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.UNDECIDED,
+                )
 
-        val absentVote =
-            AttendanceVote.create(
-                poll = poll,
-                player = player,
-                voteType = VoteType.ABSENT,
-            )
+            // when
+            vote.changeVote(VoteType.ATTEND)
 
-        // when & then
-        assertThat(attendVote.isAttending()).isTrue()
-        assertThat(attendVote.isAbsent()).isFalse()
+            // then
+            assertThat(vote.voteType).isEqualTo(VoteType.ATTEND)
+            assertThat(vote.absenceReason).isNull()
+        }
 
-        assertThat(absentVote.isAttending()).isFalse()
-        assertThat(absentVote.isAbsent()).isTrue()
+        @Test
+        fun `투표 변경 시 불참 사유를 입력할 수 있다`() {
+            // given
+            val vote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ATTEND,
+                )
+
+            // when
+            vote.changeVote(VoteType.ABSENT, AbsenceReason.WEATHER)
+
+            // then
+            assertThat(vote.voteType).isEqualTo(VoteType.ABSENT)
+            assertThat(vote.absenceReason).isEqualTo(AbsenceReason.WEATHER)
+        }
+
+        @Test
+        fun `투표 변경 시 참석으로 변경하면 사유가 초기화된다`() {
+            // given
+            val vote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ABSENT,
+                    absenceReason = AbsenceReason.INJURY,
+                )
+
+            // when
+            vote.changeVote(VoteType.ATTEND)
+
+            // then
+            assertThat(vote.voteType).isEqualTo(VoteType.ATTEND)
+            assertThat(vote.absenceReason).isNull()
+            assertThat(vote.reasonDetail).isNull()
+        }
+
+        @Test
+        fun `마감된 투표는 변경할 수 없다`() {
+            // given - 투표를 먼저 생성 후 마감
+            val vote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.UNDECIDED,
+                )
+            poll.close()
+
+            // when & then
+            assertThrows<IllegalStateException> {
+                vote.changeVote(VoteType.ATTEND)
+            }
+        }
     }
 
-    @Test
-    fun `마감된 투표에는 새로운 응답을 생성할 수 없다`() {
-        // given
-        poll.close()
+    @Nested
+    @DisplayName("투표 상태 확인")
+    inner class StatusCheck {
+        @Test
+        fun `참석 의사 확인이 가능하다`() {
+            // given
+            val attendVote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ATTEND,
+                )
 
-        // when & then
-        assertThrows<IllegalStateException> {
-            AttendanceVote.create(
-                poll = poll,
-                player = player,
-                voteType = VoteType.ATTEND,
-            )
+            val absentVote =
+                AttendanceVote.create(
+                    poll = poll,
+                    player = player,
+                    voteType = VoteType.ABSENT,
+                )
+
+            // when & then
+            assertThat(attendVote.isAttending()).isTrue()
+            assertThat(attendVote.isAbsent()).isFalse()
+
+            assertThat(absentVote.isAttending()).isFalse()
+            assertThat(absentVote.isAbsent()).isTrue()
         }
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/AttendanceVoteTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/AttendanceVoteTest.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.domain.game
 
 import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
@@ -49,7 +50,8 @@ class AttendanceVoteTest {
             assertThat(vote.game).isEqualTo(game)
             assertThat(vote.member).isEqualTo(member)
             assertThat(vote.status).isEqualTo(AttendanceStatus.UNDECIDED)
-            assertThat(vote.reason).isNull()
+            assertThat(vote.absenceReason).isNull()
+            assertThat(vote.reasonDetail).isNull()
             assertThat(vote.respondedAt).isNull()
             assertThat(vote.hasResponded).isFalse()
             assertThat(vote.isAttending).isFalse()
@@ -60,19 +62,49 @@ class AttendanceVoteTest {
     @DisplayName("투표하기")
     inner class Vote {
         @Test
-        fun `should vote attending with reason`() {
+        fun `should vote attending without reason`() {
             // given
             val vote = AttendanceVote.createForGame(game, member)
 
             // when
-            vote.vote(AttendanceStatus.ATTENDING, "참석합니다")
+            vote.vote(AttendanceStatus.ATTENDING)
 
             // then
             assertThat(vote.status).isEqualTo(AttendanceStatus.ATTENDING)
-            assertThat(vote.reason).isEqualTo("참석합니다")
+            assertThat(vote.absenceReason).isNull()
+            assertThat(vote.reasonDetail).isNull()
             assertThat(vote.respondedAt).isNotNull()
             assertThat(vote.hasResponded).isTrue()
             assertThat(vote.isAttending).isTrue()
+        }
+
+        @Test
+        fun `should vote absent with absence reason`() {
+            // given
+            val vote = AttendanceVote.createForGame(game, member)
+
+            // when
+            vote.vote(AttendanceStatus.ABSENT, AbsenceReason.INJURY)
+
+            // then
+            assertThat(vote.status).isEqualTo(AttendanceStatus.ABSENT)
+            assertThat(vote.absenceReason).isEqualTo(AbsenceReason.INJURY)
+            assertThat(vote.reasonDetail).isNull()
+            assertThat(vote.hasResponded).isTrue()
+        }
+
+        @Test
+        fun `should vote absent with OTHER reason and detail`() {
+            // given
+            val vote = AttendanceVote.createForGame(game, member)
+
+            // when
+            vote.vote(AttendanceStatus.ABSENT, AbsenceReason.OTHER, "개인 사정")
+
+            // then
+            assertThat(vote.status).isEqualTo(AttendanceStatus.ABSENT)
+            assertThat(vote.absenceReason).isEqualTo(AbsenceReason.OTHER)
+            assertThat(vote.reasonDetail).isEqualTo("개인 사정")
         }
 
         @Test
@@ -85,8 +117,41 @@ class AttendanceVoteTest {
 
             // then
             assertThat(vote.status).isEqualTo(AttendanceStatus.ABSENT)
-            assertThat(vote.reason).isNull()
+            assertThat(vote.absenceReason).isNull()
             assertThat(vote.hasResponded).isTrue()
+        }
+
+        @Test
+        fun `should throw when attending with absence reason`() {
+            // given
+            val vote = AttendanceVote.createForGame(game, member)
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                vote.vote(AttendanceStatus.ATTENDING, AbsenceReason.WORK)
+            }
+        }
+
+        @Test
+        fun `should throw when attending with reason detail`() {
+            // given
+            val vote = AttendanceVote.createForGame(game, member)
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                vote.vote(AttendanceStatus.ATTENDING, reasonDetail = "사유")
+            }
+        }
+
+        @Test
+        fun `should throw when reason detail provided without OTHER`() {
+            // given
+            val vote = AttendanceVote.createForGame(game, member)
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                vote.vote(AttendanceStatus.ABSENT, AbsenceReason.WORK, "출장")
+            }
         }
 
         @Test
@@ -113,19 +178,35 @@ class AttendanceVoteTest {
     @DisplayName("투표 변경")
     inner class ChangeVote {
         @Test
-        fun `should change vote from attending to absent`() {
+        fun `should change vote from attending to absent with reason`() {
             // given
             val vote = AttendanceVote.createForGame(game, member)
             vote.vote(AttendanceStatus.ATTENDING)
             val firstRespondedAt = vote.respondedAt
 
             // when
-            vote.changeVote(AttendanceStatus.ABSENT, "일정이 변경되었습니다")
+            vote.changeVote(AttendanceStatus.ABSENT, AbsenceReason.OTHER, "일정이 변경되었습니다")
 
             // then
             assertThat(vote.status).isEqualTo(AttendanceStatus.ABSENT)
-            assertThat(vote.reason).isEqualTo("일정이 변경되었습니다")
+            assertThat(vote.absenceReason).isEqualTo(AbsenceReason.OTHER)
+            assertThat(vote.reasonDetail).isEqualTo("일정이 변경되었습니다")
             assertThat(vote.respondedAt).isNotEqualTo(firstRespondedAt)
+        }
+
+        @Test
+        fun `should clear reason when changing to attending`() {
+            // given
+            val vote = AttendanceVote.createForGame(game, member)
+            vote.vote(AttendanceStatus.ABSENT, AbsenceReason.INJURY)
+
+            // when
+            vote.changeVote(AttendanceStatus.ATTENDING)
+
+            // then
+            assertThat(vote.status).isEqualTo(AttendanceStatus.ATTENDING)
+            assertThat(vote.absenceReason).isNull()
+            assertThat(vote.reasonDetail).isNull()
         }
 
         @Test

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/attendance/AttendanceServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/attendance/AttendanceServiceImpl.kt
@@ -4,6 +4,7 @@ import com.nextup.common.exception.AttendancePollClosedException
 import com.nextup.common.exception.AttendancePollNotFoundException
 import com.nextup.common.exception.PlayerNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.attendance.AttendancePoll
 import com.nextup.core.domain.attendance.AttendanceVote
 import com.nextup.core.domain.attendance.PollStatus
@@ -59,6 +60,8 @@ class AttendanceServiceImpl(
         pollId: Long,
         playerId: Long,
         voteType: VoteType,
+        absenceReason: AbsenceReason?,
+        reasonDetail: String?,
     ): AttendanceVote {
         val poll =
             attendancePollRepository.findById(pollId)
@@ -76,7 +79,7 @@ class AttendanceServiceImpl(
         val existingVote = attendanceVoteRepository.findByPollIdAndPlayerId(pollId, playerId)
         if (existingVote != null) {
             // Update existing vote
-            existingVote.changeVote(voteType)
+            existingVote.changeVote(voteType, absenceReason, reasonDetail)
             return attendanceVoteRepository.save(existingVote)
         }
 
@@ -85,6 +88,8 @@ class AttendanceServiceImpl(
                 poll = poll,
                 player = player,
                 voteType = voteType,
+                absenceReason = absenceReason,
+                reasonDetail = reasonDetail,
             )
 
         return attendanceVoteRepository.save(vote)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/AttendanceServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/AttendanceServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.nextup.infrastructure.service.game
 
 import com.nextup.common.exception.*
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.game.AttendanceStatus
 import com.nextup.core.domain.game.AttendanceVote
 import com.nextup.core.domain.game.GameStatus
@@ -32,7 +33,8 @@ class AttendanceServiceImpl(
         gameId: Long,
         memberId: Long,
         status: AttendanceStatus,
-        reason: String?,
+        absenceReason: AbsenceReason?,
+        reasonDetail: String?,
     ): AttendanceVote {
         val game =
             gameRepository.findByIdOrNull(gameId)
@@ -60,12 +62,12 @@ class AttendanceServiceImpl(
 
         return if (existingVote != null) {
             // 투표 변경
-            existingVote.vote(status, reason)
+            existingVote.vote(status, absenceReason, reasonDetail)
             attendanceVoteRepository.save(existingVote)
         } else {
             // 새로 투표 생성 (자동 생성되지 않은 경우 대비)
             val newVote = AttendanceVote.createForGame(game, member)
-            newVote.vote(status, reason)
+            newVote.vote(status, absenceReason, reasonDetail)
             attendanceVoteRepository.save(newVote)
         }
     }

--- a/nextup-infrastructure/src/main/resources/db/migration/V017__add_absence_reason_fields.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V017__add_absence_reason_fields.sql
@@ -1,0 +1,9 @@
+-- V017: 출석 투표 불참 사유 필드 추가 (Issue #118)
+
+-- poll_votes 테이블에 불참 사유 필드 추가
+ALTER TABLE poll_votes ADD COLUMN absence_reason VARCHAR(20);
+ALTER TABLE poll_votes ADD COLUMN reason_detail VARCHAR(500);
+
+-- attendance_votes 테이블: 기존 reason 컬럼을 reason_detail로 변경, absence_reason 추가
+ALTER TABLE attendance_votes RENAME COLUMN reason TO reason_detail;
+ALTER TABLE attendance_votes ADD COLUMN absence_reason VARCHAR(20);

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/AttendanceServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/AttendanceServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.nextup.infrastructure.service.game
 
 import com.nextup.common.exception.*
 import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.attendance.AbsenceReason
 import com.nextup.core.domain.game.AttendanceStatus
 import com.nextup.core.domain.game.AttendanceVote
 import com.nextup.core.domain.game.Game
@@ -85,11 +86,11 @@ class AttendanceServiceImplTest {
             every { attendanceVoteRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = service.vote(100L, 200L, AttendanceStatus.ATTENDING, "참석합니다")
+            val result = service.vote(100L, 200L, AttendanceStatus.ATTENDING)
 
             // then
             assertThat(result.status).isEqualTo(AttendanceStatus.ATTENDING)
-            assertThat(result.reason).isEqualTo("참석합니다")
+            assertThat(result.absenceReason).isNull()
             assertThat(result.hasResponded).isTrue()
             verify { attendanceVoteRepository.save(any()) }
         }
@@ -106,11 +107,13 @@ class AttendanceServiceImplTest {
             every { attendanceVoteRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = service.vote(100L, 200L, AttendanceStatus.ABSENT, "일정 변경")
+            val result =
+                service.vote(100L, 200L, AttendanceStatus.ABSENT, AbsenceReason.OTHER, "일정 변경")
 
             // then
             assertThat(result.status).isEqualTo(AttendanceStatus.ABSENT)
-            assertThat(result.reason).isEqualTo("일정 변경")
+            assertThat(result.absenceReason).isEqualTo(AbsenceReason.OTHER)
+            assertThat(result.reasonDetail).isEqualTo("일정 변경")
             verify { attendanceVoteRepository.save(existingVote) }
         }
 
@@ -122,7 +125,7 @@ class AttendanceServiceImplTest {
 
             // when & then
             assertThatThrownBy {
-                service.vote(100L, 999L, AttendanceStatus.ATTENDING, null)
+                service.vote(100L, 999L, AttendanceStatus.ATTENDING)
             }.isInstanceOf(TeamMemberNotFoundException::class.java)
         }
 
@@ -140,7 +143,7 @@ class AttendanceServiceImplTest {
 
             // when & then
             assertThatThrownBy {
-                service.vote(100L, 201L, AttendanceStatus.ATTENDING, null)
+                service.vote(100L, 201L, AttendanceStatus.ATTENDING)
             }.isInstanceOf(InvalidStateException::class.java)
         }
 
@@ -154,7 +157,7 @@ class AttendanceServiceImplTest {
 
             // when & then
             assertThatThrownBy {
-                service.vote(100L, 200L, AttendanceStatus.ATTENDING, null)
+                service.vote(100L, 200L, AttendanceStatus.ATTENDING)
             }.isInstanceOf(VoteClosedException::class.java)
         }
     }


### PR DESCRIPTION
## Summary

>- close #118

출석 투표 시 불참/미정 응답에 대한 **불참 사유(AbsenceReason)** 필드를 추가합니다.
시나리오 02(경기 준비 & 라인업)의 불참 사유 수집 요구사항을 충족합니다.

## Tasks

- `AbsenceReason` enum 생성 (FAMILY, INJURY, WORK, TRAVEL, WEATHER, OTHER)
- `AttendanceVote` 엔티티에 `absenceReason`, `reasonDetail` 필드 추가
- 참석 투표 시 사유 입력 불가 검증 로직 구현
- DB 마이그레이션 V017 (poll_votes, attendance_votes 테이블)
- DTO/API/Mapper 수정 (VoteRequest에 reason 파라미터)
- 단위 테스트 14건 작성 (생성, 변경, 상태확인 시나리오)

## To Reviewer

- `VoteType.ATTEND` 시 `absenceReason`과 `reasonDetail`이 모두 null이어야 합니다.
- `AbsenceReason.OTHER` 선택 시에만 `reasonDetail` 입력이 가능합니다.
- 기존 `attendance_votes` 테이블의 `reason` 컬럼은 `reason_detail`로 rename 처리했습니다.