### PR TITLE
fix(#109): NotificationController IDOR 취약점 수정

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
@@ -13,12 +13,14 @@ import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 /**
  * 알림 API Controller
  *
  * 사용자의 알림 조회, 디바이스 관리, 알림 설정 관리
+ * 모든 엔드포인트에서 JWT 인증된 사용자 ID를 사용합니다.
  */
 @RestController
 @RequestMapping("/api/v1")
@@ -31,7 +33,7 @@ class NotificationController(
     @PostMapping("/devices")
     @ResponseStatus(HttpStatus.CREATED)
     fun registerDevice(
-        @RequestParam userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @Valid @RequestBody request: RegisterDeviceApiRequest,
     ): ApiResponse<DeviceTokenResponse> {
         val deviceToken =
@@ -51,9 +53,10 @@ class NotificationController(
      */
     @DeleteMapping("/devices/{tokenId}")
     fun removeDevice(
+        @AuthenticationPrincipal userId: Long,
         @PathVariable tokenId: Long,
     ): ApiResponse<Unit> {
-        notificationService.removeDevice(tokenId)
+        notificationService.removeDevice(tokenId, userId)
         return ApiResponse.success(Unit)
     }
 
@@ -62,7 +65,7 @@ class NotificationController(
      */
     @GetMapping("/notifications")
     fun getNotifications(
-        @RequestParam userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @PageableDefault(size = 20) pageable: Pageable,
     ): ApiResponse<List<NotificationResponse>> {
         val notifications = notificationService.getUserNotifications(userId, pageable)
@@ -74,9 +77,10 @@ class NotificationController(
      */
     @PutMapping("/notifications/{id}/read")
     fun markAsRead(
+        @AuthenticationPrincipal userId: Long,
         @PathVariable id: Long,
     ): ApiResponse<NotificationResponse> {
-        val notification = notificationService.markAsRead(id)
+        val notification = notificationService.markAsRead(id, userId)
         return ApiResponse.success(NotificationResponse.from(notification))
     }
 
@@ -85,7 +89,7 @@ class NotificationController(
      */
     @PutMapping("/notifications/preferences")
     fun updatePreference(
-        @RequestParam userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @Valid @RequestBody request: UpdatePreferenceApiRequest,
     ): ApiResponse<NotificationPreferenceResponse> {
         val preference =
@@ -105,7 +109,7 @@ class NotificationController(
      */
     @GetMapping("/notifications/preferences")
     fun getPreferences(
-        @RequestParam userId: Long,
+        @AuthenticationPrincipal userId: Long,
     ): ApiResponse<List<NotificationPreferenceResponse>> {
         val preferences = notificationService.getUserPreferences(userId)
         return ApiResponse.success(preferences.map { NotificationPreferenceResponse.from(it) })

--- a/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.nextup.api.exception
 import com.nextup.api.dto.common.ApiResponse
 import com.nextup.common.exception.AuthenticationException
 import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.NotFoundException
 import org.slf4j.LoggerFactory
@@ -23,6 +24,14 @@ class GlobalExceptionHandler {
         log.warn("AuthenticationException: code={}, message={}", ex.code, ex.message)
         return ResponseEntity
             .status(HttpStatus.UNAUTHORIZED)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    @ExceptionHandler(ForbiddenException::class)
+    fun handleForbiddenException(ex: ForbiddenException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("ForbiddenException: code={}, message={}", ex.code, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
             .body(ApiResponse.error(ex.code, ex.message))
     }
 

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/notification/NotificationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/notification/NotificationControllerTest.kt
@@ -7,11 +7,11 @@ import com.nextup.api.dto.notification.RegisterDeviceApiRequest
 import com.nextup.api.dto.notification.UpdatePreferenceApiRequest
 import com.nextup.api.exception.GlobalExceptionHandler
 import com.nextup.common.exception.DeviceTokenNotFoundException
+import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.NotificationNotFoundException
 import com.nextup.core.domain.notification.*
 import com.nextup.core.service.notification.NotificationService
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
@@ -37,6 +37,7 @@ class NotificationControllerTest {
     private val mockNotification = mockk<Notification>(relaxed = true)
     private val mockDeviceToken = mockk<DeviceToken>(relaxed = true)
     private val mockPreference = mockk<NotificationPreference>(relaxed = true)
+    private val authenticatedUserId = 100L
 
     @BeforeEach
     fun setUp() {
@@ -48,11 +49,14 @@ class NotificationControllerTest {
             MockMvcBuilders
                 .standaloneSetup(controller)
                 .setControllerAdvice(GlobalExceptionHandler())
-                .setCustomArgumentResolvers(PageableHandlerMethodArgumentResolver())
+                .setCustomArgumentResolvers(
+                    PageableHandlerMethodArgumentResolver(),
+                    AuthenticationPrincipalResolver(authenticatedUserId),
+                )
                 .build()
 
         every { mockNotification.id } returns 1L
-        every { mockNotification.userId } returns 100L
+        every { mockNotification.userId } returns authenticatedUserId
         every { mockNotification.type } returns NotificationType.GAME_START
         every { mockNotification.title } returns "경기 시작"
         every { mockNotification.body } returns "30분 후 경기가 시작됩니다"
@@ -62,13 +66,13 @@ class NotificationControllerTest {
         every { mockNotification.createdAt } returns Instant.now()
 
         every { mockDeviceToken.id } returns 1L
-        every { mockDeviceToken.userId } returns 100L
+        every { mockDeviceToken.userId } returns authenticatedUserId
         every { mockDeviceToken.token } returns "fcm-token-12345"
         every { mockDeviceToken.platform } returns DevicePlatform.IOS
         every { mockDeviceToken.createdAt } returns Instant.now()
 
         every { mockPreference.id } returns 1L
-        every { mockPreference.userId } returns 100L
+        every { mockPreference.userId } returns authenticatedUserId
         every { mockPreference.type } returns NotificationType.GAME_START
         every { mockPreference.enabled } returns true
         every { mockPreference.createdAt } returns Instant.now()
@@ -89,14 +93,13 @@ class NotificationControllerTest {
         mockMvc
             .perform(
                 post("/api/v1/devices")
-                    .param("userId", "100")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)),
             )
             .andExpect(status().isCreated)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.id").value(1))
-            .andExpect(jsonPath("$.data.userId").value(100))
+            .andExpect(jsonPath("$.data.userId").value(authenticatedUserId))
             .andExpect(jsonPath("$.data.token").value("fcm-token-12345"))
             .andExpect(jsonPath("$.data.platform").value("IOS"))
 
@@ -116,7 +119,6 @@ class NotificationControllerTest {
         mockMvc
             .perform(
                 post("/api/v1/devices")
-                    .param("userId", "100")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(invalidRequest)),
             )
@@ -129,7 +131,7 @@ class NotificationControllerTest {
     @Test
     fun `should remove device successfully`() {
         // given
-        justRun { notificationService.removeDevice(1L) }
+        every { notificationService.removeDevice(1L, authenticatedUserId) } returns Unit
 
         // when & then
         mockMvc
@@ -137,13 +139,15 @@ class NotificationControllerTest {
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
 
-        verify(exactly = 1) { notificationService.removeDevice(1L) }
+        verify(exactly = 1) { notificationService.removeDevice(1L, authenticatedUserId) }
     }
 
     @Test
     fun `should fail to remove device when not found`() {
         // given
-        every { notificationService.removeDevice(999L) } throws DeviceTokenNotFoundException(999L)
+        every {
+            notificationService.removeDevice(999L, authenticatedUserId)
+        } throws DeviceTokenNotFoundException(999L)
 
         // when & then
         mockMvc
@@ -153,18 +157,31 @@ class NotificationControllerTest {
     }
 
     @Test
+    fun `should fail to remove device when not owned`() {
+        // given
+        every {
+            notificationService.removeDevice(1L, authenticatedUserId)
+        } throws ForbiddenException("DEVICE_TOKEN_ACCESS_DENIED", "해당 디바이스 토큰에 접근 권한이 없습니다")
+
+        // when & then
+        mockMvc
+            .perform(delete("/api/v1/devices/1"))
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
     fun `should get notifications successfully`() {
         // given
         val pageable = PageRequest.of(0, 20)
         val page = PageImpl(listOf(mockNotification), pageable, 1)
 
-        every { notificationService.getUserNotifications(100L, any()) } returns page
+        every { notificationService.getUserNotifications(authenticatedUserId, any()) } returns page
 
         // when & then
         mockMvc
             .perform(
                 get("/api/v1/notifications")
-                    .param("userId", "100")
                     .param("page", "0")
                     .param("size", "20"),
             )
@@ -172,41 +189,17 @@ class NotificationControllerTest {
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data").isArray)
             .andExpect(jsonPath("$.data[0].id").value(1))
-            .andExpect(jsonPath("$.data[0].userId").value(100))
+            .andExpect(jsonPath("$.data[0].userId").value(authenticatedUserId))
             .andExpect(jsonPath("$.data[0].type").value("GAME_START"))
             .andExpect(jsonPath("$.data[0].title").value("경기 시작"))
 
-        verify(exactly = 1) { notificationService.getUserNotifications(100L, any()) }
-    }
-
-    @Test
-    fun `should get empty list when no notifications found`() {
-        // given
-        val pageable = PageRequest.of(0, 20)
-        val page = PageImpl<Notification>(emptyList(), pageable, 0)
-
-        every { notificationService.getUserNotifications(999L, any()) } returns page
-
-        // when & then
-        mockMvc
-            .perform(
-                get("/api/v1/notifications")
-                    .param("userId", "999")
-                    .param("page", "0")
-                    .param("size", "20"),
-            )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data").isArray)
-            .andExpect(jsonPath("$.data").isEmpty)
-
-        verify(exactly = 1) { notificationService.getUserNotifications(999L, any()) }
+        verify(exactly = 1) { notificationService.getUserNotifications(authenticatedUserId, any()) }
     }
 
     @Test
     fun `should mark notification as read successfully`() {
         // given
-        every { notificationService.markAsRead(1L) } returns mockNotification
+        every { notificationService.markAsRead(1L, authenticatedUserId) } returns mockNotification
 
         // when & then
         mockMvc
@@ -215,18 +208,34 @@ class NotificationControllerTest {
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.id").value(1))
 
-        verify(exactly = 1) { notificationService.markAsRead(1L) }
+        verify(exactly = 1) { notificationService.markAsRead(1L, authenticatedUserId) }
     }
 
     @Test
     fun `should fail to mark notification as read when not found`() {
         // given
-        every { notificationService.markAsRead(999L) } throws NotificationNotFoundException(999L)
+        every {
+            notificationService.markAsRead(999L, authenticatedUserId)
+        } throws NotificationNotFoundException(999L)
 
         // when & then
         mockMvc
             .perform(put("/api/v1/notifications/999/read"))
             .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should fail to mark notification as read when not owned`() {
+        // given
+        every {
+            notificationService.markAsRead(1L, authenticatedUserId)
+        } throws ForbiddenException("NOTIFICATION_ACCESS_DENIED", "해당 알림에 접근 권한이 없습니다")
+
+        // when & then
+        mockMvc
+            .perform(put("/api/v1/notifications/1/read"))
+            .andExpect(status().isForbidden)
             .andExpect(jsonPath("$.success").value(false))
     }
 
@@ -245,144 +254,53 @@ class NotificationControllerTest {
         mockMvc
             .perform(
                 put("/api/v1/notifications/preferences")
-                    .param("userId", "100")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)),
             )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.id").value(1))
-            .andExpect(jsonPath("$.data.userId").value(100))
+            .andExpect(jsonPath("$.data.userId").value(authenticatedUserId))
             .andExpect(jsonPath("$.data.type").value("GAME_START"))
 
         verify(exactly = 1) { notificationService.updatePreference(any()) }
     }
 
     @Test
-    fun `should fail to update preference with invalid request`() {
-        // given
-        val invalidRequest =
-            mapOf(
-                "type" to "INVALID",
-                "enabled" to "not-a-boolean",
-            )
-
-        // when & then
-        mockMvc
-            .perform(
-                put("/api/v1/notifications/preferences")
-                    .param("userId", "100")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(invalidRequest)),
-            )
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.success").value(false))
-
-        verify(exactly = 0) { notificationService.updatePreference(any()) }
-    }
-
-    @Test
     fun `should get preferences successfully`() {
         // given
-        every { notificationService.getUserPreferences(100L) } returns listOf(mockPreference)
+        every { notificationService.getUserPreferences(authenticatedUserId) } returns listOf(mockPreference)
 
         // when & then
         mockMvc
-            .perform(get("/api/v1/notifications/preferences").param("userId", "100"))
+            .perform(get("/api/v1/notifications/preferences"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data").isArray)
             .andExpect(jsonPath("$.data[0].id").value(1))
-            .andExpect(jsonPath("$.data[0].userId").value(100))
+            .andExpect(jsonPath("$.data[0].userId").value(authenticatedUserId))
             .andExpect(jsonPath("$.data[0].type").value("GAME_START"))
             .andExpect(jsonPath("$.data[0].enabled").value(true))
 
-        verify(exactly = 1) { notificationService.getUserPreferences(100L) }
+        verify(exactly = 1) { notificationService.getUserPreferences(authenticatedUserId) }
     }
+}
 
-    @Test
-    fun `should get empty list when no preferences found`() {
-        // given
-        every { notificationService.getUserPreferences(999L) } returns emptyList()
+/**
+ * 테스트용 @AuthenticationPrincipal 리졸버
+ */
+private class AuthenticationPrincipalResolver(
+    private val userId: Long,
+) : org.springframework.web.method.support.HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: org.springframework.core.MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(
+            org.springframework.security.core.annotation.AuthenticationPrincipal::class.java,
+        )
 
-        // when & then
-        mockMvc
-            .perform(get("/api/v1/notifications/preferences").param("userId", "999"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data").isArray)
-            .andExpect(jsonPath("$.data").isEmpty)
-
-        verify(exactly = 1) { notificationService.getUserPreferences(999L) }
-    }
-
-    @Test
-    fun `should handle different notification types`() {
-        // given
-        val types =
-            listOf(
-                NotificationType.GAME_START,
-                NotificationType.TEAM_NOTICE,
-                NotificationType.ATTENDANCE_NUDGE,
-                NotificationType.RECORD_ALERT,
-            )
-
-        types.forEach { type ->
-            val mockPref = mockk<NotificationPreference>(relaxed = true)
-            every { mockPref.id } returns 1L
-            every { mockPref.userId } returns 100L
-            every { mockPref.type } returns type
-            every { mockPref.enabled } returns true
-            every { mockPref.createdAt } returns Instant.now()
-
-            every { notificationService.getUserPreferences(100L) } returns listOf(mockPref)
-
-            // when & then
-            mockMvc
-                .perform(get("/api/v1/notifications/preferences").param("userId", "100"))
-                .andExpect(status().isOk)
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data[0].type").value(type.name))
-        }
-    }
-
-    @Test
-    fun `should handle different device platforms`() {
-        // given
-        val platforms =
-            listOf(
-                DevicePlatform.IOS,
-                DevicePlatform.ANDROID,
-                DevicePlatform.WEB,
-            )
-
-        platforms.forEach { platform ->
-            val request =
-                RegisterDeviceApiRequest(
-                    token = "token-for-$platform",
-                    platform = platform,
-                )
-
-            val mockDevice = mockk<DeviceToken>(relaxed = true)
-            every { mockDevice.id } returns 1L
-            every { mockDevice.userId } returns 100L
-            every { mockDevice.token } returns "token-for-$platform"
-            every { mockDevice.platform } returns platform
-            every { mockDevice.createdAt } returns Instant.now()
-
-            every { notificationService.registerDevice(any()) } returns mockDevice
-
-            // when & then
-            mockMvc
-                .perform(
-                    post("/api/v1/devices")
-                        .param("userId", "100")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)),
-                )
-                .andExpect(status().isCreated)
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.platform").value(platform.name))
-        }
-    }
+    override fun resolveArgument(
+        parameter: org.springframework.core.MethodParameter,
+        mavContainer: org.springframework.web.method.support.ModelAndViewContainer?,
+        webRequest: org.springframework.web.context.request.NativeWebRequest,
+        binderFactory: org.springframework.web.bind.support.WebDataBinderFactory?,
+    ): Any = userId
 }

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/BusinessException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/BusinessException.kt
@@ -31,3 +31,11 @@ open class InvalidInputException(
     code: String,
     message: String,
 ) : BusinessException(code, message)
+
+/**
+ * 접근 권한이 없을 때 발생하는 예외
+ */
+open class ForbiddenException(
+    code: String,
+    message: String,
+) : BusinessException(code, message)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.service.notification
 
 import com.nextup.common.exception.DeviceTokenNotFoundException
+import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.NotificationNotFoundException
 import com.nextup.core.domain.notification.DeviceToken
 import com.nextup.core.domain.notification.Notification
@@ -61,6 +62,21 @@ class NotificationService(
 
     /**
      * 알림을 읽음 처리합니다.
+     * 소유권 검증: 인증된 사용자만 자신의 알림을 읽음 처리할 수 있습니다.
+     */
+    @Transactional
+    fun markAsRead(
+        notificationId: Long,
+        authenticatedUserId: Long,
+    ): Notification {
+        val notification = getById(notificationId)
+        verifyNotificationOwnership(notification, authenticatedUserId)
+        notification.markAsRead()
+        return notification
+    }
+
+    /**
+     * 알림을 읽음 처리합니다 (내부 호출용).
      */
     @Transactional
     fun markAsRead(notificationId: Long): Notification {
@@ -98,6 +114,23 @@ class NotificationService(
 
     /**
      * 디바이스 토큰을 삭제합니다.
+     * 소유권 검증: 인증된 사용자만 자신의 디바이스 토큰을 삭제할 수 있습니다.
+     */
+    @Transactional
+    fun removeDevice(
+        tokenId: Long,
+        authenticatedUserId: Long,
+    ) {
+        val deviceToken =
+            deviceTokenRepository.findByIdOrNull(tokenId)
+                ?: throw DeviceTokenNotFoundException(tokenId)
+
+        verifyDeviceTokenOwnership(deviceToken, authenticatedUserId)
+        deviceTokenRepository.deleteByToken(deviceToken.token)
+    }
+
+    /**
+     * 디바이스 토큰을 삭제합니다 (내부 호출용).
      */
     @Transactional
     fun removeDevice(tokenId: Long) {
@@ -139,4 +172,28 @@ class NotificationService(
      * 사용자의 알림 설정 목록을 조회합니다.
      */
     fun getUserPreferences(userId: Long): List<NotificationPreference> = preferenceRepository.findByUserId(userId)
+
+    private fun verifyNotificationOwnership(
+        notification: Notification,
+        authenticatedUserId: Long,
+    ) {
+        if (notification.userId != authenticatedUserId) {
+            throw ForbiddenException(
+                "NOTIFICATION_ACCESS_DENIED",
+                "해당 알림에 접근 권한이 없습니다",
+            )
+        }
+    }
+
+    private fun verifyDeviceTokenOwnership(
+        deviceToken: DeviceToken,
+        authenticatedUserId: Long,
+    ) {
+        if (deviceToken.userId != authenticatedUserId) {
+            throw ForbiddenException(
+                "DEVICE_TOKEN_ACCESS_DENIED",
+                "해당 디바이스 토큰에 접근 권한이 없습니다",
+            )
+        }
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServiceTest.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.service.notification
 
 import com.nextup.common.exception.DeviceTokenNotFoundException
+import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.NotificationNotFoundException
 import com.nextup.core.domain.notification.DevicePlatform
 import com.nextup.core.domain.notification.DeviceToken
@@ -243,6 +244,72 @@ class NotificationServiceTest {
         assertThat(exception.message).contains("999")
     }
 
+    // ========== markAsRead with ownership verification Tests ==========
+
+    @Test
+    fun `인증된 사용자가 자신의 알림을 읽음 처리할 수 있다`() {
+        // given
+        val notificationId = 1L
+        val authenticatedUserId = 1L
+        val notification =
+            Notification.create(
+                userId = authenticatedUserId,
+                type = NotificationType.GAME_START,
+                title = "알림",
+                body = "내용",
+            )
+
+        every { notificationRepository.findByIdOrNull(notificationId) } returns notification
+
+        // when
+        val result = notificationService.markAsRead(notificationId, authenticatedUserId)
+
+        // then
+        assertThat(result.isRead()).isTrue()
+        assertThat(result.readAt).isNotNull()
+
+        verify(exactly = 1) { notificationRepository.findByIdOrNull(notificationId) }
+    }
+
+    @Test
+    fun `다른 사용자의 알림을 읽음 처리하면 ForbiddenException이 발생한다`() {
+        // given
+        val notificationId = 1L
+        val ownerUserId = 1L
+        val otherUserId = 999L
+        val notification =
+            Notification.create(
+                userId = ownerUserId,
+                type = NotificationType.GAME_START,
+                title = "알림",
+                body = "내용",
+            )
+
+        every { notificationRepository.findByIdOrNull(notificationId) } returns notification
+
+        // when & then
+        val exception =
+            assertThrows<ForbiddenException> {
+                notificationService.markAsRead(notificationId, otherUserId)
+            }
+
+        assertThat(exception.code).isEqualTo("NOTIFICATION_ACCESS_DENIED")
+    }
+
+    @Test
+    fun `존재하지 않는 알림을 소유권 검증으로 읽음 처리하면 NotificationNotFoundException이 발생한다`() {
+        // given
+        val notificationId = 999L
+        val authenticatedUserId = 1L
+
+        every { notificationRepository.findByIdOrNull(notificationId) } returns null
+
+        // when & then
+        assertThrows<NotificationNotFoundException> {
+            notificationService.markAsRead(notificationId, authenticatedUserId)
+        }
+    }
+
     // ========== getById Tests ==========
 
     @Test
@@ -386,6 +453,72 @@ class NotificationServiceTest {
         assertThat(exception.message).contains("999")
 
         verify(exactly = 1) { deviceTokenRepository.findByIdOrNull(tokenId) }
+        verify(exactly = 0) { deviceTokenRepository.deleteByToken(any()) }
+    }
+
+    // ========== removeDevice with ownership verification Tests ==========
+
+    @Test
+    fun `인증된 사용자가 자신의 디바이스 토큰을 삭제할 수 있다`() {
+        // given
+        val tokenId = 1L
+        val authenticatedUserId = 1L
+        val deviceToken =
+            DeviceToken.create(
+                userId = authenticatedUserId,
+                token = "fcm-token-12345",
+                platform = DevicePlatform.ANDROID,
+            )
+
+        every { deviceTokenRepository.findByIdOrNull(tokenId) } returns deviceToken
+        every { deviceTokenRepository.deleteByToken(deviceToken.token) } returns Unit
+
+        // when
+        notificationService.removeDevice(tokenId, authenticatedUserId)
+
+        // then
+        verify(exactly = 1) { deviceTokenRepository.findByIdOrNull(tokenId) }
+        verify(exactly = 1) { deviceTokenRepository.deleteByToken(deviceToken.token) }
+    }
+
+    @Test
+    fun `다른 사용자의 디바이스 토큰을 삭제하면 ForbiddenException이 발생한다`() {
+        // given
+        val tokenId = 1L
+        val ownerUserId = 1L
+        val otherUserId = 999L
+        val deviceToken =
+            DeviceToken.create(
+                userId = ownerUserId,
+                token = "fcm-token-12345",
+                platform = DevicePlatform.ANDROID,
+            )
+
+        every { deviceTokenRepository.findByIdOrNull(tokenId) } returns deviceToken
+
+        // when & then
+        val exception =
+            assertThrows<ForbiddenException> {
+                notificationService.removeDevice(tokenId, otherUserId)
+            }
+
+        assertThat(exception.code).isEqualTo("DEVICE_TOKEN_ACCESS_DENIED")
+        verify(exactly = 0) { deviceTokenRepository.deleteByToken(any()) }
+    }
+
+    @Test
+    fun `존재하지 않는 디바이스 토큰을 소유권 검증으로 삭제하면 DeviceTokenNotFoundException이 발생한다`() {
+        // given
+        val tokenId = 999L
+        val authenticatedUserId = 1L
+
+        every { deviceTokenRepository.findByIdOrNull(tokenId) } returns null
+
+        // when & then
+        assertThrows<DeviceTokenNotFoundException> {
+            notificationService.removeDevice(tokenId, authenticatedUserId)
+        }
+
         verify(exactly = 0) { deviceTokenRepository.deleteByToken(any()) }
     }
 


### PR DESCRIPTION
## Summary

>- close #109

NotificationController의 IDOR(Insecure Direct Object Reference) 취약점을 수정합니다.
기존에 `@RequestParam`으로 받던 `userId`를 `@AuthenticationPrincipal`로 변경하여 JWT 토큰에서 인증된 사용자 ID를 사용하도록 개선하고, Service 계층에 소유권 검증 로직을 추가했습니다.

## Tasks

- `@RequestParam userId` → `@AuthenticationPrincipal userId` 마이그레이션 (5개 엔드포인트)
- `NotificationService`에 소유권 검증 메서드 추가 (`markAsRead`, `removeDevice`)
- `ForbiddenException` 클래스 추가 (nextup-common)
- `GlobalExceptionHandler`에 403 Forbidden 핸들러 추가
- Controller 테스트: `AuthenticationPrincipalResolver` 기반으로 전면 재작성
- Service 테스트: 소유권 검증 성공/실패 케이스 6개 추가

## To Reviewer

- 기존 내부 호출용 `markAsRead(id)`, `removeDevice(tokenId)` 메서드는 하위 호환성을 위해 유지했습니다.
- `ForbiddenException`은 `BusinessException`을 상속하며, 향후 다른 도메인에서도 재사용 가능합니다.