### PR TITLE
feat(#136): 비상대책위원회 모드 및 긴급 선거 추가

### DIFF
--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/ElectionExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/ElectionExceptions.kt
@@ -27,3 +27,35 @@ class DuplicateVoteException(
     code: String = "DUPLICATE_VOTE",
     message: String = "User has already voted in this election",
 ) : BusinessException(code, message)
+
+/**
+ * 긴급 선거 발동 권한이 없을 때 발생하는 예외
+ * MANAGER 역할이 아닌 멤버가 긴급 선거를 발동하려 할 때 발생합니다.
+ */
+class UnauthorizedEmergencyElectionException(
+    memberId: Long,
+) : ForbiddenException(
+        code = "UNAUTHORIZED_EMERGENCY_ELECTION",
+        message = "Member $memberId does not have MANAGER role to trigger emergency election",
+    )
+
+/**
+ * 이미 진행 중인 선거가 있을 때 발생하는 예외
+ */
+class ActiveElectionAlreadyExistsException(
+    teamId: Long,
+) : InvalidStateException(
+        code = "ACTIVE_ELECTION_ALREADY_EXISTS",
+        message = "Team $teamId already has an active election in progress",
+    )
+
+/**
+ * 임시 구단주 지정 대상이 유효하지 않을 때 발생하는 예외
+ * MANAGER 역할이 아닌 멤버를 임시 구단주로 지정하려 할 때 발생합니다.
+ */
+class InvalidActingOwnerException(
+    memberId: Long,
+) : InvalidInputException(
+        code = "INVALID_ACTING_OWNER",
+        message = "Member $memberId is not eligible to be designated as acting owner (must be MANAGER role)",
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/election/ActingOwnerPermissions.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/election/ActingOwnerPermissions.kt
@@ -1,0 +1,33 @@
+package com.nextup.core.domain.election
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+/**
+ * 임시 구단주(Acting Owner) 권한 Value Object
+ *
+ * 비상대책위원회 모드에서 임시 구단주에게 부여되는 제한된 권한을 정의합니다.
+ * 임시 구단주는 라인업/일정 관리는 가능하나 강퇴/해산/소유권 이전은 불가합니다.
+ */
+@Embeddable
+data class ActingOwnerPermissions(
+    @Column(name = "can_manage_lineup", nullable = false)
+    val canManageLineup: Boolean = true,
+    @Column(name = "can_manage_schedule", nullable = false)
+    val canManageSchedule: Boolean = true,
+    @Column(name = "can_kick_member", nullable = false)
+    val canKickMember: Boolean = false,
+    @Column(name = "can_dissolve_team", nullable = false)
+    val canDissolveTeam: Boolean = false,
+    @Column(name = "can_transfer_ownership", nullable = false)
+    val canTransferOwnership: Boolean = false,
+) {
+    companion object {
+        /**
+         * 기본 임시 구단주 권한을 생성합니다.
+         *
+         * 라인업/일정 관리 가능, 강퇴/해산/소유권 이전 불가.
+         */
+        fun default(): ActingOwnerPermissions = ActingOwnerPermissions()
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/election/Election.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/election/Election.kt
@@ -3,11 +3,13 @@ package com.nextup.core.domain.election
 import com.nextup.core.common.BaseTimeEntity
 import jakarta.persistence.*
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 /**
  * 선거 엔티티
  *
  * 팀 내에서 진행되는 선거/투표를 나타냅니다.
+ * EMERGENCY 타입의 경우 임시 구단주(Acting Owner) 지정 및 14일 이내 정규 선거 자동 생성을 지원합니다.
  */
 @Entity
 @Table(
@@ -36,6 +38,18 @@ class Election private constructor(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
     var status: ElectionStatus = ElectionStatus.SCHEDULED,
+    /** 비상대책위원회 모드: 긴급 선거를 발동한 MANAGER 멤버 ID */
+    @Column(name = "triggered_by_member_id")
+    val triggeredByMemberId: Long? = null,
+    /** 비상대책위원회 모드: 임시 구단주로 지정된 멤버 ID */
+    @Column(name = "acting_owner_member_id")
+    var actingOwnerMemberId: Long? = null,
+    /** 비상대책위원회 모드: 임시 구단주 권한 */
+    @Embedded
+    var actingOwnerPermissions: ActingOwnerPermissions? = null,
+    /** 비상대책위원회 모드: 정규 선거 마감 기한 (긴급 선거 발동 후 14일) */
+    @Column(name = "regular_election_deadline")
+    val regularElectionDeadline: Instant? = null,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
@@ -84,6 +98,38 @@ class Election private constructor(
         status = ElectionStatus.CANCELLED
     }
 
+    /**
+     * 긴급 선거인지 확인합니다.
+     */
+    fun isEmergency(): Boolean = electionType == ElectionType.EMERGENCY
+
+    /**
+     * 임시 구단주가 지정되었는지 확인합니다.
+     */
+    fun hasActingOwner(): Boolean = actingOwnerMemberId != null
+
+    /**
+     * 임시 구단주를 지정합니다.
+     *
+     * 긴급 선거(EMERGENCY) 상태에서만 가능하며, 대상은 MANAGER 역할의 멤버여야 합니다.
+     *
+     * @param memberId 임시 구단주로 지정할 멤버 ID
+     * @throws IllegalStateException 긴급 선거가 아니거나 이미 임시 구단주가 지정된 경우
+     */
+    fun designateActingOwner(memberId: Long) {
+        require(isEmergency()) {
+            "임시 구단주 지정은 긴급 선거(EMERGENCY)에서만 가능합니다."
+        }
+        require(status == ElectionStatus.IN_PROGRESS || status == ElectionStatus.SCHEDULED) {
+            "Cannot designate acting owner: current status is $status"
+        }
+        require(!hasActingOwner()) {
+            "이미 임시 구단주(memberId=$actingOwnerMemberId)가 지정되어 있습니다."
+        }
+        actingOwnerMemberId = memberId
+        actingOwnerPermissions = ActingOwnerPermissions.default()
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Election) return false
@@ -97,6 +143,9 @@ class Election private constructor(
         "Election(id=$id, teamId=$teamId, title='$title', type=$electionType, status=$status)"
 
     companion object {
+        /** 정규 선거 마감 기한 (긴급 선거 발동 후 일수) */
+        const val REGULAR_ELECTION_DEADLINE_DAYS = 14L
+
         /**
          * Election을 생성합니다.
          *
@@ -129,6 +178,51 @@ class Election private constructor(
                 electionType = electionType,
                 startAt = startAt,
                 endAt = endAt,
+            )
+        }
+
+        /**
+         * 긴급 선거(비상대책위원회 모드)를 생성합니다.
+         *
+         * MANAGER 역할 멤버가 구단주 부재 시 긴급 선거를 발동합니다.
+         * 발동 즉시 IN_PROGRESS 상태로 시작하며, 14일 이내 정규 선거를 자동 생성해야 합니다.
+         *
+         * @param teamId 팀 ID
+         * @param triggeredByMemberId 발동한 MANAGER 멤버 ID
+         * @param title 선거 제목
+         * @param description 선거 설명
+         * @param startAt 시작 시간
+         * @param endAt 종료 시간
+         * @return 생성된 긴급 선거 (IN_PROGRESS 상태)
+         * @throws IllegalArgumentException 제목이 비어있거나 종료 시간이 시작 시간보다 이전인 경우
+         */
+        fun createEmergency(
+            teamId: Long,
+            triggeredByMemberId: Long,
+            title: String,
+            description: String? = null,
+            startAt: Instant,
+            endAt: Instant,
+        ): Election {
+            require(title.isNotBlank()) { "Title cannot be blank" }
+            require(endAt.isAfter(startAt)) {
+                "End time must be after start time"
+            }
+
+            val now = Instant.now()
+            val regularElectionDeadline =
+                now.plus(REGULAR_ELECTION_DEADLINE_DAYS, ChronoUnit.DAYS)
+
+            return Election(
+                teamId = teamId,
+                title = title,
+                description = description,
+                electionType = ElectionType.EMERGENCY,
+                startAt = startAt,
+                endAt = endAt,
+                status = ElectionStatus.IN_PROGRESS,
+                triggeredByMemberId = triggeredByMemberId,
+                regularElectionDeadline = regularElectionDeadline,
             )
         }
     }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/election/ElectionType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/election/ElectionType.kt
@@ -18,4 +18,12 @@ enum class ElectionType {
      * 일반 투표
      */
     GENERAL,
+
+    /**
+     * 비상대책위원회 긴급 선거
+     *
+     * 구단주 부재 시 MANAGER가 발동하는 긴급 모드.
+     * 임시 구단주(Acting Owner)를 지정하고, 14일 이내 정규 선거를 자동 생성합니다.
+     */
+    EMERGENCY,
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/EmergencyElectionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/EmergencyElectionService.kt
@@ -1,0 +1,148 @@
+package com.nextup.core.service.election
+
+import com.nextup.common.exception.ActiveElectionAlreadyExistsException
+import com.nextup.common.exception.ElectionNotFoundException
+import com.nextup.common.exception.InvalidActingOwnerException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.common.exception.TeamMemberNotFoundException
+import com.nextup.common.exception.UnauthorizedEmergencyElectionException
+import com.nextup.core.domain.election.Election
+import com.nextup.core.domain.election.ElectionStatus
+import com.nextup.core.domain.election.ElectionType
+import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.port.repository.ElectionRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import com.nextup.core.service.election.dto.DesignateActingOwnerRequest
+import com.nextup.core.service.election.dto.ElectionResponse
+import com.nextup.core.service.election.dto.TriggerEmergencyElectionRequest
+import com.nextup.core.service.election.dto.toResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 비상대책위원회 모드 (긴급 선거) 서비스
+ *
+ * 구단주 부재 시 MANAGER가 긴급 선거를 발동하고, 임시 구단주를 지정합니다.
+ * 긴급 선거 발동 후 14일 이내 정규 구단주 선거를 자동 생성합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class EmergencyElectionService(
+    private val electionRepository: ElectionRepositoryPort,
+    private val teamMemberRepository: TeamMemberRepositoryPort,
+) {
+    /**
+     * 긴급 선거를 발동합니다.
+     *
+     * MANAGER 역할의 멤버만 발동 가능하며, 이미 진행 중인 선거가 없어야 합니다.
+     * 긴급 선거는 발동 즉시 IN_PROGRESS 상태로 시작합니다.
+     *
+     * @param request 긴급 선거 발동 요청
+     * @return 생성된 긴급 선거 응답
+     * @throws UnauthorizedEmergencyElectionException 요청자가 MANAGER 역할이 아닌 경우
+     * @throws ActiveElectionAlreadyExistsException 이미 진행 중인 선거가 있는 경우
+     */
+    @Transactional
+    fun triggerEmergencyElection(request: TriggerEmergencyElectionRequest): ElectionResponse {
+        val requester =
+            teamMemberRepository.findByIdOrNull(request.requesterId)
+                ?: throw TeamMemberNotFoundException(request.requesterId)
+
+        if (requester.role != TeamMemberRole.MANAGER) {
+            throw UnauthorizedEmergencyElectionException(request.requesterId)
+        }
+
+        val activeElections =
+            electionRepository.findAllByTeamId(request.teamId)
+                .filter {
+                    it.status == ElectionStatus.IN_PROGRESS ||
+                        it.status == ElectionStatus.SCHEDULED
+                }
+        if (activeElections.isNotEmpty()) {
+            throw ActiveElectionAlreadyExistsException(request.teamId)
+        }
+
+        val emergencyElection =
+            Election.createEmergency(
+                teamId = request.teamId,
+                triggeredByMemberId = request.requesterId,
+                title = request.title,
+                description = request.description,
+                startAt = request.startAt,
+                endAt = request.endAt,
+            )
+
+        return electionRepository.save(emergencyElection).toResponse()
+    }
+
+    /**
+     * 임시 구단주를 지정합니다.
+     *
+     * 긴급 선거에서만 가능하며, 대상은 MANAGER 역할의 팀 멤버여야 합니다.
+     * 임시 구단주는 제한된 권한(라인업/일정 관리 가능, 강퇴/해산/소유권 이전 불가)을 갖습니다.
+     *
+     * @param request 임시 구단주 지정 요청
+     * @return 업데이트된 선거 응답
+     * @throws ElectionNotFoundException 선거를 찾을 수 없는 경우
+     * @throws InvalidStateException 긴급 선거가 아닌 경우
+     * @throws InvalidActingOwnerException 대상 멤버가 MANAGER 역할이 아닌 경우
+     */
+    @Transactional
+    fun designateActingOwner(request: DesignateActingOwnerRequest): ElectionResponse {
+        val election =
+            electionRepository.findById(request.electionId)
+                ?: throw ElectionNotFoundException(request.electionId)
+
+        if (!election.isEmergency()) {
+            throw InvalidStateException(
+                code = "NOT_EMERGENCY_ELECTION",
+                message = "Election ${request.electionId} is not an emergency election",
+            )
+        }
+
+        val actingOwnerCandidate =
+            teamMemberRepository.findByIdOrNull(request.actingOwnerMemberId)
+                ?: throw TeamMemberNotFoundException(request.actingOwnerMemberId)
+
+        if (actingOwnerCandidate.role != TeamMemberRole.MANAGER) {
+            throw InvalidActingOwnerException(request.actingOwnerMemberId)
+        }
+
+        election.designateActingOwner(request.actingOwnerMemberId)
+
+        return electionRepository.save(election).toResponse()
+    }
+
+    /**
+     * 긴급 선거 완료 후 정규 구단주 선거를 자동 생성합니다.
+     *
+     * 긴급 선거 완료 시 호출되며, regularElectionDeadline 내에 시작하는 정규 OWNER_ELECTION을 생성합니다.
+     *
+     * @param emergencyElection 완료된 긴급 선거
+     * @return 생성된 정규 선거 응답
+     * @throws InvalidStateException 긴급 선거가 아니거나 완료 상태가 아닌 경우
+     */
+    @Transactional
+    fun createRegularElectionAfterEmergency(emergencyElection: Election): ElectionResponse {
+        require(emergencyElection.isEmergency()) {
+            "정규 선거 자동 생성은 긴급 선거 완료 후에만 가능합니다."
+        }
+        val deadline =
+            checkNotNull(emergencyElection.regularElectionDeadline) {
+                "긴급 선거에 정규 선거 마감 기한이 설정되어 있지 않습니다."
+            }
+        val regularElection =
+            Election.create(
+                teamId = emergencyElection.teamId,
+                title = "[정규] 구단주 선출 선거",
+                description =
+                    "비상대책위원회 모드 해제 후 정규 구단주 선출 선거입니다. " +
+                        "마감 기한: $deadline",
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = deadline.minusSeconds(7 * 24 * 60 * 60),
+                endAt = deadline,
+            )
+
+        return electionRepository.save(regularElection).toResponse()
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/EmergencyElectionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/EmergencyElectionService.kt
@@ -3,6 +3,7 @@ package com.nextup.core.service.election
 import com.nextup.common.exception.ActiveElectionAlreadyExistsException
 import com.nextup.common.exception.ElectionNotFoundException
 import com.nextup.common.exception.InvalidActingOwnerException
+import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.TeamMemberNotFoundException
 import com.nextup.common.exception.UnauthorizedEmergencyElectionException
@@ -47,6 +48,14 @@ class EmergencyElectionService(
         val requester =
             teamMemberRepository.findByIdOrNull(request.requesterId)
                 ?: throw TeamMemberNotFoundException(request.requesterId)
+
+        // Authorization: 요청자가 해당 팀 소속인지 검증
+        if (requester.team.id != request.teamId) {
+            throw InvalidInputException(
+                code = "UNAUTHORIZED_TEAM_ACCESS",
+                message = "Member ${request.requesterId} does not belong to team ${request.teamId}",
+            )
+        }
 
         if (requester.role != TeamMemberRole.MANAGER) {
             throw UnauthorizedEmergencyElectionException(request.requesterId)
@@ -126,6 +135,16 @@ class EmergencyElectionService(
     fun createRegularElectionAfterEmergency(emergencyElection: Election): ElectionResponse {
         require(emergencyElection.isEmergency()) {
             "정규 선거 자동 생성은 긴급 선거 완료 후에만 가능합니다."
+        }
+        if (emergencyElection.status != ElectionStatus.COMPLETED) {
+            val currentStatus = emergencyElection.status
+            val electionId = emergencyElection.id
+            throw InvalidStateException(
+                code = "EMERGENCY_ELECTION_NOT_COMPLETED",
+                message =
+                    "Emergency election $electionId must be COMPLETED before creating " +
+                        "a regular election, but current status is $currentStatus",
+            )
         }
         val deadline =
             checkNotNull(emergencyElection.regularElectionDeadline) {

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/ElectionResponse.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/ElectionResponse.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.service.election.dto
 
+import com.nextup.core.domain.election.ActingOwnerPermissions
 import com.nextup.core.domain.election.Election
 import com.nextup.core.domain.election.ElectionStatus
 import com.nextup.core.domain.election.ElectionType
@@ -19,6 +20,14 @@ data class ElectionResponse(
     val status: ElectionStatus,
     val isVotingOpen: Boolean,
     val createdAt: Instant,
+    /** 긴급 선거 발동 멤버 ID (EMERGENCY 타입만 사용) */
+    val triggeredByMemberId: Long? = null,
+    /** 임시 구단주 멤버 ID (EMERGENCY 타입만 사용) */
+    val actingOwnerMemberId: Long? = null,
+    /** 임시 구단주 권한 (EMERGENCY 타입만 사용) */
+    val actingOwnerPermissions: ActingOwnerPermissions? = null,
+    /** 정규 선거 마감 기한 (EMERGENCY 타입만 사용) */
+    val regularElectionDeadline: Instant? = null,
 )
 
 /**
@@ -36,6 +45,10 @@ fun Election.toResponse(): ElectionResponse =
         status = this.status,
         isVotingOpen = this.isVotingOpen(),
         createdAt = this.createdAt,
+        triggeredByMemberId = this.triggeredByMemberId,
+        actingOwnerMemberId = this.actingOwnerMemberId,
+        actingOwnerPermissions = this.actingOwnerPermissions,
+        regularElectionDeadline = this.regularElectionDeadline,
     )
 
 /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/EmergencyElectionRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/dto/EmergencyElectionRequest.kt
@@ -1,0 +1,35 @@
+package com.nextup.core.service.election.dto
+
+import java.time.Instant
+
+/**
+ * 긴급 선거 발동 요청 DTO
+ *
+ * MANAGER 역할 멤버가 구단주 부재 시 긴급 선거를 발동할 때 사용합니다.
+ */
+data class TriggerEmergencyElectionRequest(
+    /** 팀 ID */
+    val teamId: Long,
+    /** 긴급 선거를 발동하는 MANAGER 멤버 ID */
+    val requesterId: Long,
+    /** 선거 제목 */
+    val title: String,
+    /** 선거 설명 */
+    val description: String? = null,
+    /** 긴급 선거 시작 시간 */
+    val startAt: Instant,
+    /** 긴급 선거 종료 시간 */
+    val endAt: Instant,
+)
+
+/**
+ * 임시 구단주 지정 요청 DTO
+ *
+ * 긴급 선거 상태에서 임시 구단주를 지정할 때 사용합니다.
+ */
+data class DesignateActingOwnerRequest(
+    /** 긴급 선거 ID */
+    val electionId: Long,
+    /** 임시 구단주로 지정할 MANAGER 멤버 ID */
+    val actingOwnerMemberId: Long,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/election/EmergencyElectionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/election/EmergencyElectionTest.kt
@@ -1,0 +1,282 @@
+package com.nextup.core.domain.election
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class EmergencyElectionTest {
+    @Test
+    fun `긴급 선거를 생성할 수 있다`() {
+        // given
+        val teamId = 1L
+        val triggeredByMemberId = 10L
+        val startAt = Instant.now()
+        val endAt = startAt.plus(14, ChronoUnit.DAYS)
+
+        // when
+        val election =
+            Election.createEmergency(
+                teamId = teamId,
+                triggeredByMemberId = triggeredByMemberId,
+                title = "비상대책위원회 긴급 선거",
+                description = "구단주 부재로 인한 긴급 선거",
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        // then
+        assertThat(election.teamId).isEqualTo(teamId)
+        assertThat(election.electionType).isEqualTo(ElectionType.EMERGENCY)
+        assertThat(election.status).isEqualTo(ElectionStatus.IN_PROGRESS)
+        assertThat(election.triggeredByMemberId).isEqualTo(triggeredByMemberId)
+        assertThat(election.regularElectionDeadline).isNotNull
+        assertThat(election.actingOwnerMemberId).isNull()
+        assertThat(election.actingOwnerPermissions).isNull()
+    }
+
+    @Test
+    fun `긴급 선거는 생성 즉시 IN_PROGRESS 상태이다`() {
+        // given
+        val startAt = Instant.now()
+        val endAt = startAt.plus(14, ChronoUnit.DAYS)
+
+        // when
+        val election =
+            Election.createEmergency(
+                teamId = 1L,
+                triggeredByMemberId = 10L,
+                title = "비상대책위원회 긴급 선거",
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        // then
+        assertThat(election.status).isEqualTo(ElectionStatus.IN_PROGRESS)
+    }
+
+    @Test
+    fun `긴급 선거의 정규 선거 마감 기한은 발동 후 14일이다`() {
+        // given
+        val before = Instant.now()
+        val startAt = before
+        val endAt = startAt.plus(14, ChronoUnit.DAYS)
+
+        // when
+        val election =
+            Election.createEmergency(
+                teamId = 1L,
+                triggeredByMemberId = 10L,
+                title = "비상대책위원회 긴급 선거",
+                startAt = startAt,
+                endAt = endAt,
+            )
+        val after = Instant.now()
+
+        // then
+        val deadline = election.regularElectionDeadline!!
+        val expectedMin = before.plus(Election.REGULAR_ELECTION_DEADLINE_DAYS, ChronoUnit.DAYS)
+        val expectedMax = after.plus(Election.REGULAR_ELECTION_DEADLINE_DAYS, ChronoUnit.DAYS)
+        assertThat(deadline).isAfterOrEqualTo(expectedMin)
+        assertThat(deadline).isBeforeOrEqualTo(expectedMax)
+    }
+
+    @Test
+    fun `긴급 선거 생성 시 제목이 공백이면 예외가 발생한다`() {
+        // given
+        val startAt = Instant.now()
+        val endAt = startAt.plus(14, ChronoUnit.DAYS)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            Election.createEmergency(
+                teamId = 1L,
+                triggeredByMemberId = 10L,
+                title = "",
+                startAt = startAt,
+                endAt = endAt,
+            )
+        }
+    }
+
+    @Test
+    fun `긴급 선거 생성 시 종료 시간이 시작 시간보다 이전이면 예외가 발생한다`() {
+        // given
+        val startAt = Instant.now().plus(7, ChronoUnit.DAYS)
+        val endAt = startAt.minus(1, ChronoUnit.DAYS)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            Election.createEmergency(
+                teamId = 1L,
+                triggeredByMemberId = 10L,
+                title = "비상대책위원회 긴급 선거",
+                startAt = startAt,
+                endAt = endAt,
+            )
+        }
+    }
+
+    @Test
+    fun `isEmergency는 EMERGENCY 타입일 때 true를 반환한다`() {
+        // given
+        val startAt = Instant.now()
+        val endAt = startAt.plus(14, ChronoUnit.DAYS)
+        val election =
+            Election.createEmergency(
+                teamId = 1L,
+                triggeredByMemberId = 10L,
+                title = "비상대책위원회 긴급 선거",
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        // when & then
+        assertThat(election.isEmergency()).isTrue()
+    }
+
+    @Test
+    fun `isEmergency는 일반 선거일 때 false를 반환한다`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        // when & then
+        assertThat(election.isEmergency()).isFalse()
+    }
+
+    @Test
+    fun `임시 구단주를 지정할 수 있다`() {
+        // given
+        val startAt = Instant.now()
+        val endAt = startAt.plus(14, ChronoUnit.DAYS)
+        val election =
+            Election.createEmergency(
+                teamId = 1L,
+                triggeredByMemberId = 10L,
+                title = "비상대책위원회 긴급 선거",
+                startAt = startAt,
+                endAt = endAt,
+            )
+        val actingOwnerMemberId = 20L
+
+        // when
+        election.designateActingOwner(actingOwnerMemberId)
+
+        // then
+        assertThat(election.actingOwnerMemberId).isEqualTo(actingOwnerMemberId)
+        assertThat(election.actingOwnerPermissions).isNotNull
+        assertThat(election.actingOwnerPermissions!!.canManageLineup).isTrue()
+        assertThat(election.actingOwnerPermissions!!.canManageSchedule).isTrue()
+        assertThat(election.actingOwnerPermissions!!.canKickMember).isFalse()
+        assertThat(election.actingOwnerPermissions!!.canDissolveTeam).isFalse()
+        assertThat(election.actingOwnerPermissions!!.canTransferOwnership).isFalse()
+    }
+
+    @Test
+    fun `임시 구단주 지정 후 hasActingOwner는 true를 반환한다`() {
+        // given
+        val startAt = Instant.now()
+        val endAt = startAt.plus(14, ChronoUnit.DAYS)
+        val election =
+            Election.createEmergency(
+                teamId = 1L,
+                triggeredByMemberId = 10L,
+                title = "비상대책위원회 긴급 선거",
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        assertThat(election.hasActingOwner()).isFalse()
+
+        // when
+        election.designateActingOwner(20L)
+
+        // then
+        assertThat(election.hasActingOwner()).isTrue()
+    }
+
+    @Test
+    fun `일반 선거에 임시 구단주를 지정하면 예외가 발생한다`() {
+        // given
+        val startAt = Instant.now().plus(1, ChronoUnit.DAYS)
+        val endAt = startAt.plus(7, ChronoUnit.DAYS)
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "구단주 선출",
+                electionType = ElectionType.OWNER_ELECTION,
+                startAt = startAt,
+                endAt = endAt,
+            )
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            election.designateActingOwner(20L)
+        }
+    }
+
+    @Test
+    fun `이미 임시 구단주가 지정된 선거에 다시 지정하면 예외가 발생한다`() {
+        // given
+        val startAt = Instant.now()
+        val endAt = startAt.plus(14, ChronoUnit.DAYS)
+        val election =
+            Election.createEmergency(
+                teamId = 1L,
+                triggeredByMemberId = 10L,
+                title = "비상대책위원회 긴급 선거",
+                startAt = startAt,
+                endAt = endAt,
+            )
+        election.designateActingOwner(20L)
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            election.designateActingOwner(30L)
+        }
+    }
+
+    @Test
+    fun `취소된 긴급 선거에 임시 구단주를 지정하면 예외가 발생한다`() {
+        // given
+        val startAt = Instant.now()
+        val endAt = startAt.plus(14, ChronoUnit.DAYS)
+        val election =
+            Election.createEmergency(
+                teamId = 1L,
+                triggeredByMemberId = 10L,
+                title = "비상대책위원회 긴급 선거",
+                startAt = startAt,
+                endAt = endAt,
+            )
+        election.cancel()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            election.designateActingOwner(20L)
+        }
+    }
+
+    @Test
+    fun `ActingOwnerPermissions 기본값은 라인업_일정 관리 가능 나머지 불가이다`() {
+        // when
+        val permissions = ActingOwnerPermissions.default()
+
+        // then
+        assertThat(permissions.canManageLineup).isTrue()
+        assertThat(permissions.canManageSchedule).isTrue()
+        assertThat(permissions.canKickMember).isFalse()
+        assertThat(permissions.canDissolveTeam).isFalse()
+        assertThat(permissions.canTransferOwnership).isFalse()
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/election/EmergencyElectionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/election/EmergencyElectionServiceTest.kt
@@ -3,12 +3,14 @@ package com.nextup.core.service.election
 import com.nextup.common.exception.ActiveElectionAlreadyExistsException
 import com.nextup.common.exception.ElectionNotFoundException
 import com.nextup.common.exception.InvalidActingOwnerException
+import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.TeamMemberNotFoundException
 import com.nextup.common.exception.UnauthorizedEmergencyElectionException
 import com.nextup.core.domain.election.Election
 import com.nextup.core.domain.election.ElectionStatus
 import com.nextup.core.domain.election.ElectionType
+import com.nextup.core.domain.team.Team
 import com.nextup.core.domain.team.TeamMember
 import com.nextup.core.domain.team.TeamMemberRole
 import com.nextup.core.port.repository.ElectionRepositoryPort
@@ -61,9 +63,11 @@ class EmergencyElectionServiceTest {
                     endAt = now.plus(14, ChronoUnit.DAYS),
                 )
 
+            val mockTeam = mockk<Team> { every { id } returns 1L }
             val managerMember =
                 mockk<TeamMember> {
                     every { role } returns TeamMemberRole.MANAGER
+                    every { team } returns mockTeam
                 }
 
             every { teamMemberRepository.findByIdOrNull(10L) } returns managerMember
@@ -82,6 +86,35 @@ class EmergencyElectionServiceTest {
         }
 
         @Test
+        fun `다른 팀 소속 MANAGER가 긴급 선거를 발동하면 예외가 발생한다`() {
+            // given
+            val now = Instant.now()
+            val request =
+                TriggerEmergencyElectionRequest(
+                    teamId = 1L,
+                    requesterId = 10L,
+                    title = "비상대책위원회 긴급 선거",
+                    startAt = now,
+                    endAt = now.plus(14, ChronoUnit.DAYS),
+                )
+
+            val otherTeam = mockk<Team> { every { id } returns 99L }
+            val managerMember =
+                mockk<TeamMember> {
+                    every { role } returns TeamMemberRole.MANAGER
+                    every { team } returns otherTeam
+                }
+
+            every { teamMemberRepository.findByIdOrNull(10L) } returns managerMember
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.triggerEmergencyElection(request)
+            }.isInstanceOf(InvalidInputException::class.java)
+                .hasMessageContaining("does not belong to team")
+        }
+
+        @Test
         fun `MANAGER가 아닌 멤버가 긴급 선거를 발동하면 예외가 발생한다`() {
             // given
             val now = Instant.now()
@@ -94,9 +127,11 @@ class EmergencyElectionServiceTest {
                     endAt = now.plus(14, ChronoUnit.DAYS),
                 )
 
+            val mockTeam = mockk<Team> { every { id } returns 1L }
             val memberRole =
                 mockk<TeamMember> {
                     every { role } returns TeamMemberRole.MEMBER
+                    every { team } returns mockTeam
                 }
 
             every { teamMemberRepository.findByIdOrNull(10L) } returns memberRole
@@ -120,9 +155,11 @@ class EmergencyElectionServiceTest {
                     endAt = now.plus(14, ChronoUnit.DAYS),
                 )
 
+            val mockTeam = mockk<Team> { every { id } returns 1L }
             val ownerMember =
                 mockk<TeamMember> {
                     every { role } returns TeamMemberRole.OWNER
+                    every { team } returns mockTeam
                 }
 
             every { teamMemberRepository.findByIdOrNull(10L) } returns ownerMember
@@ -167,9 +204,11 @@ class EmergencyElectionServiceTest {
                     endAt = now.plus(14, ChronoUnit.DAYS),
                 )
 
+            val mockTeam = mockk<Team> { every { id } returns 1L }
             val managerMember =
                 mockk<TeamMember> {
                     every { role } returns TeamMemberRole.MANAGER
+                    every { team } returns mockTeam
                 }
             val activeElection = createTestElection(1L, ElectionStatus.IN_PROGRESS)
 
@@ -195,9 +234,11 @@ class EmergencyElectionServiceTest {
                     endAt = now.plus(14, ChronoUnit.DAYS),
                 )
 
+            val mockTeam = mockk<Team> { every { id } returns 1L }
             val managerMember =
                 mockk<TeamMember> {
                     every { role } returns TeamMemberRole.MANAGER
+                    every { team } returns mockTeam
                 }
             val scheduledElection = createTestElection(1L, ElectionStatus.SCHEDULED)
 
@@ -223,9 +264,11 @@ class EmergencyElectionServiceTest {
                     endAt = now.plus(14, ChronoUnit.DAYS),
                 )
 
+            val mockTeam = mockk<Team> { every { id } returns 1L }
             val managerMember =
                 mockk<TeamMember> {
                     every { role } returns TeamMemberRole.MANAGER
+                    every { team } returns mockTeam
                 }
             val completedElection = createTestElection(1L, ElectionStatus.COMPLETED)
 
@@ -346,7 +389,10 @@ class EmergencyElectionServiceTest {
         @Test
         fun `긴급 선거 완료 후 정규 선거를 자동 생성할 수 있다`() {
             // given
-            val emergencyElection = createTestEmergencyElection(1L)
+            val emergencyElection =
+                createTestEmergencyElection(1L).also {
+                    it.complete()
+                }
 
             every { electionRepository.save(any()) } answers { firstArg() }
 
@@ -359,6 +405,19 @@ class EmergencyElectionServiceTest {
             assertThat(result.teamId).isEqualTo(emergencyElection.teamId)
             assertThat(result.title).contains("정규")
             verify { electionRepository.save(any()) }
+        }
+
+        @Test
+        fun `완료되지 않은 긴급 선거로 정규 선거 자동 생성을 호출하면 예외가 발생한다`() {
+            // given
+            val inProgressEmergencyElection = createTestEmergencyElection(1L)
+            // IN_PROGRESS 상태 (complete() 호출 안 함)
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.createRegularElectionAfterEmergency(inProgressEmergencyElection)
+            }.isInstanceOf(InvalidStateException::class.java)
+                .hasMessageContaining("COMPLETED")
         }
 
         @Test

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/election/EmergencyElectionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/election/EmergencyElectionServiceTest.kt
@@ -1,0 +1,430 @@
+package com.nextup.core.service.election
+
+import com.nextup.common.exception.ActiveElectionAlreadyExistsException
+import com.nextup.common.exception.ElectionNotFoundException
+import com.nextup.common.exception.InvalidActingOwnerException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.common.exception.TeamMemberNotFoundException
+import com.nextup.common.exception.UnauthorizedEmergencyElectionException
+import com.nextup.core.domain.election.Election
+import com.nextup.core.domain.election.ElectionStatus
+import com.nextup.core.domain.election.ElectionType
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.port.repository.ElectionRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import com.nextup.core.service.election.dto.DesignateActingOwnerRequest
+import com.nextup.core.service.election.dto.TriggerEmergencyElectionRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@DisplayName("EmergencyElectionService")
+class EmergencyElectionServiceTest {
+    private lateinit var electionRepository: ElectionRepositoryPort
+    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
+    private lateinit var emergencyElectionService: EmergencyElectionService
+
+    @BeforeEach
+    fun setUp() {
+        electionRepository = mockk()
+        teamMemberRepository = mockk()
+        emergencyElectionService =
+            EmergencyElectionService(
+                electionRepository,
+                teamMemberRepository,
+            )
+    }
+
+    @Nested
+    @DisplayName("triggerEmergencyElection")
+    inner class TriggerEmergencyElection {
+        @Test
+        fun `MANAGER가 긴급 선거를 발동할 수 있다`() {
+            // given
+            val now = Instant.now()
+            val request =
+                TriggerEmergencyElectionRequest(
+                    teamId = 1L,
+                    requesterId = 10L,
+                    title = "비상대책위원회 긴급 선거",
+                    description = "구단주 부재로 인한 긴급 선거",
+                    startAt = now,
+                    endAt = now.plus(14, ChronoUnit.DAYS),
+                )
+
+            val managerMember =
+                mockk<TeamMember> {
+                    every { role } returns TeamMemberRole.MANAGER
+                }
+
+            every { teamMemberRepository.findByIdOrNull(10L) } returns managerMember
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { electionRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = emergencyElectionService.triggerEmergencyElection(request)
+
+            // then
+            assertThat(result.electionType).isEqualTo(ElectionType.EMERGENCY)
+            assertThat(result.status).isEqualTo(ElectionStatus.IN_PROGRESS)
+            assertThat(result.triggeredByMemberId).isEqualTo(10L)
+            assertThat(result.regularElectionDeadline).isNotNull
+            verify { electionRepository.save(any()) }
+        }
+
+        @Test
+        fun `MANAGER가 아닌 멤버가 긴급 선거를 발동하면 예외가 발생한다`() {
+            // given
+            val now = Instant.now()
+            val request =
+                TriggerEmergencyElectionRequest(
+                    teamId = 1L,
+                    requesterId = 10L,
+                    title = "비상대책위원회 긴급 선거",
+                    startAt = now,
+                    endAt = now.plus(14, ChronoUnit.DAYS),
+                )
+
+            val memberRole =
+                mockk<TeamMember> {
+                    every { role } returns TeamMemberRole.MEMBER
+                }
+
+            every { teamMemberRepository.findByIdOrNull(10L) } returns memberRole
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.triggerEmergencyElection(request)
+            }.isInstanceOf(UnauthorizedEmergencyElectionException::class.java)
+        }
+
+        @Test
+        fun `OWNER가 긴급 선거를 발동하면 예외가 발생한다`() {
+            // given
+            val now = Instant.now()
+            val request =
+                TriggerEmergencyElectionRequest(
+                    teamId = 1L,
+                    requesterId = 10L,
+                    title = "비상대책위원회 긴급 선거",
+                    startAt = now,
+                    endAt = now.plus(14, ChronoUnit.DAYS),
+                )
+
+            val ownerMember =
+                mockk<TeamMember> {
+                    every { role } returns TeamMemberRole.OWNER
+                }
+
+            every { teamMemberRepository.findByIdOrNull(10L) } returns ownerMember
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.triggerEmergencyElection(request)
+            }.isInstanceOf(UnauthorizedEmergencyElectionException::class.java)
+        }
+
+        @Test
+        fun `존재하지 않는 멤버가 긴급 선거를 발동하면 예외가 발생한다`() {
+            // given
+            val now = Instant.now()
+            val request =
+                TriggerEmergencyElectionRequest(
+                    teamId = 1L,
+                    requesterId = 999L,
+                    title = "비상대책위원회 긴급 선거",
+                    startAt = now,
+                    endAt = now.plus(14, ChronoUnit.DAYS),
+                )
+
+            every { teamMemberRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.triggerEmergencyElection(request)
+            }.isInstanceOf(TeamMemberNotFoundException::class.java)
+        }
+
+        @Test
+        fun `이미 진행 중인 선거가 있으면 긴급 선거 발동 시 예외가 발생한다`() {
+            // given
+            val now = Instant.now()
+            val request =
+                TriggerEmergencyElectionRequest(
+                    teamId = 1L,
+                    requesterId = 10L,
+                    title = "비상대책위원회 긴급 선거",
+                    startAt = now,
+                    endAt = now.plus(14, ChronoUnit.DAYS),
+                )
+
+            val managerMember =
+                mockk<TeamMember> {
+                    every { role } returns TeamMemberRole.MANAGER
+                }
+            val activeElection = createTestElection(1L, ElectionStatus.IN_PROGRESS)
+
+            every { teamMemberRepository.findByIdOrNull(10L) } returns managerMember
+            every { electionRepository.findAllByTeamId(1L) } returns listOf(activeElection)
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.triggerEmergencyElection(request)
+            }.isInstanceOf(ActiveElectionAlreadyExistsException::class.java)
+        }
+
+        @Test
+        fun `이미 예정된 선거가 있으면 긴급 선거 발동 시 예외가 발생한다`() {
+            // given
+            val now = Instant.now()
+            val request =
+                TriggerEmergencyElectionRequest(
+                    teamId = 1L,
+                    requesterId = 10L,
+                    title = "비상대책위원회 긴급 선거",
+                    startAt = now,
+                    endAt = now.plus(14, ChronoUnit.DAYS),
+                )
+
+            val managerMember =
+                mockk<TeamMember> {
+                    every { role } returns TeamMemberRole.MANAGER
+                }
+            val scheduledElection = createTestElection(1L, ElectionStatus.SCHEDULED)
+
+            every { teamMemberRepository.findByIdOrNull(10L) } returns managerMember
+            every { electionRepository.findAllByTeamId(1L) } returns listOf(scheduledElection)
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.triggerEmergencyElection(request)
+            }.isInstanceOf(ActiveElectionAlreadyExistsException::class.java)
+        }
+
+        @Test
+        fun `완료된 선거만 있을 때 긴급 선거를 발동할 수 있다`() {
+            // given
+            val now = Instant.now()
+            val request =
+                TriggerEmergencyElectionRequest(
+                    teamId = 1L,
+                    requesterId = 10L,
+                    title = "비상대책위원회 긴급 선거",
+                    startAt = now,
+                    endAt = now.plus(14, ChronoUnit.DAYS),
+                )
+
+            val managerMember =
+                mockk<TeamMember> {
+                    every { role } returns TeamMemberRole.MANAGER
+                }
+            val completedElection = createTestElection(1L, ElectionStatus.COMPLETED)
+
+            every { teamMemberRepository.findByIdOrNull(10L) } returns managerMember
+            every { electionRepository.findAllByTeamId(1L) } returns listOf(completedElection)
+            every { electionRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = emergencyElectionService.triggerEmergencyElection(request)
+
+            // then
+            assertThat(result.electionType).isEqualTo(ElectionType.EMERGENCY)
+            assertThat(result.status).isEqualTo(ElectionStatus.IN_PROGRESS)
+        }
+    }
+
+    @Nested
+    @DisplayName("designateActingOwner")
+    inner class DesignateActingOwner {
+        @Test
+        fun `긴급 선거에서 MANAGER 멤버를 임시 구단주로 지정할 수 있다`() {
+            // given
+            val emergencyElection = createTestEmergencyElection(1L)
+            val managerMember =
+                mockk<TeamMember> {
+                    every { role } returns TeamMemberRole.MANAGER
+                }
+
+            every { electionRepository.findById(1L) } returns emergencyElection
+            every { teamMemberRepository.findByIdOrNull(20L) } returns managerMember
+            every { electionRepository.save(any()) } answers { firstArg() }
+
+            val request = DesignateActingOwnerRequest(electionId = 1L, actingOwnerMemberId = 20L)
+
+            // when
+            val result = emergencyElectionService.designateActingOwner(request)
+
+            // then
+            assertThat(result.actingOwnerMemberId).isEqualTo(20L)
+            assertThat(result.actingOwnerPermissions).isNotNull
+            assertThat(result.actingOwnerPermissions!!.canManageLineup).isTrue()
+            assertThat(result.actingOwnerPermissions!!.canManageSchedule).isTrue()
+            assertThat(result.actingOwnerPermissions!!.canKickMember).isFalse()
+            assertThat(result.actingOwnerPermissions!!.canDissolveTeam).isFalse()
+            assertThat(result.actingOwnerPermissions!!.canTransferOwnership).isFalse()
+            verify { electionRepository.save(any()) }
+        }
+
+        @Test
+        fun `긴급 선거가 아닌 선거에서 임시 구단주를 지정하면 예외가 발생한다`() {
+            // given
+            val normalElection = createTestElection(1L, ElectionStatus.IN_PROGRESS)
+
+            every { electionRepository.findById(1L) } returns normalElection
+
+            val request = DesignateActingOwnerRequest(electionId = 1L, actingOwnerMemberId = 20L)
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.designateActingOwner(request)
+            }.isInstanceOf(InvalidStateException::class.java)
+                .hasMessageContaining("not an emergency election")
+        }
+
+        @Test
+        fun `존재하지 않는 선거에서 임시 구단주를 지정하면 예외가 발생한다`() {
+            // given
+            every { electionRepository.findById(999L) } returns null
+
+            val request = DesignateActingOwnerRequest(electionId = 999L, actingOwnerMemberId = 20L)
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.designateActingOwner(request)
+            }.isInstanceOf(ElectionNotFoundException::class.java)
+        }
+
+        @Test
+        fun `MANAGER가 아닌 멤버를 임시 구단주로 지정하면 예외가 발생한다`() {
+            // given
+            val emergencyElection = createTestEmergencyElection(1L)
+            val regularMember =
+                mockk<TeamMember> {
+                    every { role } returns TeamMemberRole.MEMBER
+                }
+
+            every { electionRepository.findById(1L) } returns emergencyElection
+            every { teamMemberRepository.findByIdOrNull(20L) } returns regularMember
+
+            val request = DesignateActingOwnerRequest(electionId = 1L, actingOwnerMemberId = 20L)
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.designateActingOwner(request)
+            }.isInstanceOf(InvalidActingOwnerException::class.java)
+        }
+
+        @Test
+        fun `존재하지 않는 멤버를 임시 구단주로 지정하면 예외가 발생한다`() {
+            // given
+            val emergencyElection = createTestEmergencyElection(1L)
+
+            every { electionRepository.findById(1L) } returns emergencyElection
+            every { teamMemberRepository.findByIdOrNull(999L) } returns null
+
+            val request = DesignateActingOwnerRequest(electionId = 1L, actingOwnerMemberId = 999L)
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.designateActingOwner(request)
+            }.isInstanceOf(TeamMemberNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("createRegularElectionAfterEmergency")
+    inner class CreateRegularElectionAfterEmergency {
+        @Test
+        fun `긴급 선거 완료 후 정규 선거를 자동 생성할 수 있다`() {
+            // given
+            val emergencyElection = createTestEmergencyElection(1L)
+
+            every { electionRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result =
+                emergencyElectionService.createRegularElectionAfterEmergency(emergencyElection)
+
+            // then
+            assertThat(result.electionType).isEqualTo(ElectionType.OWNER_ELECTION)
+            assertThat(result.teamId).isEqualTo(emergencyElection.teamId)
+            assertThat(result.title).contains("정규")
+            verify { electionRepository.save(any()) }
+        }
+
+        @Test
+        fun `일반 선거로 정규 선거 자동 생성을 호출하면 예외가 발생한다`() {
+            // given
+            val normalElection = createTestElection(1L, ElectionStatus.COMPLETED)
+
+            // when & then
+            assertThatThrownBy {
+                emergencyElectionService.createRegularElectionAfterEmergency(normalElection)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    // --- helper methods ---
+
+    private fun createTestElection(
+        id: Long,
+        status: ElectionStatus,
+    ): Election {
+        val now = Instant.now()
+        val election =
+            Election.create(
+                teamId = 1L,
+                title = "테스트 선거",
+                description = "테스트 설명",
+                electionType = ElectionType.CAPTAIN_ELECTION,
+                startAt = now.plus(1, ChronoUnit.DAYS),
+                endAt = now.plus(7, ChronoUnit.DAYS),
+            )
+        setElectionId(election, id)
+
+        when (status) {
+            ElectionStatus.IN_PROGRESS -> election.start()
+            ElectionStatus.COMPLETED -> {
+                election.start()
+                election.complete()
+            }
+            ElectionStatus.CANCELLED -> election.cancel()
+            ElectionStatus.SCHEDULED -> {}
+        }
+
+        return election
+    }
+
+    private fun createTestEmergencyElection(id: Long): Election {
+        val now = Instant.now()
+        val election =
+            Election.createEmergency(
+                teamId = 1L,
+                triggeredByMemberId = 10L,
+                title = "비상대책위원회 긴급 선거",
+                description = "테스트 긴급 선거",
+                startAt = now,
+                endAt = now.plus(14, ChronoUnit.DAYS),
+            )
+        setElectionId(election, id)
+        return election
+    }
+
+    private fun setElectionId(
+        election: Election,
+        id: Long,
+    ) {
+        val idField = Election::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(election, id)
+    }
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V019__add_emergency_election_columns.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V019__add_emergency_election_columns.sql
@@ -1,0 +1,21 @@
+-- 비상대책위원회 모드 (긴급 선거) 관련 컬럼 추가
+-- Election 엔티티에 긴급 선거 전용 필드 추가
+
+ALTER TABLE elections
+    ADD COLUMN triggered_by_member_id    BIGINT,
+    ADD COLUMN acting_owner_member_id    BIGINT,
+    ADD COLUMN regular_election_deadline TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN can_manage_lineup         BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN can_manage_schedule       BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN can_kick_member           BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN can_dissolve_team         BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN can_transfer_ownership    BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN elections.triggered_by_member_id IS '긴급 선거를 발동한 MANAGER 멤버 ID (EMERGENCY 타입 전용)';
+COMMENT ON COLUMN elections.acting_owner_member_id IS '임시 구단주로 지정된 멤버 ID (EMERGENCY 타입 전용)';
+COMMENT ON COLUMN elections.regular_election_deadline IS '정규 선거 마감 기한 - 긴급 선거 발동 후 14일 (EMERGENCY 타입 전용)';
+COMMENT ON COLUMN elections.can_manage_lineup IS '임시 구단주 라인업 관리 권한';
+COMMENT ON COLUMN elections.can_manage_schedule IS '임시 구단주 일정 관리 권한';
+COMMENT ON COLUMN elections.can_kick_member IS '임시 구단주 멤버 강퇴 권한 (기본값: 불가)';
+COMMENT ON COLUMN elections.can_dissolve_team IS '임시 구단주 팀 해산 권한 (기본값: 불가)';
+COMMENT ON COLUMN elections.can_transfer_ownership IS '임시 구단주 소유권 이전 권한 (기본값: 불가)';


### PR DESCRIPTION
## Summary

>- close #136

감독이 갑자기 직무를 수행할 수 없는 경우를 위한 **비상대책위원회 모드**를 구현합니다. MANAGER가 긴급 선거를 발동하고, 임시 대행자를 지정할 수 있습니다.

## Tasks

- ElectionType.EMERGENCY 추가
- Election 엔티티에 긴급 선거 필드 및 비즈니스 로직 추가 (createEmergency, designateActingOwner)
- ActingOwnerPermissions 값 객체 생성 (제한된 권한: 라인업/일정 관리만 가능)
- EmergencyElectionService 구현 (발동, 대행자 지정, 14일 내 정식 선거 자동 생성)
- 예외 클래스 추가 (UnauthorizedEmergencyElectionException 등)
- EmergencyElectionTest (12개) + EmergencyElectionServiceTest (13개) 단위 테스트

## To Reviewer

- 긴급 선거는 IN_PROGRESS 상태로 즉시 생성됩니다 (일반 선거와 달리 후보 등록 단계 불필요).
- ActingOwnerPermissions는 @Embeddable로 Election 엔티티에 내장됩니다.
- 빌드 성공 (87 tasks passed)