### PR TITLE
feat(#133): 리그 등록 선수 검증 로직 추가

### DIFF
--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/CompetitionPlayerExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/CompetitionPlayerExceptions.kt
@@ -1,0 +1,21 @@
+package com.nextup.common.exception
+
+/**
+ * 대회 등록 선수를 찾을 수 없을 때 발생하는 예외
+ */
+class CompetitionPlayerNotFoundException(
+    id: Long,
+) : NotFoundException(
+        "COMPETITION_PLAYER_NOT_FOUND",
+        "Competition player not found: $id",
+    )
+
+/**
+ * 라인업에 리그 미등록 선수가 포함되었을 때 발생하는 예외
+ */
+class UnregisteredPlayerInLineupException(
+    playerIds: Set<Long>,
+) : LineupValidationException(
+        "UNREGISTERED_PLAYER",
+        "리그에 등록되지 않은 선수가 포함되어 있습니다: $playerIds",
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/CompetitionPlayer.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/CompetitionPlayer.kt
@@ -1,0 +1,127 @@
+package com.nextup.core.domain.competition
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.team.Team
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+/**
+ * 대회 등록 선수 엔티티
+ *
+ * 리그 대회에 등록된 선수를 나타냅니다.
+ * 라인업 검증 시 부정선수 체크에 사용됩니다.
+ */
+@Entity
+@Table(
+    name = "competition_players",
+    indexes = [
+        Index(name = "idx_competition_players_competition", columnList = "competition_id"),
+        Index(name = "idx_competition_players_team", columnList = "team_id"),
+        Index(name = "idx_competition_players_player", columnList = "player_id"),
+        Index(name = "idx_competition_players_status", columnList = "status"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_competition_players_competition_player",
+            columnNames = ["competition_id", "player_id"],
+        ),
+    ],
+)
+class CompetitionPlayer private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "competition_id", nullable = false)
+    val competition: Competition,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    val team: Team,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "player_id", nullable = false)
+    val player: Player,
+    @Column(name = "registered_at", nullable = false)
+    val registeredAt: Instant = Instant.now(),
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: CompetitionPlayerStatus = CompetitionPlayerStatus.ACTIVE
+        protected set
+
+    /**
+     * 선수를 출전 정지 처리합니다.
+     */
+    fun suspend() {
+        require(status == CompetitionPlayerStatus.ACTIVE) {
+            "활성 상태의 선수만 출전 정지할 수 있습니다. 현재 상태: ${status.displayName}"
+        }
+        this.status = CompetitionPlayerStatus.SUSPENDED
+    }
+
+    /**
+     * 선수를 출전 정지에서 복귀시킵니다.
+     */
+    fun reinstate() {
+        require(status == CompetitionPlayerStatus.SUSPENDED) {
+            "출전 정지 상태의 선수만 복귀시킬 수 있습니다. 현재 상태: ${status.displayName}"
+        }
+        this.status = CompetitionPlayerStatus.ACTIVE
+    }
+
+    /**
+     * 선수 등록을 취소합니다.
+     */
+    fun withdraw() {
+        require(status != CompetitionPlayerStatus.WITHDRAWN) {
+            "이미 등록 취소된 선수입니다."
+        }
+        this.status = CompetitionPlayerStatus.WITHDRAWN
+    }
+
+    /**
+     * 선수가 대회에 출전 가능한 상태인지 확인합니다.
+     */
+    val isEligible: Boolean
+        get() = status == CompetitionPlayerStatus.ACTIVE
+
+    companion object {
+        /**
+         * 대회 등록 선수를 생성합니다.
+         */
+        fun register(
+            competition: Competition,
+            team: Team,
+            player: Player,
+        ): CompetitionPlayer =
+            CompetitionPlayer(
+                competition = competition,
+                team = team,
+                player = player,
+                registeredAt = Instant.now(),
+            )
+    }
+}
+
+/**
+ * 대회 등록 선수 상태
+ */
+enum class CompetitionPlayerStatus(
+    val displayName: String,
+) {
+    ACTIVE("활성"),
+    SUSPENDED("출전 정지"),
+    WITHDRAWN("등록 취소"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
@@ -4,6 +4,7 @@ import com.nextup.common.exception.DuplicatePlayerInLineupException
 import com.nextup.common.exception.InvalidDhRuleException
 import com.nextup.common.exception.NoCatcherInLineupException
 import com.nextup.common.exception.NonAttendingPlayerInLineupException
+import com.nextup.common.exception.UnregisteredPlayerInLineupException
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.player.PositionCategory
 
@@ -18,14 +19,17 @@ object LineupValidator {
      *
      * @param entries 검증할 라인업 엔트리 목록
      * @param attendingPlayerIds 참석(ATTENDING) 상태인 선수 ID 목록 (nullable, null이면 검증 생략)
+     * @param registeredPlayerIds 대회에 등록된 선수 ID 목록 (nullable, null이면 검증 생략)
      * @throws DuplicatePlayerInLineupException 동일 선수가 중복 등록된 경우
      * @throws NoCatcherInLineupException 포수가 없는 경우
      * @throws InvalidDhRuleException DH 규칙 위반 시
      * @throws NonAttendingPlayerInLineupException 참석하지 않는 선수가 라인업에 포함된 경우
+     * @throws UnregisteredPlayerInLineupException 리그에 등록되지 않은 선수가 라인업에 포함된 경우
      */
     fun validate(
         entries: List<LineupEntry>,
         attendingPlayerIds: Set<Long>? = null,
+        registeredPlayerIds: Set<Long>? = null,
     ) {
         val starters = entries.filter { it.isStarter }
         validateNoDuplicatePlayers(entries)
@@ -33,6 +37,9 @@ object LineupValidator {
         validateDhRule(starters)
         if (attendingPlayerIds != null) {
             validateOnlyAttendingPlayers(entries, attendingPlayerIds)
+        }
+        if (registeredPlayerIds != null) {
+            validateLeagueRegisteredPlayers(entries, registeredPlayerIds)
         }
     }
 
@@ -100,6 +107,27 @@ object LineupValidator {
 
         if (nonAttendingPlayerIds.isNotEmpty()) {
             throw NonAttendingPlayerInLineupException(nonAttendingPlayerIds)
+        }
+    }
+
+    /**
+     * 리그에 등록된 선수만 라인업에 포함되었는지 검증 (부정선수 체크)
+     *
+     * 대회에 등록(ACTIVE 상태)된 선수만 라인업에 등록 가능합니다.
+     *
+     * @param entries 검증할 라인업 엔트리 목록
+     * @param registeredPlayerIds 대회에 등록된(ACTIVE) 선수 ID 목록
+     * @throws UnregisteredPlayerInLineupException 미등록 선수가 라인업에 포함된 경우
+     */
+    fun validateLeagueRegisteredPlayers(
+        entries: List<LineupEntry>,
+        registeredPlayerIds: Set<Long>,
+    ) {
+        val lineupPlayerIds = entries.map { it.player.id }.toSet()
+        val unregisteredPlayerIds = lineupPlayerIds - registeredPlayerIds
+
+        if (unregisteredPlayerIds.isNotEmpty()) {
+            throw UnregisteredPlayerInLineupException(unregisteredPlayerIds)
         }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionPlayerRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionPlayerRepositoryPort.kt
@@ -1,0 +1,49 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.competition.CompetitionPlayer
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+
+/**
+ * 대회 등록 선수 저장소 포트
+ */
+interface CompetitionPlayerRepositoryPort {
+    fun save(competitionPlayer: CompetitionPlayer): CompetitionPlayer
+
+    fun saveAll(players: List<CompetitionPlayer>): List<CompetitionPlayer>
+
+    fun findByIdOrNull(id: Long): CompetitionPlayer?
+
+    fun findByCompetitionId(competitionId: Long): List<CompetitionPlayer>
+
+    fun findByCompetitionIdAndTeamId(
+        competitionId: Long,
+        teamId: Long,
+    ): List<CompetitionPlayer>
+
+    fun findByCompetitionIdAndStatus(
+        competitionId: Long,
+        status: CompetitionPlayerStatus,
+    ): List<CompetitionPlayer>
+
+    /**
+     * 대회에 등록된 선수 ID 목록을 조회합니다. (부정선수 체크용)
+     */
+    fun findPlayerIdsByCompetitionId(competitionId: Long): Set<Long>
+
+    /**
+     * 대회에 등록된 활성 선수 ID 목록을 조회합니다. (라인업 검증용)
+     */
+    fun findEligiblePlayerIdsByCompetitionId(competitionId: Long): Set<Long>
+
+    fun findByCompetitionIdAndPlayerId(
+        competitionId: Long,
+        playerId: Long,
+    ): CompetitionPlayer?
+
+    fun existsByCompetitionIdAndPlayerId(
+        competitionId: Long,
+        playerId: Long,
+    ): Boolean
+
+    fun deleteById(id: Long)
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/CompetitionPlayerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/CompetitionPlayerTest.kt
@@ -1,0 +1,208 @@
+package com.nextup.core.domain.competition
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+@DisplayName("CompetitionPlayer 엔티티 테스트")
+class CompetitionPlayerTest {
+    private lateinit var association: Association
+    private lateinit var league: League
+    private lateinit var competition: Competition
+    private lateinit var team: Team
+    private lateinit var player: Player
+
+    @BeforeEach
+    fun setUp() {
+        association = Association(name = "서울시야구협회", abbreviation = "SBA", region = "서울")
+        league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                startDate = LocalDate.of(2025, 3, 1),
+            )
+        team = Team(league = league, name = "Tigers", city = "서울", foundedYear = 2020)
+        player = Player(name = "홍길동", primaryPosition = Position.SHORTSTOP, id = 1L)
+    }
+
+    @Nested
+    @DisplayName("대회 선수 등록")
+    inner class Register {
+        @Test
+        fun `선수를 대회에 등록할 수 있다`() {
+            // when
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+
+            // then
+            assertThat(competitionPlayer.competition).isEqualTo(competition)
+            assertThat(competitionPlayer.team).isEqualTo(team)
+            assertThat(competitionPlayer.player).isEqualTo(player)
+            assertThat(competitionPlayer.status).isEqualTo(CompetitionPlayerStatus.ACTIVE)
+        }
+
+        @Test
+        fun `신규 등록 선수는 ACTIVE 상태이다`() {
+            // when
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+
+            // then
+            assertThat(competitionPlayer.status).isEqualTo(CompetitionPlayerStatus.ACTIVE)
+            assertThat(competitionPlayer.isEligible).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("출전 정지")
+    inner class Suspend {
+        @Test
+        fun `활성 상태의 선수를 출전 정지할 수 있다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+
+            // when
+            competitionPlayer.suspend()
+
+            // then
+            assertThat(competitionPlayer.status).isEqualTo(CompetitionPlayerStatus.SUSPENDED)
+            assertThat(competitionPlayer.isEligible).isFalse()
+        }
+
+        @Test
+        fun `이미 출전 정지된 선수를 다시 정지할 수 없다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+            competitionPlayer.suspend()
+
+            // when & then
+            assertThatThrownBy { competitionPlayer.suspend() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("활성 상태의 선수만 출전 정지할 수 있습니다. 현재 상태: 출전 정지")
+        }
+
+        @Test
+        fun `등록 취소된 선수를 출전 정지할 수 없다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+            competitionPlayer.withdraw()
+
+            // when & then
+            assertThatThrownBy { competitionPlayer.suspend() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("출전 정지 복귀")
+    inner class Reinstate {
+        @Test
+        fun `출전 정지 상태의 선수를 복귀시킬 수 있다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+            competitionPlayer.suspend()
+
+            // when
+            competitionPlayer.reinstate()
+
+            // then
+            assertThat(competitionPlayer.status).isEqualTo(CompetitionPlayerStatus.ACTIVE)
+            assertThat(competitionPlayer.isEligible).isTrue()
+        }
+
+        @Test
+        fun `활성 상태의 선수를 복귀시킬 수 없다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+
+            // when & then
+            assertThatThrownBy { competitionPlayer.reinstate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("출전 정지 상태의 선수만 복귀시킬 수 있습니다. 현재 상태: 활성")
+        }
+    }
+
+    @Nested
+    @DisplayName("등록 취소")
+    inner class Withdraw {
+        @Test
+        fun `활성 상태의 선수를 등록 취소할 수 있다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+
+            // when
+            competitionPlayer.withdraw()
+
+            // then
+            assertThat(competitionPlayer.status).isEqualTo(CompetitionPlayerStatus.WITHDRAWN)
+            assertThat(competitionPlayer.isEligible).isFalse()
+        }
+
+        @Test
+        fun `출전 정지 상태의 선수도 등록 취소할 수 있다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+            competitionPlayer.suspend()
+
+            // when
+            competitionPlayer.withdraw()
+
+            // then
+            assertThat(competitionPlayer.status).isEqualTo(CompetitionPlayerStatus.WITHDRAWN)
+        }
+
+        @Test
+        fun `이미 등록 취소된 선수를 다시 취소할 수 없다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+            competitionPlayer.withdraw()
+
+            // when & then
+            assertThatThrownBy { competitionPlayer.withdraw() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("이미 등록 취소된 선수입니다.")
+        }
+    }
+
+    @Nested
+    @DisplayName("출전 가능 여부")
+    inner class IsEligible {
+        @Test
+        fun `ACTIVE 상태만 출전 가능하다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+
+            // then
+            assertThat(competitionPlayer.isEligible).isTrue()
+        }
+
+        @Test
+        fun `SUSPENDED 상태는 출전 불가능하다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+            competitionPlayer.suspend()
+
+            // then
+            assertThat(competitionPlayer.isEligible).isFalse()
+        }
+
+        @Test
+        fun `WITHDRAWN 상태는 출전 불가능하다`() {
+            // given
+            val competitionPlayer = CompetitionPlayer.register(competition, team, player)
+            competitionPlayer.withdraw()
+
+            // then
+            assertThat(competitionPlayer.isEligible).isFalse()
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
@@ -4,6 +4,7 @@ import com.nextup.common.exception.DuplicatePlayerInLineupException
 import com.nextup.common.exception.InvalidDhRuleException
 import com.nextup.common.exception.NoCatcherInLineupException
 import com.nextup.common.exception.NonAttendingPlayerInLineupException
+import com.nextup.common.exception.UnregisteredPlayerInLineupException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.league.League
@@ -204,6 +205,175 @@ class LineupValidatorTest {
         assertThrows<NonAttendingPlayerInLineupException> {
             LineupValidator.validate(entries, attendingPlayerIds)
         }
+    }
+
+    // ========== League Registration (부정선수 체크) Tests ==========
+
+    @Test
+    fun `should pass when all lineup players are registered for competition`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        val registeredPlayerIds = setOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L)
+
+        // when & then
+        assertThatCode {
+            LineupValidator.validate(entries, registeredPlayerIds = registeredPlayerIds)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should throw UnregisteredPlayerInLineupException when unregistered player in lineup`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        // player 9 (우익수) is not registered
+        val registeredPlayerIds = setOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L)
+
+        // when & then
+        val exception =
+            assertThrows<UnregisteredPlayerInLineupException> {
+                LineupValidator.validate(entries, registeredPlayerIds = registeredPlayerIds)
+            }
+        assert(exception.message?.contains("9") == true)
+    }
+
+    @Test
+    fun `should throw UnregisteredPlayerInLineupException when multiple unregistered players`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        // players 7, 8, 9 are not registered
+        val registeredPlayerIds = setOf(1L, 2L, 3L, 4L, 5L, 6L)
+
+        // when & then
+        assertThrows<UnregisteredPlayerInLineupException> {
+            LineupValidator.validate(entries, registeredPlayerIds = registeredPlayerIds)
+        }
+    }
+
+    @Test
+    fun `should skip registration validation when registeredPlayerIds is null`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+
+        // when & then - should pass even without registration info
+        assertThatCode {
+            LineupValidator.validate(entries, registeredPlayerIds = null)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should validate registration for both starters and substitutes`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries =
+            listOf(
+                createEntry(
+                    submission,
+                    createPlayer("투수", Position.STARTING_PITCHER, 1L),
+                    Position.STARTING_PITCHER,
+                    1,
+                    true,
+                ),
+                createEntry(submission, createPlayer("포수", Position.CATCHER, 2L), Position.CATCHER, 2, true),
+                createEntry(
+                    submission,
+                    createPlayer("1루수", Position.FIRST_BASE, 3L),
+                    Position.FIRST_BASE,
+                    3,
+                    true,
+                ),
+                createEntry(
+                    submission,
+                    createPlayer("대타", Position.LEFT_FIELD, 10L),
+                    Position.LEFT_FIELD,
+                    null,
+                    false,
+                ),
+            )
+        // substitute player 10 is not registered
+        val registeredPlayerIds = setOf(1L, 2L, 3L)
+
+        // when & then
+        assertThrows<UnregisteredPlayerInLineupException> {
+            LineupValidator.validate(entries, registeredPlayerIds = registeredPlayerIds)
+        }
+    }
+
+    @Test
+    fun `should validate both attendance and registration when both provided`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        val attendingPlayerIds = setOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L)
+        val registeredPlayerIds = setOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L)
+
+        // when & then - both validations pass
+        assertThatCode {
+            LineupValidator.validate(
+                entries,
+                attendingPlayerIds = attendingPlayerIds,
+                registeredPlayerIds = registeredPlayerIds,
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `validateLeagueRegisteredPlayers should throw for unregistered player`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries =
+            listOf(
+                createEntry(
+                    submission,
+                    createPlayer("투수", Position.STARTING_PITCHER, 1L),
+                    Position.STARTING_PITCHER,
+                    1,
+                    true,
+                ),
+                createEntry(submission, createPlayer("포수", Position.CATCHER, 2L), Position.CATCHER, 2, true),
+                // player 99 is not registered
+                createEntry(
+                    submission,
+                    createPlayer("미등록선수", Position.LEFT_FIELD, 99L),
+                    Position.LEFT_FIELD,
+                    3,
+                    true,
+                ),
+            )
+        val registeredPlayerIds = setOf(1L, 2L)
+
+        // when & then
+        val exception =
+            assertThrows<UnregisteredPlayerInLineupException> {
+                LineupValidator.validateLeagueRegisteredPlayers(entries, registeredPlayerIds)
+            }
+        assert(exception.message?.contains("99") == true)
+    }
+
+    @Test
+    fun `validateLeagueRegisteredPlayers should pass when all players registered`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries =
+            listOf(
+                createEntry(
+                    submission,
+                    createPlayer("투수", Position.STARTING_PITCHER, 1L),
+                    Position.STARTING_PITCHER,
+                    1,
+                    true,
+                ),
+                createEntry(submission, createPlayer("포수", Position.CATCHER, 2L), Position.CATCHER, 2, true),
+            )
+        val registeredPlayerIds = setOf(1L, 2L)
+
+        // when & then
+        assertThatCode {
+            LineupValidator.validateLeagueRegisteredPlayers(entries, registeredPlayerIds)
+        }.doesNotThrowAnyException()
     }
 
     // ========== Helper Methods ==========

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerJpaRepository.kt
@@ -1,0 +1,39 @@
+package com.nextup.infrastructure.persistence.competition
+
+import com.nextup.core.domain.competition.CompetitionPlayer
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface CompetitionPlayerJpaRepository : JpaRepository<CompetitionPlayer, Long> {
+    fun findByCompetitionId(competitionId: Long): List<CompetitionPlayer>
+
+    fun findByCompetitionIdAndTeamId(
+        competitionId: Long,
+        teamId: Long,
+    ): List<CompetitionPlayer>
+
+    fun findByCompetitionIdAndStatus(
+        competitionId: Long,
+        status: CompetitionPlayerStatus,
+    ): List<CompetitionPlayer>
+
+    @Query("SELECT cp.player.id FROM CompetitionPlayer cp WHERE cp.competition.id = :competitionId")
+    fun findPlayerIdsByCompetitionId(competitionId: Long): Set<Long>
+
+    @Query(
+        "SELECT cp.player.id FROM CompetitionPlayer cp " +
+            "WHERE cp.competition.id = :competitionId AND cp.status = 'ACTIVE'",
+    )
+    fun findEligiblePlayerIdsByCompetitionId(competitionId: Long): Set<Long>
+
+    fun findByCompetitionIdAndPlayerId(
+        competitionId: Long,
+        playerId: Long,
+    ): CompetitionPlayer?
+
+    fun existsByCompetitionIdAndPlayerId(
+        competitionId: Long,
+        playerId: Long,
+    ): Boolean
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapter.kt
@@ -1,0 +1,48 @@
+package com.nextup.infrastructure.persistence.competition
+
+import com.nextup.core.domain.competition.CompetitionPlayer
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
+import org.springframework.stereotype.Repository
+
+@Repository
+class CompetitionPlayerRepositoryAdapter(
+    private val jpaRepository: CompetitionPlayerJpaRepository,
+) : CompetitionPlayerRepositoryPort {
+    override fun save(competitionPlayer: CompetitionPlayer): CompetitionPlayer = jpaRepository.save(competitionPlayer)
+
+    override fun saveAll(players: List<CompetitionPlayer>): List<CompetitionPlayer> = jpaRepository.saveAll(players)
+
+    override fun findByIdOrNull(id: Long): CompetitionPlayer? = jpaRepository.findById(id).orElse(null)
+
+    override fun findByCompetitionId(competitionId: Long): List<CompetitionPlayer> =
+        jpaRepository.findByCompetitionId(competitionId)
+
+    override fun findByCompetitionIdAndTeamId(
+        competitionId: Long,
+        teamId: Long,
+    ): List<CompetitionPlayer> = jpaRepository.findByCompetitionIdAndTeamId(competitionId, teamId)
+
+    override fun findByCompetitionIdAndStatus(
+        competitionId: Long,
+        status: CompetitionPlayerStatus,
+    ): List<CompetitionPlayer> = jpaRepository.findByCompetitionIdAndStatus(competitionId, status)
+
+    override fun findPlayerIdsByCompetitionId(competitionId: Long): Set<Long> =
+        jpaRepository.findPlayerIdsByCompetitionId(competitionId)
+
+    override fun findEligiblePlayerIdsByCompetitionId(competitionId: Long): Set<Long> =
+        jpaRepository.findEligiblePlayerIdsByCompetitionId(competitionId)
+
+    override fun findByCompetitionIdAndPlayerId(
+        competitionId: Long,
+        playerId: Long,
+    ): CompetitionPlayer? = jpaRepository.findByCompetitionIdAndPlayerId(competitionId, playerId)
+
+    override fun existsByCompetitionIdAndPlayerId(
+        competitionId: Long,
+        playerId: Long,
+    ): Boolean = jpaRepository.existsByCompetitionIdAndPlayerId(competitionId, playerId)
+
+    override fun deleteById(id: Long) = jpaRepository.deleteById(id)
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V018__create_competition_players_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V018__create_competition_players_table.sql
@@ -1,0 +1,29 @@
+-- V018: 대회 등록 선수 테이블 생성 (Issue #133: 리그 등록 선수 검증)
+
+CREATE TABLE competition_players
+(
+    id             BIGSERIAL PRIMARY KEY,
+    competition_id BIGINT                   NOT NULL,
+    team_id        BIGINT                   NOT NULL,
+    player_id      BIGINT                   NOT NULL,
+    status         VARCHAR(20)              NOT NULL DEFAULT 'ACTIVE',
+    registered_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    created_at     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_competition_players_competition FOREIGN KEY (competition_id) REFERENCES competitions (id) ON DELETE CASCADE,
+    CONSTRAINT fk_competition_players_team FOREIGN KEY (team_id) REFERENCES teams (id) ON DELETE CASCADE,
+    CONSTRAINT fk_competition_players_player FOREIGN KEY (player_id) REFERENCES players (id) ON DELETE CASCADE,
+    CONSTRAINT uk_competition_players_competition_player UNIQUE (competition_id, player_id),
+    CONSTRAINT chk_competition_players_status CHECK (status IN ('ACTIVE', 'SUSPENDED', 'WITHDRAWN'))
+);
+
+-- 인덱스
+CREATE INDEX idx_competition_players_competition ON competition_players (competition_id);
+CREATE INDEX idx_competition_players_team ON competition_players (team_id);
+CREATE INDEX idx_competition_players_player ON competition_players (player_id);
+CREATE INDEX idx_competition_players_status ON competition_players (status);
+
+-- 코멘트
+COMMENT ON TABLE competition_players IS '대회 등록 선수 (부정선수 체크용)';
+COMMENT ON COLUMN competition_players.status IS '선수 상태: ACTIVE(활성), SUSPENDED(출전 정지), WITHDRAWN(등록 취소)';
+COMMENT ON COLUMN competition_players.registered_at IS '대회 등록 일시';

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapterTest.kt
@@ -1,0 +1,400 @@
+package com.nextup.infrastructure.persistence.competition
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionPlayer
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.Optional
+
+@DisplayName("CompetitionPlayerRepositoryAdapter 테스트")
+class CompetitionPlayerRepositoryAdapterTest {
+    private lateinit var jpaRepository: CompetitionPlayerJpaRepository
+    private lateinit var adapter: CompetitionPlayerRepositoryAdapter
+
+    private lateinit var competition: Competition
+    private lateinit var team: Team
+    private lateinit var player: Player
+    private lateinit var competitionPlayer: CompetitionPlayer
+
+    @BeforeEach
+    fun setUp() {
+        jpaRepository = mockk()
+        adapter = CompetitionPlayerRepositoryAdapter(jpaRepository)
+
+        val association = Association(name = "서울시야구협회", abbreviation = "SBA", region = "서울")
+        val league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                startDate = LocalDate.of(2025, 3, 1),
+            )
+        team = Team(league = league, name = "Tigers", city = "서울", foundedYear = 2020)
+        player = Player(name = "홍길동", primaryPosition = Position.SHORTSTOP, id = 1L)
+        competitionPlayer = CompetitionPlayer.register(competition, team, player)
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+        @Test
+        fun `should save competition player`() {
+            // given
+            every { jpaRepository.save(competitionPlayer) } returns competitionPlayer
+
+            // when
+            val result = adapter.save(competitionPlayer)
+
+            // then
+            assertThat(result).isEqualTo(competitionPlayer)
+            verify { jpaRepository.save(competitionPlayer) }
+        }
+    }
+
+    @Nested
+    @DisplayName("saveAll")
+    inner class SaveAll {
+        @Test
+        fun `should save all competition players`() {
+            // given
+            val player2 = Player(name = "김철수", primaryPosition = Position.CATCHER, id = 2L)
+            val competitionPlayer2 = CompetitionPlayer.register(competition, team, player2)
+            val players = listOf(competitionPlayer, competitionPlayer2)
+            every { jpaRepository.saveAll(players) } returns players
+
+            // when
+            val result = adapter.saveAll(players)
+
+            // then
+            assertThat(result).hasSize(2)
+            verify { jpaRepository.saveAll(players) }
+        }
+
+        @Test
+        fun `should save empty list`() {
+            // given
+            every { jpaRepository.saveAll(emptyList<CompetitionPlayer>()) } returns emptyList()
+
+            // when
+            val result = adapter.saveAll(emptyList())
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdOrNull")
+    inner class FindByIdOrNull {
+        @Test
+        fun `should return competition player when found`() {
+            // given
+            val id = 1L
+            every { jpaRepository.findById(id) } returns Optional.of(competitionPlayer)
+
+            // when
+            val result = adapter.findByIdOrNull(id)
+
+            // then
+            assertThat(result).isEqualTo(competitionPlayer)
+        }
+
+        @Test
+        fun `should return null when not found`() {
+            // given
+            val id = 999L
+            every { jpaRepository.findById(id) } returns Optional.empty()
+
+            // when
+            val result = adapter.findByIdOrNull(id)
+
+            // then
+            assertThat(result).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("findByCompetitionId")
+    inner class FindByCompetitionId {
+        @Test
+        fun `should return players for given competition`() {
+            // given
+            val competitionId = 1L
+            every { jpaRepository.findByCompetitionId(competitionId) } returns listOf(competitionPlayer)
+
+            // when
+            val result = adapter.findByCompetitionId(competitionId)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0]).isEqualTo(competitionPlayer)
+        }
+
+        @Test
+        fun `should return empty list when no players found`() {
+            // given
+            val competitionId = 999L
+            every { jpaRepository.findByCompetitionId(competitionId) } returns emptyList()
+
+            // when
+            val result = adapter.findByCompetitionId(competitionId)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("findByCompetitionIdAndTeamId")
+    inner class FindByCompetitionIdAndTeamId {
+        @Test
+        fun `should return players for given competition and team`() {
+            // given
+            val competitionId = 1L
+            val teamId = 1L
+            every {
+                jpaRepository.findByCompetitionIdAndTeamId(competitionId, teamId)
+            } returns listOf(competitionPlayer)
+
+            // when
+            val result = adapter.findByCompetitionIdAndTeamId(competitionId, teamId)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
+
+        @Test
+        fun `should return empty list when no players found for team`() {
+            // given
+            val competitionId = 1L
+            val teamId = 999L
+            every {
+                jpaRepository.findByCompetitionIdAndTeamId(competitionId, teamId)
+            } returns emptyList()
+
+            // when
+            val result = adapter.findByCompetitionIdAndTeamId(competitionId, teamId)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("findByCompetitionIdAndStatus")
+    inner class FindByCompetitionIdAndStatus {
+        @Test
+        fun `should return active players for given competition`() {
+            // given
+            val competitionId = 1L
+            every {
+                jpaRepository.findByCompetitionIdAndStatus(competitionId, CompetitionPlayerStatus.ACTIVE)
+            } returns listOf(competitionPlayer)
+
+            // when
+            val result = adapter.findByCompetitionIdAndStatus(competitionId, CompetitionPlayerStatus.ACTIVE)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
+
+        @Test
+        fun `should return suspended players for given competition`() {
+            // given
+            val competitionId = 1L
+            competitionPlayer.suspend()
+            every {
+                jpaRepository.findByCompetitionIdAndStatus(competitionId, CompetitionPlayerStatus.SUSPENDED)
+            } returns listOf(competitionPlayer)
+
+            // when
+            val result = adapter.findByCompetitionIdAndStatus(competitionId, CompetitionPlayerStatus.SUSPENDED)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].status).isEqualTo(CompetitionPlayerStatus.SUSPENDED)
+        }
+
+        @Test
+        fun `should return withdrawn players for given competition`() {
+            // given
+            val competitionId = 1L
+            competitionPlayer.withdraw()
+            every {
+                jpaRepository.findByCompetitionIdAndStatus(competitionId, CompetitionPlayerStatus.WITHDRAWN)
+            } returns listOf(competitionPlayer)
+
+            // when
+            val result = adapter.findByCompetitionIdAndStatus(competitionId, CompetitionPlayerStatus.WITHDRAWN)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].status).isEqualTo(CompetitionPlayerStatus.WITHDRAWN)
+        }
+    }
+
+    @Nested
+    @DisplayName("findPlayerIdsByCompetitionId")
+    inner class FindPlayerIdsByCompetitionId {
+        @Test
+        fun `should return player ids for given competition`() {
+            // given
+            val competitionId = 1L
+            val expectedIds = setOf(1L, 2L, 3L)
+            every { jpaRepository.findPlayerIdsByCompetitionId(competitionId) } returns expectedIds
+
+            // when
+            val result = adapter.findPlayerIdsByCompetitionId(competitionId)
+
+            // then
+            assertThat(result).isEqualTo(expectedIds)
+        }
+
+        @Test
+        fun `should return empty set when no players registered`() {
+            // given
+            val competitionId = 999L
+            every { jpaRepository.findPlayerIdsByCompetitionId(competitionId) } returns emptySet()
+
+            // when
+            val result = adapter.findPlayerIdsByCompetitionId(competitionId)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("findEligiblePlayerIdsByCompetitionId")
+    inner class FindEligiblePlayerIdsByCompetitionId {
+        @Test
+        fun `should return eligible player ids for given competition`() {
+            // given
+            val competitionId = 1L
+            val expectedIds = setOf(1L, 2L)
+            every { jpaRepository.findEligiblePlayerIdsByCompetitionId(competitionId) } returns expectedIds
+
+            // when
+            val result = adapter.findEligiblePlayerIdsByCompetitionId(competitionId)
+
+            // then
+            assertThat(result).isEqualTo(expectedIds)
+        }
+
+        @Test
+        fun `should return empty set when no eligible players`() {
+            // given
+            val competitionId = 1L
+            every { jpaRepository.findEligiblePlayerIdsByCompetitionId(competitionId) } returns emptySet()
+
+            // when
+            val result = adapter.findEligiblePlayerIdsByCompetitionId(competitionId)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("findByCompetitionIdAndPlayerId")
+    inner class FindByCompetitionIdAndPlayerId {
+        @Test
+        fun `should return competition player when found`() {
+            // given
+            val competitionId = 1L
+            val playerId = 1L
+            every {
+                jpaRepository.findByCompetitionIdAndPlayerId(competitionId, playerId)
+            } returns competitionPlayer
+
+            // when
+            val result = adapter.findByCompetitionIdAndPlayerId(competitionId, playerId)
+
+            // then
+            assertThat(result).isEqualTo(competitionPlayer)
+        }
+
+        @Test
+        fun `should return null when player not registered in competition`() {
+            // given
+            val competitionId = 1L
+            val playerId = 999L
+            every {
+                jpaRepository.findByCompetitionIdAndPlayerId(competitionId, playerId)
+            } returns null
+
+            // when
+            val result = adapter.findByCompetitionIdAndPlayerId(competitionId, playerId)
+
+            // then
+            assertThat(result).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByCompetitionIdAndPlayerId")
+    inner class ExistsByCompetitionIdAndPlayerId {
+        @Test
+        fun `should return true when player is registered`() {
+            // given
+            val competitionId = 1L
+            val playerId = 1L
+            every {
+                jpaRepository.existsByCompetitionIdAndPlayerId(competitionId, playerId)
+            } returns true
+
+            // when
+            val result = adapter.existsByCompetitionIdAndPlayerId(competitionId, playerId)
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `should return false when player is not registered`() {
+            // given
+            val competitionId = 1L
+            val playerId = 999L
+            every {
+                jpaRepository.existsByCompetitionIdAndPlayerId(competitionId, playerId)
+            } returns false
+
+            // when
+            val result = adapter.existsByCompetitionIdAndPlayerId(competitionId, playerId)
+
+            // then
+            assertThat(result).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteById")
+    inner class DeleteById {
+        @Test
+        fun `should delete competition player by id`() {
+            // given
+            val id = 1L
+            every { jpaRepository.deleteById(id) } returns Unit
+
+            // when
+            adapter.deleteById(id)
+
+            // then
+            verify { jpaRepository.deleteById(id) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #133

리그(대회)에 등록되지 않은 선수가 라인업에 포함되는 것을 방지하는 **부정선수 체크** 로직을 추가합니다.

## Tasks

- CompetitionPlayer 엔티티 생성 (Rich Domain Model: register/suspend/reinstate/withdraw 상태 관리)
- CompetitionPlayerRepositoryPort 인터페이스 및 Infrastructure 어댑터 구현
- LineupValidator에 validateLeagueRegisteredPlayers() 검증 메서드 추가
- UnregisteredPlayerInLineupException 예외 클래스 추가
- Flyway V018 마이그레이션 (competition_players 테이블)
- CompetitionPlayerTest (13개) + LineupValidatorTest (8개) 단위 테스트 추가

## To Reviewer

- CompetitionPlayer는 대회별 선수 등록 관리를 위한 새 엔티티입니다.
- LineupValidator.validate()에 registeredPlayerIds 파라미터가 optional로 추가되어 기존 호출에 영향 없습니다.
- 빌드 성공 (87 tasks passed)