### PR TITLE
fix(#130): Swagger(OpenAPI) 프로덕션 환경 비활성화

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
@@ -74,19 +74,19 @@ class SecurityConfig(
                     .permitAll()
                     .requestMatchers("/login/oauth2/**")
                     .permitAll()
-
-                // Swagger/OpenAPI - 프로덕션 환경에서는 비활성화
-                if (swaggerEnabled) {
-                    auth
-                        .requestMatchers(
-                            "/swagger-ui/**",
-                            "/swagger-ui.html",
-                            "/v3/api-docs/**",
-                            "/swagger-resources/**",
-                        ).permitAll()
-                }
-
-                auth
+                    // Swagger/OpenAPI - 프로덕션 환경에서는 비활성화
+                    .let { registry ->
+                        if (swaggerEnabled) {
+                            registry.requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                            ).permitAll()
+                        } else {
+                            registry
+                        }
+                    }
                     // Actuator endpoints
                     .requestMatchers("/actuator/health")
                     .permitAll()

--- a/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
@@ -8,6 +8,7 @@ import com.nextup.infrastructure.security.jwt.JwtProperties
 import com.nextup.infrastructure.security.oauth2.CustomOAuth2UserService
 import com.nextup.infrastructure.security.oauth2.OAuth2AuthenticationFailureHandler
 import com.nextup.infrastructure.security.oauth2.OAuth2AuthenticationSuccessHandler
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -39,6 +40,8 @@ class SecurityConfig(
     private val customOAuth2UserService: CustomOAuth2UserService,
     private val oAuth2AuthenticationSuccessHandler: OAuth2AuthenticationSuccessHandler,
     private val oAuth2AuthenticationFailureHandler: OAuth2AuthenticationFailureHandler,
+    @Value("\${springdoc.swagger-ui.enabled:true}")
+    private val swaggerEnabled: Boolean,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain =
@@ -71,13 +74,19 @@ class SecurityConfig(
                     .permitAll()
                     .requestMatchers("/login/oauth2/**")
                     .permitAll()
-                    // Swagger/OpenAPI
-                    .requestMatchers(
-                        "/swagger-ui/**",
-                        "/swagger-ui.html",
-                        "/v3/api-docs/**",
-                        "/swagger-resources/**",
-                    ).permitAll()
+
+                // Swagger/OpenAPI - 프로덕션 환경에서는 비활성화
+                if (swaggerEnabled) {
+                    auth
+                        .requestMatchers(
+                            "/swagger-ui/**",
+                            "/swagger-ui.html",
+                            "/v3/api-docs/**",
+                            "/swagger-resources/**",
+                        ).permitAll()
+                }
+
+                auth
                     // Actuator endpoints
                     .requestMatchers("/actuator/health")
                     .permitAll()

--- a/nextup-api/src/main/resources/application-prod.yml
+++ b/nextup-api/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
@@ -59,19 +59,19 @@ class SecurityConfig(
                     // Health check
                     .requestMatchers("/actuator/health")
                     .permitAll()
-
-                // Swagger/OpenAPI - 프로덕션 환경에서는 비활성화
-                if (swaggerEnabled) {
-                    auth
-                        .requestMatchers(
-                            "/swagger-ui/**",
-                            "/swagger-ui.html",
-                            "/v3/api-docs/**",
-                            "/swagger-resources/**",
-                        ).permitAll()
-                }
-
-                auth
+                    // Swagger/OpenAPI - 프로덕션 환경에서는 비활성화
+                    .let { registry ->
+                        if (swaggerEnabled) {
+                            registry.requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                            ).permitAll()
+                        } else {
+                            registry
+                        }
+                    }
                     // All other endpoints require ADMIN role
                     .anyRequest()
                     .hasRole("ADMIN")

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
@@ -5,6 +5,7 @@ import com.nextup.infrastructure.security.handler.CustomAccessDeniedHandler
 import com.nextup.infrastructure.security.handler.CustomAuthenticationEntryPoint
 import com.nextup.infrastructure.security.jwt.JwtAuthenticationFilter
 import com.nextup.infrastructure.security.jwt.JwtProperties
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -31,6 +32,8 @@ class SecurityConfig(
     private val rateLimitFilter: RateLimitFilter,
     private val customAuthenticationEntryPoint: CustomAuthenticationEntryPoint,
     private val customAccessDeniedHandler: CustomAccessDeniedHandler,
+    @Value("\${springdoc.swagger-ui.enabled:true}")
+    private val swaggerEnabled: Boolean,
 ) {
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain =
@@ -56,13 +59,19 @@ class SecurityConfig(
                     // Health check
                     .requestMatchers("/actuator/health")
                     .permitAll()
-                    // Swagger/OpenAPI
-                    .requestMatchers(
-                        "/swagger-ui/**",
-                        "/swagger-ui.html",
-                        "/v3/api-docs/**",
-                        "/swagger-resources/**",
-                    ).permitAll()
+
+                // Swagger/OpenAPI - 프로덕션 환경에서는 비활성화
+                if (swaggerEnabled) {
+                    auth
+                        .requestMatchers(
+                            "/swagger-ui/**",
+                            "/swagger-ui.html",
+                            "/v3/api-docs/**",
+                            "/swagger-resources/**",
+                        ).permitAll()
+                }
+
+                auth
                     // All other endpoints require ADMIN role
                     .anyRequest()
                     .hasRole("ADMIN")

--- a/nextup-backoffice/src/main/resources/application-prod.yml
+++ b/nextup-backoffice/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/SecurityConfig.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/SecurityConfig.kt
@@ -57,28 +57,25 @@ class SecurityConfig(
                 auth
                     // Health check
                     .requestMatchers("/health", "/actuator/health").permitAll()
-
-                // Swagger/OpenAPI - 프로덕션 환경에서는 비활성화
-                if (swaggerEnabled) {
-                    auth
-                        .requestMatchers(
-                            "/swagger-ui/**",
-                            "/swagger-ui.html",
-                            "/v3/api-docs/**",
-                            "/swagger-resources/**",
-                        ).permitAll()
-                }
-
+                    // Swagger/OpenAPI - 프로덕션 환경에서는 비활성화
+                    .let { registry ->
+                        if (swaggerEnabled) {
+                            registry.requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                            ).permitAll()
+                        } else {
+                            registry
+                        }
+                    }
                     // WebSocket endpoints - HTTP 핸드셰이크 허용 (STOMP CONNECT에서 JWT 검증)
-
                     .requestMatchers("/ws/**").permitAll()
-
                     // Scorer API endpoints
                     .requestMatchers("/api/scorer/**").hasAnyRole("SCORER", "ADMIN")
-
                     // League management in scorer module
                     .requestMatchers("/api/leagues/**").hasAnyRole("SCORER", "ADMIN")
-
                     // All other endpoints require authentication with SCORER or ADMIN role
                     .anyRequest().hasAnyRole("SCORER", "ADMIN")
             }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/SecurityConfig.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/SecurityConfig.kt
@@ -5,6 +5,7 @@ import com.nextup.infrastructure.security.handler.CustomAccessDeniedHandler
 import com.nextup.infrastructure.security.handler.CustomAuthenticationEntryPoint
 import com.nextup.infrastructure.security.jwt.JwtAuthenticationFilter
 import com.nextup.infrastructure.security.jwt.JwtProperties
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -30,6 +31,8 @@ class SecurityConfig(
     private val rateLimitFilter: RateLimitFilter,
     private val customAuthenticationEntryPoint: CustomAuthenticationEntryPoint,
     private val customAccessDeniedHandler: CustomAccessDeniedHandler,
+    @Value("\${springdoc.swagger-ui.enabled:true}")
+    private val swaggerEnabled: Boolean,
 ) {
 
     @Bean
@@ -55,14 +58,18 @@ class SecurityConfig(
                     // Health check
                     .requestMatchers("/health", "/actuator/health").permitAll()
 
-                    // Swagger/OpenAPI
-                    .requestMatchers(
-                        "/swagger-ui/**",
-                        "/swagger-ui.html",
-                        "/v3/api-docs/**",
-                        "/swagger-resources/**"
-                    ).permitAll()
+                // Swagger/OpenAPI - 프로덕션 환경에서는 비활성화
+                if (swaggerEnabled) {
+                    auth
+                        .requestMatchers(
+                            "/swagger-ui/**",
+                            "/swagger-ui.html",
+                            "/v3/api-docs/**",
+                            "/swagger-resources/**",
+                        ).permitAll()
+                }
 
+                auth
                     // WebSocket endpoints (for real-time scoreboard)
                     .requestMatchers("/ws/**").permitAll()
 

--- a/nextup-scorer/src/main/resources/application-prod.yml
+++ b/nextup-scorer/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
## Summary

>- closes #130 

Swagger UI가 프로덕션 환경에서도 접근 가능하여 전체 API 명세가 노출되는 보안 취약점을 수정합니다.
이중 방어 전략으로 SecurityConfig 조건부 접근 제어 + application-prod.yml springdoc 비활성화를 적용했습니다.

## Tasks

- 3개 모듈(api, backoffice, scorer) SecurityConfig: `springdoc.swagger-ui.enabled` 프로퍼티 기반 조건부 Swagger 경로 permitAll
- `application-prod.yml` 생성 (3개 모듈): springdoc api-docs, swagger-ui 비활성화
- 개발/스테이징 환경에서는 기존대로 Swagger 접근 가능 (기본값 true)

## To Reviewer

- 이중 방어: springdoc 자체 비활성화(application-prod.yml) + SecurityFilterChain에서 경로 차단
- 기본값 `true`이므로 기존 개발 환경에 영향 없음\n- prod 프로필 활성화 시 자동으로 Swagger 차단