### PR TITLE
refactor(#126): GlobalExceptionHandler 3중 복제 → BaseExceptionHandler 추출

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/StandingsSimulationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/StandingsSimulationController.kt
@@ -1,10 +1,10 @@
 package com.nextup.api.controller.competition
 
-import com.nextup.api.dto.common.ApiResponse
 import com.nextup.api.dto.standings.MagicNumberResponse
 import com.nextup.api.dto.standings.PlayoffScenarioResponse
 import com.nextup.api.dto.standings.SimulationApiRequest
 import com.nextup.api.dto.standings.SimulationResultResponse
+import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.standings.StandingsSimulationService
 import com.nextup.core.service.standings.dto.SimulatedGameResult
 import com.nextup.core.service.standings.dto.SimulationRequest

--- a/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/exception/GlobalExceptionHandler.kt
@@ -2,22 +2,17 @@ package com.nextup.api.exception
 
 import com.nextup.common.dto.ApiResponse
 import com.nextup.common.exception.AuthenticationException
-import com.nextup.common.exception.BusinessException
 import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.InvalidStateException
-import com.nextup.common.exception.NotFoundException
-import org.slf4j.LoggerFactory
+import com.nextup.infrastructure.exception.BaseExceptionHandler
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.http.converter.HttpMessageNotReadableException
-import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
 @RestControllerAdvice
-class GlobalExceptionHandler {
-    private val log = LoggerFactory.getLogger(javaClass)
+class GlobalExceptionHandler : BaseExceptionHandler() {
 
     @ExceptionHandler(AuthenticationException::class)
     fun handleAuthenticationException(ex: AuthenticationException): ResponseEntity<ApiResponse<Nothing>> {
@@ -35,38 +30,12 @@ class GlobalExceptionHandler {
             .body(ApiResponse.error(ex.code, ex.message))
     }
 
-    @ExceptionHandler(NotFoundException::class)
-    fun handleNotFoundException(ex: NotFoundException): ResponseEntity<ApiResponse<Nothing>> {
-        log.warn("NotFoundException: code={}, message={}", ex.code, ex.message)
-        return ResponseEntity
-            .status(HttpStatus.NOT_FOUND)
-            .body(ApiResponse.error(ex.code, ex.message))
-    }
-
     @ExceptionHandler(InvalidStateException::class)
     fun handleInvalidStateException(ex: InvalidStateException): ResponseEntity<ApiResponse<Nothing>> {
         log.warn("InvalidStateException: code={}, message={}", ex.code, ex.message)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.error(ex.code, ex.message))
-    }
-
-    @ExceptionHandler(BusinessException::class)
-    fun handleBusinessException(ex: BusinessException): ResponseEntity<ApiResponse<Nothing>> {
-        log.warn("BusinessException: code={}, message={}", ex.code, ex.message)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error(ex.code, ex.message))
-    }
-
-    @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleHttpMessageNotReadableException(
-        ex: HttpMessageNotReadableException,
-    ): ResponseEntity<ApiResponse<Nothing>> {
-        log.warn("HttpMessageNotReadableException: {}", ex.message)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error("INVALID_REQUEST", "요청 본문을 읽을 수 없습니다"))
     }
 
     @ExceptionHandler(MissingServletRequestParameterException::class)
@@ -79,38 +48,11 @@ class GlobalExceptionHandler {
             .body(ApiResponse.error("MISSING_PARAMETER", ex.message))
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
-        val errors =
-            ex.bindingResult.fieldErrors
-                .joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
-        log.warn("ValidationException: {}", errors)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error("VALIDATION_ERROR", errors))
-    }
-
-    @ExceptionHandler(IllegalArgumentException::class)
-    fun handleIllegalArgumentException(ex: IllegalArgumentException): ResponseEntity<ApiResponse<Nothing>> {
-        log.warn("IllegalArgumentException: {}", ex.message)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error("INVALID_ARGUMENT", ex.message ?: "Invalid argument"))
-    }
-
     @ExceptionHandler(IllegalStateException::class)
     fun handleIllegalStateException(ex: IllegalStateException): ResponseEntity<ApiResponse<Nothing>> {
         log.warn("IllegalStateException: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.error("INVALID_STATE", ex.message ?: "Invalid state"))
-    }
-
-    @ExceptionHandler(Exception::class)
-    fun handleException(ex: Exception): ResponseEntity<ApiResponse<Nothing>> {
-        log.error("UnexpectedException: {}", ex.message, ex)
-        return ResponseEntity
-            .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ApiResponse.error("INTERNAL_ERROR", "An unexpected error occurred"))
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/stadium/BookingTransferController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/stadium/BookingTransferController.kt
@@ -1,10 +1,10 @@
 package com.nextup.backoffice.controller.stadium
 
-import com.nextup.backoffice.dto.common.ApiResponse
 import com.nextup.backoffice.dto.stadium.AcceptBookingTransferRequest
 import com.nextup.backoffice.dto.stadium.BookingTransferResponse
 import com.nextup.backoffice.dto.stadium.CancelBookingTransferRequest
 import com.nextup.backoffice.dto.stadium.CreateBookingTransferRequest
+import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.stadium.BookingTransferService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/exception/GlobalExceptionHandler.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/exception/GlobalExceptionHandler.kt
@@ -1,70 +1,7 @@
 package com.nextup.backoffice.exception
 
-import com.nextup.common.dto.ApiResponse
-import com.nextup.common.exception.BusinessException
-import com.nextup.common.exception.NotFoundException
-import org.slf4j.LoggerFactory
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
-import org.springframework.http.converter.HttpMessageNotReadableException
-import org.springframework.web.bind.MethodArgumentNotValidException
-import org.springframework.web.bind.annotation.ExceptionHandler
+import com.nextup.infrastructure.exception.BaseExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
 @RestControllerAdvice
-class GlobalExceptionHandler {
-    private val log = LoggerFactory.getLogger(javaClass)
-
-    @ExceptionHandler(NotFoundException::class)
-    fun handleNotFoundException(ex: NotFoundException): ResponseEntity<ApiResponse<Nothing>> {
-        log.warn("NotFoundException: code={}, message={}", ex.code, ex.message)
-        return ResponseEntity
-            .status(HttpStatus.NOT_FOUND)
-            .body(ApiResponse.error(ex.code, ex.message))
-    }
-
-    @ExceptionHandler(BusinessException::class)
-    fun handleBusinessException(ex: BusinessException): ResponseEntity<ApiResponse<Nothing>> {
-        log.warn("BusinessException: code={}, message={}", ex.code, ex.message)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error(ex.code, ex.message))
-    }
-
-    @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleHttpMessageNotReadableException(
-        ex: HttpMessageNotReadableException,
-    ): ResponseEntity<ApiResponse<Nothing>> {
-        log.warn("HttpMessageNotReadableException: {}", ex.message)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error("INVALID_REQUEST", "요청 본문을 읽을 수 없습니다"))
-    }
-
-    @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
-        val errors =
-            ex.bindingResult.fieldErrors
-                .joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
-        log.warn("ValidationException: {}", errors)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error("VALIDATION_ERROR", errors))
-    }
-
-    @ExceptionHandler(IllegalArgumentException::class)
-    fun handleIllegalArgumentException(ex: IllegalArgumentException): ResponseEntity<ApiResponse<Nothing>> {
-        log.warn("IllegalArgumentException: {}", ex.message)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error("INVALID_ARGUMENT", ex.message ?: "Invalid argument"))
-    }
-
-    @ExceptionHandler(Exception::class)
-    fun handleException(ex: Exception): ResponseEntity<ApiResponse<Nothing>> {
-        log.error("UnexpectedException: {}", ex.message, ex)
-        return ResponseEntity
-            .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ApiResponse.error("INTERNAL_ERROR", "An unexpected error occurred"))
-    }
-}
+class GlobalExceptionHandler : BaseExceptionHandler()

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/exception/BaseExceptionHandler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/exception/BaseExceptionHandler.kt
@@ -1,0 +1,77 @@
+package com.nextup.infrastructure.exception
+
+import com.nextup.common.dto.ApiResponse
+import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.NotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+/**
+ * 공통 예외 처리 기본 클래스
+ *
+ * 3개 API 모듈(api, backoffice, scorer)에서 공통으로 사용되는
+ * 예외 처리 로직을 중앙화합니다.
+ * 각 모듈의 GlobalExceptionHandler는 이 클래스를 상속하여 사용하며,
+ * 모듈별 고유 예외가 있는 경우 override로 확장합니다.
+ */
+abstract class BaseExceptionHandler {
+
+    protected val log = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(NotFoundException::class)
+    fun handleNotFoundException(ex: NotFoundException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("NotFoundException: code={}, message={}", ex.code, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    @ExceptionHandler(BusinessException::class)
+    open fun handleBusinessException(ex: BusinessException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("BusinessException: code={}, message={}", ex.code, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadableException(
+        ex: HttpMessageNotReadableException,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("HttpMessageNotReadableException: {}", ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("INVALID_REQUEST", "요청 본문을 읽을 수 없습니다"))
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
+        val errors =
+            ex.bindingResult.fieldErrors
+                .joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
+        log.warn("ValidationException: {}", errors)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("VALIDATION_ERROR", errors))
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(ex: IllegalArgumentException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("IllegalArgumentException: {}", ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("INVALID_ARGUMENT", ex.message ?: "Invalid argument"))
+    }
+
+    @ExceptionHandler(Exception::class)
+    open fun handleException(ex: Exception): ResponseEntity<ApiResponse<Nothing>> {
+        log.error("UnexpectedException: {}", ex.message, ex)
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.error("INTERNAL_ERROR", "An unexpected error occurred"))
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
@@ -5,10 +5,9 @@ import com.nextup.common.exception.BusinessException
 import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.NotFoundException
+import com.nextup.infrastructure.exception.BaseExceptionHandler
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.http.converter.HttpMessageNotReadableException
-import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -16,15 +15,22 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
  * 전역 예외 핸들러
  *
  * 모든 컨트롤러에서 발생하는 예외를 처리합니다.
+ * 공통 예외 처리 로직은 BaseExceptionHandler에서 상속받으며,
+ * scorer 모듈 전용 동작을 override합니다.
  */
 @RestControllerAdvice
-class GlobalExceptionHandler {
+class GlobalExceptionHandler : BaseExceptionHandler() {
 
     /**
      * 비즈니스 예외 처리
+     *
+     * 예외 타입에 따라 HTTP 상태 코드를 결정합니다.
+     * - NotFoundException → 404
+     * - InvalidStateException / InvalidInputException → 400
+     * - 기타 BusinessException → 500
      */
     @ExceptionHandler(BusinessException::class)
-    fun handleBusinessException(ex: BusinessException): ResponseEntity<ApiResponse<Unit>> {
+    override fun handleBusinessException(ex: BusinessException): ResponseEntity<ApiResponse<Nothing>> {
         val status =
             when (ex) {
                 is NotFoundException -> HttpStatus.NOT_FOUND
@@ -38,42 +44,11 @@ class GlobalExceptionHandler {
     }
 
     /**
-     * 입력 검증 예외 처리
-     */
-    @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Unit>> {
-        val message =
-            ex.bindingResult.fieldErrors
-                .joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error("VALIDATION_ERROR", message))
-    }
-
-    /**
-     * JSON 파싱 예외 처리 (잘못된 요청 본문)
-     */
-    @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleHttpMessageNotReadable(ex: HttpMessageNotReadableException): ResponseEntity<ApiResponse<Unit>> =
-        ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error("INVALID_REQUEST_BODY", "요청 본문이 올바르지 않습니다."))
-
-    /**
-     * IllegalArgumentException 처리 (도메인 로직 검증 실패)
-     */
-    @ExceptionHandler(IllegalArgumentException::class)
-    fun handleIllegalArgumentException(ex: IllegalArgumentException): ResponseEntity<ApiResponse<Unit>> {
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error("INVALID_ARGUMENT", ex.message ?: "Invalid argument"))
-    }
-
-    /**
      * 기타 예외 처리
      */
     @ExceptionHandler(Exception::class)
-    fun handleException(ex: Exception): ResponseEntity<ApiResponse<Unit>> {
+    override fun handleException(ex: Exception): ResponseEntity<ApiResponse<Nothing>> {
+        log.error("UnexpectedException: {}", ex.message, ex)
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ApiResponse.error("INTERNAL_SERVER_ERROR", "An unexpected error occurred"))


### PR DESCRIPTION
## Summary

>- close #126
> **선행 PR**: #157 (ApiResponse → common 이동) 머지 후 이 PR을 머지해주세요.

3개 API 모듈에 동일하게 복제된 `GlobalExceptionHandler`의 공통 로직을 `nextup-infrastructure`의 `BaseExceptionHandler`로 추출합니다.

## Tasks

- `BaseExceptionHandler` 추상 클래스 생성 (nextup-infrastructure): 6개 공통 핸들러
- nextup-api: Base 상속 + API 전용 핸들러 5개 유지
- nextup-backoffice: Base 상속만 (2줄로 축소)
- nextup-scorer: Base 상속 + 2개 override (기존 테스트 보존)
- 코드 162줄 제거, 93줄 추가 (순 -69줄)

## To Reviewer

- `handleBusinessException`과 `handleException`은 `open`으로 선언하여 scorer가 override 가능
- scorer의 override는 기존 테스트의 에러 코드 기대값을 보존하기 위함
- #157 (ApiResponse common 이동) 머지 후 이 PR을 머지해야 빌드 성공