### PR TITLE
test(#124): 보안 설정 테스트 추가 (JWT, SecurityConfig, 42건)

### DIFF
--- a/nextup-api/src/test/kotlin/com/nextup/api/config/SecurityConfigUrlPatternTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/config/SecurityConfigUrlPatternTest.kt
@@ -1,0 +1,215 @@
+package com.nextup.api.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.util.AntPathMatcher
+
+/**
+ * SecurityConfig의 URL 패턴 규칙을 단위 테스트로 검증합니다.
+ *
+ * Spring 컨텍스트 없이 AntPathMatcher를 사용하여 패턴 매칭 로직을 검증합니다.
+ * 실제 SecurityFilterChain 동작은 통합 테스트에서 검증해야 하지만,
+ * URL 패턴 정의 자체의 정확성을 단위 테스트로 빠르게 검증할 수 있습니다.
+ */
+@DisplayName("SecurityConfig URL 패턴 테스트")
+class SecurityConfigUrlPatternTest {
+    private val matcher = AntPathMatcher()
+
+    // SecurityConfig에서 정의된 public 패턴 목록
+    private val publicPatterns =
+        listOf(
+            "/api/auth/**",
+            "/oauth2/**",
+            "/login/oauth2/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/actuator/health",
+        )
+
+    // GET 전용 public 패턴
+    private val publicGetPatterns =
+        listOf(
+            "/api/associations/**",
+            "/api/stats/**",
+        )
+
+    // ADMIN 전용 패턴
+    private val adminPatterns =
+        listOf(
+            "/api/admin/**",
+        )
+
+    // SCORER or ADMIN 패턴
+    private val scorerAdminPatterns =
+        listOf(
+            "/api/games/*/records/**",
+        )
+
+    private fun matchesAnyPublicPattern(url: String): Boolean = publicPatterns.any { matcher.match(it, url) }
+
+    private fun matchesAnyPublicGetPattern(url: String): Boolean = publicGetPatterns.any { matcher.match(it, url) }
+
+    private fun matchesAnyAdminPattern(url: String): Boolean = adminPatterns.any { matcher.match(it, url) }
+
+    private fun matchesAnyScorerAdminPattern(url: String): Boolean = scorerAdminPatterns.any { matcher.match(it, url) }
+
+    @Nested
+    @DisplayName("인증 엔드포인트 - public")
+    inner class AuthEndpoints {
+        @Test
+        fun `api auth 로그인 경로는 public이어야 한다`() {
+            assertThat(matchesAnyPublicPattern("/api/auth/login")).isTrue()
+        }
+
+        @Test
+        fun `api auth 회원가입 경로는 public이어야 한다`() {
+            assertThat(matchesAnyPublicPattern("/api/auth/register")).isTrue()
+        }
+
+        @Test
+        fun `api auth 토큰 갱신 경로는 public이어야 한다`() {
+            assertThat(matchesAnyPublicPattern("/api/auth/refresh")).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("OAuth2 엔드포인트 - public")
+    inner class OAuth2Endpoints {
+        @Test
+        fun `oauth2 authorization 경로는 public이어야 한다`() {
+            assertThat(matchesAnyPublicPattern("/oauth2/authorization/google")).isTrue()
+        }
+
+        @Test
+        fun `login oauth2 code 경로는 public이어야 한다`() {
+            assertThat(matchesAnyPublicPattern("/login/oauth2/code/kakao")).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("Swagger 엔드포인트 - public")
+    inner class SwaggerEndpoints {
+        @Test
+        fun `swagger ui html은 public이어야 한다`() {
+            assertThat(matchesAnyPublicPattern("/swagger-ui.html")).isTrue()
+        }
+
+        @Test
+        fun `swagger ui 경로는 public이어야 한다`() {
+            assertThat(matchesAnyPublicPattern("/swagger-ui/index.html")).isTrue()
+        }
+
+        @Test
+        fun `v3 api docs 경로는 public이어야 한다`() {
+            assertThat(matchesAnyPublicPattern("/v3/api-docs/swagger-config")).isTrue()
+        }
+
+        @Test
+        fun `swagger resources 경로는 public이어야 한다`() {
+            assertThat(matchesAnyPublicPattern("/swagger-resources/configuration/ui")).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("Actuator 엔드포인트")
+    inner class ActuatorEndpoints {
+        @Test
+        fun `actuator health는 public이어야 한다`() {
+            assertThat(matchesAnyPublicPattern("/actuator/health")).isTrue()
+        }
+
+        @Test
+        fun `actuator metrics는 public 패턴에 포함되지 않아야 한다`() {
+            // /actuator/health 만 허용, 나머지 actuator는 인증 필요
+            assertThat(matchesAnyPublicPattern("/actuator/metrics")).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("공개 조회 엔드포인트 (GET only)")
+    inner class PublicGetEndpoints {
+        @Test
+        fun `api associations 경로는 GET public 패턴에 포함된다`() {
+            assertThat(matchesAnyPublicGetPattern("/api/associations/1")).isTrue()
+        }
+
+        @Test
+        fun `api stats 경로는 GET public 패턴에 포함된다`() {
+            assertThat(matchesAnyPublicGetPattern("/api/stats/batting")).isTrue()
+        }
+
+        @Test
+        fun `api teams 경로는 GET public 패턴에 포함되지 않는다`() {
+            // /api/teams/**은 GET public 패턴 아님 - 인증 필요
+            assertThat(matchesAnyPublicGetPattern("/api/teams/1")).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("ADMIN 전용 엔드포인트")
+    inner class AdminEndpoints {
+        @Test
+        fun `api admin 경로는 ADMIN 패턴에 포함된다`() {
+            assertThat(matchesAnyAdminPattern("/api/admin/users")).isTrue()
+        }
+
+        @Test
+        fun `api admin 하위 경로도 ADMIN 패턴에 포함된다`() {
+            assertThat(matchesAnyAdminPattern("/api/admin/teams/1/promote")).isTrue()
+        }
+
+        @Test
+        fun `api auth 경로는 ADMIN 패턴에 포함되지 않는다`() {
+            assertThat(matchesAnyAdminPattern("/api/auth/login")).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("SCORER or ADMIN 전용 엔드포인트")
+    inner class ScorerAdminEndpoints {
+        @Test
+        fun `api games records 경로는 SCORER ADMIN 패턴에 포함된다`() {
+            assertThat(matchesAnyScorerAdminPattern("/api/games/123/records/batting")).isTrue()
+        }
+
+        @Test
+        fun `api games records 중첩 경로도 SCORER ADMIN 패턴에 포함된다`() {
+            assertThat(matchesAnyScorerAdminPattern("/api/games/456/records/pitching/events")).isTrue()
+        }
+
+        @Test
+        fun `api games 기본 경로는 SCORER ADMIN 패턴에 포함되지 않는다`() {
+            // /api/games/123 만으로는 records 패턴에 해당하지 않음
+            assertThat(matchesAnyScorerAdminPattern("/api/games/123")).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("보호된 엔드포인트 - 인증 필요")
+    inner class ProtectedEndpoints {
+        @Test
+        fun `api teams 경로는 어떤 public 패턴에도 해당하지 않는다`() {
+            val url = "/api/teams/1"
+            assertThat(matchesAnyPublicPattern(url)).isFalse()
+            assertThat(matchesAnyPublicGetPattern(url)).isFalse()
+        }
+
+        @Test
+        fun `api players 경로는 어떤 public 패턴에도 해당하지 않는다`() {
+            val url = "/api/players/1"
+            assertThat(matchesAnyPublicPattern(url)).isFalse()
+            assertThat(matchesAnyPublicGetPattern(url)).isFalse()
+        }
+
+        @Test
+        fun `api notifications 경로는 어떤 public 패턴에도 해당하지 않는다`() {
+            val url = "/api/notifications"
+            assertThat(matchesAnyPublicPattern(url)).isFalse()
+            assertThat(matchesAnyPublicGetPattern(url)).isFalse()
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtPropertiesTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtPropertiesTest.kt
@@ -112,4 +112,79 @@ class JwtPropertiesTest {
             assertThat(properties.issuer).isEqualTo("nextup")
         }
     }
+
+    @Nested
+    @DisplayName("커스텀 값 설정")
+    inner class CustomValues {
+        @Test
+        fun `should accept custom access token expiration`() {
+            // given
+            val customExpiration = 3_600_000L // 1시간
+
+            // when
+            val properties =
+                JwtProperties(
+                    secret = validSecret,
+                    accessTokenExpiration = customExpiration,
+                )
+
+            // then
+            assertThat(properties.accessTokenExpiration).isEqualTo(customExpiration)
+        }
+
+        @Test
+        fun `should accept custom refresh token expiration`() {
+            // given
+            val customExpiration = 86_400_000L // 1일
+
+            // when
+            val properties =
+                JwtProperties(
+                    secret = validSecret,
+                    refreshTokenExpiration = customExpiration,
+                )
+
+            // then
+            assertThat(properties.refreshTokenExpiration).isEqualTo(customExpiration)
+        }
+
+        @Test
+        fun `should accept custom issuer`() {
+            // given
+            val customIssuer = "my-custom-issuer"
+
+            // when
+            val properties =
+                JwtProperties(
+                    secret = validSecret,
+                    issuer = customIssuer,
+                )
+
+            // then
+            assertThat(properties.issuer).isEqualTo(customIssuer)
+        }
+    }
+
+    @Nested
+    @DisplayName("만료 시간 비교")
+    inner class ExpirationComparison {
+        @Test
+        fun `refresh token expiration should be longer than access token expiration`() {
+            // given
+            val properties = JwtProperties(secret = validSecret)
+
+            // then
+            assertThat(properties.refreshTokenExpiration)
+                .isGreaterThan(properties.accessTokenExpiration)
+        }
+
+        @Test
+        fun `access token expiration should be positive`() {
+            // given
+            val properties = JwtProperties(secret = validSecret)
+
+            // then
+            assertThat(properties.accessTokenExpiration).isPositive()
+        }
+    }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtTokenProviderEdgeCaseTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/jwt/JwtTokenProviderEdgeCaseTest.kt
@@ -1,0 +1,268 @@
+package com.nextup.infrastructure.security.jwt
+
+import com.nextup.common.exception.InvalidTokenException
+import com.nextup.common.exception.TokenExpiredException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * JwtTokenProvider 엣지 케이스 및 추가 시나리오 테스트
+ *
+ * 기존 JwtTokenProviderTest에서 다루지 않은 시나리오를 검증합니다:
+ * - 이메일 추출 (getEmail)
+ * - 다양한 역할 조합
+ * - 만료된 토큰에서의 다양한 메서드 호출
+ * - 토큰 타입 상호 배타성
+ */
+@DisplayName("JwtTokenProvider 엣지 케이스 테스트")
+class JwtTokenProviderEdgeCaseTest {
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private val testSecret =
+        "dGhpcyBpcyBhIHNhbXBsZSBiYXNlNjQgZW5jb2RlZCBzZWNyZXQga2V5IGZvciBkZXZlbG9wbWVudCBvbmx5"
+    private val testIssuer = "nextup"
+
+    @BeforeEach
+    fun setUp() {
+        val jwtProperties =
+            JwtProperties(
+                secret = testSecret,
+                accessTokenExpiration = 1_800_000L,
+                refreshTokenExpiration = 604_800_000L,
+                issuer = testIssuer,
+            )
+        jwtTokenProvider = JwtTokenProvider(jwtProperties)
+    }
+
+    @Nested
+    @DisplayName("이메일 추출 (getEmail)")
+    inner class GetEmail {
+        @Test
+        fun `should extract email from access token`() {
+            // given
+            val email = "user@nextup.com"
+            val token =
+                jwtTokenProvider.createAccessToken(1L, email, setOf("USER"))
+
+            // when
+            val extracted = jwtTokenProvider.getEmail(token)
+
+            // then
+            assertThat(extracted).isEqualTo(email)
+        }
+
+        @Test
+        fun `should extract email with special characters`() {
+            // given
+            val email = "user+tag@example.co.kr"
+            val token =
+                jwtTokenProvider.createAccessToken(42L, email, setOf("USER"))
+
+            // when
+            val extracted = jwtTokenProvider.getEmail(token)
+
+            // then
+            assertThat(extracted).isEqualTo(email)
+        }
+
+        @Test
+        fun `should throw TokenExpiredException when getting email from expired token`() {
+            // given
+            val expiredProperties =
+                JwtProperties(
+                    secret = testSecret,
+                    accessTokenExpiration = -1_000L,
+                    refreshTokenExpiration = 604_800_000L,
+                    issuer = testIssuer,
+                )
+            val expiredProvider = JwtTokenProvider(expiredProperties)
+            val expiredToken =
+                expiredProvider.createAccessToken(1L, "test@example.com", setOf("USER"))
+
+            // when & then
+            assertThatThrownBy {
+                jwtTokenProvider.getEmail(expiredToken)
+            }.isInstanceOf(TokenExpiredException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("역할(Role) 처리")
+    inner class RoleHandling {
+        @Test
+        fun `should handle single role correctly`() {
+            // given
+            val token =
+                jwtTokenProvider.createAccessToken(1L, "test@example.com", setOf("USER"))
+
+            // when
+            val roles = jwtTokenProvider.getRoles(token)
+
+            // then
+            assertThat(roles).containsExactly("USER")
+        }
+
+        @Test
+        fun `should handle all predefined roles`() {
+            // given
+            val allRoles = setOf("USER", "ADMIN", "SCORER", "TEAM_MANAGER", "ASSOCIATION_ADMIN")
+            val token =
+                jwtTokenProvider.createAccessToken(1L, "admin@nextup.com", allRoles)
+
+            // when
+            val extracted = jwtTokenProvider.getRoles(token)
+
+            // then
+            assertThat(extracted).containsExactlyInAnyOrderElementsOf(allRoles)
+        }
+
+        @Test
+        fun `should handle empty roles set in access token`() {
+            // given
+            val token =
+                jwtTokenProvider.createAccessToken(1L, "test@example.com", emptySet())
+
+            // when
+            val roles = jwtTokenProvider.getRoles(token)
+
+            // then
+            assertThat(roles).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("만료 토큰 처리")
+    inner class ExpiredTokenHandling {
+        private lateinit var expiredToken: String
+
+        @BeforeEach
+        fun createExpiredToken() {
+            val expiredProperties =
+                JwtProperties(
+                    secret = testSecret,
+                    accessTokenExpiration = -1_000L,
+                    refreshTokenExpiration = 604_800_000L,
+                    issuer = testIssuer,
+                )
+            val expiredProvider = JwtTokenProvider(expiredProperties)
+            expiredToken =
+                expiredProvider.createAccessToken(99L, "expired@example.com", setOf("USER"))
+        }
+
+        @Test
+        fun `should return false when validating expired token`() {
+            // when
+            val isValid = jwtTokenProvider.validateToken(expiredToken)
+
+            // then
+            assertThat(isValid).isFalse()
+        }
+
+        @Test
+        fun `should throw TokenExpiredException when extracting userId from expired token`() {
+            assertThatThrownBy {
+                jwtTokenProvider.getUserId(expiredToken)
+            }.isInstanceOf(TokenExpiredException::class.java)
+                .hasMessageContaining("expired")
+        }
+
+        @Test
+        fun `should throw TokenExpiredException when extracting roles from expired token`() {
+            assertThatThrownBy {
+                jwtTokenProvider.getRoles(expiredToken)
+            }.isInstanceOf(TokenExpiredException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 타입 상호 배타성")
+    inner class TokenTypeMutualExclusivity {
+        @Test
+        fun `access token should not be identified as refresh token`() {
+            // given
+            val accessToken =
+                jwtTokenProvider.createAccessToken(1L, "test@example.com", setOf("USER"))
+
+            // then
+            assertThat(jwtTokenProvider.isAccessToken(accessToken)).isTrue()
+            assertThat(jwtTokenProvider.isRefreshToken(accessToken)).isFalse()
+        }
+
+        @Test
+        fun `refresh token should not be identified as access token`() {
+            // given
+            val refreshToken = jwtTokenProvider.createRefreshToken(1L)
+
+            // then
+            assertThat(jwtTokenProvider.isRefreshToken(refreshToken)).isTrue()
+            assertThat(jwtTokenProvider.isAccessToken(refreshToken)).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("변조 토큰 처리")
+    inner class TamperedTokenHandling {
+        @Test
+        fun `should return false for token with tampered payload`() {
+            // given - base64 payload 부분을 변조
+            val validToken =
+                jwtTokenProvider.createAccessToken(1L, "test@example.com", setOf("USER"))
+            val parts = validToken.split(".")
+            val tamperedPayload = "eyJzdWIiOiI5OTkiLCJlbWFpbCI6ImhhY2tlckBleGFtcGxlLmNvbSJ9"
+            val tamperedToken = "${parts[0]}.$tamperedPayload.${parts[2]}"
+
+            // when
+            val isValid = jwtTokenProvider.validateToken(tamperedToken)
+
+            // then
+            assertThat(isValid).isFalse()
+        }
+
+        @Test
+        fun `should throw InvalidTokenException for null bytes in token`() {
+            // given
+            val nullToken = "\u0000\u0000\u0000"
+
+            // when & then
+            assertThatThrownBy {
+                jwtTokenProvider.getUserId(nullToken)
+            }.isInstanceOf(InvalidTokenException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("Refresh Token 만료 시간")
+    inner class RefreshTokenExpiration {
+        @Test
+        fun `should return expiration further in future for longer refresh expiration config`() {
+            // given
+            val longExpProperties =
+                JwtProperties(
+                    secret = testSecret,
+                    accessTokenExpiration = 1_800_000L,
+                    refreshTokenExpiration = 2_592_000_000L, // 30일
+                    issuer = testIssuer,
+                )
+            val longExpProvider = JwtTokenProvider(longExpProperties)
+
+            val shortExpProperties =
+                JwtProperties(
+                    secret = testSecret,
+                    accessTokenExpiration = 1_800_000L,
+                    refreshTokenExpiration = 604_800_000L, // 7일
+                    issuer = testIssuer,
+                )
+            val shortExpProvider = JwtTokenProvider(shortExpProperties)
+
+            // when
+            val longExp = longExpProvider.getRefreshTokenExpiration()
+            val shortExp = shortExpProvider.getRefreshTokenExpiration()
+
+            // then
+            assertThat(longExp).isAfter(shortExp)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #124

JWT 토큰, SecurityConfig URL 패턴, 보안 필터 등 보안 설정이 실제로 동작하는지 검증하는 테스트 42건을 추가합니다.

## Tasks

- JwtPropertiesTest (9건): 기본값, 커스텀값, 만료시간 비교
- JwtTokenProviderEdgeCaseTest (14건): 이메일 추출, 역할 처리, 만료 토큰, 변조 토큰, 토큰 타입
- SecurityConfigUrlPatternTest (19건): AntPathMatcher로 URL 패턴 규칙 검증 (public/admin/scorer/protected)

## To Reviewer

- @SpringBootTest 없이 단위테스트 수준으로 작성하여 빠른 실행
- SecurityConfig URL 패턴은 AntPathMatcher로 검증 (실제 SecurityFilterChain과 동일한 매칭 로직)
- 기존 JwtTokenProviderTest와 중복 없이 엣지케이스만 추가