### PR TITLE
refactor(#113): BattingRecord 중복 메서드 통합

### DIFF
--- a/nextup-api/src/test/kotlin/com/nextup/api/mapper/game/BattingRecordMapperTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/mapper/game/BattingRecordMapperTest.kt
@@ -18,8 +18,9 @@ class BattingRecordMapperTest {
 
         val battingRecord =
             BattingRecord.create(gamePlayer).apply {
-                recordPlateAppearance(PlateAppearanceResult.SINGLE, 1, true)
-                recordPlateAppearance(PlateAppearanceResult.HOME_RUN, 2, true)
+                applyPlateAppearanceResult(PlateAppearanceResult.SINGLE, rbis = 1)
+                recordRun() // 단타 후 주루 득점 별도 기록
+                applyPlateAppearanceResult(PlateAppearanceResult.HOME_RUN, rbis = 2)
             }
 
         // when
@@ -32,7 +33,7 @@ class BattingRecordMapperTest {
         assertThat(response.hits).isEqualTo(2)
         assertThat(response.singles).isEqualTo(1)
         assertThat(response.homeRuns).isEqualTo(1)
-        assertThat(response.runs).isEqualTo(2)
+        assertThat(response.runs).isEqualTo(2) // 단타 주루 득점 1 + 홈런 자동 득점 1
         assertThat(response.runsBattedIn).isEqualTo(3)
         assertThat(response.totalBases).isEqualTo(5) // 1 + 4
     }
@@ -46,10 +47,10 @@ class BattingRecordMapperTest {
         val battingRecord =
             BattingRecord.create(gamePlayer).apply {
                 repeat(3) {
-                    recordPlateAppearance(PlateAppearanceResult.SINGLE)
+                    applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
                 }
                 repeat(2) {
-                    recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
+                    applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
                 }
             }
 
@@ -69,7 +70,7 @@ class BattingRecordMapperTest {
 
         val battingRecord =
             BattingRecord.create(gamePlayer).apply {
-                recordPlateAppearance(PlateAppearanceResult.WALK)
+                applyPlateAppearanceResult(PlateAppearanceResult.WALK)
             }
 
         // when
@@ -89,10 +90,10 @@ class BattingRecordMapperTest {
         val battingRecord =
             BattingRecord.create(gamePlayer).apply {
                 // 2 hits (1 single, 1 home run) in 3 at-bats, 1 walk
-                recordPlateAppearance(PlateAppearanceResult.SINGLE)
-                recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
-                recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
-                recordPlateAppearance(PlateAppearanceResult.WALK)
+                applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+                applyPlateAppearanceResult(PlateAppearanceResult.HOME_RUN)
+                applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
+                applyPlateAppearanceResult(PlateAppearanceResult.WALK)
             }
 
         // when
@@ -155,10 +156,10 @@ class BattingRecordMapperTest {
 
         val battingRecord =
             BattingRecord.create(gamePlayer).apply {
-                recordPlateAppearance(PlateAppearanceResult.SINGLE)
-                recordPlateAppearance(PlateAppearanceResult.DOUBLE)
-                recordPlateAppearance(PlateAppearanceResult.TRIPLE)
-                recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
+                applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+                applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE)
+                applyPlateAppearanceResult(PlateAppearanceResult.TRIPLE)
+                applyPlateAppearanceResult(PlateAppearanceResult.HOME_RUN)
             }
 
         // when
@@ -181,9 +182,9 @@ class BattingRecordMapperTest {
 
         val battingRecord =
             BattingRecord.create(gamePlayer).apply {
-                recordPlateAppearance(PlateAppearanceResult.WALK)
-                recordPlateAppearance(PlateAppearanceResult.WALK)
-                recordPlateAppearance(PlateAppearanceResult.INTENTIONAL_WALK)
+                applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+                applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+                applyPlateAppearanceResult(PlateAppearanceResult.INTENTIONAL_WALK)
             }
 
         // when
@@ -203,8 +204,8 @@ class BattingRecordMapperTest {
 
         val battingRecord =
             BattingRecord.create(gamePlayer).apply {
-                recordPlateAppearance(PlateAppearanceResult.SACRIFICE_BUNT)
-                recordPlateAppearance(PlateAppearanceResult.SACRIFICE_FLY)
+                applyPlateAppearanceResult(PlateAppearanceResult.SACRIFICE_BUNT)
+                applyPlateAppearanceResult(PlateAppearanceResult.SACRIFICE_FLY)
             }
 
         // when
@@ -227,10 +228,10 @@ class BattingRecordMapperTest {
         val records =
             listOf(
                 BattingRecord.create(gamePlayer1).apply {
-                    recordPlateAppearance(PlateAppearanceResult.SINGLE)
+                    applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
                 },
                 BattingRecord.create(gamePlayer2).apply {
-                    recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
+                    applyPlateAppearanceResult(PlateAppearanceResult.HOME_RUN)
                 },
             )
 
@@ -272,9 +273,9 @@ class BattingRecordMapperTest {
 
         val battingRecord =
             BattingRecord.create(gamePlayer).apply {
-                recordPlateAppearance(PlateAppearanceResult.STRIKEOUT)
-                recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
-                recordPlateAppearance(PlateAppearanceResult.DOUBLE_PLAY)
+                applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT)
+                applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
+                applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE_PLAY)
             }
 
         // when

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
@@ -186,52 +186,11 @@ class BattingRecord(
     // Business logic
 
     /**
-     * 타석 결과를 기록합니다.
-     */
-    fun recordPlateAppearance(
-        result: PlateAppearanceResult,
-        runsBattedIn: Int = 0,
-        runsScored: Boolean = false,
-    ) {
-        require(runsBattedIn >= 0) { "타점은 0 이상이어야 합니다." }
-
-        plateAppearances++
-
-        if (result.isAtBat) {
-            atBats++
-        }
-
-        if (result.isHit) {
-            hits++
-            when (result) {
-                PlateAppearanceResult.DOUBLE -> doubles++
-                PlateAppearanceResult.TRIPLE -> triples++
-                PlateAppearanceResult.HOME_RUN -> homeRuns++
-                else -> { /* single */ }
-            }
-        }
-
-        when (result) {
-            PlateAppearanceResult.STRIKEOUT -> strikeouts++
-            PlateAppearanceResult.WALK -> walks++
-            PlateAppearanceResult.INTENTIONAL_WALK -> intentionalWalks++
-            PlateAppearanceResult.HIT_BY_PITCH -> hitByPitch++
-            PlateAppearanceResult.SACRIFICE_BUNT -> sacrificeBunts++
-            PlateAppearanceResult.SACRIFICE_FLY -> sacrificeFlies++
-            PlateAppearanceResult.DOUBLE_PLAY, PlateAppearanceResult.TRIPLE_PLAY -> groundedIntoDoublePlays++
-            else -> { /* no additional tracking needed */ }
-        }
-
-        this.runsBattedIn += runsBattedIn
-
-        if (runsScored) {
-            runs++
-        }
-    }
-
-    /**
-     * 타석 결과에 따른 기록을 자동으로 갱신합니다 (BoxScore 계산용).
-     * recordPlateAppearance와 유사하지만 더 명시적인 API를 제공합니다.
+     * 타석 결과에 따른 기록을 갱신합니다.
+     *
+     * 모든 타석 결과를 망라하는 단일 정규 메서드입니다.
+     * 홈런은 타자 자신의 득점(runs)도 자동으로 포함됩니다.
+     * 주루 중 별도 득점은 [recordRun]을 사용하세요.
      */
     fun applyPlateAppearanceResult(
         result: PlateAppearanceResult,

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/BattingRecordService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/BattingRecordService.kt
@@ -48,6 +48,9 @@ class BattingRecordService(
 
     /**
      * 타석 결과를 기록합니다.
+     *
+     * 홈런은 [applyPlateAppearanceResult]에서 득점이 자동 처리됩니다.
+     * 주루 중 별도 득점이 있으면 [runsScored] 플래그로 [recordRun]을 추가 호출합니다.
      */
     @Transactional
     fun recordPlateAppearance(
@@ -57,7 +60,10 @@ class BattingRecordService(
         runsScored: Boolean = false,
     ) {
         val battingRecord = getByGamePlayerId(gamePlayerId)
-        battingRecord.recordPlateAppearance(result, runsBattedIn, runsScored)
+        battingRecord.applyPlateAppearanceResult(result, runsBattedIn)
+        if (runsScored) {
+            battingRecord.recordRun()
+        }
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
@@ -26,7 +26,7 @@ class BattingRecordTest {
         @Test
         fun `단타를 기록하면 타석, 타수, 안타가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
 
             // then
             assertThat(battingRecord.plateAppearances).isEqualTo(1)
@@ -37,7 +37,7 @@ class BattingRecordTest {
         @Test
         fun `2루타를 기록하면 doubles가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.DOUBLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE)
 
             // then
             assertThat(battingRecord.hits).isEqualTo(1)
@@ -47,7 +47,7 @@ class BattingRecordTest {
         @Test
         fun `3루타를 기록하면 triples가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.TRIPLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.TRIPLE)
 
             // then
             assertThat(battingRecord.hits).isEqualTo(1)
@@ -57,7 +57,7 @@ class BattingRecordTest {
         @Test
         fun `홈런을 기록하면 homeRuns가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.HOME_RUN)
 
             // then
             assertThat(battingRecord.hits).isEqualTo(1)
@@ -67,7 +67,7 @@ class BattingRecordTest {
         @Test
         fun `삼진을 기록하면 타수가 증가하고 strikeouts가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.STRIKEOUT)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT)
 
             // then
             assertThat(battingRecord.atBats).isEqualTo(1)
@@ -78,7 +78,7 @@ class BattingRecordTest {
         @Test
         fun `볼넷을 기록하면 타수는 증가하지 않고 walks가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.WALK)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
 
             // then
             assertThat(battingRecord.plateAppearances).isEqualTo(1)
@@ -89,7 +89,7 @@ class BattingRecordTest {
         @Test
         fun `고의사구를 기록하면 intentionalWalks가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.INTENTIONAL_WALK)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.INTENTIONAL_WALK)
 
             // then
             assertThat(battingRecord.atBats).isEqualTo(0)
@@ -99,7 +99,7 @@ class BattingRecordTest {
         @Test
         fun `사구를 기록하면 hitByPitch가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.HIT_BY_PITCH)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.HIT_BY_PITCH)
 
             // then
             assertThat(battingRecord.atBats).isEqualTo(0)
@@ -109,7 +109,7 @@ class BattingRecordTest {
         @Test
         fun `희생번트를 기록하면 타수는 증가하지 않고 sacrificeBunts가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SACRIFICE_BUNT)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SACRIFICE_BUNT)
 
             // then
             assertThat(battingRecord.atBats).isEqualTo(0)
@@ -119,7 +119,7 @@ class BattingRecordTest {
         @Test
         fun `희생플라이를 기록하면 타수는 증가하지 않고 sacrificeFlies가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SACRIFICE_FLY)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SACRIFICE_FLY)
 
             // then
             assertThat(battingRecord.atBats).isEqualTo(0)
@@ -129,7 +129,7 @@ class BattingRecordTest {
         @Test
         fun `병살타를 기록하면 groundedIntoDoublePlays가 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.DOUBLE_PLAY)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE_PLAY)
 
             // then
             assertThat(battingRecord.groundedIntoDoublePlays).isEqualTo(1)
@@ -138,16 +138,16 @@ class BattingRecordTest {
         @Test
         fun `타점을 함께 기록할 수 있다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE, runsBattedIn = 2)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE, rbis = 2)
 
             // then
             assertThat(battingRecord.runsBattedIn).isEqualTo(2)
         }
 
         @Test
-        fun `득점을 함께 기록할 수 있다`() {
+        fun `홈런을 기록하면 타자 자신의 득점도 자동으로 증가한다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.HOME_RUN, runsScored = true)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.HOME_RUN)
 
             // then
             assertThat(battingRecord.runs).isEqualTo(1)
@@ -157,7 +157,7 @@ class BattingRecordTest {
         fun `음수 타점은 허용되지 않는다`() {
             // when & then
             assertThatThrownBy {
-                battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE, runsBattedIn = -1)
+                battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE, rbis = -1)
             }.isInstanceOf(IllegalArgumentException::class.java)
         }
     }
@@ -203,10 +203,10 @@ class BattingRecordTest {
         @Test
         fun `singles는 안타에서 장타를 뺀 값이다`() {
             // given
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.DOUBLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.HOME_RUN)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.HOME_RUN)
 
             // then
             assertThat(battingRecord.singles).isEqualTo(2)
@@ -215,10 +215,10 @@ class BattingRecordTest {
         @Test
         fun `totalBases를 올바르게 계산한다`() {
             // given
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE) // 1
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.DOUBLE) // 2
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.TRIPLE) // 3
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.HOME_RUN) // 4
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE) // 1
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE) // 2
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.TRIPLE) // 3
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.HOME_RUN) // 4
 
             // then
             assertThat(battingRecord.totalBases).isEqualTo(10)
@@ -227,9 +227,9 @@ class BattingRecordTest {
         @Test
         fun `extraBaseHits를 올바르게 계산한다`() {
             // given
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.DOUBLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.TRIPLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.TRIPLE)
 
             // then
             assertThat(battingRecord.extraBaseHits).isEqualTo(2)
@@ -238,8 +238,8 @@ class BattingRecordTest {
         @Test
         fun `sacrifices를 올바르게 계산한다`() {
             // given
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SACRIFICE_BUNT)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SACRIFICE_FLY)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SACRIFICE_BUNT)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SACRIFICE_FLY)
 
             // then
             assertThat(battingRecord.sacrifices).isEqualTo(2)
@@ -248,9 +248,9 @@ class BattingRecordTest {
         @Test
         fun `totalWalks를 올바르게 계산한다`() {
             // given
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.WALK)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.WALK)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.INTENTIONAL_WALK)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.INTENTIONAL_WALK)
 
             // then
             assertThat(battingRecord.totalWalks).isEqualTo(3)
@@ -263,7 +263,7 @@ class BattingRecordTest {
         @Test
         fun `타수가 0이면 타율은 0이다`() {
             // when
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.WALK)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
 
             // then
             assertThat(battingRecord.battingAverage).isEqualTo(BigDecimal("0.000"))
@@ -272,9 +272,9 @@ class BattingRecordTest {
         @Test
         fun `3타수 1안타면 타율은 0_333이다`() {
             // given
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.STRIKEOUT)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
 
             // then
             assertThat(battingRecord.battingAverage).isEqualTo(BigDecimal("0.333"))
@@ -283,10 +283,10 @@ class BattingRecordTest {
         @Test
         fun `4타수 2안타면 타율은 0_500이다`() {
             // given
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.DOUBLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.STRIKEOUT)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
 
             // then
             assertThat(battingRecord.battingAverage).isEqualTo(BigDecimal("0.500"))
@@ -305,11 +305,11 @@ class BattingRecordTest {
         @Test
         fun `출루율은 안타, 볼넷, 사구를 타수, 볼넷, 사구, 희생플라이로 나눈 값이다`() {
             // given: 4타수 1안타 1볼넷 1사구
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE) // H=1, AB=1
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.WALK) // BB=1
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.HIT_BY_PITCH) // HBP=1
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.STRIKEOUT) // AB=2
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.GROUND_OUT) // AB=3
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE) // H=1, AB=1
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK) // BB=1
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.HIT_BY_PITCH) // HBP=1
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT) // AB=2
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT) // AB=3
 
             // when: OBP = (1 + 1 + 1) / (3 + 1 + 1 + 0) = 3/5 = 0.600
             // then
@@ -329,10 +329,10 @@ class BattingRecordTest {
         @Test
         fun `총루타를 타수로 나눈 값이다`() {
             // given: 4타수 - 단타(1), 2루타(2), 삼진(0), 땅볼(0) = 3루타
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE) // 1
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.DOUBLE) // 2
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.STRIKEOUT) // 0
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.GROUND_OUT) // 0
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE) // 1
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE) // 2
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT) // 0
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT) // 0
 
             // when: SLG = 3/4 = 0.750
             // then
@@ -346,10 +346,10 @@ class BattingRecordTest {
         @Test
         fun `OPS는 출루율 + 장타율이다`() {
             // given: 간단한 예시 - 4타수 2안타(단타 2개)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.STRIKEOUT)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.GROUND_OUT)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
 
             // AVG = 0.500, OBP = 0.500, SLG = 0.500
             // OPS = 1.000
@@ -386,9 +386,9 @@ class BattingRecordTest {
         @Test
         fun `정상적인 기록은 검증에 통과한다`() {
             // given
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.SINGLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.DOUBLE)
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.STRIKEOUT)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT)
 
             // when & then
             battingRecord.validate() // 예외 없이 통과
@@ -895,11 +895,11 @@ class BattingRecordTest {
     }
 
     @Nested
-    @DisplayName("recordPlateAppearance - 삼중살 기록")
+    @DisplayName("applyPlateAppearanceResult - 삼중살 기록")
     inner class RecordTriplePlayTest {
         @Test
         fun `삼중살을 기록하면 groundedIntoDoublePlays가 증가한다`() {
-            battingRecord.recordPlateAppearance(PlateAppearanceResult.TRIPLE_PLAY)
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.TRIPLE_PLAY)
 
             assertThat(battingRecord.groundedIntoDoublePlays).isEqualTo(1)
             assertThat(battingRecord.atBats).isEqualTo(1)

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/BattingRecordServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/BattingRecordServiceTest.kt
@@ -129,6 +129,25 @@ class BattingRecordServiceTest {
     }
 
     @Test
+    fun `should record plate appearance without run when runsScored is false`() {
+        // given
+        val gamePlayerId = 1L
+        val result = PlateAppearanceResult.SINGLE
+        val runsBattedIn = 0
+        val runsScored = false
+
+        every { battingRecordRepository.findByGamePlayerId(gamePlayerId) } returns mockBattingRecord
+        every { mockBattingRecord.applyPlateAppearanceResult(result, runsBattedIn) } returns Unit
+
+        // when
+        battingRecordService.recordPlateAppearance(gamePlayerId, result, runsBattedIn, runsScored)
+
+        // then
+        verify(exactly = 1) { mockBattingRecord.applyPlateAppearanceResult(result, runsBattedIn) }
+        verify(exactly = 0) { mockBattingRecord.recordRun() }
+    }
+
+    @Test
     fun `should record stolen base successfully`() {
         // given
         val gamePlayerId = 1L

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/BattingRecordServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/BattingRecordServiceTest.kt
@@ -117,13 +117,15 @@ class BattingRecordServiceTest {
         val runsScored = true
 
         every { battingRecordRepository.findByGamePlayerId(gamePlayerId) } returns mockBattingRecord
-        every { mockBattingRecord.recordPlateAppearance(result, runsBattedIn, runsScored) } returns Unit
+        every { mockBattingRecord.applyPlateAppearanceResult(result, runsBattedIn) } returns Unit
+        every { mockBattingRecord.recordRun() } returns Unit
 
         // when
         battingRecordService.recordPlateAppearance(gamePlayerId, result, runsBattedIn, runsScored)
 
         // then
-        verify(exactly = 1) { mockBattingRecord.recordPlateAppearance(result, runsBattedIn, runsScored) }
+        verify(exactly = 1) { mockBattingRecord.applyPlateAppearanceResult(result, runsBattedIn) }
+        verify(exactly = 1) { mockBattingRecord.recordRun() }
     }
 
     @Test


### PR DESCRIPTION
## Summary

>- close #113

`BattingRecord` 엔티티에 타석 결과를 기록하는 메서드가 2개 중복 존재하던 문제를 해결합니다.
`recordPlateAppearance()`를 제거하고 `applyPlateAppearanceResult()`를 단일 정규 메서드로 통합했습니다.

## Tasks

- `recordPlateAppearance`와 `applyPlateAppearanceResult` 차이점 분석 및 정규 메서드 선정
- `applyPlateAppearanceResult`를 단일 정규 메서드로 채택 (exhaustive when, revert 대칭성)
- `BattingRecordService`에서 호출 방식 통합
- 기존 테스트 전부 통합된 메서드로 교체 및 통과 확인

## To Reviewer

- `applyPlateAppearanceResult`가 `recordPlateAppearance`보다 완전한 이유: exhaustive when 처리, INTERFERENCE 케이스 포함, revert 메서드와 완전 대칭
- `BattingRecordService.recordPlateAppearance()` 서비스 메서드는 유지하되 내부에서 `applyPlateAppearanceResult()` + `recordRun()` 위임으로 변경