### PR TITLE
fix(#112): OAuth2 토큰 URL query parameter 노출 수정

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/auth/AuthController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/auth/AuthController.kt
@@ -7,7 +7,11 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 /**
  * 인증 관련 API Controller
@@ -88,6 +92,37 @@ class AuthController(
     ): ResponseEntity<ApiResponse<Unit>> {
         authenticationService.logoutAll(userId)
         return ResponseEntity.ok(ApiResponse.success(Unit))
+    }
+
+    /**
+     * OAuth2 인가 코드로 JWT 토큰 교환
+     *
+     * POST /api/auth/oauth2/token
+     */
+    @PostMapping("/oauth2/token")
+    fun exchangeOAuth2Token(
+        @Valid @RequestBody request: OAuth2TokenExchangeRequest,
+        httpRequest: HttpServletRequest,
+    ): ResponseEntity<ApiResponse<OAuth2TokenResponse>> {
+        val deviceInfo = httpRequest.getHeader("User-Agent")
+        val ipAddress = getClientIpAddress(httpRequest)
+
+        val result =
+            authenticationService.exchangeOAuth2Code(
+                code = request.code,
+                deviceInfo = deviceInfo,
+                ipAddress = ipAddress,
+            )
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                OAuth2TokenResponse(
+                    accessToken = result.accessToken,
+                    refreshToken = result.refreshToken,
+                    isNewUser = result.isNewUser,
+                ),
+            ),
+        )
     }
 
     /**

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthRequest.kt
@@ -56,3 +56,11 @@ data class ChangePasswordRequest(
     @field:Size(min = 8, max = 100, message = "Password must be 8-100 characters")
     val newPassword: String,
 )
+
+/**
+ * OAuth2 인가 코드로 토큰 교환 요청 DTO
+ */
+data class OAuth2TokenExchangeRequest(
+    @field:NotBlank(message = "Authorization code is required")
+    val code: String,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/auth/AuthResponse.kt
@@ -38,3 +38,13 @@ data class SignUpResponse(
     val email: String,
     val nickname: String,
 )
+
+/**
+ * OAuth2 토큰 교환 응답 DTO
+ */
+data class OAuth2TokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val tokenType: String = "Bearer",
+    val isNewUser: Boolean,
+)

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/auth/AuthControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/auth/AuthControllerTest.kt
@@ -2,9 +2,11 @@ package com.nextup.api.controller.auth
 
 import com.nextup.api.dto.auth.LoginRequest
 import com.nextup.api.dto.auth.LogoutRequest
+import com.nextup.api.dto.auth.OAuth2TokenExchangeRequest
 import com.nextup.api.dto.auth.RefreshTokenRequest
 import com.nextup.core.domain.user.User
 import com.nextup.infrastructure.security.AuthenticationService
+import com.nextup.infrastructure.security.OAuth2TokenResult
 import com.nextup.infrastructure.security.TokenPair
 import com.nextup.infrastructure.security.userdetails.CustomUserDetails
 import io.mockk.every
@@ -169,6 +171,71 @@ class AuthControllerTest {
             assertThat(response.statusCode.value()).isEqualTo(200)
             assertThat(response.body?.success).isTrue()
             verify { authenticationService.logoutAll(userId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("OAuth2 토큰 교환")
+    inner class ExchangeOAuth2Token {
+        @Test
+        fun `should return tokens on valid auth code`() {
+            // given
+            val request = OAuth2TokenExchangeRequest(code = "valid-auth-code")
+            val result =
+                OAuth2TokenResult(
+                    accessToken = "access_token",
+                    refreshToken = "refresh_token",
+                    isNewUser = false,
+                )
+
+            every { httpServletRequest.getHeader("User-Agent") } returns "Mozilla/5.0"
+            every { httpServletRequest.getHeader("X-Forwarded-For") } returns null
+            every { httpServletRequest.remoteAddr } returns "127.0.0.1"
+            every {
+                authenticationService.exchangeOAuth2Code(
+                    code = "valid-auth-code",
+                    deviceInfo = "Mozilla/5.0",
+                    ipAddress = "127.0.0.1",
+                )
+            } returns result
+
+            // when
+            val response = authController.exchangeOAuth2Token(request, httpServletRequest)
+
+            // then
+            assertThat(response.statusCode.value()).isEqualTo(200)
+            assertThat(response.body?.data?.accessToken).isEqualTo("access_token")
+            assertThat(response.body?.data?.refreshToken).isEqualTo("refresh_token")
+            assertThat(response.body?.data?.isNewUser).isFalse()
+            assertThat(response.body?.data?.tokenType).isEqualTo("Bearer")
+        }
+
+        @Test
+        fun `should return isNewUser true for new users`() {
+            // given
+            val request = OAuth2TokenExchangeRequest(code = "new-user-code")
+            val result =
+                OAuth2TokenResult(
+                    accessToken = "access_token",
+                    refreshToken = "refresh_token",
+                    isNewUser = true,
+                )
+
+            every { httpServletRequest.getHeader("User-Agent") } returns "Chrome"
+            every { httpServletRequest.getHeader("X-Forwarded-For") } returns "10.0.0.1"
+            every {
+                authenticationService.exchangeOAuth2Code(
+                    code = "new-user-code",
+                    deviceInfo = "Chrome",
+                    ipAddress = "10.0.0.1",
+                )
+            } returns result
+
+            // when
+            val response = authController.exchangeOAuth2Token(request, httpServletRequest)
+
+            // then
+            assertThat(response.body?.data?.isNewUser).isTrue()
         }
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/AuthenticationService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/AuthenticationService.kt
@@ -5,6 +5,7 @@ import com.nextup.core.domain.auth.RefreshToken
 import com.nextup.core.domain.user.User
 import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
 import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import com.nextup.infrastructure.security.oauth2.AuthCodeStore
 import com.nextup.infrastructure.security.userdetails.CustomUserDetails
 import com.nextup.infrastructure.security.userdetails.UserJpaRepository
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -21,6 +22,7 @@ class AuthenticationService(
     private val refreshTokenRepository: RefreshTokenRepository,
     private val jwtTokenProvider: JwtTokenProvider,
     private val passwordEncoder: PasswordEncoder,
+    private val authCodeStore: AuthCodeStore,
 ) {
     /**
      * 로그인 처리
@@ -134,6 +136,38 @@ class AuthenticationService(
         return CustomUserDetails.from(user)
     }
 
+    /**
+     * OAuth2 인가 코드를 JWT 토큰으로 교환합니다.
+     *
+     * @param code 일회용 인가 코드
+     * @param deviceInfo 디바이스 정보 (선택)
+     * @param ipAddress IP 주소 (선택)
+     * @return OAuth2TokenResult (accessToken, refreshToken, isNewUser)
+     * @throws InvalidInputException 유효하지 않거나 만료된 인가 코드인 경우
+     */
+    fun exchangeOAuth2Code(
+        code: String,
+        deviceInfo: String? = null,
+        ipAddress: String? = null,
+    ): OAuth2TokenResult {
+        val authCodeResult =
+            authCodeStore.consume(code)
+                ?: throw InvalidInputException("INVALID_AUTH_CODE", "유효하지 않거나 만료된 인가 코드입니다")
+
+        val user =
+            userJpaRepository
+                .findById(authCodeResult.userId)
+                .orElseThrow { UserNotFoundException(authCodeResult.userId) }
+
+        val tokenPair = generateTokenPair(user, deviceInfo, ipAddress)
+
+        return OAuth2TokenResult(
+            accessToken = tokenPair.accessToken,
+            refreshToken = tokenPair.refreshToken,
+            isNewUser = authCodeResult.isNewUser,
+        )
+    }
+
     private fun generateTokenPair(
         user: User,
         deviceInfo: String?,
@@ -172,4 +206,13 @@ class AuthenticationService(
 data class TokenPair(
     val accessToken: String,
     val refreshToken: String,
+)
+
+/**
+ * OAuth2 토큰 교환 결과
+ */
+data class OAuth2TokenResult(
+    val accessToken: String,
+    val refreshToken: String,
+    val isNewUser: Boolean,
 )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/AuthCodeStore.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/AuthCodeStore.kt
@@ -1,0 +1,74 @@
+package com.nextup.infrastructure.security.oauth2
+
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * OAuth2 일회용 인가 코드 저장소
+ *
+ * OAuth2 인증 성공 시 생성된 일회용 코드를 저장하고,
+ * 토큰 교환 시 코드를 소비(1회 사용 후 즉시 삭제)합니다.
+ * TTL 30초 이내에 사용되지 않은 코드는 자동 만료됩니다.
+ */
+@Component
+class AuthCodeStore {
+    private val store = ConcurrentHashMap<String, AuthCodeEntry>()
+
+    companion object {
+        private const val CODE_TTL_SECONDS = 30L
+    }
+
+    /**
+     * 일회용 인가 코드를 생성하고 저장합니다.
+     *
+     * @param userId 사용자 ID
+     * @param isNewUser 신규 사용자 여부
+     * @return 생성된 인가 코드
+     */
+    fun generate(
+        userId: Long,
+        isNewUser: Boolean,
+    ): String {
+        cleanExpired()
+        val code = UUID.randomUUID().toString()
+        store[code] =
+            AuthCodeEntry(
+                userId = userId,
+                isNewUser = isNewUser,
+                expiresAt = Instant.now().plusSeconds(CODE_TTL_SECONDS),
+            )
+        return code
+    }
+
+    /**
+     * 인가 코드를 소비하고 삭제합니다 (1회 사용).
+     *
+     * @param code 인가 코드
+     * @return 사용자 정보 (userId, isNewUser), 유효하지 않거나 만료된 경우 null
+     */
+    fun consume(code: String): AuthCodeResult? {
+        val entry = store.remove(code) ?: return null
+        if (entry.expiresAt.isBefore(Instant.now())) {
+            return null
+        }
+        return AuthCodeResult(userId = entry.userId, isNewUser = entry.isNewUser)
+    }
+
+    private fun cleanExpired() {
+        val now = Instant.now()
+        store.entries.removeIf { it.value.expiresAt.isBefore(now) }
+    }
+
+    private data class AuthCodeEntry(
+        val userId: Long,
+        val isNewUser: Boolean,
+        val expiresAt: Instant,
+    )
+}
+
+data class AuthCodeResult(
+    val userId: Long,
+    val isNewUser: Boolean,
+)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
@@ -1,8 +1,5 @@
 package com.nextup.infrastructure.security.oauth2
 
-import com.nextup.core.domain.auth.RefreshToken
-import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
-import com.nextup.infrastructure.security.jwt.JwtTokenProvider
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value
@@ -14,12 +11,14 @@ import org.springframework.web.util.UriComponentsBuilder
 /**
  * OAuth2 인증 성공 핸들러
  *
- * 인증 성공 시 JWT 토큰을 발급하고 프론트엔드로 리다이렉트합니다.
+ * 인증 성공 시 일회용 인가 코드를 생성하고 프론트엔드로 리다이렉트합니다.
+ * 프론트엔드는 인가 코드로 POST /api/auth/oauth2/token 요청하여 JWT 토큰을 수신합니다.
+ *
+ * 보안: accessToken/refreshToken을 URL query parameter에 직접 노출하지 않습니다.
  */
 @Component
 class OAuth2AuthenticationSuccessHandler(
-    private val jwtTokenProvider: JwtTokenProvider,
-    private val refreshTokenRepository: RefreshTokenRepository,
+    private val authCodeStore: AuthCodeStore,
     @Value("\${app.oauth2.redirect-uri:http://localhost:3000/oauth/callback}")
     private val redirectUri: String,
 ) : SimpleUrlAuthenticationSuccessHandler() {
@@ -30,43 +29,19 @@ class OAuth2AuthenticationSuccessHandler(
     ) {
         val principal = authentication.principal as OAuth2UserPrincipal
 
-        val roles = principal.getRoleNames()
-        val accessToken =
-            jwtTokenProvider.createAccessToken(
+        val authCode =
+            authCodeStore.generate(
                 userId = principal.userId,
-                email = principal.email,
-                roles = roles,
+                isNewUser = principal.isNewUser,
             )
-
-        val refreshTokenString = jwtTokenProvider.createRefreshToken(principal.userId)
-        val refreshToken =
-            RefreshToken.create(
-                userId = principal.userId,
-                token = refreshTokenString,
-                expiresAt = jwtTokenProvider.getRefreshTokenExpiration(),
-                deviceInfo = request.getHeader("User-Agent"),
-                ipAddress = getClientIpAddress(request),
-            )
-        refreshTokenRepository.save(refreshToken)
 
         val targetUrl =
             UriComponentsBuilder
                 .fromUriString(redirectUri)
-                .queryParam("accessToken", accessToken)
-                .queryParam("refreshToken", refreshTokenString)
-                .queryParam("isNewUser", principal.isNewUser)
+                .queryParam("code", authCode)
                 .build()
                 .toUriString()
 
         response.sendRedirect(targetUrl)
-    }
-
-    private fun getClientIpAddress(request: HttpServletRequest): String {
-        val xForwardedFor = request.getHeader("X-Forwarded-For")
-        return if (!xForwardedFor.isNullOrBlank()) {
-            xForwardedFor.split(",").first().trim()
-        } else {
-            request.remoteAddr
-        }
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/AuthenticationServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/AuthenticationServiceTest.kt
@@ -5,6 +5,8 @@ import com.nextup.core.domain.auth.RefreshToken
 import com.nextup.core.domain.user.User
 import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
 import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import com.nextup.infrastructure.security.oauth2.AuthCodeResult
+import com.nextup.infrastructure.security.oauth2.AuthCodeStore
 import com.nextup.infrastructure.security.userdetails.UserJpaRepository
 import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
@@ -23,6 +25,7 @@ class AuthenticationServiceTest {
     private lateinit var refreshTokenRepository: RefreshTokenRepository
     private lateinit var jwtTokenProvider: JwtTokenProvider
     private lateinit var passwordEncoder: PasswordEncoder
+    private lateinit var authCodeStore: AuthCodeStore
     private lateinit var authenticationService: AuthenticationService
 
     @BeforeEach
@@ -31,12 +34,14 @@ class AuthenticationServiceTest {
         refreshTokenRepository = mockk()
         jwtTokenProvider = mockk()
         passwordEncoder = mockk()
+        authCodeStore = mockk()
         authenticationService =
             AuthenticationService(
                 userJpaRepository,
                 refreshTokenRepository,
                 jwtTokenProvider,
                 passwordEncoder,
+                authCodeStore,
             )
     }
 
@@ -276,6 +281,76 @@ class AuthenticationServiceTest {
             // when & then
             assertThatThrownBy {
                 authenticationService.getUserDetails(999L)
+            }.isInstanceOf(UserNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("exchangeOAuth2Code")
+    inner class ExchangeOAuth2Code {
+        @Test
+        fun `should return OAuth2TokenResult on valid code`() {
+            // given
+            val code = "valid-auth-code"
+            val user = createTestUser(1L, "test@example.com", "password")
+
+            every { authCodeStore.consume(code) } returns AuthCodeResult(userId = 1L, isNewUser = false)
+            every { userJpaRepository.findById(1L) } returns Optional.of(user)
+            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access_token"
+            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh_token"
+            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(3600)
+            every { refreshTokenRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = authenticationService.exchangeOAuth2Code(code)
+
+            // then
+            assertThat(result.accessToken).isEqualTo("access_token")
+            assertThat(result.refreshToken).isEqualTo("refresh_token")
+            assertThat(result.isNewUser).isFalse()
+        }
+
+        @Test
+        fun `should return isNewUser true for new users`() {
+            // given
+            val code = "new-user-code"
+            val user = createTestUser(1L, "new@example.com", "password")
+
+            every { authCodeStore.consume(code) } returns AuthCodeResult(userId = 1L, isNewUser = true)
+            every { userJpaRepository.findById(1L) } returns Optional.of(user)
+            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access_token"
+            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh_token"
+            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(3600)
+            every { refreshTokenRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = authenticationService.exchangeOAuth2Code(code)
+
+            // then
+            assertThat(result.isNewUser).isTrue()
+        }
+
+        @Test
+        fun `should throw InvalidInputException on invalid code`() {
+            // given
+            every { authCodeStore.consume("invalid-code") } returns null
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.exchangeOAuth2Code("invalid-code")
+            }.isInstanceOf(InvalidInputException::class.java)
+                .hasMessageContaining("유효하지 않거나 만료된 인가 코드입니다")
+        }
+
+        @Test
+        fun `should throw UserNotFoundException when user not found`() {
+            // given
+            every { authCodeStore.consume("valid-code") } returns AuthCodeResult(userId = 999L, isNewUser = false)
+            every { userJpaRepository.findById(999L) } returns Optional.empty()
+
+            // when & then
+            assertThatThrownBy {
+                authenticationService.exchangeOAuth2Code("valid-code")
             }.isInstanceOf(UserNotFoundException::class.java)
         }
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/AuthCodeStoreTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/AuthCodeStoreTest.kt
@@ -1,0 +1,82 @@
+package com.nextup.infrastructure.security.oauth2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("AuthCodeStore 테스트")
+class AuthCodeStoreTest {
+    private lateinit var authCodeStore: AuthCodeStore
+
+    @BeforeEach
+    fun setUp() {
+        authCodeStore = AuthCodeStore()
+    }
+
+    @Test
+    fun `인가 코드를 생성하고 소비할 수 있다`() {
+        // given
+        val code = authCodeStore.generate(userId = 1L, isNewUser = false)
+
+        // when
+        val result = authCodeStore.consume(code)
+
+        // then
+        assertThat(result).isNotNull
+        assertThat(result!!.userId).isEqualTo(1L)
+        assertThat(result.isNewUser).isFalse()
+    }
+
+    @Test
+    fun `인가 코드는 1회만 사용할 수 있다`() {
+        // given
+        val code = authCodeStore.generate(userId = 1L, isNewUser = false)
+
+        // when
+        val firstConsume = authCodeStore.consume(code)
+        val secondConsume = authCodeStore.consume(code)
+
+        // then
+        assertThat(firstConsume).isNotNull
+        assertThat(secondConsume).isNull()
+    }
+
+    @Test
+    fun `존재하지 않는 코드는 null을 반환한다`() {
+        // when
+        val result = authCodeStore.consume("non-existent-code")
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `isNewUser 플래그가 올바르게 전달된다`() {
+        // given
+        val code = authCodeStore.generate(userId = 2L, isNewUser = true)
+
+        // when
+        val result = authCodeStore.consume(code)
+
+        // then
+        assertThat(result).isNotNull
+        assertThat(result!!.userId).isEqualTo(2L)
+        assertThat(result.isNewUser).isTrue()
+    }
+
+    @Test
+    fun `서로 다른 코드는 독립적으로 동작한다`() {
+        // given
+        val code1 = authCodeStore.generate(userId = 1L, isNewUser = false)
+        val code2 = authCodeStore.generate(userId = 2L, isNewUser = true)
+
+        // when
+        val result1 = authCodeStore.consume(code1)
+        val result2 = authCodeStore.consume(code2)
+
+        // then
+        assertThat(result1!!.userId).isEqualTo(1L)
+        assertThat(result2!!.userId).isEqualTo(2L)
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/AuthCodeStoreTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/AuthCodeStoreTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
 
 @DisplayName("AuthCodeStore 테스트")
 class AuthCodeStoreTest {
@@ -78,5 +80,41 @@ class AuthCodeStoreTest {
         // then
         assertThat(result1!!.userId).isEqualTo(1L)
         assertThat(result2!!.userId).isEqualTo(2L)
+    }
+
+    @Test
+    fun `만료된 인가 코드는 null을 반환한다`() {
+        // given - 리플렉션으로 만료된 엔트리를 직접 삽입
+        val storeField = AuthCodeStore::class.java.getDeclaredField("store")
+        storeField.isAccessible = true
+
+        @Suppress("UNCHECKED_CAST")
+        val store = storeField.get(authCodeStore) as ConcurrentHashMap<String, Any>
+
+        val entryClass =
+            Class.forName(
+                "com.nextup.infrastructure.security.oauth2.AuthCodeStore\$AuthCodeEntry",
+            )
+        val entryConstructor =
+            entryClass.getDeclaredConstructor(
+                Long::class.java,
+                Boolean::class.java,
+                Instant::class.java,
+            )
+        entryConstructor.isAccessible = true
+        val expiredEntry =
+            entryConstructor.newInstance(
+                1L,
+                false,
+                Instant.now().minusSeconds(60),
+            )
+
+        store["expired-code"] = expiredEntry
+
+        // when
+        val result = authCodeStore.consume("expired-code")
+
+        // then
+        assertThat(result).isNull()
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationHandlersTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/OAuth2AuthenticationHandlersTest.kt
@@ -1,10 +1,7 @@
 package com.nextup.infrastructure.security.oauth2
 
-import com.nextup.core.domain.auth.RefreshToken
 import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.User
-import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
-import com.nextup.infrastructure.security.jwt.JwtTokenProvider
 import com.nextup.infrastructure.security.oauth2.impl.KakaoOAuth2UserInfo
 import io.mockk.*
 import jakarta.servlet.http.HttpServletRequest
@@ -17,15 +14,13 @@ import org.junit.jupiter.api.Test
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import org.springframework.security.oauth2.core.OAuth2Error
-import java.time.Instant
 
 @DisplayName("OAuth2 Authentication Handlers 테스트")
 class OAuth2AuthenticationHandlersTest {
     @Nested
     @DisplayName("OAuth2AuthenticationSuccessHandler")
     inner class SuccessHandlerTest {
-        private lateinit var jwtTokenProvider: JwtTokenProvider
-        private lateinit var refreshTokenRepository: RefreshTokenRepository
+        private lateinit var authCodeStore: AuthCodeStore
         private lateinit var successHandler: OAuth2AuthenticationSuccessHandler
         private lateinit var request: HttpServletRequest
         private lateinit var response: HttpServletResponse
@@ -35,12 +30,10 @@ class OAuth2AuthenticationHandlersTest {
 
         @BeforeEach
         fun setUp() {
-            jwtTokenProvider = mockk()
-            refreshTokenRepository = mockk(relaxed = true)
+            authCodeStore = mockk()
             successHandler =
                 OAuth2AuthenticationSuccessHandler(
-                    jwtTokenProvider,
-                    refreshTokenRepository,
+                    authCodeStore,
                     redirectUri,
                 )
             request = mockk(relaxed = true)
@@ -68,97 +61,59 @@ class OAuth2AuthenticationHandlersTest {
         }
 
         @Test
-        fun `should redirect with tokens on success`() {
+        fun `should redirect with auth code instead of tokens`() {
             // given
             val principal = createPrincipal(userId = 1L, isNewUser = false)
             val redirectUrlSlot = slot<String>()
 
             every { authentication.principal } returns principal
-            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access-token"
-            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh-token"
-            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(604800)
-            every { request.getHeader("User-Agent") } returns "Mozilla/5.0"
-            every { request.getHeader("X-Forwarded-For") } returns null
-            every { request.remoteAddr } returns "127.0.0.1"
-            every { refreshTokenRepository.save(any<RefreshToken>()) } returns mockk()
+            every { authCodeStore.generate(1L, false) } returns "test-auth-code"
             every { response.sendRedirect(capture(redirectUrlSlot)) } just Runs
 
             // when
             successHandler.onAuthenticationSuccess(request, response, authentication)
 
             // then
-            verify { refreshTokenRepository.save(any<RefreshToken>()) }
-            assertThat(redirectUrlSlot.captured).contains("accessToken=access-token")
-            assertThat(redirectUrlSlot.captured).contains("refreshToken=refresh-token")
-            assertThat(redirectUrlSlot.captured).contains("isNewUser=false")
+            assertThat(redirectUrlSlot.captured).contains("code=test-auth-code")
+            assertThat(redirectUrlSlot.captured).doesNotContain("accessToken")
+            assertThat(redirectUrlSlot.captured).doesNotContain("refreshToken")
+
+            verify(exactly = 1) { authCodeStore.generate(1L, false) }
         }
 
         @Test
-        fun `should set isNewUser to true for new users`() {
+        fun `should pass isNewUser flag to auth code store`() {
             // given
             val principal = createPrincipal(userId = 1L, isNewUser = true)
+
+            every { authentication.principal } returns principal
+            every { authCodeStore.generate(1L, true) } returns "new-user-code"
+            every { response.sendRedirect(any()) } just Runs
+
+            // when
+            successHandler.onAuthenticationSuccess(request, response, authentication)
+
+            // then
+            verify(exactly = 1) { authCodeStore.generate(1L, true) }
+        }
+
+        @Test
+        fun `should redirect to correct URI with code parameter`() {
+            // given
+            val principal = createPrincipal(userId = 5L, isNewUser = false)
             val redirectUrlSlot = slot<String>()
 
             every { authentication.principal } returns principal
-            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access-token"
-            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh-token"
-            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(604800)
-            every { request.getHeader("User-Agent") } returns "Mozilla/5.0"
-            every { request.getHeader("X-Forwarded-For") } returns null
-            every { request.remoteAddr } returns "127.0.0.1"
-            every { refreshTokenRepository.save(any<RefreshToken>()) } returns mockk()
+            every { authCodeStore.generate(5L, false) } returns "abc-123"
             every { response.sendRedirect(capture(redirectUrlSlot)) } just Runs
 
             // when
             successHandler.onAuthenticationSuccess(request, response, authentication)
 
             // then
-            assertThat(redirectUrlSlot.captured).contains("isNewUser=true")
-        }
-
-        @Test
-        fun `should use X-Forwarded-For header for client IP`() {
-            // given
-            val principal = createPrincipal(userId = 1L, isNewUser = false)
-            val refreshTokenSlot = slot<RefreshToken>()
-
-            every { authentication.principal } returns principal
-            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access-token"
-            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh-token"
-            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(604800)
-            every { request.getHeader("User-Agent") } returns "Mozilla/5.0"
-            every { request.getHeader("X-Forwarded-For") } returns "192.168.1.1, 10.0.0.1"
-            every { refreshTokenRepository.save(capture(refreshTokenSlot)) } returns mockk()
-            every { response.sendRedirect(any()) } just Runs
-
-            // when
-            successHandler.onAuthenticationSuccess(request, response, authentication)
-
-            // then
-            assertThat(refreshTokenSlot.captured.ipAddress).isEqualTo("192.168.1.1")
-        }
-
-        @Test
-        fun `should use remoteAddr when X-Forwarded-For is not present`() {
-            // given
-            val principal = createPrincipal(userId = 1L, isNewUser = false)
-            val refreshTokenSlot = slot<RefreshToken>()
-
-            every { authentication.principal } returns principal
-            every { jwtTokenProvider.createAccessToken(any(), any(), any()) } returns "access-token"
-            every { jwtTokenProvider.createRefreshToken(any()) } returns "refresh-token"
-            every { jwtTokenProvider.getRefreshTokenExpiration() } returns Instant.now().plusSeconds(604800)
-            every { request.getHeader("User-Agent") } returns "Mozilla/5.0"
-            every { request.getHeader("X-Forwarded-For") } returns null
-            every { request.remoteAddr } returns "10.0.0.5"
-            every { refreshTokenRepository.save(capture(refreshTokenSlot)) } returns mockk()
-            every { response.sendRedirect(any()) } just Runs
-
-            // when
-            successHandler.onAuthenticationSuccess(request, response, authentication)
-
-            // then
-            assertThat(refreshTokenSlot.captured.ipAddress).isEqualTo("10.0.0.5")
+            assertThat(redirectUrlSlot.captured)
+                .startsWith("http://localhost:3000/oauth/callback")
+            assertThat(redirectUrlSlot.captured).contains("code=abc-123")
         }
     }
 


### PR DESCRIPTION
## Summary

>- close #112 

OAuth2 인증 성공 후 `accessToken`/`refreshToken`이 redirect URL의 query parameter로 노출되는 보안 취약점을 수정합니다.
Authorization Code 패턴을 도입하여, URL에는 일회용 인가 코드만 전달하고, 프론트엔드가 POST 요청으로 토큰을 안전하게 수신하도록 변경했습니다.

## Tasks

- `AuthCodeStore` 생성: ConcurrentHashMap 기반 인메모리 저장소 (TTL 30초, 1회 사용 후 즉시 폐기)
- `OAuth2AuthenticationSuccessHandler` 수정: JWT 토큰 직접 전달 → 일회용 인가 코드 전달
- `POST /api/auth/oauth2/token` 엔드포인트 추가: 인가 코드 → JWT 토큰 교환
- `OAuth2TokenExchangeRequest`, `OAuth2TokenResponse`, `OAuth2TokenResult` DTO 추가
- `AuthenticationService.exchangeOAuth2Code()` 메서드 추가
- 테스트: AuthCodeStore(5개), AuthenticationService(4개), SuccessHandler(3개) 테스트 추가/수정

## To Reviewer

- 프론트엔드 플로우 변경: `/oauth/callback?code=xxx` → `POST /api/auth/oauth2/token {code}` → 토큰 수신
- 현재 Redis 미사용으로 ConcurrentHashMap 인메모리 구현. 추후 Redis 도입 시 교체 가능
- `/api/auth/**`가 이미 permitAll이므로 SecurityConfig 변경 불필요