### PR TITLE
feat(#119): @PreAuthorize 메서드 수준 인가 적용

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/ElectionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/ElectionController.kt
@@ -61,6 +61,7 @@ class ElectionController(
      * 선거를 시작합니다.
      */
     @PutMapping("/{electionId}/start")
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun startElection(
         @PathVariable teamId: Long,
         @PathVariable electionId: Long,
@@ -70,6 +71,7 @@ class ElectionController(
      * 선거를 완료합니다.
      */
     @PutMapping("/{electionId}/complete")
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun completeElection(
         @PathVariable teamId: Long,
         @PathVariable electionId: Long,
@@ -79,6 +81,7 @@ class ElectionController(
      * 선거를 취소합니다.
      */
     @PutMapping("/{electionId}/cancel")
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun cancelElection(
         @PathVariable teamId: Long,
         @PathVariable electionId: Long,

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/ElectionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/ElectionController.kt
@@ -12,6 +12,7 @@ import com.nextup.core.service.election.dto.ElectionResultResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 
 /**
@@ -28,6 +29,7 @@ class ElectionController(
      * 선거를 생성합니다.
      */
     @PostMapping
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun createElection(
         @PathVariable teamId: Long,
         @RequestBody @Valid request: CreateElectionApiRequest,

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/lineup/LineupController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/lineup/LineupController.kt
@@ -11,6 +11,7 @@ import com.nextup.core.service.lineup.LineupService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -141,6 +142,7 @@ class LineupController(
      * 라인업을 기록원에게 제출합니다.
      */
     @PostMapping("/{submissionId}/submit")
+    @PreAuthorize("@lineupSecurity.canSubmit(#submissionId, authentication.principal)")
     fun submitLineup(
         @PathVariable submissionId: Long,
     ): ResponseEntity<ApiResponse<LineupSubmissionResponse>> {

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamController.kt
@@ -15,6 +15,7 @@ import com.nextup.core.port.repository.TeamRepositoryPort
 import com.nextup.core.service.team.TeamMembershipService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -170,6 +171,7 @@ class TeamController(
      * DELETE /api/v1/teams/{teamId}
      */
     @DeleteMapping("/{teamId}")
+    @PreAuthorize("@teamSecurity.isOwner(#teamId, authentication.principal)")
     fun deleteTeam(
         @PathVariable teamId: Long,
         @AuthenticationPrincipal userId: Long,

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMembershipController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMembershipController.kt
@@ -77,6 +77,7 @@ class TeamMembershipController(
      * 가입 신청을 거부합니다.
      */
     @PostMapping("/join-requests/{requestId}/reject")
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun rejectJoinRequest(
         @PathVariable teamId: Long,
         @PathVariable requestId: Long,

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMembershipController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMembershipController.kt
@@ -7,6 +7,7 @@ import com.nextup.api.mapper.team.toResponse
 import com.nextup.core.service.team.TeamMembershipService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
@@ -55,6 +56,7 @@ class TeamMembershipController(
      * 가입 신청을 승인합니다.
      */
     @PostMapping("/join-requests/{requestId}/approve")
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun approveJoinRequest(
         @PathVariable teamId: Long,
         @PathVariable requestId: Long,
@@ -105,6 +107,7 @@ class TeamMembershipController(
      * 멤버를 강퇴합니다.
      */
     @DeleteMapping("/members/{memberId}")
+    @PreAuthorize("@teamSecurity.isOwner(#teamId, authentication.principal)")
     fun kickMember(
         @PathVariable teamId: Long,
         @PathVariable memberId: Long,
@@ -147,6 +150,7 @@ class TeamMembershipController(
      * 멤버의 역할을 변경합니다.
      */
     @PatchMapping("/members/{memberId}/role")
+    @PreAuthorize("@teamSecurity.isOwner(#teamId, authentication.principal)")
     fun changeRole(
         @PathVariable teamId: Long,
         @PathVariable memberId: Long,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/expression/LineupSecurityExpression.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/expression/LineupSecurityExpression.kt
@@ -1,0 +1,43 @@
+package com.nextup.infrastructure.security.expression
+
+import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import org.springframework.stereotype.Component
+
+/**
+ * 라인업 권한 검증을 위한 커스텀 보안 표현식
+ *
+ * @PreAuthorize("@lineupSecurity.canSubmit(#submissionId, authentication.principal)") 형태로 사용합니다.
+ * authentication.principal은 JwtAuthenticationFilter에서 Long(userId)로 설정됩니다.
+ */
+@Component("lineupSecurity")
+class LineupSecurityExpression(
+    private val lineupSubmissionRepository: LineupSubmissionRepositoryPort,
+    private val teamMemberRepository: TeamMemberRepositoryPort,
+) {
+    /**
+     * 요청자가 해당 라인업 제출의 팀에서 OWNER 또는 MANAGER인지 확인합니다.
+     *
+     * @param submissionId 라인업 제출 ID
+     * @param principal JWT 인증 principal (userId: Long)
+     * @return OWNER 또는 MANAGER이면 true
+     */
+    fun canSubmit(
+        submissionId: Long,
+        principal: Any?,
+    ): Boolean {
+        val userId = extractUserId(principal) ?: return false
+        val submission = lineupSubmissionRepository.findByIdOrNull(submissionId) ?: return false
+        val teamId = submission.team.id
+        val member = teamMemberRepository.findByTeamIdAndUserId(teamId, userId) ?: return false
+        return member.canManageMembers()
+    }
+
+    private fun extractUserId(principal: Any?): Long? =
+        when (principal) {
+            is Long -> principal
+            is Number -> principal.toLong()
+            is String -> principal.toLongOrNull()
+            else -> null
+        }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/expression/TeamSecurityExpression.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/expression/TeamSecurityExpression.kt
@@ -1,0 +1,71 @@
+package com.nextup.infrastructure.security.expression
+
+import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import org.springframework.stereotype.Component
+
+/**
+ * 팀 권한 검증을 위한 커스텀 보안 표현식
+ *
+ * @PreAuthorize("@teamSecurity.isOwner(#teamId, authentication.principal)") 형태로 사용합니다.
+ * authentication.principal은 JwtAuthenticationFilter에서 Long(userId)로 설정됩니다.
+ */
+@Component("teamSecurity")
+class TeamSecurityExpression(
+    private val teamMemberRepository: TeamMemberRepositoryPort,
+) {
+    /**
+     * 요청자가 해당 팀의 OWNER인지 확인합니다.
+     *
+     * @param teamId 팀 ID
+     * @param principal JWT 인증 principal (userId: Long)
+     * @return OWNER이면 true
+     */
+    fun isOwner(
+        teamId: Long,
+        principal: Any?,
+    ): Boolean {
+        val userId = extractUserId(principal) ?: return false
+        val member = teamMemberRepository.findByTeamIdAndUserId(teamId, userId) ?: return false
+        return member.role == TeamMemberRole.OWNER
+    }
+
+    /**
+     * 요청자가 해당 팀의 OWNER 또는 MANAGER인지 확인합니다.
+     *
+     * @param teamId 팀 ID
+     * @param principal JWT 인증 principal (userId: Long)
+     * @return OWNER 또는 MANAGER이면 true
+     */
+    fun isOwnerOrManager(
+        teamId: Long,
+        principal: Any?,
+    ): Boolean {
+        val userId = extractUserId(principal) ?: return false
+        val member = teamMemberRepository.findByTeamIdAndUserId(teamId, userId) ?: return false
+        return member.role == TeamMemberRole.OWNER || member.role == TeamMemberRole.MANAGER
+    }
+
+    /**
+     * 요청자가 해당 팀의 활성 멤버인지 확인합니다.
+     *
+     * @param teamId 팀 ID
+     * @param principal JWT 인증 principal (userId: Long)
+     * @return 활성 멤버이면 true
+     */
+    fun isMember(
+        teamId: Long,
+        principal: Any?,
+    ): Boolean {
+        val userId = extractUserId(principal) ?: return false
+        return teamMemberRepository.findByTeamIdAndUserId(teamId, userId) != null
+    }
+
+    private fun extractUserId(principal: Any?): Long? =
+        when (principal) {
+            is Long -> principal
+            is Number -> principal.toLong()
+            is String -> principal.toLongOrNull()
+            else -> null
+        }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/expression/LineupSecurityExpressionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/expression/LineupSecurityExpressionTest.kt
@@ -1,0 +1,95 @@
+package com.nextup.infrastructure.security.expression
+
+import com.nextup.core.domain.game.LineupSubmission
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("LineupSecurityExpression")
+class LineupSecurityExpressionTest {
+    private lateinit var lineupSubmissionRepository: LineupSubmissionRepositoryPort
+    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
+    private lateinit var lineupSecurityExpression: LineupSecurityExpression
+
+    private val teamId = 1L
+    private val userId = 10L
+    private val submissionId = 100L
+
+    private val mockTeam =
+        mockk<Team> {
+            every { id } returns teamId
+        }
+
+    private val mockSubmission =
+        mockk<LineupSubmission> {
+            every { team } returns mockTeam
+        }
+
+    @BeforeEach
+    fun setUp() {
+        lineupSubmissionRepository = mockk()
+        teamMemberRepository = mockk()
+        lineupSecurityExpression = LineupSecurityExpression(lineupSubmissionRepository, teamMemberRepository)
+    }
+
+    private fun mockMember(canManage: Boolean): TeamMember =
+        mockk {
+            every { canManageMembers() } returns canManage
+        }
+
+    @Nested
+    @DisplayName("canSubmit()")
+    inner class CanSubmit {
+        @Test
+        fun `returns true when user is OWNER of the submission team`() {
+            every { lineupSubmissionRepository.findByIdOrNull(submissionId) } returns mockSubmission
+            every { teamMemberRepository.findByTeamIdAndUserId(teamId, userId) } returns mockMember(true)
+
+            assertThat(lineupSecurityExpression.canSubmit(submissionId, userId)).isTrue()
+        }
+
+        @Test
+        fun `returns true when user is MANAGER of the submission team`() {
+            every { lineupSubmissionRepository.findByIdOrNull(submissionId) } returns mockSubmission
+            every { teamMemberRepository.findByTeamIdAndUserId(teamId, userId) } returns mockMember(true)
+
+            assertThat(lineupSecurityExpression.canSubmit(submissionId, userId)).isTrue()
+        }
+
+        @Test
+        fun `returns false when user is MEMBER of the submission team`() {
+            every { lineupSubmissionRepository.findByIdOrNull(submissionId) } returns mockSubmission
+            every { teamMemberRepository.findByTeamIdAndUserId(teamId, userId) } returns mockMember(false)
+
+            assertThat(lineupSecurityExpression.canSubmit(submissionId, userId)).isFalse()
+        }
+
+        @Test
+        fun `returns false when submission is not found`() {
+            every { lineupSubmissionRepository.findByIdOrNull(submissionId) } returns null
+
+            assertThat(lineupSecurityExpression.canSubmit(submissionId, userId)).isFalse()
+        }
+
+        @Test
+        fun `returns false when user is not a member of the submission team`() {
+            every { lineupSubmissionRepository.findByIdOrNull(submissionId) } returns mockSubmission
+            every { teamMemberRepository.findByTeamIdAndUserId(teamId, userId) } returns null
+
+            assertThat(lineupSecurityExpression.canSubmit(submissionId, userId)).isFalse()
+        }
+
+        @Test
+        fun `returns false when principal is null`() {
+            assertThat(lineupSecurityExpression.canSubmit(submissionId, null)).isFalse()
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/expression/TeamSecurityExpressionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/expression/TeamSecurityExpressionTest.kt
@@ -1,0 +1,160 @@
+package com.nextup.infrastructure.security.expression
+
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("TeamSecurityExpression")
+class TeamSecurityExpressionTest {
+    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
+    private lateinit var teamSecurityExpression: TeamSecurityExpression
+
+    @BeforeEach
+    fun setUp() {
+        teamMemberRepository = mockk()
+        teamSecurityExpression = TeamSecurityExpression(teamMemberRepository)
+    }
+
+    private fun mockMember(role: TeamMemberRole): TeamMember =
+        mockk {
+            every { this@mockk.role } returns role
+        }
+
+    @Nested
+    @DisplayName("isOwner()")
+    inner class IsOwner {
+        @Test
+        fun `returns true when user is OWNER`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.OWNER)
+            assertThat(teamSecurityExpression.isOwner(1L, 10L)).isTrue()
+        }
+
+        @Test
+        fun `returns false when user is MANAGER`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.MANAGER)
+            assertThat(teamSecurityExpression.isOwner(1L, 10L)).isFalse()
+        }
+
+        @Test
+        fun `returns false when user is MEMBER`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.MEMBER)
+            assertThat(teamSecurityExpression.isOwner(1L, 10L)).isFalse()
+        }
+
+        @Test
+        fun `returns false when user is not a team member`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns null
+            assertThat(teamSecurityExpression.isOwner(1L, 10L)).isFalse()
+        }
+
+        @Test
+        fun `returns false when principal is null`() {
+            assertThat(teamSecurityExpression.isOwner(1L, null)).isFalse()
+        }
+
+        @Test
+        fun `accepts String principal`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.OWNER)
+            assertThat(teamSecurityExpression.isOwner(1L, "10")).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("isOwnerOrManager()")
+    inner class IsOwnerOrManager {
+        @Test
+        fun `returns true when user is OWNER`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.OWNER)
+            assertThat(teamSecurityExpression.isOwnerOrManager(1L, 10L)).isTrue()
+        }
+
+        @Test
+        fun `returns true when user is MANAGER`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.MANAGER)
+            assertThat(teamSecurityExpression.isOwnerOrManager(1L, 10L)).isTrue()
+        }
+
+        @Test
+        fun `returns false when user is MEMBER`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.MEMBER)
+            assertThat(teamSecurityExpression.isOwnerOrManager(1L, 10L)).isFalse()
+        }
+
+        @Test
+        fun `returns false when user is GUEST`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.GUEST)
+            assertThat(teamSecurityExpression.isOwnerOrManager(1L, 10L)).isFalse()
+        }
+
+        @Test
+        fun `returns false when user is not a team member`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns null
+            assertThat(teamSecurityExpression.isOwnerOrManager(1L, 10L)).isFalse()
+        }
+
+        @Test
+        fun `returns false when principal is null`() {
+            assertThat(teamSecurityExpression.isOwnerOrManager(1L, null)).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("isMember()")
+    inner class IsMember {
+        @Test
+        fun `returns true when user is any team member`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.MEMBER)
+            assertThat(teamSecurityExpression.isMember(1L, 10L)).isTrue()
+        }
+
+        @Test
+        fun `returns false when user is not a team member`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns null
+            assertThat(teamSecurityExpression.isMember(1L, 10L)).isFalse()
+        }
+
+        @Test
+        fun `returns false when principal is null`() {
+            assertThat(teamSecurityExpression.isMember(1L, null)).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("principal type handling")
+    inner class PrincipalTypeHandling {
+        @Test
+        fun `accepts Long principal`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.OWNER)
+            assertThat(teamSecurityExpression.isOwner(1L, 10L)).isTrue()
+        }
+
+        @Test
+        fun `accepts Int principal as Number`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.OWNER)
+            assertThat(teamSecurityExpression.isOwner(1L, 10)).isTrue()
+        }
+
+        @Test
+        fun `accepts String principal`() {
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns mockMember(TeamMemberRole.OWNER)
+            assertThat(teamSecurityExpression.isOwner(1L, "10")).isTrue()
+        }
+
+        @Test
+        fun `returns false for invalid String principal`() {
+            assertThat(teamSecurityExpression.isOwner(1L, "not-a-number")).isFalse()
+        }
+
+        @Test
+        fun `returns false for unknown principal type`() {
+            assertThat(teamSecurityExpression.isOwner(1L, Any())).isFalse()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #119

핵심 관리자 API에 `@PreAuthorize` 메서드 수준 인가를 적용하여 도메인 수준의 세밀한 권한 검증을 추가합니다.

## Tasks

- `TeamSecurityExpression` 커스텀 보안 표현식 추가 (isOwner, isOwnerOrManager, isMember)
- `LineupSecurityExpression` 라인업 제출 권한 표현식 추가
- TeamMembershipController: kickMember/changeRole(@isOwner), approveJoinRequest(@isOwnerOrManager)
- ElectionController: createElection(@isOwnerOrManager)
- LineupController: submitLineup(@lineupSecurity.canSubmit)
- TeamSecurityExpressionTest 13건, LineupSecurityExpressionTest 6건 추가

## To Reviewer

- `@EnableMethodSecurity(prePostEnabled = true)`는 이미 각 SecurityConfig에 존재하여 추가 변경 불필요
- `authentication.principal`은 `Long` (userId) - JwtAuthenticationFilter에서 직접 설정
- `extractUserId()` 헬퍼가 Long/Number/String 타입을 방어적으로 처리