### PR TITLE
refactor(#128): League/Team Entity 풍부화 (Rich Domain Model)

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/league/League.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/league/League.kt
@@ -3,6 +3,7 @@ package com.nextup.core.domain.league
 import com.nextup.core.common.BaseTimeEntity
 import com.nextup.core.domain.association.Association
 import jakarta.persistence.*
+import java.time.LocalDate
 
 /**
  * 리그 엔티티
@@ -36,6 +37,8 @@ class League(
     var logoUrl: String? = null,
     @Column(name = "is_active", nullable = false)
     var isActive: Boolean = true,
+    @Column(name = "max_team_count")
+    val maxTeamCount: Int? = null,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
@@ -54,5 +57,51 @@ class League(
     ) {
         this.description = description
         this.logoUrl = logoUrl
+    }
+
+    /**
+     * 리그가 추가 팀을 수용할 수 있는지 확인합니다.
+     *
+     * maxTeamCount가 설정되지 않은 경우 제한 없이 수용합니다.
+     *
+     * @param currentTeamCount 현재 등록된 팀 수
+     * @return 팀 추가 가능 여부
+     */
+    fun canAcceptTeam(currentTeamCount: Int): Boolean {
+        val limit = maxTeamCount ?: return true
+        return currentTeamCount < limit
+    }
+
+    /**
+     * 리그 등록 기간 내인지 확인합니다.
+     *
+     * @param registrationStartDate 등록 시작일
+     * @param registrationEndDate 등록 종료일
+     * @param today 기준 날짜 (기본값: 오늘)
+     * @return 등록 기간 내 여부
+     */
+    fun isRegistrationOpen(
+        registrationStartDate: LocalDate,
+        registrationEndDate: LocalDate,
+        today: LocalDate = LocalDate.now(),
+    ): Boolean =
+        isActive &&
+            !today.isBefore(registrationStartDate) &&
+            !today.isAfter(registrationEndDate)
+
+    /**
+     * 시즌 날짜 유효성을 검증합니다.
+     *
+     * @param startDate 시즌 시작일
+     * @param endDate 시즌 종료일
+     * @throws IllegalArgumentException 시작일이 종료일 이후이거나 같은 경우
+     */
+    fun validateSeasonDates(
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ) {
+        require(startDate.isBefore(endDate)) {
+            "시즌 시작일은 종료일보다 이전이어야 합니다. (시작일: $startDate, 종료일: $endDate)"
+        }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/team/Team.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/team/Team.kt
@@ -73,4 +73,32 @@ class Team(
             this.abbreviation = abbreviation
         }
     }
+
+    /**
+     * 팀이 추가 멤버를 수용할 수 있는지 확인합니다.
+     *
+     * 사회인 야구 팀의 일반적인 최대 인원은 30명입니다.
+     *
+     * @param currentMemberCount 현재 활성 멤버 수
+     * @return 멤버 추가 가능 여부
+     */
+    fun canAcceptMember(currentMemberCount: Int): Boolean = currentMemberCount < MAX_MEMBER_COUNT
+
+    /**
+     * 팀 가입 자격을 검증합니다.
+     *
+     * 비활성화된 팀에는 가입할 수 없습니다.
+     *
+     * @throws IllegalStateException 팀이 비활성 상태인 경우
+     */
+    fun validateJoinEligibility() {
+        check(isActive) {
+            "비활성화된 팀에는 가입할 수 없습니다. (팀: $fullName)"
+        }
+    }
+
+    companion object {
+        /** 팀 최대 멤버 수 (사회인 야구 일반 기준) */
+        const val MAX_MEMBER_COUNT = 30
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/league/LeagueTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/league/LeagueTest.kt
@@ -2,10 +2,12 @@ package com.nextup.core.domain.league
 
 import com.nextup.core.domain.association.Association
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 @DisplayName("League 엔티티 테스트")
 class LeagueTest {
@@ -21,7 +23,10 @@ class LeagueTest {
             )
     }
 
-    private fun createLeague(isActive: Boolean = true): League =
+    private fun createLeague(
+        isActive: Boolean = true,
+        maxTeamCount: Int? = null,
+    ): League =
         League(
             association = association,
             name = "1부 리그",
@@ -31,6 +36,7 @@ class LeagueTest {
             description = "최상위 리그",
             logoUrl = "https://example.com/logo.png",
             isActive = isActive,
+            maxTeamCount = maxTeamCount,
         )
 
     @Nested
@@ -135,6 +141,167 @@ class LeagueTest {
             assertThat(league.abbreviation).isEqualTo("1st")
             assertThat(league.foundedYear).isEqualTo(2020)
             assertThat(league.divisionLevel).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("팀 수용 가능 여부")
+    inner class CanAcceptTeamTests {
+        @Test
+        fun `최대 팀 수 미만이면 팀을 수용할 수 있다`() {
+            // given
+            val league = createLeague(maxTeamCount = 10)
+
+            // when
+            val result = league.canAcceptTeam(currentTeamCount = 9)
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `현재 팀 수가 최대 팀 수에 도달하면 팀을 수용할 수 없다`() {
+            // given
+            val league = createLeague(maxTeamCount = 10)
+
+            // when
+            val result = league.canAcceptTeam(currentTeamCount = 10)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `최대 팀 수가 설정되지 않으면 제한 없이 팀을 수용할 수 있다`() {
+            // given
+            val league = createLeague(maxTeamCount = null)
+
+            // when
+            val result = league.canAcceptTeam(currentTeamCount = 100)
+
+            // then
+            assertThat(result).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("등록 기간 확인")
+    inner class IsRegistrationOpenTests {
+        @Test
+        fun `등록 기간 내이고 리그가 활성화되어 있으면 등록이 열려 있다`() {
+            // given
+            val league = createLeague(isActive = true)
+            val today = LocalDate.of(2025, 3, 15)
+
+            // when
+            val result =
+                league.isRegistrationOpen(
+                    registrationStartDate = LocalDate.of(2025, 3, 1),
+                    registrationEndDate = LocalDate.of(2025, 3, 31),
+                    today = today,
+                )
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `등록 기간이 지나면 등록이 닫혀 있다`() {
+            // given
+            val league = createLeague(isActive = true)
+            val today = LocalDate.of(2025, 4, 1)
+
+            // when
+            val result =
+                league.isRegistrationOpen(
+                    registrationStartDate = LocalDate.of(2025, 3, 1),
+                    registrationEndDate = LocalDate.of(2025, 3, 31),
+                    today = today,
+                )
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `등록 시작일 이전이면 등록이 닫혀 있다`() {
+            // given
+            val league = createLeague(isActive = true)
+            val today = LocalDate.of(2025, 2, 28)
+
+            // when
+            val result =
+                league.isRegistrationOpen(
+                    registrationStartDate = LocalDate.of(2025, 3, 1),
+                    registrationEndDate = LocalDate.of(2025, 3, 31),
+                    today = today,
+                )
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `리그가 비활성화되어 있으면 등록이 닫혀 있다`() {
+            // given
+            val league = createLeague(isActive = false)
+            val today = LocalDate.of(2025, 3, 15)
+
+            // when
+            val result =
+                league.isRegistrationOpen(
+                    registrationStartDate = LocalDate.of(2025, 3, 1),
+                    registrationEndDate = LocalDate.of(2025, 3, 31),
+                    today = today,
+                )
+
+            // then
+            assertThat(result).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("시즌 날짜 유효성 검증")
+    inner class ValidateSeasonDatesTests {
+        @Test
+        fun `시작일이 종료일보다 이전이면 유효하다`() {
+            // given
+            val league = createLeague()
+
+            // when & then (예외 발생 없음)
+            league.validateSeasonDates(
+                startDate = LocalDate.of(2025, 4, 1),
+                endDate = LocalDate.of(2025, 10, 31),
+            )
+        }
+
+        @Test
+        fun `시작일이 종료일과 같으면 예외가 발생한다`() {
+            // given
+            val league = createLeague()
+            val sameDate = LocalDate.of(2025, 4, 1)
+
+            // when & then
+            assertThrows(IllegalArgumentException::class.java) {
+                league.validateSeasonDates(
+                    startDate = sameDate,
+                    endDate = sameDate,
+                )
+            }
+        }
+
+        @Test
+        fun `시작일이 종료일보다 이후이면 예외가 발생한다`() {
+            // given
+            val league = createLeague()
+
+            // when & then
+            assertThrows(IllegalArgumentException::class.java) {
+                league.validateSeasonDates(
+                    startDate = LocalDate.of(2025, 10, 31),
+                    endDate = LocalDate.of(2025, 4, 1),
+                )
+            }
         }
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamTest.kt
@@ -3,6 +3,7 @@ package com.nextup.core.domain.team
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.league.League
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -131,6 +132,73 @@ class TeamTest {
 
             // then
             assertThat(team.logoUrl).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("멤버 수용 가능 여부")
+    inner class CanAcceptMemberTests {
+        @Test
+        fun `현재 멤버 수가 최대 인원 미만이면 멤버를 수용할 수 있다`() {
+            // given
+            val team = createTeam()
+
+            // when
+            val result = team.canAcceptMember(currentMemberCount = 29)
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `현재 멤버 수가 최대 인원에 도달하면 멤버를 수용할 수 없다`() {
+            // given
+            val team = createTeam()
+
+            // when
+            val result = team.canAcceptMember(currentMemberCount = Team.MAX_MEMBER_COUNT)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `팀 최대 멤버 수는 30명이다`() {
+            assertThat(Team.MAX_MEMBER_COUNT).isEqualTo(30)
+        }
+    }
+
+    @Nested
+    @DisplayName("가입 자격 검증")
+    inner class ValidateJoinEligibilityTests {
+        @Test
+        fun `활성화된 팀은 가입 자격 검증을 통과한다`() {
+            // given
+            val team = createTeam(isActive = true)
+
+            // when & then (예외 발생 없음)
+            team.validateJoinEligibility()
+        }
+
+        @Test
+        fun `비활성화된 팀에 가입하려 하면 예외가 발생한다`() {
+            // given
+            val team = createTeam(isActive = false)
+
+            // when & then
+            assertThrows(IllegalStateException::class.java) {
+                team.validateJoinEligibility()
+            }
+        }
+
+        @Test
+        fun `비활성화 후 활성화된 팀은 가입 자격 검증을 통과한다`() {
+            // given
+            val team = createTeam(isActive = false)
+            team.activate()
+
+            // when & then (예외 발생 없음)
+            team.validateJoinEligibility()
         }
     }
 }

--- a/nextup-infrastructure/src/main/resources/db/migration/V018__add_max_team_count_to_leagues.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V018__add_max_team_count_to_leagues.sql
@@ -1,0 +1,5 @@
+-- Add max_team_count column to leagues table
+-- Allows configuring the maximum number of teams a league can accept
+-- NULL means no limit
+ALTER TABLE leagues
+    ADD COLUMN IF NOT EXISTS max_team_count INTEGER;

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceUndoTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceUndoTest.kt
@@ -326,6 +326,1016 @@ class GameScorerServiceUndoTest {
             assertThat(game.isTopInning).isTrue() // 1회초로 복원
             assertThat(game.gameState.outs).isEqualTo(3) // 3아웃 상태로 복원
         }
+
+        // ============================================================
+        // 추가 Undo 테스트 (15건+)
+        // ============================================================
+
+        @Test
+        fun `should undo double play and revert two out counts and batting record`() {
+            // given - 병살타: 2아웃 발생, 주자 1명 있었음
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.outs = 2
+                }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE_PLAY, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    // 병살타: 투수에게 2아웃 기록
+                    recordOut()
+                    recordOut()
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.DOUBLE_PLAY,
+                    outCountBefore = 0,
+                    outCountAfter = 2,
+                    runnersBeforeJson = "1루:30",
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(game.gameState.outs).isEqualTo(0) // 아웃 카운트 복원
+            assertThat(battingRecord.groundedIntoDoublePlays).isEqualTo(0)
+            assertThat(battingRecord.plateAppearances).isEqualTo(0)
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(30L) // 1루 주자 복원
+        }
+
+        @Test
+        fun `should undo sacrifice bunt and revert sacrifice bunt count and runner`() {
+            // given - 희생번트: 타수 제외, 주자 1루→2루 진루, 타자 아웃
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.outs = 1
+                }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.SACRIFICE_BUNT, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    recordOut()
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.SACRIFICE_BUNT,
+                    outCountBefore = 0,
+                    outCountAfter = 1,
+                    runnersBeforeJson = "1루:30",
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(game.gameState.outs).isEqualTo(0)
+            assertThat(battingRecord.sacrificeBunts).isEqualTo(0)
+            assertThat(battingRecord.plateAppearances).isEqualTo(0)
+            assertThat(battingRecord.atBats).isEqualTo(0) // 희생번트는 타수 제외
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(30L) // 주자 복원
+        }
+
+        @Test
+        fun `should undo walk and revert walk count`() {
+            // given - 볼넷: 타수 제외, 타자 1루 진루
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.WALK, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.WALK)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.WALK,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.walks).isEqualTo(0)
+            assertThat(battingRecord.plateAppearances).isEqualTo(0)
+            assertThat(battingRecord.atBats).isEqualTo(0) // 볼넷은 타수 제외
+            assertThat(pitchingRecord.walksAllowed).isEqualTo(0)
+        }
+
+        @Test
+        fun `should undo walk with rbi and revert score`() {
+            // given - 볼넷 + 타점 (만루 볼넷): 1점 득점
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.WALK, 1)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.WALK)
+                    recordEarnedRun(1)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.WALK,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = "1루:30,2루:31,3루:32",
+                    runsScored = 1,
+                    rbis = 1,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.runsBattedIn).isEqualTo(0)
+            assertThat(pitchingRecord.earnedRuns).isEqualTo(0)
+            assertThat(pitchingRecord.runsAllowed).isEqualTo(0)
+            verify { gameTeam.subtractRunInInning(any(), eq(1)) }
+        }
+
+        @Test
+        fun `should undo inning change from top to bottom and restore previous inning state`() {
+            // given - 2회초 종료 후 2회말로 전환 Undo
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 2
+                    isTopInning = false
+                    gameState.outs = 0
+                }
+
+            val event =
+                GameEvent(
+                    game = game,
+                    inning = 2,
+                    isTopInning = true,
+                    outCountBefore = 3,
+                    outCountAfter = 0,
+                    eventType = GameEventType.INNING_CHANGE,
+                    description = "2회초 종료, 2회말 시작",
+                )
+            setEntityId(event, 200L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(game.currentInning).isEqualTo(2)
+            assertThat(game.isTopInning).isTrue() // 2회초로 복원
+            assertThat(game.gameState.outs).isEqualTo(3)
+        }
+
+        @Test
+        fun `should undo inning change from bottom to next inning top and restore inning`() {
+            // given - 1회말 종료 후 2회초로 전환 Undo
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 2
+                    isTopInning = true
+                    gameState.outs = 0
+                }
+
+            val event =
+                GameEvent(
+                    game = game,
+                    inning = 1,
+                    isTopInning = false,
+                    outCountBefore = 3,
+                    outCountAfter = 0,
+                    eventType = GameEventType.INNING_CHANGE,
+                    description = "1회말 종료, 2회초 시작",
+                )
+            setEntityId(event, 300L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(game.currentInning).isEqualTo(1) // 1회로 복원
+            assertThat(game.isTopInning).isFalse() // 1회말로 복원
+            assertThat(game.gameState.outs).isEqualTo(3)
+        }
+
+        @Test
+        fun `should undo triple and revert triple count and runner positions`() {
+            // given - 3루타: 타자가 3루에 있었음
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            game.gameState.runnerOnThirdId = 10L
+
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.TRIPLE, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.TRIPLE)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.TRIPLE,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.triples).isEqualTo(0)
+            assertThat(battingRecord.hits).isEqualTo(0)
+            assertThat(battingRecord.atBats).isEqualTo(0)
+            assertThat(pitchingRecord.hitsAllowed).isEqualTo(0)
+        }
+
+        @Test
+        fun `should undo home run with multiple runners and revert all runs scored`() {
+            // given - 만루 홈런: 4점 득점
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.HOME_RUN, 4)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.HOME_RUN)
+                    recordEarnedRun(4)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.HOME_RUN,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = "1루:30,2루:31,3루:32",
+                    runsScored = 4,
+                    rbis = 4,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.homeRuns).isEqualTo(0)
+            assertThat(battingRecord.runsBattedIn).isEqualTo(0)
+            assertThat(pitchingRecord.earnedRuns).isEqualTo(0)
+            assertThat(pitchingRecord.runsAllowed).isEqualTo(0)
+            assertThat(pitchingRecord.homeRunsAllowed).isEqualTo(0)
+            // 만루 주자 복원 확인
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(30L)
+            assertThat(game.gameState.runnerOnSecondId).isEqualTo(31L)
+            assertThat(game.gameState.runnerOnThirdId).isEqualTo(32L)
+            verify { gameTeam.subtractRunInInning(any(), eq(4)) }
+        }
+
+        @Test
+        fun `should undo error and revert at bat count`() {
+            // given - 실책: 타자 출루, 타수 기록
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.ERROR, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher)
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.ERROR,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.atBats).isEqualTo(0)
+            assertThat(battingRecord.plateAppearances).isEqualTo(0)
+            assertThat(battingRecord.hits).isEqualTo(0) // 실책은 안타가 아님
+        }
+
+        @Test
+        fun `should undo fly out and revert out count and at bat`() {
+            // given - 플라이 아웃
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.outs = 1
+                }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.FLY_OUT, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    recordOut()
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.FLY_OUT,
+                    outCountBefore = 0,
+                    outCountAfter = 1,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(game.gameState.outs).isEqualTo(0)
+            assertThat(battingRecord.atBats).isEqualTo(0)
+            assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(0)
+        }
+
+        @Test
+        fun `should undo ground out and revert out count`() {
+            // given - 땅볼 아웃
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.outs = 2
+                }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    recordOut()
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.GROUND_OUT,
+                    outCountBefore = 1,
+                    outCountAfter = 2,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(game.gameState.outs).isEqualTo(1) // outCountBefore로 복원
+            assertThat(battingRecord.atBats).isEqualTo(0)
+            assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(0)
+        }
+
+        @Test
+        fun `should undo hit by pitch and revert hit by pitch count`() {
+            // given - 사구
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.HIT_BY_PITCH, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.HIT_BY_PITCH)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.HIT_BY_PITCH,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.hitByPitch).isEqualTo(0)
+            assertThat(battingRecord.atBats).isEqualTo(0) // 사구는 타수 제외
+            assertThat(pitchingRecord.hitBatsmen).isEqualTo(0)
+        }
+
+        @Test
+        fun `should undo sacrifice fly and revert sacrifice fly count and rbi`() {
+            // given - 희생플라이: 타자 아웃, 3루 주자 득점
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.outs = 1
+                }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.SACRIFICE_FLY, 1)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    recordOut()
+                    recordEarnedRun(1)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.SACRIFICE_FLY,
+                    outCountBefore = 0,
+                    outCountAfter = 1,
+                    runnersBeforeJson = "3루:32",
+                    runsScored = 1,
+                    rbis = 1,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.sacrificeFlies).isEqualTo(0)
+            assertThat(battingRecord.runsBattedIn).isEqualTo(0)
+            assertThat(game.gameState.outs).isEqualTo(0)
+            assertThat(game.gameState.runnerOnThirdId).isEqualTo(32L) // 3루 주자 복원
+            verify { gameTeam.subtractRunInInning(any(), eq(1)) }
+        }
+
+        @Test
+        fun `should undo double and revert double count and runners before state`() {
+            // given - 2루타: 1루 주자가 있었고 2루타로 타자 2루, 1루 주자 득점
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.DOUBLE, 1)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.DOUBLE)
+                    recordEarnedRun(1)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.DOUBLE,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = "1루:30",
+                    runsScored = 1,
+                    rbis = 1,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.doubles).isEqualTo(0)
+            assertThat(battingRecord.hits).isEqualTo(0)
+            assertThat(battingRecord.runsBattedIn).isEqualTo(0)
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(30L) // 1루 주자 복원
+            assertThat(pitchingRecord.earnedRuns).isEqualTo(0)
+            verify { gameTeam.subtractRunInInning(any(), eq(1)) }
+        }
+
+        @Test
+        fun `should undo intentional walk and revert intentional walk count`() {
+            // given - 고의사구
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.INTENTIONAL_WALK, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.INTENTIONAL_WALK)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.INTENTIONAL_WALK,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.intentionalWalks).isEqualTo(0)
+            assertThat(battingRecord.atBats).isEqualTo(0) // 고의사구는 타수 제외
+            assertThat(pitchingRecord.walksAllowed).isEqualTo(0)
+        }
+
+        @Test
+        fun `should undo line out and revert out count and at bat`() {
+            // given - 라인 드라이브 아웃
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.outs = 1
+                }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.LINE_OUT, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    recordOut()
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.LINE_OUT,
+                    outCountBefore = 0,
+                    outCountAfter = 1,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(game.gameState.outs).isEqualTo(0)
+            assertThat(battingRecord.atBats).isEqualTo(0)
+            assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(0)
+        }
+
+        @Test
+        fun `should undo fielders choice and revert at bat and runner state`() {
+            // given - 야수선택: 주자 있었고 타자가 1루에 진루
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.FIELDERS_CHOICE, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    recordOut()
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.FIELDERS_CHOICE,
+                    outCountBefore = 0,
+                    outCountAfter = 1,
+                    runnersBeforeJson = "1루:30",
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.atBats).isEqualTo(0)
+            assertThat(battingRecord.plateAppearances).isEqualTo(0)
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(30L) // 주자 복원
+        }
+
+        @Test
+        fun `should undo third strikeout and restore two outs state`() {
+            // given - 2아웃 상태에서 삼진, Undo 후 2아웃으로 복원
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.outs = 3
+                }
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.STRIKEOUT)
+                    recordOut()
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    outCountBefore = 2,
+                    outCountAfter = 3,
+                    runnersBeforeJson = "1루:30,2루:31",
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(game.gameState.outs).isEqualTo(2) // 2아웃으로 복원
+            assertThat(battingRecord.strikeouts).isEqualTo(0)
+            assertThat(pitchingRecord.strikeouts).isEqualTo(0)
+            // 주자 상태 복원
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(30L)
+            assertThat(game.gameState.runnerOnSecondId).isEqualTo(31L)
+        }
+
+        @Test
+        fun `should undo when game status is finished and throw UndoNotAvailableException`() {
+            // given - 종료된 경기는 Undo 불가
+            val game = createGame(1L, GameStatus.FINISHED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { gameScorerService.undoLastEvent(1L) }
+                .isInstanceOf(UndoNotAvailableException::class.java)
+        }
+
+        @Test
+        fun `should undo when game status is forfeited and throw UndoNotAvailableException`() {
+            // given - 몰수 처리된 경기는 Undo 불가
+            val game = createGame(1L, GameStatus.FORFEITED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { gameScorerService.undoLastEvent(1L) }
+                .isInstanceOf(UndoNotAvailableException::class.java)
+        }
+
+        @Test
+        fun `should undo single with rbi and revert rbi and team hit`() {
+            // given - 단타 + 타점: 3루 주자 득점
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+            every { batter.gameTeam } returns gameTeam
+
+            val battingRecord =
+                createBattingRecord(batter).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.SINGLE, 1)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    applyBatterFaced(PlateAppearanceResult.SINGLE)
+                    recordEarnedRun(1)
+                }
+
+            val event =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.SINGLE,
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = "3루:32",
+                    runsScored = 1,
+                    rbis = 1,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event
+            every { battingRecordRepository.findByGamePlayer(batter) } returns battingRecord
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event.undone).isTrue()
+            assertThat(battingRecord.hits).isEqualTo(0)
+            assertThat(battingRecord.runsBattedIn).isEqualTo(0)
+            assertThat(pitchingRecord.hitsAllowed).isEqualTo(0)
+            assertThat(pitchingRecord.earnedRuns).isEqualTo(0)
+            assertThat(game.gameState.runnerOnThirdId).isEqualTo(32L) // 3루 주자 복원
+            verify { gameTeam.subtractRunInInning(any(), eq(1)) }
+            verify { gameTeam.subtractHit() }
+        }
+
+        @Test
+        fun `should undo multiple sequential strikeouts correctly`() {
+            // given - 연속 2번의 삼진 중 두 번째 삼진 Undo
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    gameState.outs = 2
+                }
+            val batter2 = createGamePlayer(11L)
+            val pitcher = createGamePlayer(20L)
+
+            val battingRecord2 =
+                createBattingRecord(batter2).apply {
+                    applyPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT, 0)
+                }
+            val pitchingRecord =
+                createPitchingRecord(pitcher).apply {
+                    // 2번의 삼진이 기록된 투수
+                    applyBatterFaced(PlateAppearanceResult.STRIKEOUT)
+                    recordOut()
+                    applyBatterFaced(PlateAppearanceResult.STRIKEOUT)
+                    recordOut()
+                }
+
+            val event2 =
+                createPlateAppearanceEvent(
+                    game = game,
+                    batter = batter2,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    outCountBefore = 1,
+                    outCountAfter = 2,
+                    runnersBeforeJson = null,
+                    runsScored = 0,
+                )
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameEventRepository.findLastActiveEvent(1L) } returns event2
+            every { battingRecordRepository.findByGamePlayer(batter2) } returns battingRecord2
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            gameScorerService.undoLastEvent(1L)
+
+            // then
+            assertThat(event2.undone).isTrue()
+            assertThat(battingRecord2.strikeouts).isEqualTo(0) // 두 번째 타자 삼진 취소
+            assertThat(game.gameState.outs).isEqualTo(1) // 1아웃으로 복원
+            // 투수: 1번 삼진만 남음
+            assertThat(pitchingRecord.strikeouts).isEqualTo(1)
+            assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(1)
+        }
     }
 
     // Helper methods
@@ -373,7 +1383,7 @@ class GameScorerServiceUndoTest {
 
     private fun setEntityId(
         entity: Any,
-        id: Long
+        id: Long,
     ) {
         val idField = entity::class.java.getDeclaredField("id")
         idField.isAccessible = true


### PR DESCRIPTION
## Summary

>- close #128

`League`와 `Team` Entity에 야구 도메인에 필요한 비즈니스 메서드를 추가하여 Rich Domain Model을 완성합니다.

## Tasks

- League Entity: `canAcceptTeam()`, `isRegistrationOpen()`, `validateSeasonDates()` 추가
- Team Entity: `canAcceptMember()`, `validateJoinEligibility()` 추가, `MAX_MEMBER_COUNT=30` 상수 정의
- League 단위 테스트 8건 추가
- Team 단위 테스트 6건 추가
- DB 마이그레이션: `V018__add_max_team_count_to_leagues.sql` (leagues 테이블에 max_team_count 컬럼)

## To Reviewer

- YAGNI 원칙에 따라 실제 사용되는 비즈니스 규칙만 추가
- Entity 메서드는 순수 도메인 로직만 포함 (DB 조회 없이 자체 상태로 판단)
- `maxTeamCount`는 nullable로 설계 (null이면 제한 없음)