### PR TITLE
feat(#116): GUEST 역할 추가 (TeamMemberRole)

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/team/TeamMember.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/team/TeamMember.kt
@@ -67,10 +67,26 @@ class TeamMember private constructor(
         get() = status == TeamMemberStatus.ACTIVE
 
     /**
-     * 투표 가능한지 확인합니다 (ACTIVE, SUSPENDED 모두 가능).
+     * 출석 투표 가능한지 확인합니다 (ACTIVE, SUSPENDED 모두 가능, GUEST 제외).
      */
     val canVote: Boolean
-        get() = status in listOf(TeamMemberStatus.ACTIVE, TeamMemberStatus.SUSPENDED)
+        get() =
+            status in listOf(TeamMemberStatus.ACTIVE, TeamMemberStatus.SUSPENDED) &&
+                role.canVoteInPoll()
+
+    /**
+     * 선거 참여 가능한지 확인합니다 (ACTIVE, SUSPENDED 모두 가능, GUEST 제외).
+     */
+    val canParticipateInElection: Boolean
+        get() =
+            status in listOf(TeamMemberStatus.ACTIVE, TeamMemberStatus.SUSPENDED) &&
+                role.canParticipateInElection()
+
+    /**
+     * 라인업에 포함 가능한지 확인합니다 (ACTIVE이면 GUEST 포함 가능).
+     */
+    val canBeInLineup: Boolean
+        get() = status == TeamMemberStatus.ACTIVE
 
     /**
      * OWNER 역할인지 확인합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/team/TeamMemberRole.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/team/TeamMemberRole.kt
@@ -17,7 +17,20 @@ enum class TeamMemberRole(
 
     /** 일반 회원 - 투표 참여, 게시글 작성 */
     MEMBER("일반 회원", 10),
+
+    /** 게스트 - 경기 참여만 가능, 투표/선거 불가 */
+    GUEST("게스트", 1),
     ;
+
+    /**
+     * 투표 참여 가능 여부를 확인합니다 (GUEST 제외).
+     */
+    fun canVoteInPoll(): Boolean = this != GUEST
+
+    /**
+     * 선거 참여 가능 여부를 확인합니다 (GUEST 제외).
+     */
+    fun canParticipateInElection(): Boolean = this != GUEST
 
     /**
      * 가입 승인 권한이 있는지 확인합니다.

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamMemberRoleTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamMemberRoleTest.kt
@@ -26,10 +26,16 @@ class TeamMemberRoleTest {
         }
 
         @Test
+        fun `should GUEST not have approve join permission`() {
+            assertThat(TeamMemberRole.GUEST.canApproveJoin()).isFalse()
+        }
+
+        @Test
         fun `should only OWNER have kick permission`() {
             assertThat(TeamMemberRole.OWNER.canKickMember()).isTrue()
             assertThat(TeamMemberRole.MANAGER.canKickMember()).isFalse()
             assertThat(TeamMemberRole.MEMBER.canKickMember()).isFalse()
+            assertThat(TeamMemberRole.GUEST.canKickMember()).isFalse()
         }
 
         @Test
@@ -37,6 +43,23 @@ class TeamMemberRoleTest {
             assertThat(TeamMemberRole.OWNER.canChangeRole()).isTrue()
             assertThat(TeamMemberRole.MANAGER.canChangeRole()).isFalse()
             assertThat(TeamMemberRole.MEMBER.canChangeRole()).isFalse()
+            assertThat(TeamMemberRole.GUEST.canChangeRole()).isFalse()
+        }
+
+        @Test
+        fun `should GUEST not be able to vote in poll`() {
+            assertThat(TeamMemberRole.GUEST.canVoteInPoll()).isFalse()
+            assertThat(TeamMemberRole.MEMBER.canVoteInPoll()).isTrue()
+            assertThat(TeamMemberRole.MANAGER.canVoteInPoll()).isTrue()
+            assertThat(TeamMemberRole.OWNER.canVoteInPoll()).isTrue()
+        }
+
+        @Test
+        fun `should GUEST not be able to participate in election`() {
+            assertThat(TeamMemberRole.GUEST.canParticipateInElection()).isFalse()
+            assertThat(TeamMemberRole.MEMBER.canParticipateInElection()).isTrue()
+            assertThat(TeamMemberRole.MANAGER.canParticipateInElection()).isTrue()
+            assertThat(TeamMemberRole.OWNER.canParticipateInElection()).isTrue()
         }
     }
 
@@ -74,6 +97,9 @@ class TeamMemberRoleTest {
             assertThat(TeamMemberRole.OWNER.isHigherOrEqual(TeamMemberRole.MANAGER)).isTrue()
             assertThat(TeamMemberRole.MANAGER.isHigherOrEqual(TeamMemberRole.MANAGER)).isTrue()
             assertThat(TeamMemberRole.MEMBER.isHigherOrEqual(TeamMemberRole.MANAGER)).isFalse()
+            assertThat(TeamMemberRole.MEMBER.isHigherThan(TeamMemberRole.GUEST)).isTrue()
+            assertThat(TeamMemberRole.GUEST.isHigherOrEqual(TeamMemberRole.GUEST)).isTrue()
+            assertThat(TeamMemberRole.GUEST.isHigherOrEqual(TeamMemberRole.MEMBER)).isFalse()
         }
     }
 
@@ -85,6 +111,7 @@ class TeamMemberRoleTest {
             assertThat(TeamMemberRole.OWNER.displayName).isEqualTo("감독")
             assertThat(TeamMemberRole.MANAGER.displayName).isEqualTo("운영진")
             assertThat(TeamMemberRole.MEMBER.displayName).isEqualTo("일반 회원")
+            assertThat(TeamMemberRole.GUEST.displayName).isEqualTo("게스트")
         }
 
         @Test
@@ -92,6 +119,7 @@ class TeamMemberRoleTest {
             assertThat(TeamMemberRole.OWNER.level).isEqualTo(100)
             assertThat(TeamMemberRole.MANAGER.level).isEqualTo(50)
             assertThat(TeamMemberRole.MEMBER.level).isEqualTo(10)
+            assertThat(TeamMemberRole.GUEST.level).isEqualTo(1)
         }
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamMemberTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamMemberTest.kt
@@ -351,6 +351,94 @@ class TeamMemberTest {
             // then
             assertThat(member.canParticipateInGame).isFalse()
         }
+
+        @Test
+        fun `should check if member can participate in election`() {
+            assertThat(member.canParticipateInElection).isTrue()
+            assertThat(owner.canParticipateInElection).isTrue()
+        }
+
+        @Test
+        fun `should check if member can be in lineup`() {
+            assertThat(member.canBeInLineup).isTrue()
+            assertThat(owner.canBeInLineup).isTrue()
+        }
+
+        @Test
+        fun `should not allow suspended member in lineup`() {
+            // given
+            member.suspend("test", owner)
+
+            // then
+            assertThat(member.canBeInLineup).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("GUEST 역할")
+    inner class GuestRole {
+        private lateinit var guestUser: User
+        private lateinit var guestPlayer: Player
+        private lateinit var guest: TeamMember
+
+        @BeforeEach
+        fun setUpGuest() {
+            guestUser = User.createLocalUser("guest@example.com", "password", "게스트")
+            guestPlayer = Player(name = "게스트", primaryPosition = Position.DESIGNATED_HITTER)
+            guest = TeamMember.create(team, guestUser, guestPlayer, 99, TeamMemberRole.GUEST)
+            setTeamMemberId(guest, 10L)
+        }
+
+        @Test
+        fun `should create guest member`() {
+            assertThat(guest.role).isEqualTo(TeamMemberRole.GUEST)
+            assertThat(guest.status).isEqualTo(TeamMemberStatus.ACTIVE)
+            assertThat(guest.isActive).isTrue()
+        }
+
+        @Test
+        fun `GUEST should not be able to vote`() {
+            assertThat(guest.canVote).isFalse()
+        }
+
+        @Test
+        fun `GUEST should not be able to participate in election`() {
+            assertThat(guest.canParticipateInElection).isFalse()
+        }
+
+        @Test
+        fun `GUEST should be able to participate in game`() {
+            assertThat(guest.canParticipateInGame).isTrue()
+        }
+
+        @Test
+        fun `GUEST should be able to be in lineup`() {
+            assertThat(guest.canBeInLineup).isTrue()
+        }
+
+        @Test
+        fun `GUEST should not be able to manage members`() {
+            assertThat(guest.canManageMembers()).isFalse()
+        }
+
+        @Test
+        fun `GUEST should have lowest level`() {
+            assertThat(TeamMemberRole.GUEST.level).isEqualTo(1)
+            assertThat(TeamMemberRole.MEMBER.isHigherThan(TeamMemberRole.GUEST)).isTrue()
+            assertThat(TeamMemberRole.GUEST.isHigherThan(TeamMemberRole.MEMBER)).isFalse()
+        }
+
+        @Test
+        fun `GUEST should be kickable by owner`() {
+            guest.kick("게스트 기간 종료", owner)
+            assertThat(guest.status).isEqualTo(TeamMemberStatus.KICKED)
+        }
+
+        @Test
+        fun `GUEST should be able to leave`() {
+            guest.leave()
+            assertThat(guest.status).isEqualTo(TeamMemberStatus.LEFT)
+        }
     }
 
     private fun setTeamMemberId(


### PR DESCRIPTION
## Summary

>- close #116

시나리오 01(팀 & 멤버십)의 **4단계 역할(OWNER/MANAGER/MEMBER/GUEST)** 요구사항을 충족합니다.
용병/체험 가입자를 GUEST 역할로 구분하여 권한을 제한합니다.

## Tasks

- `TeamMemberRole`에 `GUEST`(게스트, level=1) 추가
- GUEST 권한 정의: 투표/선거 불가, 경기 참여 및 라인업 포함 가능
- `TeamMember`에 `canVote`, `canParticipateInElection`, `canBeInLineup` 속성 강화
- `TeamMemberRoleTest`에 GUEST 권한/레벨/속성 테스트 추가
- `TeamMemberTest`에 GUEST 전용 시나리오 테스트 8건 추가

## To Reviewer

- GUEST는 `canVoteInPoll()=false`, `canParticipateInElection()=false`
- GUEST는 `canBeInLineup=true` (ACTIVE 상태이면 라인업 포함 가능)
- DB 마이그레이션 불필요 (role 컬럼이 `VARCHAR(20)` + `EnumType.STRING`이므로 새 enum 값 자동 지원)