### PR TITLE
feat(#117): 선거 완료 시 감독 권한 자동 이양

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/ElectionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/ElectionService.kt
@@ -6,10 +6,13 @@ import com.nextup.common.exception.ElectionNotFoundException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.core.domain.election.Candidate
 import com.nextup.core.domain.election.Election
+import com.nextup.core.domain.election.ElectionType
 import com.nextup.core.domain.election.ElectionVote
+import com.nextup.core.domain.team.TeamMemberRole
 import com.nextup.core.port.repository.CandidateRepositoryPort
 import com.nextup.core.port.repository.ElectionRepositoryPort
 import com.nextup.core.port.repository.ElectionVoteRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.election.dto.*
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -25,6 +28,7 @@ class ElectionService(
     private val electionRepository: ElectionRepositoryPort,
     private val candidateRepository: CandidateRepositoryPort,
     private val electionVoteRepository: ElectionVoteRepositoryPort,
+    private val teamMemberRepository: TeamMemberRepositoryPort,
 ) {
     /**
      * 선거를 생성합니다.
@@ -55,12 +59,63 @@ class ElectionService(
 
     /**
      * 선거를 완료합니다.
+     * OWNER_ELECTION인 경우, 단독 최다 득표자에게 자동으로 OWNER 권한을 이양합니다.
+     * 동률이거나 투표가 없으면 자동 이양하지 않습니다.
      */
     @Transactional
     fun completeElection(electionId: Long): ElectionResponse {
         val election = findElection(electionId)
         election.complete()
+
+        if (election.electionType == ElectionType.OWNER_ELECTION) {
+            transferOwnershipToWinner(election)
+        }
+
         return election.toResponse()
+    }
+
+    /**
+     * OWNER 선거 완료 후 당선자에게 OWNER 권한을 자동 이양합니다.
+     * 동률이거나 투표가 없으면 이양하지 않습니다.
+     */
+    private fun transferOwnershipToWinner(election: Election) {
+        val voteCounts =
+            electionVoteRepository.countByElectionIdGroupByCandidateId(election.id)
+
+        // 투표가 없으면 이양하지 않음
+        if (voteCounts.isEmpty()) return
+
+        // 최다 득표수 확인
+        val maxVotes = voteCounts.values.max()
+        val topCandidates = voteCounts.filter { it.value == maxVotes }
+
+        // 동률이면 이양하지 않음
+        if (topCandidates.size > 1) return
+
+        val winnerCandidateId = topCandidates.keys.first()
+        val winnerCandidate =
+            candidateRepository.findById(winnerCandidateId) ?: return
+
+        val winner =
+            teamMemberRepository.findByIdOrNull(winnerCandidate.memberId) ?: return
+
+        // 당선자가 이미 OWNER이면 이양 불필요
+        if (winner.role == TeamMemberRole.OWNER) return
+
+        // 기존 OWNER를 MEMBER로 강등
+        val teamMembers =
+            teamMemberRepository.findByTeamId(election.teamId)
+        val currentOwner =
+            teamMembers.firstOrNull { it.role == TeamMemberRole.OWNER }
+
+        if (currentOwner != null) {
+            currentOwner.role = TeamMemberRole.MEMBER
+            teamMemberRepository.save(currentOwner)
+        }
+
+        // 당선자를 OWNER로 승격
+        winner.role = TeamMemberRole.OWNER
+        teamMemberRepository.save(winner)
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/election/ElectionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/election/ElectionServiceTest.kt
@@ -5,9 +5,12 @@ import com.nextup.common.exception.DuplicateVoteException
 import com.nextup.common.exception.ElectionNotFoundException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.core.domain.election.*
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberRole
 import com.nextup.core.port.repository.CandidateRepositoryPort
 import com.nextup.core.port.repository.ElectionRepositoryPort
 import com.nextup.core.port.repository.ElectionVoteRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.election.dto.*
 import io.mockk.every
 import io.mockk.mockk
@@ -26,6 +29,7 @@ class ElectionServiceTest {
     private lateinit var electionRepository: ElectionRepositoryPort
     private lateinit var candidateRepository: CandidateRepositoryPort
     private lateinit var electionVoteRepository: ElectionVoteRepositoryPort
+    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
     private lateinit var electionService: ElectionService
 
     @BeforeEach
@@ -33,7 +37,14 @@ class ElectionServiceTest {
         electionRepository = mockk()
         candidateRepository = mockk()
         electionVoteRepository = mockk()
-        electionService = ElectionService(electionRepository, candidateRepository, electionVoteRepository)
+        teamMemberRepository = mockk()
+        electionService =
+            ElectionService(
+                electionRepository,
+                candidateRepository,
+                electionVoteRepository,
+                teamMemberRepository,
+            )
     }
 
     @Nested
@@ -183,6 +194,150 @@ class ElectionServiceTest {
             assertThatThrownBy {
                 electionService.completeElection(999L)
             }.isInstanceOf(ElectionNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("completeElection - 자동 OWNER 이양")
+    inner class CompleteElectionOwnerTransfer {
+        @Test
+        fun `OWNER_ELECTION 완료 시 단독 최다 득표자에게 OWNER 이양`() {
+            // given
+            val election = createTestOwnerElection(1L, ElectionStatus.IN_PROGRESS)
+            val winnerCandidate = createTestCandidate(10L, 1L, 100L, "김철수")
+            val currentOwner =
+                mockk<TeamMember>(relaxed = true) {
+                    every { id } returns 200L
+                    every { role } returns TeamMemberRole.OWNER
+                }
+            val winner =
+                mockk<TeamMember>(relaxed = true) {
+                    every { id } returns 100L
+                    every { role } returns TeamMemberRole.MEMBER
+                }
+
+            every { electionRepository.findById(1L) } returns election
+            every {
+                electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+            } returns mapOf(10L to 5L, 11L to 3L)
+            every { candidateRepository.findById(10L) } returns winnerCandidate
+            every { teamMemberRepository.findByIdOrNull(100L) } returns winner
+            every { teamMemberRepository.findByTeamId(1L) } returns listOf(currentOwner, winner)
+            every { teamMemberRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = electionService.completeElection(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
+            verify { winner.role = TeamMemberRole.OWNER }
+            verify { currentOwner.role = TeamMemberRole.MEMBER }
+            verify(exactly = 2) { teamMemberRepository.save(any()) }
+        }
+
+        @Test
+        fun `OWNER_ELECTION 동률이면 자동 이양하지 않음`() {
+            // given
+            val election = createTestOwnerElection(1L, ElectionStatus.IN_PROGRESS)
+
+            every { electionRepository.findById(1L) } returns election
+            every {
+                electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+            } returns mapOf(10L to 5L, 11L to 5L)
+
+            // when
+            val result = electionService.completeElection(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
+            verify(exactly = 0) { teamMemberRepository.save(any()) }
+        }
+
+        @Test
+        fun `OWNER_ELECTION 투표가 없으면 자동 이양하지 않음`() {
+            // given
+            val election = createTestOwnerElection(1L, ElectionStatus.IN_PROGRESS)
+
+            every { electionRepository.findById(1L) } returns election
+            every {
+                electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+            } returns emptyMap()
+
+            // when
+            val result = electionService.completeElection(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
+            verify(exactly = 0) { teamMemberRepository.save(any()) }
+        }
+
+        @Test
+        fun `당선자가 이미 OWNER이면 이양하지 않음`() {
+            // given
+            val election = createTestOwnerElection(1L, ElectionStatus.IN_PROGRESS)
+            val winnerCandidate = createTestCandidate(10L, 1L, 100L, "김철수")
+            val winner =
+                mockk<TeamMember>(relaxed = true) {
+                    every { id } returns 100L
+                    every { role } returns TeamMemberRole.OWNER
+                }
+
+            every { electionRepository.findById(1L) } returns election
+            every {
+                electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+            } returns mapOf(10L to 5L)
+            every { candidateRepository.findById(10L) } returns winnerCandidate
+            every { teamMemberRepository.findByIdOrNull(100L) } returns winner
+
+            // when
+            val result = electionService.completeElection(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
+            verify(exactly = 0) { teamMemberRepository.save(any()) }
+        }
+
+        @Test
+        fun `CAPTAIN_ELECTION이면 자동 이양하지 않음`() {
+            // given
+            val election = createTestElection(1L, ElectionStatus.IN_PROGRESS)
+            every { electionRepository.findById(1L) } returns election
+
+            // when
+            val result = electionService.completeElection(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
+            verify(exactly = 0) { teamMemberRepository.save(any()) }
+        }
+
+        @Test
+        fun `기존 OWNER가 없어도 당선자에게 OWNER 부여`() {
+            // given
+            val election = createTestOwnerElection(1L, ElectionStatus.IN_PROGRESS)
+            val winnerCandidate = createTestCandidate(10L, 1L, 100L, "김철수")
+            val winner =
+                mockk<TeamMember>(relaxed = true) {
+                    every { id } returns 100L
+                    every { role } returns TeamMemberRole.MEMBER
+                }
+
+            every { electionRepository.findById(1L) } returns election
+            every {
+                electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+            } returns mapOf(10L to 5L)
+            every { candidateRepository.findById(10L) } returns winnerCandidate
+            every { teamMemberRepository.findByIdOrNull(100L) } returns winner
+            every { teamMemberRepository.findByTeamId(1L) } returns listOf(winner)
+            every { teamMemberRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = electionService.completeElection(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
+            verify { winner.role = TeamMemberRole.OWNER }
+            verify(exactly = 1) { teamMemberRepository.save(any()) }
         }
     }
 
@@ -784,6 +939,35 @@ class ElectionServiceTest {
     }
 
     // Test helper methods
+    private fun createTestOwnerElection(
+        id: Long,
+        status: ElectionStatus,
+    ): Election {
+        val now = Instant.now()
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                description = "새 구단주를 선출합니다",
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = now.plus(1, ChronoUnit.DAYS),
+                endAt = now.plus(7, ChronoUnit.DAYS),
+            )
+        setElectionId(election, id)
+
+        when (status) {
+            ElectionStatus.IN_PROGRESS -> election.start()
+            ElectionStatus.COMPLETED -> {
+                election.start()
+                election.complete()
+            }
+            ElectionStatus.CANCELLED -> election.cancel()
+            ElectionStatus.SCHEDULED -> {}
+        }
+
+        return election
+    }
+
     private fun createTestElection(
         id: Long,
         status: ElectionStatus,


### PR DESCRIPTION
## Summary

>- close #117

OWNER_ELECTION 타입 선거 완료 시, 단독 최다 득표자에게 자동으로 OWNER 권한을 이양하는 기능을 구현합니다.

## Tasks

- `ElectionService.transferOwnershipToWinner()` private 메서드 추가
- OWNER_ELECTION 완료 시 득표 집계 → 단독 최다 득표자 확인 → 권한 이양 로직
- 기존 OWNER는 MEMBER로 강등, 당선자는 OWNER로 승격
- 동률/무투표/이미 OWNER인 경우 이양 스킵 처리
- 6개 시나리오 테스트 추가 (단독 당선, 동률, 무투표, 이미 OWNER, 비OWNER선거, OWNER 부재)

## To Reviewer

- `transferOwnershipToWinner()`는 `completeElection()` 내부에서만 호출되며, OWNER_ELECTION 타입일 때만 실행됩니다.
- 동률 발생 시 자동 이양하지 않으므로, 관리자가 수동으로 처리해야 합니다.
- 기존 OWNER가 없는 경우(탈퇴 등)에도 당선자에게 OWNER를 부여합니다.