### PR TITLE
refactor(#127): Competition Entity Rich Domain Model 수정

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/Competition.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/Competition.kt
@@ -26,7 +26,7 @@ class Competition(
     @JoinColumn(name = "league_id", nullable = false)
     val league: League,
     @Column(nullable = false, length = 100)
-    val name: String,
+    var name: String,
     @Column(nullable = false)
     val year: Int,
     @Column(nullable = false)
@@ -75,6 +75,32 @@ class Competition(
     fun cancel() {
         require(status != CompetitionStatus.COMPLETED) { "완료된 대회는 취소할 수 없습니다." }
         this.status = CompetitionStatus.CANCELLED
+    }
+
+    /**
+     * 대회를 연기합니다.
+     */
+    fun postpone() {
+        require(
+            status == CompetitionStatus.SCHEDULED || status == CompetitionStatus.IN_PROGRESS,
+        ) { "예정 중이거나 진행 중인 대회만 연기할 수 있습니다." }
+        this.status = CompetitionStatus.POSTPONED
+    }
+
+    /**
+     * 대회 정보를 업데이트합니다.
+     */
+    fun updateInfo(
+        name: String? = null,
+        description: String? = null,
+        endDate: LocalDate? = null,
+    ) {
+        endDate?.let {
+            require(!it.isBefore(startDate)) { "종료일은 시작일 이후여야 합니다." }
+            this.endDate = it
+        }
+        name?.let { this.name = it }
+        description?.let { this.description = it }
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/competition/CompetitionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/competition/CompetitionService.kt
@@ -106,14 +106,16 @@ class CompetitionService(
     @Transactional
     fun update(
         id: Long,
-        description: String?,
-        endDate: LocalDate?,
+        name: String? = null,
+        description: String? = null,
+        endDate: LocalDate? = null,
     ): Competition {
         val competition = getById(id)
-
-        description?.let { competition.description = it }
-        endDate?.let { competition.endDate = it }
-
+        try {
+            competition.updateInfo(name = name, description = description, endDate = endDate)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidCompetitionStateException(e.message ?: "Cannot update competition")
+        }
         return competition
     }
 
@@ -168,10 +170,11 @@ class CompetitionService(
     @Transactional
     fun postpone(id: Long): Competition {
         val competition = getById(id)
-        if (competition.status != CompetitionStatus.SCHEDULED) {
-            throw InvalidCompetitionStateException("Only scheduled competitions can be postponed")
+        try {
+            competition.postpone()
+        } catch (e: IllegalArgumentException) {
+            throw InvalidCompetitionStateException(e.message ?: "Cannot postpone competition")
         }
-        competition.status = CompetitionStatus.POSTPONED
         return competition
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/CompetitionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/CompetitionTest.kt
@@ -170,6 +170,143 @@ class CompetitionTest {
     }
 
     @Nested
+    @DisplayName("대회 연기")
+    inner class Postpone {
+        @Test
+        fun `예정된 대회를 연기할 수 있다`() {
+            // given
+            val competition = createCompetition(status = CompetitionStatus.SCHEDULED)
+
+            // when
+            competition.postpone()
+
+            // then
+            assertThat(competition.status).isEqualTo(CompetitionStatus.POSTPONED)
+        }
+
+        @Test
+        fun `진행 중인 대회를 연기할 수 있다`() {
+            // given
+            val competition = createCompetition(status = CompetitionStatus.IN_PROGRESS)
+
+            // when
+            competition.postpone()
+
+            // then
+            assertThat(competition.status).isEqualTo(CompetitionStatus.POSTPONED)
+        }
+
+        @Test
+        fun `완료된 대회는 연기할 수 없다`() {
+            // given
+            val competition = createCompetition(status = CompetitionStatus.COMPLETED)
+
+            // when & then
+            assertThatThrownBy { competition.postpone() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("예정 중이거나 진행 중인 대회만 연기할 수 있습니다.")
+        }
+
+        @Test
+        fun `취소된 대회는 연기할 수 없다`() {
+            // given
+            val competition = createCompetition(status = CompetitionStatus.CANCELLED)
+
+            // when & then
+            assertThatThrownBy { competition.postpone() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("예정 중이거나 진행 중인 대회만 연기할 수 있습니다.")
+        }
+    }
+
+    @Nested
+    @DisplayName("대회 정보 업데이트")
+    inner class UpdateInfo {
+        @Test
+        fun `대회명을 변경할 수 있다`() {
+            // given
+            val competition = createCompetition()
+            val newName = "2025 추계대회"
+
+            // when
+            competition.updateInfo(name = newName)
+
+            // then
+            assertThat(competition.name).isEqualTo(newName)
+        }
+
+        @Test
+        fun `설명을 변경할 수 있다`() {
+            // given
+            val competition = createCompetition()
+            val newDescription = "2025 정규 리그 추계 시즌"
+
+            // when
+            competition.updateInfo(description = newDescription)
+
+            // then
+            assertThat(competition.description).isEqualTo(newDescription)
+        }
+
+        @Test
+        fun `종료일을 변경할 수 있다`() {
+            // given
+            val competition = createCompetition(startDate = LocalDate.of(2025, 3, 1))
+            val newEndDate = LocalDate.of(2025, 9, 30)
+
+            // when
+            competition.updateInfo(endDate = newEndDate)
+
+            // then
+            assertThat(competition.endDate).isEqualTo(newEndDate)
+        }
+
+        @Test
+        fun `종료일이 시작일보다 이전이면 업데이트할 수 없다`() {
+            // given
+            val competition = createCompetition(startDate = LocalDate.of(2025, 3, 1))
+
+            // when & then
+            assertThatThrownBy { competition.updateInfo(endDate = LocalDate.of(2025, 2, 28)) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("종료일은 시작일 이후여야 합니다.")
+        }
+
+        @Test
+        fun `여러 필드를 동시에 업데이트할 수 있다`() {
+            // given
+            val competition = createCompetition(startDate = LocalDate.of(2025, 3, 1))
+            val newName = "2025 추계대회"
+            val newDescription = "추계 시즌"
+            val newEndDate = LocalDate.of(2025, 10, 31)
+
+            // when
+            competition.updateInfo(name = newName, description = newDescription, endDate = newEndDate)
+
+            // then
+            assertThat(competition.name).isEqualTo(newName)
+            assertThat(competition.description).isEqualTo(newDescription)
+            assertThat(competition.endDate).isEqualTo(newEndDate)
+        }
+
+        @Test
+        fun `null 값은 기존 값을 유지한다`() {
+            // given
+            val competition =
+                createCompetition(startDate = LocalDate.of(2025, 3, 1)).apply {
+                    updateInfo(description = "원본 설명")
+                }
+
+            // when
+            competition.updateInfo(name = null, description = null, endDate = null)
+
+            // then
+            assertThat(competition.name).isEqualTo("2025 춘계대회")
+            assertThat(competition.description).isEqualTo("원본 설명")
+        }
+    }
+
+    @Nested
     @DisplayName("활성 상태 확인")
     inner class IsActive {
         @Test

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/competition/CompetitionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/competition/CompetitionServiceTest.kt
@@ -326,6 +326,144 @@ class CompetitionServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("update")
+    inner class Update {
+        @Test
+        fun `should update competition description`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1)
+            every { competitionRepository.findByIdOrNull(id) } returns competition
+
+            // when
+            val result = competitionService.update(id, description = "업데이트된 설명")
+
+            // then
+            assertThat(result.description).isEqualTo("업데이트된 설명")
+        }
+
+        @Test
+        fun `should update competition name`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1)
+            every { competitionRepository.findByIdOrNull(id) } returns competition
+
+            // when
+            val result = competitionService.update(id, name = "2025 추계대회")
+
+            // then
+            assertThat(result.name).isEqualTo("2025 추계대회")
+        }
+
+        @Test
+        fun `should update competition endDate`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1)
+            val newEndDate = LocalDate.of(2025, 9, 30)
+            every { competitionRepository.findByIdOrNull(id) } returns competition
+
+            // when
+            val result = competitionService.update(id, endDate = newEndDate)
+
+            // then
+            assertThat(result.endDate).isEqualTo(newEndDate)
+        }
+
+        @Test
+        fun `should throw exception when endDate is before startDate`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1)
+            every { competitionRepository.findByIdOrNull(id) } returns competition
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.update(id, endDate = LocalDate.of(2025, 1, 1))
+            }.isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("postpone")
+    inner class Postpone {
+        @Test
+        fun `should postpone scheduled competition`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1)
+            every { competitionRepository.findByIdOrNull(id) } returns competition
+
+            // when
+            val result = competitionService.postpone(id)
+
+            // then
+            assertThat(result.status).isEqualTo(CompetitionStatus.POSTPONED)
+        }
+
+        @Test
+        fun `should postpone in-progress competition`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1).apply { start() }
+            every { competitionRepository.findByIdOrNull(id) } returns competition
+
+            // when
+            val result = competitionService.postpone(id)
+
+            // then
+            assertThat(result.status).isEqualTo(CompetitionStatus.POSTPONED)
+        }
+
+        @Test
+        fun `should throw exception when competition is completed`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition =
+                createCompetition(id, league, "2025 춘계대회", 2025, 1).apply {
+                    start()
+                    complete()
+                }
+            every { competitionRepository.findByIdOrNull(id) } returns competition
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.postpone(id)
+            }.isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when competition is cancelled`() {
+            // given
+            val id = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(id, league, "2025 춘계대회", 2025, 1).apply { cancel() }
+            every { competitionRepository.findByIdOrNull(id) } returns competition
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.postpone(id)
+            }.isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+    }
+
     private fun createAssociation(
         id: Long,
         name: String,


### PR DESCRIPTION
## Summary

>- close #127

`CompetitionService`에서 Entity 상태를 직접 변경하던 코드를 Entity 메서드로 추출하여 Rich Domain Model 원칙을 준수하도록 수정합니다.

## Tasks

- `Competition.postpone()` Entity 메서드 추가 (상태 검증: SCHEDULED/IN_PROGRESS만 연기 가능)
- `Competition.updateInfo()` Entity 메서드 추가 (name/description/endDate 선택적 업데이트, 날짜 유효성 검증)
- `CompetitionService`에서 직접 속성 변경 → Entity 메서드 호출로 변경
- Entity 단위 테스트 10건 추가 (postpone 4건, updateInfo 6건)
- Service 단위 테스트 8건 추가 (update 4건, postpone 4건)

## To Reviewer

- 기존 `start()`, `complete()`, `cancel()` 패턴과 동일한 형태로 `postpone()` 추가
- `name` 필드를 `val` → `var`로 변경하여 `updateInfo()`에서 수정 가능하도록 함