### PR TITLE
feat(#131): 보안 이벤트 감사 로그(Audit Log) AOP 추가

### DIFF
--- a/nextup-common/src/main/kotlin/com/nextup/common/audit/AuditLog.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/audit/AuditLog.kt
@@ -1,0 +1,22 @@
+package com.nextup.common.audit
+
+/**
+ * 보안 이벤트 감사 로그 어노테이션
+ *
+ * AOP 기반으로 보안에 민감한 작업을 자동으로 로깅합니다.
+ * OWASP A09 (Security Logging and Monitoring Failures) 준수
+ *
+ * 사용 예:
+ * ```kotlin
+ * @AuditLog(action = "KICK_MEMBER", severity = AuditSeverity.WARN)
+ * fun kickMember(memberId: Long, kickerUserId: Long, reason: String, addToBlacklist: Boolean)
+ * ```
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AuditLog(
+    /** 감사 대상 액션 명칭 (예: "KICK_MEMBER", "ROLE_CHANGE") */
+    val action: String,
+    /** 감사 로그 심각도 */
+    val severity: AuditSeverity = AuditSeverity.INFO,
+)

--- a/nextup-common/src/main/kotlin/com/nextup/common/audit/AuditSeverity.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/audit/AuditSeverity.kt
@@ -1,0 +1,17 @@
+package com.nextup.common.audit
+
+/**
+ * 감사 로그 심각도 레벨
+ *
+ * OWASP A09 (Security Logging and Monitoring Failures) 준수를 위한 심각도 분류
+ */
+enum class AuditSeverity {
+    /** 일반적인 감사 이벤트 (조회, 생성 등) */
+    INFO,
+
+    /** 주의가 필요한 이벤트 (역할 변경, 강제 탈퇴 등) */
+    WARN,
+
+    /** 즉각적인 조치가 필요한 이벤트 (보안 위반, 권한 남용 등) */
+    ERROR,
+}

--- a/nextup-infrastructure/build.gradle.kts
+++ b/nextup-infrastructure/build.gradle.kts
@@ -48,6 +48,9 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
 
+    // Spring AOP (for AuditLog aspect)
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
     // Rate Limiting
     implementation("com.bucket4j:bucket4j-core:8.10.1")
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/aspect/AuditLogAspect.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/aspect/AuditLogAspect.kt
@@ -1,0 +1,143 @@
+package com.nextup.infrastructure.aspect
+
+import com.nextup.common.audit.AuditLog
+import com.nextup.common.audit.AuditSeverity
+import com.nextup.infrastructure.security.userdetails.CustomUserDetails
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import java.time.Instant
+
+/**
+ * AOP 기반 보안 이벤트 감사 로그 Aspect
+ *
+ * @AuditLog 어노테이션이 적용된 메서드 실행 시 구조화된 감사 로그를 기록합니다.
+ * OWASP A09 (Security Logging and Monitoring Failures) 준수
+ *
+ * 로그 포맷:
+ * [AUDIT] timestamp=... action=... severity=... user=... ip=... result=SUCCESS|FAILURE
+ *
+ * 민감 정보 처리:
+ * - 비밀번호, 토큰 등 민감 정보는 로깅하지 않습니다.
+ * - 파라미터는 타입명만 기록합니다.
+ */
+@Aspect
+@Component
+class AuditLogAspect {
+    private val log = LoggerFactory.getLogger(AuditLogAspect::class.java)
+
+    @Around("@annotation(auditLog)")
+    fun audit(
+        joinPoint: ProceedingJoinPoint,
+        auditLog: AuditLog
+    ): Any? {
+        val timestamp = Instant.now()
+        val action = auditLog.action
+        val severity = auditLog.severity
+        val userId = resolveUserId()
+        val ip = resolveClientIp()
+
+        return try {
+            val result = joinPoint.proceed()
+            logAuditEvent(
+                timestamp = timestamp,
+                action = action,
+                severity = severity,
+                userId = userId,
+                ip = ip,
+                result = "SUCCESS",
+                errorMessage = null,
+            )
+            result
+        } catch (ex: Exception) {
+            logAuditEvent(
+                timestamp = timestamp,
+                action = action,
+                severity = AuditSeverity.ERROR,
+                userId = userId,
+                ip = ip,
+                result = "FAILURE",
+                errorMessage = ex.javaClass.simpleName,
+            )
+            throw ex
+        }
+    }
+
+    private fun logAuditEvent(
+        timestamp: Instant,
+        action: String,
+        severity: AuditSeverity,
+        userId: String,
+        ip: String,
+        result: String,
+        errorMessage: String?,
+    ) {
+        val message =
+            buildString {
+                append("[AUDIT]")
+                append(" timestamp=$timestamp")
+                append(" action=$action")
+                append(" severity=$severity")
+                append(" user=$userId")
+                append(" ip=$ip")
+                append(" result=$result")
+                if (errorMessage != null) {
+                    append(" error=$errorMessage")
+                }
+            }
+
+        when (severity) {
+            AuditSeverity.INFO -> log.info(message)
+            AuditSeverity.WARN -> log.warn(message)
+            AuditSeverity.ERROR -> log.error(message)
+        }
+    }
+
+    private fun resolveUserId(): String {
+        val authentication =
+            SecurityContextHolder.getContext().authentication
+                ?: return ANONYMOUS_USER
+
+        if (!authentication.isAuthenticated) return ANONYMOUS_USER
+
+        return when (val principal = authentication.principal) {
+            is CustomUserDetails -> principal.id.toString()
+            is String -> principal
+            else -> authentication.name ?: ANONYMOUS_USER
+        }
+    }
+
+    private fun resolveClientIp(): String {
+        val requestAttributes =
+            RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes
+                ?: return UNKNOWN_IP
+
+        val request = requestAttributes.request
+
+        // X-Forwarded-For 헤더 우선 확인 (프록시/로드밸런서 환경)
+        val forwardedFor = request.getHeader(HEADER_X_FORWARDED_FOR)
+        if (!forwardedFor.isNullOrBlank()) {
+            return forwardedFor.split(",").first().trim()
+        }
+
+        // X-Real-IP 헤더 확인 (Nginx 프록시 환경)
+        val realIp = request.getHeader(HEADER_X_REAL_IP)
+        if (!realIp.isNullOrBlank()) {
+            return realIp.trim()
+        }
+
+        return request.remoteAddr ?: UNKNOWN_IP
+    }
+
+    companion object {
+        private const val ANONYMOUS_USER = "anonymous"
+        private const val UNKNOWN_IP = "unknown"
+        private const val HEADER_X_FORWARDED_FOR = "X-Forwarded-For"
+        private const val HEADER_X_REAL_IP = "X-Real-IP"
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
@@ -1,5 +1,7 @@
 package com.nextup.infrastructure.service.team
 
+import com.nextup.common.audit.AuditLog
+import com.nextup.common.audit.AuditSeverity
 import com.nextup.common.exception.*
 import com.nextup.core.domain.team.*
 import com.nextup.core.port.repository.*
@@ -161,6 +163,7 @@ class TeamMembershipServiceImpl(
         return teamJoinRequestRepository.save(joinRequest)
     }
 
+    @AuditLog(action = "KICK_MEMBER", severity = AuditSeverity.WARN)
     @Transactional
     override fun kickMember(
         memberId: Long,
@@ -213,6 +216,7 @@ class TeamMembershipServiceImpl(
         teamMemberRepository.save(member)
     }
 
+    @AuditLog(action = "ROLE_CHANGE", severity = AuditSeverity.WARN)
     @Transactional
     override fun changeRole(
         memberId: Long,
@@ -295,6 +299,7 @@ class TeamMembershipServiceImpl(
         return savedTeam
     }
 
+    @AuditLog(action = "DELETE_TEAM", severity = AuditSeverity.WARN)
     @Transactional
     override fun deleteTeam(
         teamId: Long,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/aspect/AuditLogAspectTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/aspect/AuditLogAspectTest.kt
@@ -1,0 +1,214 @@
+package com.nextup.infrastructure.aspect
+
+import com.nextup.common.audit.AuditLog
+import com.nextup.common.audit.AuditSeverity
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
+import org.aspectj.lang.ProceedingJoinPoint
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+
+/**
+ * AuditLogAspect 단위 테스트
+ *
+ * SecurityContextHolder와 RequestContextHolder를 실제 구현으로 사용하여
+ * 다른 테스트와의 static mock 간섭을 방지합니다.
+ */
+@DisplayName("AuditLogAspect")
+class AuditLogAspectTest {
+    private lateinit var aspect: AuditLogAspect
+
+    @BeforeEach
+    fun setUp() {
+        aspect = AuditLogAspect()
+        SecurityContextHolder.clearContext()
+        RequestContextHolder.resetRequestAttributes()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+        RequestContextHolder.resetRequestAttributes()
+    }
+
+    private fun auditLog(
+        action: String,
+        severity: AuditSeverity = AuditSeverity.INFO,
+    ): AuditLog {
+        val annotation = mockk<AuditLog>()
+        every { annotation.action } returns action
+        every { annotation.severity } returns severity
+        return annotation
+    }
+
+    private fun setAuthenticatedUser(userId: Long) {
+        val principal =
+            mockk<com.nextup.infrastructure.security.userdetails.CustomUserDetails> {
+                every { id } returns userId
+            }
+        val auth =
+            UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                listOf(SimpleGrantedAuthority("ROLE_USER")),
+            )
+        SecurityContextHolder.getContext().authentication = auth
+    }
+
+    private fun setRequestAttributes(
+        remoteAddr: String = "127.0.0.1",
+        xForwardedFor: String? = null,
+        xRealIp: String? = null,
+    ) {
+        val request = MockHttpServletRequest()
+        request.remoteAddr = remoteAddr
+        xForwardedFor?.let { request.addHeader("X-Forwarded-For", it) }
+        xRealIp?.let { request.addHeader("X-Real-IP", it) }
+        RequestContextHolder.setRequestAttributes(ServletRequestAttributes(request))
+    }
+
+    private fun mockHttpServletRequest(
+        remoteAddr: String = "127.0.0.1",
+        xForwardedFor: String? = null,
+        xRealIp: String? = null,
+    ): HttpServletRequest {
+        val request = mockk<HttpServletRequest>()
+        every { request.getHeader("X-Forwarded-For") } returns xForwardedFor
+        every { request.getHeader("X-Real-IP") } returns xRealIp
+        every { request.remoteAddr } returns remoteAddr
+        return request
+    }
+
+    @Nested
+    @DisplayName("audit()")
+    inner class AuditMethod {
+        @Test
+        @DisplayName("성공 시 결과를 그대로 반환한다")
+        fun `should return result on success`() {
+            setAuthenticatedUser(userId = 1L)
+            setRequestAttributes()
+
+            val joinPoint = mockk<ProceedingJoinPoint>()
+            every { joinPoint.proceed() } returns "result"
+
+            val result = aspect.audit(joinPoint, auditLog("TEST_ACTION"))
+
+            assertThat(result).isEqualTo("result")
+        }
+
+        @Test
+        @DisplayName("예외 발생 시 예외를 그대로 재던진다")
+        fun `should rethrow exception on failure`() {
+            setAuthenticatedUser(userId = 1L)
+            setRequestAttributes()
+
+            val joinPoint = mockk<ProceedingJoinPoint>()
+            every { joinPoint.proceed() } throws RuntimeException("test error")
+
+            assertThatThrownBy {
+                aspect.audit(joinPoint, auditLog("TEST_ACTION"))
+            }.isInstanceOf(RuntimeException::class.java)
+                .hasMessage("test error")
+        }
+
+        @Test
+        @DisplayName("인증 정보가 없을 때 anonymous 사용자로 기록한다")
+        fun `should log as anonymous when no authentication`() {
+            // SecurityContext에 인증 정보 없음 (clearContext 상태)
+            setRequestAttributes()
+
+            val joinPoint = mockk<ProceedingJoinPoint>()
+            every { joinPoint.proceed() } returns Unit
+
+            aspect.audit(joinPoint, auditLog("TEST_ACTION", AuditSeverity.INFO))
+        }
+
+        @Test
+        @DisplayName("X-Forwarded-For 헤더가 있을 때 해당 IP를 사용한다")
+        fun `should use X-Forwarded-For header when present`() {
+            setAuthenticatedUser(userId = 1L)
+            setRequestAttributes(xForwardedFor = "10.0.0.1, 10.0.0.2")
+
+            val joinPoint = mockk<ProceedingJoinPoint>()
+            every { joinPoint.proceed() } returns Unit
+
+            aspect.audit(joinPoint, auditLog("TEST_ACTION"))
+        }
+
+        @Test
+        @DisplayName("X-Real-IP 헤더가 있을 때 해당 IP를 사용한다")
+        fun `should use X-Real-IP header when present`() {
+            setAuthenticatedUser(userId = 1L)
+            setRequestAttributes(xRealIp = "192.168.1.100")
+
+            val joinPoint = mockk<ProceedingJoinPoint>()
+            every { joinPoint.proceed() } returns Unit
+
+            aspect.audit(joinPoint, auditLog("TEST_ACTION"))
+        }
+
+        @Test
+        @DisplayName("RequestContextHolder에 요청 정보가 없을 때 unknown IP를 사용한다")
+        fun `should use unknown IP when no request attributes`() {
+            setAuthenticatedUser(userId = 1L)
+            // RequestContextHolder에 아무것도 설정하지 않음
+
+            val joinPoint = mockk<ProceedingJoinPoint>()
+            every { joinPoint.proceed() } returns Unit
+
+            aspect.audit(joinPoint, auditLog("TEST_ACTION"))
+        }
+
+        @Test
+        @DisplayName("WARN 심각도로 로깅한다")
+        fun `should log with WARN severity`() {
+            setAuthenticatedUser(userId = 42L)
+            setRequestAttributes(remoteAddr = "10.10.10.10")
+
+            val joinPoint = mockk<ProceedingJoinPoint>()
+            every { joinPoint.proceed() } returns Unit
+
+            aspect.audit(joinPoint, auditLog("KICK_MEMBER", AuditSeverity.WARN))
+        }
+
+        @Test
+        @DisplayName("예외 발생 시 ERROR 심각도로 로깅한다")
+        fun `should log with ERROR severity on exception`() {
+            setAuthenticatedUser(userId = 1L)
+            setRequestAttributes()
+
+            val joinPoint = mockk<ProceedingJoinPoint>()
+            every { joinPoint.proceed() } throws IllegalStateException("forbidden")
+
+            assertThatThrownBy {
+                aspect.audit(joinPoint, auditLog("ROLE_CHANGE", AuditSeverity.WARN))
+            }.isInstanceOf(IllegalStateException::class.java)
+        }
+
+        @Test
+        @DisplayName("null 반환 메서드도 정상 처리한다")
+        fun `should handle null return value`() {
+            setAuthenticatedUser(userId = 1L)
+            setRequestAttributes()
+
+            val joinPoint = mockk<ProceedingJoinPoint>()
+            every { joinPoint.proceed() } returns null
+
+            val result = aspect.audit(joinPoint, auditLog("DELETE_TEAM", AuditSeverity.WARN))
+
+            assertThat(result).isNull()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #131

AOP 기반 감사 로그 시스템을 추가하여 보안에 민감한 작업(멤버 강퇴, 권한 변경, 팀 삭제 등)을 구조화된 로그로 기록합니다.

## Tasks

- `@AuditLog` 어노테이션 + `AuditSeverity` enum 생성 (nextup-common)
- `AuditLogAspect` AOP 클래스 생성 (nextup-infrastructure)
- 구조화 로그 포맷: `[AUDIT] timestamp=... action=... severity=... user=... ip=... result=SUCCESS|FAILURE`
- TeamMembershipServiceImpl: kickMember, changeRole, deleteTeam에 @AuditLog 적용
- AuditLogAspectTest 8건 단위 테스트 추가
- spring-boot-starter-aop 의존성 추가

## To Reviewer

- 의존성 방향 준수: @AuditLog(common) → AuditLogAspect(infrastructure)
- IP 추출: X-Forwarded-For → X-Real-IP → remoteAddr 순서
- 민감정보(비밀번호, 토큰)는 로깅하지 않음
- OWASP A09 (Logging & Monitoring Failures) 대응