### PR TITLE
refactor(#115): Repository Old→New Adapter 패턴 통일

### DIFF
--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/AttendanceVoteRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/AttendanceVoteRepository.kt
@@ -2,42 +2,37 @@ package com.nextup.infrastructure.repository
 
 import com.nextup.core.domain.game.AttendanceStatus
 import com.nextup.core.domain.game.GameParticipation
-import com.nextup.core.port.repository.AttendanceVoteRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 /**
- * GameParticipation Repository
- * JpaRepository 상속 + Port 인터페이스 구현
+ * GameParticipation JPA Repository
+ * JPA 전용 쿼리 메서드 정의
  */
-interface AttendanceVoteRepository :
-    JpaRepository<GameParticipation, Long>,
-    AttendanceVoteRepositoryPort {
-    override fun findByIdOrNull(id: Long): GameParticipation? = findById(id).orElse(null)
-
+interface AttendanceVoteRepository : JpaRepository<GameParticipation, Long> {
     @Query("SELECT av FROM GameParticipation av WHERE av.game.id = :gameId")
-    override fun findByGameId(gameId: Long): List<GameParticipation>
+    fun findByGameId(gameId: Long): List<GameParticipation>
 
     @Query("SELECT av FROM GameParticipation av WHERE av.game.id = :gameId AND av.member.id = :memberId")
-    override fun findByGameIdAndMemberId(
+    fun findByGameIdAndMemberId(
         gameId: Long,
         memberId: Long,
     ): GameParticipation?
 
     @Query("SELECT av FROM GameParticipation av WHERE av.game.id = :gameId AND av.status = :status")
-    override fun findByGameIdAndStatus(
+    fun findByGameIdAndStatus(
         gameId: Long,
         status: AttendanceStatus,
     ): List<GameParticipation>
 
     @Query("SELECT av FROM GameParticipation av WHERE av.game.id = :gameId AND av.respondedAt IS NULL")
-    override fun findNonVotersByGameId(gameId: Long): List<GameParticipation>
+    fun findNonVotersByGameId(gameId: Long): List<GameParticipation>
 
     @Query("SELECT COUNT(av) FROM GameParticipation av WHERE av.game.id = :gameId")
-    override fun countByGameId(gameId: Long): Long
+    fun countByGameId(gameId: Long): Long
 
     @Query("SELECT COUNT(av) FROM GameParticipation av WHERE av.game.id = :gameId AND av.status = :status")
-    override fun countByGameIdAndStatus(
+    fun countByGameIdAndStatus(
         gameId: Long,
         status: AttendanceStatus,
     ): Long

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/GameAttendanceVoteRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/GameAttendanceVoteRepositoryAdapter.kt
@@ -1,0 +1,53 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.game.AttendanceStatus
+import com.nextup.core.domain.game.GameParticipation
+import com.nextup.core.port.repository.AttendanceVoteRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+/**
+ * GameAttendanceVote Repository Adapter
+ * Hexagonal Architecture Outbound Adapter - game 도메인 AttendanceVoteRepositoryPort 구현
+ */
+@Repository
+class GameAttendanceVoteRepositoryAdapter(
+    private val jpaRepository: AttendanceVoteRepository,
+) : AttendanceVoteRepositoryPort {
+    override fun save(attendanceVote: GameParticipation): GameParticipation = jpaRepository.save(attendanceVote)
+
+    override fun saveAll(attendanceVotes: List<GameParticipation>): List<GameParticipation> =
+        jpaRepository.saveAll(attendanceVotes)
+
+    override fun findByIdOrNull(id: Long): GameParticipation? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByGameId(gameId: Long): List<GameParticipation> = jpaRepository.findByGameId(gameId)
+
+    override fun findByGameIdAndMemberId(
+        gameId: Long,
+        memberId: Long,
+    ): GameParticipation? = jpaRepository.findByGameIdAndMemberId(gameId, memberId)
+
+    override fun findByGameIdAndStatus(
+        gameId: Long,
+        status: AttendanceStatus,
+    ): List<GameParticipation> = jpaRepository.findByGameIdAndStatus(gameId, status)
+
+    override fun findNonVotersByGameId(gameId: Long): List<GameParticipation> =
+        jpaRepository.findNonVotersByGameId(gameId)
+
+    override fun countByGameId(gameId: Long): Long = jpaRepository.countByGameId(gameId)
+
+    override fun countByGameIdAndStatus(
+        gameId: Long,
+        status: AttendanceStatus,
+    ): Long = jpaRepository.countByGameIdAndStatus(gameId, status)
+
+    override fun delete(attendanceVote: GameParticipation) {
+        jpaRepository.delete(attendanceVote)
+    }
+
+    override fun deleteById(id: Long) {
+        jpaRepository.deleteById(id)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamBlacklistRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamBlacklistRepository.kt
@@ -1,7 +1,6 @@
 package com.nextup.infrastructure.repository
 
 import com.nextup.core.domain.team.TeamBlacklist
-import com.nextup.core.port.repository.TeamBlacklistRepositoryPort
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -9,41 +8,21 @@ import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
 
 /**
- * TeamBlacklist Repository
- * JpaRepository 상속 + Port 인터페이스 구현
+ * TeamBlacklist JPA Repository
+ * JPA 전용 쿼리 메서드 정의
  */
-interface TeamBlacklistRepository :
-    JpaRepository<TeamBlacklist, Long>,
-    TeamBlacklistRepositoryPort {
-    override fun findByIdOrNull(id: Long): TeamBlacklist? = findById(id).orElse(null)
-
+interface TeamBlacklistRepository : JpaRepository<TeamBlacklist, Long> {
     @Query("SELECT tbl FROM TeamBlacklist tbl WHERE tbl.team.id = :teamId")
-    override fun findByTeamId(
+    fun findByTeamId(
         teamId: Long,
         pageable: Pageable,
     ): Page<TeamBlacklist>
 
     @Query("SELECT tbl FROM TeamBlacklist tbl WHERE tbl.team.id = :teamId AND tbl.user.id = :userId")
-    override fun findByTeamIdAndUserId(
+    fun findByTeamIdAndUserId(
         teamId: Long,
         userId: Long,
     ): TeamBlacklist?
-
-    @Query(
-        """
-        SELECT CASE WHEN COUNT(tbl) > 0 THEN true ELSE false END
-        FROM TeamBlacklist tbl
-        WHERE tbl.team.id = :teamId
-        AND tbl.user.id = :userId
-        AND (tbl.expiresAt IS NULL OR tbl.expiresAt > :now)
-        """,
-    )
-    override fun existsActiveByTeamIdAndUserId(
-        teamId: Long,
-        userId: Long,
-    ): Boolean {
-        return existsActiveByTeamIdAndUserIdWithTime(teamId, userId, LocalDateTime.now())
-    }
 
     @Query(
         """

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamBlacklistRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamBlacklistRepositoryAdapter.kt
@@ -1,0 +1,45 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.team.TeamBlacklist
+import com.nextup.core.port.repository.TeamBlacklistRepositoryPort
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+/**
+ * TeamBlacklist Repository Adapter
+ * Hexagonal Architecture Outbound Adapter - TeamBlacklistRepositoryPort 구현
+ */
+@Repository
+class TeamBlacklistRepositoryAdapter(
+    private val jpaRepository: TeamBlacklistRepository,
+) : TeamBlacklistRepositoryPort {
+    override fun save(teamBlacklist: TeamBlacklist): TeamBlacklist = jpaRepository.save(teamBlacklist)
+
+    override fun findByIdOrNull(id: Long): TeamBlacklist? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByTeamId(
+        teamId: Long,
+        pageable: Pageable,
+    ): Page<TeamBlacklist> = jpaRepository.findByTeamId(teamId, pageable)
+
+    override fun findByTeamIdAndUserId(
+        teamId: Long,
+        userId: Long,
+    ): TeamBlacklist? = jpaRepository.findByTeamIdAndUserId(teamId, userId)
+
+    override fun existsActiveByTeamIdAndUserId(
+        teamId: Long,
+        userId: Long,
+    ): Boolean = jpaRepository.existsActiveByTeamIdAndUserIdWithTime(teamId, userId, LocalDateTime.now())
+
+    override fun delete(teamBlacklist: TeamBlacklist) {
+        jpaRepository.delete(teamBlacklist)
+    }
+
+    override fun deleteById(id: Long) {
+        jpaRepository.deleteById(id)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamJoinRequestRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamJoinRequestRepository.kt
@@ -2,38 +2,33 @@ package com.nextup.infrastructure.repository
 
 import com.nextup.core.domain.team.JoinRequestStatus
 import com.nextup.core.domain.team.TeamJoinRequest
-import com.nextup.core.port.repository.TeamJoinRequestRepositoryPort
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 /**
- * TeamJoinRequest Repository
- * JpaRepository 상속 + Port 인터페이스 구현
+ * TeamJoinRequest JPA Repository
+ * JPA 전용 쿼리 메서드 정의
  */
-interface TeamJoinRequestRepository :
-    JpaRepository<TeamJoinRequest, Long>,
-    TeamJoinRequestRepositoryPort {
-    override fun findByIdOrNull(id: Long): TeamJoinRequest? = findById(id).orElse(null)
-
+interface TeamJoinRequestRepository : JpaRepository<TeamJoinRequest, Long> {
     @Query("SELECT tjr FROM TeamJoinRequest tjr WHERE tjr.team.id = :teamId")
-    override fun findByTeamId(teamId: Long): List<TeamJoinRequest>
+    fun findByTeamId(teamId: Long): List<TeamJoinRequest>
 
     @Query("SELECT tjr FROM TeamJoinRequest tjr WHERE tjr.team.id = :teamId AND tjr.status = :status")
-    override fun findByTeamIdAndStatus(
+    fun findByTeamIdAndStatus(
         teamId: Long,
         status: JoinRequestStatus,
         pageable: Pageable,
     ): Page<TeamJoinRequest>
 
     @Query("SELECT tjr FROM TeamJoinRequest tjr WHERE tjr.user.id = :userId")
-    override fun findByUserId(userId: Long): List<TeamJoinRequest>
+    fun findByUserId(userId: Long): List<TeamJoinRequest>
 
     @Query(
         "SELECT tjr FROM TeamJoinRequest tjr WHERE tjr.team.id = :teamId AND tjr.user.id = :userId AND tjr.status = 'PENDING'"
     )
-    override fun findPendingByTeamIdAndUserId(
+    fun findPendingByTeamIdAndUserId(
         teamId: Long,
         userId: Long,
     ): TeamJoinRequest?
@@ -41,7 +36,7 @@ interface TeamJoinRequestRepository :
     @Query(
         "SELECT CASE WHEN COUNT(tjr) > 0 THEN true ELSE false END FROM TeamJoinRequest tjr WHERE tjr.team.id = :teamId AND tjr.user.id = :userId AND tjr.status = 'PENDING'"
     )
-    override fun existsPendingByTeamIdAndUserId(
+    fun existsPendingByTeamIdAndUserId(
         teamId: Long,
         userId: Long,
     ): Boolean

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamJoinRequestRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamJoinRequestRepositoryAdapter.kt
@@ -1,0 +1,50 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.team.JoinRequestStatus
+import com.nextup.core.domain.team.TeamJoinRequest
+import com.nextup.core.port.repository.TeamJoinRequestRepositoryPort
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+/**
+ * TeamJoinRequest Repository Adapter
+ * Hexagonal Architecture Outbound Adapter - TeamJoinRequestRepositoryPort 구현
+ */
+@Repository
+class TeamJoinRequestRepositoryAdapter(
+    private val jpaRepository: TeamJoinRequestRepository,
+) : TeamJoinRequestRepositoryPort {
+    override fun save(teamJoinRequest: TeamJoinRequest): TeamJoinRequest = jpaRepository.save(teamJoinRequest)
+
+    override fun findByIdOrNull(id: Long): TeamJoinRequest? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByTeamId(teamId: Long): List<TeamJoinRequest> = jpaRepository.findByTeamId(teamId)
+
+    override fun findByTeamIdAndStatus(
+        teamId: Long,
+        status: JoinRequestStatus,
+        pageable: Pageable,
+    ): Page<TeamJoinRequest> = jpaRepository.findByTeamIdAndStatus(teamId, status, pageable)
+
+    override fun findByUserId(userId: Long): List<TeamJoinRequest> = jpaRepository.findByUserId(userId)
+
+    override fun findPendingByTeamIdAndUserId(
+        teamId: Long,
+        userId: Long,
+    ): TeamJoinRequest? = jpaRepository.findPendingByTeamIdAndUserId(teamId, userId)
+
+    override fun existsPendingByTeamIdAndUserId(
+        teamId: Long,
+        userId: Long,
+    ): Boolean = jpaRepository.existsPendingByTeamIdAndUserId(teamId, userId)
+
+    override fun delete(teamJoinRequest: TeamJoinRequest) {
+        jpaRepository.delete(teamJoinRequest)
+    }
+
+    override fun deleteById(id: Long) {
+        jpaRepository.deleteById(id)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepository.kt
@@ -2,47 +2,42 @@ package com.nextup.infrastructure.repository
 
 import com.nextup.core.domain.team.TeamMember
 import com.nextup.core.domain.team.TeamMemberStatus
-import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 /**
- * TeamMember Repository
- * JpaRepository 상속 + Port 인터페이스 구현
+ * TeamMember JPA Repository
+ * JPA 전용 쿼리 메서드 정의
  */
-interface TeamMemberRepository :
-    JpaRepository<TeamMember, Long>,
-    TeamMemberRepositoryPort {
-    override fun findByIdOrNull(id: Long): TeamMember? = findById(id).orElse(null)
-
+interface TeamMemberRepository : JpaRepository<TeamMember, Long> {
     @Query("SELECT tm FROM TeamMember tm WHERE tm.team.id = :teamId AND tm.user.id = :userId")
-    override fun findByTeamIdAndUserId(
+    fun findByTeamIdAndUserId(
         teamId: Long,
         userId: Long,
     ): TeamMember?
 
     @Query("SELECT tm FROM TeamMember tm WHERE tm.team.id = :teamId")
-    override fun findByTeamId(teamId: Long): List<TeamMember>
+    fun findByTeamId(teamId: Long): List<TeamMember>
 
     @Query("SELECT tm FROM TeamMember tm WHERE tm.team.id = :teamId AND tm.status = :status")
-    override fun findByTeamIdAndStatus(
+    fun findByTeamIdAndStatus(
         teamId: Long,
         status: TeamMemberStatus,
     ): List<TeamMember>
 
     @Query("SELECT tm FROM TeamMember tm WHERE tm.team.id = :teamId AND tm.status IN :statuses")
-    override fun findByTeamIdAndStatusIn(
+    fun findByTeamIdAndStatusIn(
         teamId: Long,
         statuses: Set<TeamMemberStatus>,
     ): List<TeamMember>
 
     @Query("SELECT tm FROM TeamMember tm WHERE tm.user.id = :userId")
-    override fun findByUserId(userId: Long): List<TeamMember>
+    fun findByUserId(userId: Long): List<TeamMember>
 
     @Query("SELECT tm FROM TeamMember tm WHERE tm.user.id = :userId AND tm.status = 'ACTIVE'")
-    override fun findActiveByUserId(userId: Long): TeamMember?
+    fun findActiveByUserId(userId: Long): TeamMember?
 
     @Query(
         """
@@ -52,7 +47,7 @@ interface TeamMemberRepository :
         WHERE tm.team.id = :teamId
         """,
     )
-    override fun findByTeamIdWithUserAndPlayer(
+    fun findByTeamIdWithUserAndPlayer(
         teamId: Long,
         pageable: Pageable,
     ): Page<TeamMember>
@@ -60,7 +55,7 @@ interface TeamMemberRepository :
     @Query(
         "SELECT CASE WHEN COUNT(tm) > 0 THEN true ELSE false END FROM TeamMember tm WHERE tm.team.id = :teamId AND tm.user.id = :userId"
     )
-    override fun existsByTeamIdAndUserId(
+    fun existsByTeamIdAndUserId(
         teamId: Long,
         userId: Long,
     ): Boolean
@@ -68,20 +63,20 @@ interface TeamMemberRepository :
     @Query(
         "SELECT CASE WHEN COUNT(tm) > 0 THEN true ELSE false END FROM TeamMember tm WHERE tm.team.id = :teamId AND tm.uniformNumber = :uniformNumber AND tm.status = :status"
     )
-    override fun existsByTeamIdAndUniformNumberAndStatus(
+    fun existsByTeamIdAndUniformNumberAndStatus(
         teamId: Long,
         uniformNumber: Int,
         status: TeamMemberStatus,
     ): Boolean
 
     @Query("SELECT COUNT(tm) FROM TeamMember tm WHERE tm.team.id = :teamId AND tm.role = 'OWNER'")
-    override fun countOwnersByTeamId(teamId: Long): Long
+    fun countOwnersByTeamId(teamId: Long): Long
 
     @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.player.id = :playerId AND tm.status = 'ACTIVE'")
-    override fun findByPlayerIdActive(playerId: Long): List<TeamMember>
+    fun findByPlayerIdActive(playerId: Long): List<TeamMember>
 
     @Query("SELECT COUNT(tm) FROM TeamMember tm WHERE tm.team.id = :teamId AND tm.status = :status")
-    override fun countByTeamIdAndStatus(
+    fun countByTeamIdAndStatus(
         teamId: Long,
         status: TeamMemberStatus,
     ): Long

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapter.kt
@@ -1,0 +1,76 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberStatus
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+/**
+ * TeamMember Repository Adapter
+ * Hexagonal Architecture Outbound Adapter - TeamMemberRepositoryPort 구현
+ */
+@Repository
+class TeamMemberRepositoryAdapter(
+    private val jpaRepository: TeamMemberRepository,
+) : TeamMemberRepositoryPort {
+    override fun save(teamMember: TeamMember): TeamMember = jpaRepository.save(teamMember)
+
+    override fun findByIdOrNull(id: Long): TeamMember? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByTeamIdAndUserId(
+        teamId: Long,
+        userId: Long,
+    ): TeamMember? = jpaRepository.findByTeamIdAndUserId(teamId, userId)
+
+    override fun findByTeamId(teamId: Long): List<TeamMember> = jpaRepository.findByTeamId(teamId)
+
+    override fun findByTeamIdAndStatus(
+        teamId: Long,
+        status: TeamMemberStatus,
+    ): List<TeamMember> = jpaRepository.findByTeamIdAndStatus(teamId, status)
+
+    override fun findByTeamIdAndStatusIn(
+        teamId: Long,
+        statuses: Set<TeamMemberStatus>,
+    ): List<TeamMember> = jpaRepository.findByTeamIdAndStatusIn(teamId, statuses)
+
+    override fun findByUserId(userId: Long): List<TeamMember> = jpaRepository.findByUserId(userId)
+
+    override fun findActiveByUserId(userId: Long): TeamMember? = jpaRepository.findActiveByUserId(userId)
+
+    override fun findByTeamIdWithUserAndPlayer(
+        teamId: Long,
+        pageable: Pageable,
+    ): Page<TeamMember> = jpaRepository.findByTeamIdWithUserAndPlayer(teamId, pageable)
+
+    override fun existsByTeamIdAndUserId(
+        teamId: Long,
+        userId: Long,
+    ): Boolean = jpaRepository.existsByTeamIdAndUserId(teamId, userId)
+
+    override fun existsByTeamIdAndUniformNumberAndStatus(
+        teamId: Long,
+        uniformNumber: Int,
+        status: TeamMemberStatus,
+    ): Boolean = jpaRepository.existsByTeamIdAndUniformNumberAndStatus(teamId, uniformNumber, status)
+
+    override fun countOwnersByTeamId(teamId: Long): Long = jpaRepository.countOwnersByTeamId(teamId)
+
+    override fun delete(teamMember: TeamMember) {
+        jpaRepository.delete(teamMember)
+    }
+
+    override fun deleteById(id: Long) {
+        jpaRepository.deleteById(id)
+    }
+
+    override fun findByPlayerIdActive(playerId: Long): List<TeamMember> = jpaRepository.findByPlayerIdActive(playerId)
+
+    override fun countByTeamIdAndStatus(
+        teamId: Long,
+        status: TeamMemberStatus,
+    ): Long = jpaRepository.countByTeamIdAndStatus(teamId, status)
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/GameAttendanceVoteRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/GameAttendanceVoteRepositoryAdapterTest.kt
@@ -1,0 +1,215 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.game.AttendanceStatus
+import com.nextup.core.domain.game.GameParticipation
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+
+@DisplayName("GameAttendanceVoteRepositoryAdapter 테스트")
+class GameAttendanceVoteRepositoryAdapterTest {
+
+    private val jpaRepository: AttendanceVoteRepository = mockk()
+    private lateinit var adapter: GameAttendanceVoteRepositoryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        adapter = GameAttendanceVoteRepositoryAdapter(jpaRepository)
+    }
+
+    @Test
+    @DisplayName("save - GameParticipation 저장 시 JPA repository에 위임한다")
+    fun `should delegate save to jpa repository`() {
+        // given
+        val vote = mockk<GameParticipation>()
+        every { jpaRepository.save(vote) } returns vote
+
+        // when
+        val result = adapter.save(vote)
+
+        // then
+        assertThat(result).isEqualTo(vote)
+        verify(exactly = 1) { jpaRepository.save(vote) }
+    }
+
+    @Test
+    @DisplayName("saveAll - 여러 GameParticipation 저장 시 JPA repository에 위임한다")
+    fun `should delegate saveAll to jpa repository`() {
+        // given
+        val votes = listOf(mockk<GameParticipation>(), mockk<GameParticipation>())
+        every { jpaRepository.saveAll(votes) } returns votes
+
+        // when
+        val result = adapter.saveAll(votes)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result).isEqualTo(votes)
+        verify(exactly = 1) { jpaRepository.saveAll(votes) }
+    }
+
+    @Test
+    @DisplayName("findByIdOrNull - ID로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByIdOrNull to jpa repository`() {
+        // given
+        val vote = mockk<GameParticipation>()
+        every { jpaRepository.findByIdOrNull(1L) } returns vote
+
+        // when
+        val result = adapter.findByIdOrNull(1L)
+
+        // then
+        assertThat(result).isEqualTo(vote)
+        verify(exactly = 1) { jpaRepository.findByIdOrNull(1L) }
+    }
+
+    @Test
+    @DisplayName("findByIdOrNull - 존재하지 않는 ID 조회 시 null을 반환한다")
+    fun `should return null when id not found`() {
+        // given
+        every { jpaRepository.findByIdOrNull(99L) } returns null
+
+        // when
+        val result = adapter.findByIdOrNull(99L)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    @DisplayName("findByGameId - gameId로 투표 목록 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByGameId to jpa repository`() {
+        // given
+        val votes = listOf(mockk<GameParticipation>(), mockk<GameParticipation>())
+        every { jpaRepository.findByGameId(1L) } returns votes
+
+        // when
+        val result = adapter.findByGameId(1L)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result).isEqualTo(votes)
+        verify(exactly = 1) { jpaRepository.findByGameId(1L) }
+    }
+
+    @Test
+    @DisplayName("findByGameIdAndMemberId - gameId와 memberId로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByGameIdAndMemberId to jpa repository`() {
+        // given
+        val vote = mockk<GameParticipation>()
+        every { jpaRepository.findByGameIdAndMemberId(1L, 2L) } returns vote
+
+        // when
+        val result = adapter.findByGameIdAndMemberId(1L, 2L)
+
+        // then
+        assertThat(result).isEqualTo(vote)
+        verify(exactly = 1) { jpaRepository.findByGameIdAndMemberId(1L, 2L) }
+    }
+
+    @Test
+    @DisplayName("findByGameIdAndMemberId - 투표가 없을 때 null을 반환한다")
+    fun `should return null when vote not found`() {
+        // given
+        every { jpaRepository.findByGameIdAndMemberId(1L, 2L) } returns null
+
+        // when
+        val result = adapter.findByGameIdAndMemberId(1L, 2L)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    @DisplayName("findByGameIdAndStatus - gameId와 status로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByGameIdAndStatus to jpa repository`() {
+        // given
+        val votes = listOf(mockk<GameParticipation>())
+        every { jpaRepository.findByGameIdAndStatus(1L, AttendanceStatus.ATTENDING) } returns votes
+
+        // when
+        val result = adapter.findByGameIdAndStatus(1L, AttendanceStatus.ATTENDING)
+
+        // then
+        assertThat(result).hasSize(1)
+        assertThat(result).isEqualTo(votes)
+        verify(exactly = 1) { jpaRepository.findByGameIdAndStatus(1L, AttendanceStatus.ATTENDING) }
+    }
+
+    @Test
+    @DisplayName("findNonVotersByGameId - 미투표자 조회 시 JPA repository에 위임한다")
+    fun `should delegate findNonVotersByGameId to jpa repository`() {
+        // given
+        val votes = listOf(mockk<GameParticipation>(), mockk<GameParticipation>())
+        every { jpaRepository.findNonVotersByGameId(1L) } returns votes
+
+        // when
+        val result = adapter.findNonVotersByGameId(1L)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result).isEqualTo(votes)
+        verify(exactly = 1) { jpaRepository.findNonVotersByGameId(1L) }
+    }
+
+    @Test
+    @DisplayName("countByGameId - gameId로 투표 수 조회 시 JPA repository에 위임한다")
+    fun `should delegate countByGameId to jpa repository`() {
+        // given
+        every { jpaRepository.countByGameId(1L) } returns 10L
+
+        // when
+        val result = adapter.countByGameId(1L)
+
+        // then
+        assertThat(result).isEqualTo(10L)
+        verify(exactly = 1) { jpaRepository.countByGameId(1L) }
+    }
+
+    @Test
+    @DisplayName("countByGameIdAndStatus - gameId와 status로 투표 수 조회 시 JPA repository에 위임한다")
+    fun `should delegate countByGameIdAndStatus to jpa repository`() {
+        // given
+        every { jpaRepository.countByGameIdAndStatus(1L, AttendanceStatus.ATTENDING) } returns 7L
+
+        // when
+        val result = adapter.countByGameIdAndStatus(1L, AttendanceStatus.ATTENDING)
+
+        // then
+        assertThat(result).isEqualTo(7L)
+        verify(exactly = 1) { jpaRepository.countByGameIdAndStatus(1L, AttendanceStatus.ATTENDING) }
+    }
+
+    @Test
+    @DisplayName("delete - GameParticipation 삭제 시 JPA repository에 위임한다")
+    fun `should delegate delete to jpa repository`() {
+        // given
+        val vote = mockk<GameParticipation>()
+        justRun { jpaRepository.delete(vote) }
+
+        // when
+        adapter.delete(vote)
+
+        // then
+        verify(exactly = 1) { jpaRepository.delete(vote) }
+    }
+
+    @Test
+    @DisplayName("deleteById - ID로 삭제 시 JPA repository에 위임한다")
+    fun `should delegate deleteById to jpa repository`() {
+        // given
+        justRun { jpaRepository.deleteById(1L) }
+
+        // when
+        adapter.deleteById(1L)
+
+        // then
+        verify(exactly = 1) { jpaRepository.deleteById(1L) }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamBlacklistRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamBlacklistRepositoryAdapterTest.kt
@@ -1,0 +1,184 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.team.TeamBlacklist
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDateTime
+
+@DisplayName("TeamBlacklistRepositoryAdapter 테스트")
+class TeamBlacklistRepositoryAdapterTest {
+
+    private val jpaRepository: TeamBlacklistRepository = mockk()
+    private lateinit var adapter: TeamBlacklistRepositoryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        adapter = TeamBlacklistRepositoryAdapter(jpaRepository)
+    }
+
+    @Test
+    @DisplayName("save - TeamBlacklist 저장 시 JPA repository에 위임한다")
+    fun `should delegate save to jpa repository`() {
+        // given
+        val blacklist = mockk<TeamBlacklist>()
+        every { jpaRepository.save(blacklist) } returns blacklist
+
+        // when
+        val result = adapter.save(blacklist)
+
+        // then
+        assertThat(result).isEqualTo(blacklist)
+        verify(exactly = 1) { jpaRepository.save(blacklist) }
+    }
+
+    @Test
+    @DisplayName("findByIdOrNull - ID로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByIdOrNull to jpa repository`() {
+        // given
+        val blacklist = mockk<TeamBlacklist>()
+        every { jpaRepository.findByIdOrNull(1L) } returns blacklist
+
+        // when
+        val result = adapter.findByIdOrNull(1L)
+
+        // then
+        assertThat(result).isEqualTo(blacklist)
+        verify(exactly = 1) { jpaRepository.findByIdOrNull(1L) }
+    }
+
+    @Test
+    @DisplayName("findByIdOrNull - 존재하지 않는 ID 조회 시 null을 반환한다")
+    fun `should return null when id not found`() {
+        // given
+        every { jpaRepository.findByIdOrNull(99L) } returns null
+
+        // when
+        val result = adapter.findByIdOrNull(99L)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    @DisplayName("findByTeamId - teamId로 페이지 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByTeamId to jpa repository`() {
+        // given
+        val pageable = mockk<Pageable>()
+        val blacklist = mockk<TeamBlacklist>()
+        val page = PageImpl(listOf(blacklist))
+        every { jpaRepository.findByTeamId(1L, pageable) } returns page
+
+        // when
+        val result = adapter.findByTeamId(1L, pageable)
+
+        // then
+        assertThat(result.content).hasSize(1)
+        assertThat(result.content[0]).isEqualTo(blacklist)
+        verify(exactly = 1) { jpaRepository.findByTeamId(1L, pageable) }
+    }
+
+    @Test
+    @DisplayName("findByTeamIdAndUserId - teamId와 userId로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByTeamIdAndUserId to jpa repository`() {
+        // given
+        val blacklist = mockk<TeamBlacklist>()
+        every { jpaRepository.findByTeamIdAndUserId(1L, 2L) } returns blacklist
+
+        // when
+        val result = adapter.findByTeamIdAndUserId(1L, 2L)
+
+        // then
+        assertThat(result).isEqualTo(blacklist)
+        verify(exactly = 1) { jpaRepository.findByTeamIdAndUserId(1L, 2L) }
+    }
+
+    @Test
+    @DisplayName("findByTeamIdAndUserId - 블랙리스트 항목이 없을 때 null을 반환한다")
+    fun `should return null when blacklist entry not found`() {
+        // given
+        every { jpaRepository.findByTeamIdAndUserId(1L, 2L) } returns null
+
+        // when
+        val result = adapter.findByTeamIdAndUserId(1L, 2L)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    @DisplayName("existsActiveByTeamIdAndUserId - 활성 블랙리스트 존재 여부 확인 시 현재 시각을 전달하여 JPA repository에 위임한다")
+    fun `should delegate existsActiveByTeamIdAndUserId with current time to jpa repository`() {
+        // given
+        val nowSlot = slot<LocalDateTime>()
+        val beforeCall = LocalDateTime.now().minusSeconds(1)
+        every {
+            jpaRepository.existsActiveByTeamIdAndUserIdWithTime(1L, 2L, capture(nowSlot))
+        } returns true
+
+        // when
+        val result = adapter.existsActiveByTeamIdAndUserId(1L, 2L)
+
+        // then
+        assertThat(result).isTrue()
+        verify(exactly = 1) {
+            jpaRepository.existsActiveByTeamIdAndUserIdWithTime(1L, 2L, any())
+        }
+        // 전달된 시각이 호출 전후 사이의 값인지 검증
+        val capturedTime = nowSlot.captured
+        val afterCall = LocalDateTime.now().plusSeconds(1)
+        assertThat(capturedTime).isAfter(beforeCall)
+        assertThat(capturedTime).isBefore(afterCall)
+    }
+
+    @Test
+    @DisplayName("existsActiveByTeamIdAndUserId - 활성 블랙리스트가 없을 때 false를 반환한다")
+    fun `should return false when no active blacklist exists`() {
+        // given
+        every {
+            jpaRepository.existsActiveByTeamIdAndUserIdWithTime(1L, 2L, any())
+        } returns false
+
+        // when
+        val result = adapter.existsActiveByTeamIdAndUserId(1L, 2L)
+
+        // then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    @DisplayName("delete - TeamBlacklist 삭제 시 JPA repository에 위임한다")
+    fun `should delegate delete to jpa repository`() {
+        // given
+        val blacklist = mockk<TeamBlacklist>()
+        justRun { jpaRepository.delete(blacklist) }
+
+        // when
+        adapter.delete(blacklist)
+
+        // then
+        verify(exactly = 1) { jpaRepository.delete(blacklist) }
+    }
+
+    @Test
+    @DisplayName("deleteById - ID로 삭제 시 JPA repository에 위임한다")
+    fun `should delegate deleteById to jpa repository`() {
+        // given
+        justRun { jpaRepository.deleteById(1L) }
+
+        // when
+        adapter.deleteById(1L)
+
+        // then
+        verify(exactly = 1) { jpaRepository.deleteById(1L) }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamJoinRequestRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamJoinRequestRepositoryAdapterTest.kt
@@ -1,0 +1,205 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.team.JoinRequestStatus
+import com.nextup.core.domain.team.TeamJoinRequest
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+
+@DisplayName("TeamJoinRequestRepositoryAdapter 테스트")
+class TeamJoinRequestRepositoryAdapterTest {
+
+    private val jpaRepository: TeamJoinRequestRepository = mockk()
+    private lateinit var adapter: TeamJoinRequestRepositoryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        adapter = TeamJoinRequestRepositoryAdapter(jpaRepository)
+    }
+
+    @Test
+    @DisplayName("save - TeamJoinRequest 저장 시 JPA repository에 위임한다")
+    fun `should delegate save to jpa repository`() {
+        // given
+        val request = mockk<TeamJoinRequest>()
+        every { jpaRepository.save(request) } returns request
+
+        // when
+        val result = adapter.save(request)
+
+        // then
+        assertThat(result).isEqualTo(request)
+        verify(exactly = 1) { jpaRepository.save(request) }
+    }
+
+    @Test
+    @DisplayName("findByIdOrNull - ID로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByIdOrNull to jpa repository`() {
+        // given
+        val request = mockk<TeamJoinRequest>()
+        every { jpaRepository.findByIdOrNull(1L) } returns request
+
+        // when
+        val result = adapter.findByIdOrNull(1L)
+
+        // then
+        assertThat(result).isEqualTo(request)
+        verify(exactly = 1) { jpaRepository.findByIdOrNull(1L) }
+    }
+
+    @Test
+    @DisplayName("findByIdOrNull - 존재하지 않는 ID 조회 시 null을 반환한다")
+    fun `should return null when id not found`() {
+        // given
+        every { jpaRepository.findByIdOrNull(99L) } returns null
+
+        // when
+        val result = adapter.findByIdOrNull(99L)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    @DisplayName("findByTeamId - teamId로 목록 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByTeamId to jpa repository`() {
+        // given
+        val requests = listOf(mockk<TeamJoinRequest>(), mockk<TeamJoinRequest>())
+        every { jpaRepository.findByTeamId(1L) } returns requests
+
+        // when
+        val result = adapter.findByTeamId(1L)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result).isEqualTo(requests)
+        verify(exactly = 1) { jpaRepository.findByTeamId(1L) }
+    }
+
+    @Test
+    @DisplayName("findByTeamIdAndStatus - teamId와 status로 페이지 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByTeamIdAndStatus to jpa repository`() {
+        // given
+        val pageable = mockk<Pageable>()
+        val request = mockk<TeamJoinRequest>()
+        val page = PageImpl(listOf(request))
+        every {
+            jpaRepository.findByTeamIdAndStatus(1L, JoinRequestStatus.PENDING, pageable)
+        } returns page
+
+        // when
+        val result = adapter.findByTeamIdAndStatus(1L, JoinRequestStatus.PENDING, pageable)
+
+        // then
+        assertThat(result.content).hasSize(1)
+        assertThat(result.content[0]).isEqualTo(request)
+        verify(exactly = 1) {
+            jpaRepository.findByTeamIdAndStatus(1L, JoinRequestStatus.PENDING, pageable)
+        }
+    }
+
+    @Test
+    @DisplayName("findByUserId - userId로 목록 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByUserId to jpa repository`() {
+        // given
+        val requests = listOf(mockk<TeamJoinRequest>())
+        every { jpaRepository.findByUserId(10L) } returns requests
+
+        // when
+        val result = adapter.findByUserId(10L)
+
+        // then
+        assertThat(result).isEqualTo(requests)
+        verify(exactly = 1) { jpaRepository.findByUserId(10L) }
+    }
+
+    @Test
+    @DisplayName("findPendingByTeamIdAndUserId - 대기 중인 신청 조회 시 JPA repository에 위임한다")
+    fun `should delegate findPendingByTeamIdAndUserId to jpa repository`() {
+        // given
+        val request = mockk<TeamJoinRequest>()
+        every { jpaRepository.findPendingByTeamIdAndUserId(1L, 2L) } returns request
+
+        // when
+        val result = adapter.findPendingByTeamIdAndUserId(1L, 2L)
+
+        // then
+        assertThat(result).isEqualTo(request)
+        verify(exactly = 1) { jpaRepository.findPendingByTeamIdAndUserId(1L, 2L) }
+    }
+
+    @Test
+    @DisplayName("findPendingByTeamIdAndUserId - 대기 중인 신청이 없을 때 null을 반환한다")
+    fun `should return null when no pending request exists`() {
+        // given
+        every { jpaRepository.findPendingByTeamIdAndUserId(1L, 2L) } returns null
+
+        // when
+        val result = adapter.findPendingByTeamIdAndUserId(1L, 2L)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    @DisplayName("existsPendingByTeamIdAndUserId - 대기 중인 신청 존재 여부 확인 시 JPA repository에 위임한다")
+    fun `should delegate existsPendingByTeamIdAndUserId to jpa repository`() {
+        // given
+        every { jpaRepository.existsPendingByTeamIdAndUserId(1L, 2L) } returns true
+
+        // when
+        val result = adapter.existsPendingByTeamIdAndUserId(1L, 2L)
+
+        // then
+        assertThat(result).isTrue()
+        verify(exactly = 1) { jpaRepository.existsPendingByTeamIdAndUserId(1L, 2L) }
+    }
+
+    @Test
+    @DisplayName("existsPendingByTeamIdAndUserId - 대기 중인 신청이 없을 때 false를 반환한다")
+    fun `should return false when no pending request exists`() {
+        // given
+        every { jpaRepository.existsPendingByTeamIdAndUserId(1L, 2L) } returns false
+
+        // when
+        val result = adapter.existsPendingByTeamIdAndUserId(1L, 2L)
+
+        // then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    @DisplayName("delete - TeamJoinRequest 삭제 시 JPA repository에 위임한다")
+    fun `should delegate delete to jpa repository`() {
+        // given
+        val request = mockk<TeamJoinRequest>()
+        justRun { jpaRepository.delete(request) }
+
+        // when
+        adapter.delete(request)
+
+        // then
+        verify(exactly = 1) { jpaRepository.delete(request) }
+    }
+
+    @Test
+    @DisplayName("deleteById - ID로 삭제 시 JPA repository에 위임한다")
+    fun `should delegate deleteById to jpa repository`() {
+        // given
+        justRun { jpaRepository.deleteById(1L) }
+
+        // when
+        adapter.deleteById(1L)
+
+        // then
+        verify(exactly = 1) { jpaRepository.deleteById(1L) }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapterTest.kt
@@ -1,0 +1,284 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberStatus
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+
+@DisplayName("TeamMemberRepositoryAdapter 테스트")
+class TeamMemberRepositoryAdapterTest {
+
+    private val jpaRepository: TeamMemberRepository = mockk()
+    private lateinit var adapter: TeamMemberRepositoryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        adapter = TeamMemberRepositoryAdapter(jpaRepository)
+    }
+
+    @Test
+    @DisplayName("save - TeamMember 저장 시 JPA repository에 위임한다")
+    fun `should delegate save to jpa repository`() {
+        // given
+        val teamMember = mockk<TeamMember>()
+        every { jpaRepository.save(teamMember) } returns teamMember
+
+        // when
+        val result = adapter.save(teamMember)
+
+        // then
+        assertThat(result).isEqualTo(teamMember)
+        verify(exactly = 1) { jpaRepository.save(teamMember) }
+    }
+
+    @Test
+    @DisplayName("findByIdOrNull - ID로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByIdOrNull to jpa repository`() {
+        // given
+        val teamMember = mockk<TeamMember>()
+        every { jpaRepository.findByIdOrNull(1L) } returns teamMember
+
+        // when
+        val result = adapter.findByIdOrNull(1L)
+
+        // then
+        assertThat(result).isEqualTo(teamMember)
+        verify(exactly = 1) { jpaRepository.findByIdOrNull(1L) }
+    }
+
+    @Test
+    @DisplayName("findByIdOrNull - 존재하지 않는 ID 조회 시 null을 반환한다")
+    fun `should return null when id not found`() {
+        // given
+        every { jpaRepository.findByIdOrNull(99L) } returns null
+
+        // when
+        val result = adapter.findByIdOrNull(99L)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    @DisplayName("findByTeamIdAndUserId - teamId와 userId로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByTeamIdAndUserId to jpa repository`() {
+        // given
+        val teamMember = mockk<TeamMember>()
+        every { jpaRepository.findByTeamIdAndUserId(1L, 2L) } returns teamMember
+
+        // when
+        val result = adapter.findByTeamIdAndUserId(1L, 2L)
+
+        // then
+        assertThat(result).isEqualTo(teamMember)
+        verify(exactly = 1) { jpaRepository.findByTeamIdAndUserId(1L, 2L) }
+    }
+
+    @Test
+    @DisplayName("findByTeamId - teamId로 목록 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByTeamId to jpa repository`() {
+        // given
+        val members = listOf(mockk<TeamMember>(), mockk<TeamMember>())
+        every { jpaRepository.findByTeamId(1L) } returns members
+
+        // when
+        val result = adapter.findByTeamId(1L)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result).isEqualTo(members)
+        verify(exactly = 1) { jpaRepository.findByTeamId(1L) }
+    }
+
+    @Test
+    @DisplayName("findByTeamIdAndStatus - teamId와 status로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByTeamIdAndStatus to jpa repository`() {
+        // given
+        val members = listOf(mockk<TeamMember>())
+        every { jpaRepository.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE) } returns members
+
+        // when
+        val result = adapter.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE)
+
+        // then
+        assertThat(result).hasSize(1)
+        assertThat(result).isEqualTo(members)
+        verify(exactly = 1) { jpaRepository.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE) }
+    }
+
+    @Test
+    @DisplayName("findByTeamIdAndStatusIn - teamId와 status 목록으로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByTeamIdAndStatusIn to jpa repository`() {
+        // given
+        val statuses = setOf(TeamMemberStatus.ACTIVE, TeamMemberStatus.SUSPENDED)
+        val members = listOf(mockk<TeamMember>(), mockk<TeamMember>())
+        every { jpaRepository.findByTeamIdAndStatusIn(1L, statuses) } returns members
+
+        // when
+        val result = adapter.findByTeamIdAndStatusIn(1L, statuses)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result).isEqualTo(members)
+        verify(exactly = 1) { jpaRepository.findByTeamIdAndStatusIn(1L, statuses) }
+    }
+
+    @Test
+    @DisplayName("findByUserId - userId로 목록 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByUserId to jpa repository`() {
+        // given
+        val members = listOf(mockk<TeamMember>())
+        every { jpaRepository.findByUserId(10L) } returns members
+
+        // when
+        val result = adapter.findByUserId(10L)
+
+        // then
+        assertThat(result).isEqualTo(members)
+        verify(exactly = 1) { jpaRepository.findByUserId(10L) }
+    }
+
+    @Test
+    @DisplayName("findActiveByUserId - 활성 상태 멤버 조회 시 JPA repository에 위임한다")
+    fun `should delegate findActiveByUserId to jpa repository`() {
+        // given
+        val teamMember = mockk<TeamMember>()
+        every { jpaRepository.findActiveByUserId(10L) } returns teamMember
+
+        // when
+        val result = adapter.findActiveByUserId(10L)
+
+        // then
+        assertThat(result).isEqualTo(teamMember)
+        verify(exactly = 1) { jpaRepository.findActiveByUserId(10L) }
+    }
+
+    @Test
+    @DisplayName("findByTeamIdWithUserAndPlayer - 페이지 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByTeamIdWithUserAndPlayer to jpa repository`() {
+        // given
+        val pageable = mockk<Pageable>()
+        val member = mockk<TeamMember>()
+        val page = PageImpl(listOf(member))
+        every { jpaRepository.findByTeamIdWithUserAndPlayer(1L, pageable) } returns page
+
+        // when
+        val result = adapter.findByTeamIdWithUserAndPlayer(1L, pageable)
+
+        // then
+        assertThat(result.content).hasSize(1)
+        assertThat(result.content[0]).isEqualTo(member)
+        verify(exactly = 1) { jpaRepository.findByTeamIdWithUserAndPlayer(1L, pageable) }
+    }
+
+    @Test
+    @DisplayName("existsByTeamIdAndUserId - 존재 여부 확인 시 JPA repository에 위임한다")
+    fun `should delegate existsByTeamIdAndUserId to jpa repository`() {
+        // given
+        every { jpaRepository.existsByTeamIdAndUserId(1L, 2L) } returns true
+
+        // when
+        val result = adapter.existsByTeamIdAndUserId(1L, 2L)
+
+        // then
+        assertThat(result).isTrue()
+        verify(exactly = 1) { jpaRepository.existsByTeamIdAndUserId(1L, 2L) }
+    }
+
+    @Test
+    @DisplayName("existsByTeamIdAndUniformNumberAndStatus - 등번호와 상태로 존재 여부 확인 시 JPA repository에 위임한다")
+    fun `should delegate existsByTeamIdAndUniformNumberAndStatus to jpa repository`() {
+        // given
+        every {
+            jpaRepository.existsByTeamIdAndUniformNumberAndStatus(1L, 7, TeamMemberStatus.ACTIVE)
+        } returns false
+
+        // when
+        val result = adapter.existsByTeamIdAndUniformNumberAndStatus(1L, 7, TeamMemberStatus.ACTIVE)
+
+        // then
+        assertThat(result).isFalse()
+        verify(exactly = 1) {
+            jpaRepository.existsByTeamIdAndUniformNumberAndStatus(1L, 7, TeamMemberStatus.ACTIVE)
+        }
+    }
+
+    @Test
+    @DisplayName("countOwnersByTeamId - 팀 OWNER 수 조회 시 JPA repository에 위임한다")
+    fun `should delegate countOwnersByTeamId to jpa repository`() {
+        // given
+        every { jpaRepository.countOwnersByTeamId(1L) } returns 1L
+
+        // when
+        val result = adapter.countOwnersByTeamId(1L)
+
+        // then
+        assertThat(result).isEqualTo(1L)
+        verify(exactly = 1) { jpaRepository.countOwnersByTeamId(1L) }
+    }
+
+    @Test
+    @DisplayName("delete - TeamMember 삭제 시 JPA repository에 위임한다")
+    fun `should delegate delete to jpa repository`() {
+        // given
+        val teamMember = mockk<TeamMember>()
+        justRun { jpaRepository.delete(teamMember) }
+
+        // when
+        adapter.delete(teamMember)
+
+        // then
+        verify(exactly = 1) { jpaRepository.delete(teamMember) }
+    }
+
+    @Test
+    @DisplayName("deleteById - ID로 삭제 시 JPA repository에 위임한다")
+    fun `should delegate deleteById to jpa repository`() {
+        // given
+        justRun { jpaRepository.deleteById(1L) }
+
+        // when
+        adapter.deleteById(1L)
+
+        // then
+        verify(exactly = 1) { jpaRepository.deleteById(1L) }
+    }
+
+    @Test
+    @DisplayName("findByPlayerIdActive - 활성 선수 ID로 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByPlayerIdActive to jpa repository`() {
+        // given
+        val members = listOf(mockk<TeamMember>())
+        every { jpaRepository.findByPlayerIdActive(5L) } returns members
+
+        // when
+        val result = adapter.findByPlayerIdActive(5L)
+
+        // then
+        assertThat(result).isEqualTo(members)
+        verify(exactly = 1) { jpaRepository.findByPlayerIdActive(5L) }
+    }
+
+    @Test
+    @DisplayName("countByTeamIdAndStatus - 팀 상태별 멤버 수 조회 시 JPA repository에 위임한다")
+    fun `should delegate countByTeamIdAndStatus to jpa repository`() {
+        // given
+        every { jpaRepository.countByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE) } returns 5L
+
+        // when
+        val result = adapter.countByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE)
+
+        // then
+        assertThat(result).isEqualTo(5L)
+        verify(exactly = 1) { jpaRepository.countByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE) }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #115

JpaRepository가 Port를 직접 상속하는 Old 패턴을 별도 Adapter 클래스를 사용하는 New 패턴으로 통일합니다. Hexagonal Architecture Port/Adapter 원칙을 준수합니다.

## Tasks

- Old 패턴 Repository 전수 조사 (4개 식별)
- TeamMemberRepository → TeamMemberRepositoryAdapter 분리
- TeamJoinRequestRepository → TeamJoinRequestRepositoryAdapter 분리
- TeamBlacklistRepository → TeamBlacklistRepositoryAdapter 분리
- AttendanceVoteRepository(game) → GameAttendanceVoteRepositoryAdapter 분리
- Port 인터페이스(core) 변경 없음

## To Reviewer

- `GameAttendanceVoteRepositoryAdapter` 명명: attendance 도메인에 이미 `AttendanceVoteRepositoryAdapter`가 존재하여 충돌 방지
- `TeamBlacklist`의 `existsActiveByTeamIdAndUserId`: 기존 default method의 `LocalDateTime.now()` 로직을 Adapter로 이동
- Port 인터페이스는 변경 없음 → 기존 Service 코드 영향 없음