### PR TITLE
feat(#135): PostGIS 기반 구장 거리 검색 쿼리 구현

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/StadiumController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/StadiumController.kt
@@ -7,6 +7,9 @@ import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.stadium.StadiumService
 import com.nextup.core.service.stadium.dto.BookSlotRequest
 import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDate
@@ -30,6 +33,20 @@ class StadiumController(
     ): ApiResponse<List<StadiumResponse>> {
         val stadiums = stadiumService.searchStadiums(latitude, longitude, radiusKm)
         return ApiResponse.success(stadiums.map { StadiumResponse.from(it) })
+    }
+
+    /**
+     * 위치 기반으로 근처 구장을 거리 순으로 페이징하여 검색합니다.
+     */
+    @GetMapping("/nearby")
+    fun findNearbyStadiums(
+        @RequestParam latitude: Double,
+        @RequestParam longitude: Double,
+        @RequestParam(defaultValue = "10") radiusKm: Double,
+        @PageableDefault(size = 20) pageable: Pageable,
+    ): ApiResponse<Page<StadiumResponse>> {
+        val page = stadiumService.findNearbyStadiums(latitude, longitude, radiusKm, pageable)
+        return ApiResponse.success(page.map { StadiumResponse.from(it) })
     }
 
     /**

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/StadiumControllerExtendedTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/StadiumControllerExtendedTest.kt
@@ -1,0 +1,147 @@
+package com.nextup.api.controller.stadium
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.SlotNotFoundException
+import com.nextup.common.exception.StadiumNotFoundException
+import com.nextup.core.service.stadium.StadiumService
+import com.nextup.core.service.stadium.dto.BookSlotRequest
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+
+@DisplayName("StadiumController - Extended")
+class StadiumControllerExtendedTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var stadiumService: StadiumService
+    private lateinit var controller: StadiumController
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        stadiumService = mockk()
+        controller = StadiumController(stadiumService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .setCustomArgumentResolvers(PageableHandlerMethodArgumentResolver())
+                .build()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/stadiums/{id}")
+    inner class GetStadium {
+        @Test
+        fun `should return 404 when stadium not found`() {
+            // given
+            every { stadiumService.getById(999L) } throws StadiumNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/stadiums/999"))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("STADIUM_NOT_FOUND"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/stadiums/{id}/slots")
+    inner class GetAvailableSlots {
+        @Test
+        fun `should return 404 when stadium not found for slots`() {
+            // given
+            every {
+                stadiumService.getAvailableSlots(999L, LocalDate.of(2024, 12, 25))
+            } throws StadiumNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/999/slots")
+                        .param("date", "2024-12-25"),
+                ).andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("STADIUM_NOT_FOUND"))
+        }
+
+        @Test
+        fun `should return empty list when no slots available`() {
+            // given
+            every {
+                stadiumService.getAvailableSlots(1L, LocalDate.of(2024, 12, 25))
+            } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/1/slots")
+                        .param("date", "2024-12-25"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(0))
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/stadiums/book")
+    inner class BookSlot {
+        @Test
+        fun `should return 404 when slot not found`() {
+            // given
+            val request = BookSlotRequest(slotId = 999L, teamId = 100L, bookedBy = 200L)
+            every { stadiumService.bookSlot(request) } throws SlotNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/stadiums/book")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("SLOT_NOT_FOUND"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/stadiums/search - error cases")
+    inner class SearchStadiumsErrors {
+        @Test
+        fun `should return empty list when no stadiums in range`() {
+            // given
+            every {
+                stadiumService.searchStadiums(37.5, 127.0, 0.5)
+            } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/search")
+                        .param("latitude", "37.5")
+                        .param("longitude", "127.0")
+                        .param("radiusKm", "0.5"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(0))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/StadiumControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/StadiumControllerTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.InvalidInputException
 import com.nextup.core.domain.stadium.Stadium
 import com.nextup.core.domain.stadium.StadiumBooking
 import com.nextup.core.domain.stadium.StadiumSlot
@@ -15,6 +16,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -36,8 +41,118 @@ class StadiumControllerTest {
     fun setUp() {
         stadiumService = mockk()
         controller = StadiumController(stadiumService)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).setControllerAdvice(GlobalExceptionHandler()).build()
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .setCustomArgumentResolvers(PageableHandlerMethodArgumentResolver())
+                .build()
         objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/stadiums/nearby")
+    inner class FindNearbyStadiums {
+        @Test
+        fun `should return paged stadiums ordered by distance`() {
+            // given
+            val stadiums =
+                listOf(
+                    createStadium(1L, "잠실 야구장", 37.5121, 127.0717),
+                    createStadium(2L, "고척 야구장", 37.4981, 126.8671),
+                )
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(stadiums, pageable, 2)
+            every { stadiumService.findNearbyStadiums(37.5, 127.0, 10.0, any<Pageable>()) } returns page
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/nearby")
+                        .param("latitude", "37.5")
+                        .param("longitude", "127.0")
+                        .param("radiusKm", "10.0"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content").isArray)
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.content[0].name").value("잠실 야구장"))
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+        }
+
+        @Test
+        fun `should use default radiusKm of 10 when not provided`() {
+            // given
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(emptyList<Stadium>(), pageable, 0)
+            every { stadiumService.findNearbyStadiums(37.5, 127.0, 10.0, any<Pageable>()) } returns page
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/nearby")
+                        .param("latitude", "37.5")
+                        .param("longitude", "127.0"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+        }
+
+        @Test
+        fun `should return 400 when invalid latitude is provided`() {
+            // given
+            every {
+                stadiumService.findNearbyStadiums(91.0, 127.0, 10.0, any<Pageable>())
+            } throws InvalidInputException("INVALID_LATITUDE", "위도는 -90 ~ 90 범위여야 합니다: 91.0")
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/nearby")
+                        .param("latitude", "91.0")
+                        .param("longitude", "127.0")
+                        .param("radiusKm", "10.0"),
+                ).andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_LATITUDE"))
+        }
+
+        @Test
+        fun `should return 400 when invalid longitude is provided`() {
+            // given
+            every {
+                stadiumService.findNearbyStadiums(37.5, 181.0, 10.0, any<Pageable>())
+            } throws InvalidInputException("INVALID_LONGITUDE", "경도는 -180 ~ 180 범위여야 합니다: 181.0")
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/nearby")
+                        .param("latitude", "37.5")
+                        .param("longitude", "181.0")
+                        .param("radiusKm", "10.0"),
+                ).andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_LONGITUDE"))
+        }
+
+        @Test
+        fun `should return 400 when radiusKm is zero`() {
+            // given
+            every {
+                stadiumService.findNearbyStadiums(37.5, 127.0, 0.0, any<Pageable>())
+            } throws InvalidInputException("INVALID_RADIUS", "검색 반경은 0보다 커야 합니다: 0.0")
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/stadiums/nearby")
+                        .param("latitude", "37.5")
+                        .param("longitude", "127.0")
+                        .param("radiusKm", "0.0"),
+                ).andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_RADIUS"))
+        }
     }
 
     @Nested

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumRepositoryPort.kt
@@ -1,6 +1,8 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.stadium.Stadium
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 /**
  * 구장 리포지토리 포트 인터페이스
@@ -27,4 +29,20 @@ interface StadiumRepositoryPort {
         longitude: Double,
         radiusKm: Double,
     ): List<Stadium>
+
+    /**
+     * 특정 위치 근처의 구장을 페이징하여 거리 순으로 검색합니다 (PostGIS 활용).
+     *
+     * @param latitude 위도 (-90 ~ 90)
+     * @param longitude 경도 (-180 ~ 180)
+     * @param radiusKm 검색 반경 (킬로미터, 0 초과)
+     * @param pageable 페이징 정보
+     * @return 거리 순으로 정렬된 구장 페이지
+     */
+    fun findNearbyStadiums(
+        latitude: Double,
+        longitude: Double,
+        radiusKm: Double,
+        pageable: Pageable,
+    ): Page<Stadium>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumService.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.service.stadium
 
 import com.nextup.common.exception.BookingNotFoundException
+import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.SlotNotFoundException
 import com.nextup.common.exception.StadiumNotFoundException
 import com.nextup.core.domain.stadium.BookingStatus
@@ -12,6 +13,8 @@ import com.nextup.core.port.repository.StadiumBookingRepositoryPort
 import com.nextup.core.port.repository.StadiumRepositoryPort
 import com.nextup.core.port.repository.StadiumSlotRepositoryPort
 import com.nextup.core.service.stadium.dto.BookSlotRequest
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -36,6 +39,42 @@ class StadiumService(
         longitude: Double,
         radiusKm: Double,
     ): List<Stadium> = stadiumRepository.findNearby(latitude, longitude, radiusKm)
+
+    /**
+     * 위치 기반으로 근처 구장을 거리 순으로 페이징하여 검색합니다.
+     *
+     * @param latitude 위도 (-90 ~ 90)
+     * @param longitude 경도 (-180 ~ 180)
+     * @param radiusKm 검색 반경 킬로미터 (0 초과)
+     * @param pageable 페이징 정보
+     * @return 거리 순으로 정렬된 구장 페이지
+     */
+    fun findNearbyStadiums(
+        latitude: Double,
+        longitude: Double,
+        radiusKm: Double,
+        pageable: Pageable,
+    ): Page<Stadium> {
+        if (latitude !in -90.0..90.0) {
+            throw InvalidInputException(
+                "INVALID_LATITUDE",
+                "위도는 -90 ~ 90 범위여야 합니다: $latitude",
+            )
+        }
+        if (longitude !in -180.0..180.0) {
+            throw InvalidInputException(
+                "INVALID_LONGITUDE",
+                "경도는 -180 ~ 180 범위여야 합니다: $longitude",
+            )
+        }
+        if (radiusKm <= 0) {
+            throw InvalidInputException(
+                "INVALID_RADIUS",
+                "검색 반경은 0보다 커야 합니다: $radiusKm",
+            )
+        }
+        return stadiumRepository.findNearbyStadiums(latitude, longitude, radiusKm, pageable)
+    }
 
     /**
      * ID로 구장을 조회합니다.

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumAdminServiceExtendedTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumAdminServiceExtendedTest.kt
@@ -1,0 +1,150 @@
+package com.nextup.core.service.stadium
+
+import com.nextup.common.exception.StadiumNotFoundException
+import com.nextup.core.domain.stadium.Stadium
+import com.nextup.core.port.repository.StadiumRepositoryPort
+import com.nextup.core.port.repository.StadiumSlotRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("StadiumAdminService - Extended")
+class StadiumAdminServiceExtendedTest {
+    private lateinit var stadiumRepository: StadiumRepositoryPort
+    private lateinit var slotRepository: StadiumSlotRepositoryPort
+    private lateinit var stadiumAdminService: StadiumAdminService
+
+    @BeforeEach
+    fun setUp() {
+        stadiumRepository = mockk()
+        slotRepository = mockk()
+        stadiumAdminService = StadiumAdminService(stadiumRepository, slotRepository)
+    }
+
+    @Nested
+    @DisplayName("deactivateStadium")
+    inner class DeactivateStadium {
+        @Test
+        fun `should throw exception when stadium not found`() {
+            // given
+            every { stadiumRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                stadiumAdminService.deactivateStadium(999L)
+            }.isInstanceOf(StadiumNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should deactivate active stadium`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            assertThat(stadium.isActive).isTrue()
+            every { stadiumRepository.findByIdOrNull(1L) } returns stadium
+
+            // when
+            val result = stadiumAdminService.deactivateStadium(1L)
+
+            // then
+            assertThat(result.isActive).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("activateStadium")
+    inner class ActivateStadium {
+        @Test
+        fun `should throw exception when stadium not found`() {
+            // given
+            every { stadiumRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                stadiumAdminService.activateStadium(999L)
+            }.isInstanceOf(StadiumNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should activate deactivated stadium`() {
+            // given
+            val stadium =
+                createStadium(1L, "잠실 야구장", 37.5121, 127.0717).apply {
+                    deactivate()
+                }
+            assertThat(stadium.isActive).isFalse()
+            every { stadiumRepository.findByIdOrNull(1L) } returns stadium
+
+            // when
+            val result = stadiumAdminService.activateStadium(1L)
+
+            // then
+            assertThat(result.isActive).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStadium - additional cases")
+    inner class UpdateStadium {
+        @Test
+        fun `should update latitude and longitude when provided`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            every { stadiumRepository.findByIdOrNull(1L) } returns stadium
+
+            // when
+            val result =
+                stadiumAdminService.updateStadium(
+                    id = 1L,
+                    latitude = 37.6000,
+                    longitude = 127.1000,
+                )
+
+            // then
+            assertThat(result.latitude).isEqualTo(37.6000)
+            assertThat(result.longitude).isEqualTo(127.1000)
+        }
+
+        @Test
+        fun `should update contactInfo and imageUrls when provided`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            every { stadiumRepository.findByIdOrNull(1L) } returns stadium
+
+            // when
+            val result =
+                stadiumAdminService.updateStadium(
+                    id = 1L,
+                    contactInfo = "02-9999-8888",
+                    imageUrls = "https://example.com/img.jpg",
+                )
+
+            // then
+            assertThat(result.contactInfo).isEqualTo("02-9999-8888")
+            assertThat(result.imageUrls).isEqualTo("https://example.com/img.jpg")
+        }
+    }
+
+    private fun createStadium(
+        id: Long,
+        name: String,
+        latitude: Double,
+        longitude: Double,
+    ): Stadium {
+        val stadium =
+            Stadium.create(
+                name = name,
+                address = "서울특별시",
+                latitude = latitude,
+                longitude = longitude,
+            )
+        val idField = Stadium::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(stadium, id)
+        return stadium
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumServiceTest.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.service.stadium
 
 import com.nextup.common.exception.BookingNotFoundException
+import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.SlotNotFoundException
 import com.nextup.common.exception.StadiumNotFoundException
 import com.nextup.core.domain.stadium.BookingStatus
@@ -21,6 +22,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -37,6 +40,93 @@ class StadiumServiceTest {
         slotRepository = mockk()
         bookingRepository = mockk()
         stadiumService = StadiumService(stadiumRepository, slotRepository, bookingRepository)
+    }
+
+    @Nested
+    @DisplayName("findNearbyStadiums")
+    inner class FindNearbyStadiums {
+        @Test
+        fun `should return paged stadiums ordered by distance`() {
+            // given
+            val stadiums =
+                listOf(
+                    createStadium(1L, "잠실 야구장", 37.5121, 127.0717),
+                    createStadium(2L, "고척 야구장", 37.4981, 126.8671),
+                )
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(stadiums, pageable, 2)
+            every { stadiumRepository.findNearbyStadiums(37.5, 127.0, 10.0, pageable) } returns page
+
+            // when
+            val result = stadiumService.findNearbyStadiums(37.5, 127.0, 10.0, pageable)
+
+            // then
+            assertThat(result.content).hasSize(2)
+            assertThat(result.totalElements).isEqualTo(2)
+            assertThat(result.content[0].name).isEqualTo("잠실 야구장")
+        }
+
+        @Test
+        fun `should throw InvalidInputException when latitude is out of range`() {
+            // given
+            val pageable = PageRequest.of(0, 20)
+
+            // when & then
+            assertThatThrownBy {
+                stadiumService.findNearbyStadiums(91.0, 127.0, 10.0, pageable)
+            }.isInstanceOf(InvalidInputException::class.java)
+                .hasMessageContaining("위도는 -90 ~ 90 범위여야 합니다")
+        }
+
+        @Test
+        fun `should throw InvalidInputException when longitude is out of range`() {
+            // given
+            val pageable = PageRequest.of(0, 20)
+
+            // when & then
+            assertThatThrownBy {
+                stadiumService.findNearbyStadiums(37.5, 181.0, 10.0, pageable)
+            }.isInstanceOf(InvalidInputException::class.java)
+                .hasMessageContaining("경도는 -180 ~ 180 범위여야 합니다")
+        }
+
+        @Test
+        fun `should throw InvalidInputException when radiusKm is zero`() {
+            // given
+            val pageable = PageRequest.of(0, 20)
+
+            // when & then
+            assertThatThrownBy {
+                stadiumService.findNearbyStadiums(37.5, 127.0, 0.0, pageable)
+            }.isInstanceOf(InvalidInputException::class.java)
+                .hasMessageContaining("검색 반경은 0보다 커야 합니다")
+        }
+
+        @Test
+        fun `should throw InvalidInputException when radiusKm is negative`() {
+            // given
+            val pageable = PageRequest.of(0, 20)
+
+            // when & then
+            assertThatThrownBy {
+                stadiumService.findNearbyStadiums(37.5, 127.0, -5.0, pageable)
+            }.isInstanceOf(InvalidInputException::class.java)
+                .hasMessageContaining("검색 반경은 0보다 커야 합니다")
+        }
+
+        @Test
+        fun `should accept boundary latitude values`() {
+            // given
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(emptyList<Stadium>(), pageable, 0)
+            every { stadiumRepository.findNearbyStadiums(90.0, 180.0, 10.0, pageable) } returns page
+
+            // when
+            val result = stadiumService.findNearbyStadiums(90.0, 180.0, 10.0, pageable)
+
+            // then
+            assertThat(result.content).isEmpty()
+        }
     }
 
     @Nested

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumJpaRepository.kt
@@ -31,21 +31,21 @@ interface StadiumJpaRepository : JpaRepository<Stadium, Long> {
         value = """
         SELECT s.* FROM stadiums s
         WHERE ST_DWithin(
-            s.location,
-            ST_SetSRID(ST_Point(:longitude, :latitude), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(s.longitude, s.latitude), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
             :radiusMeters
         )
         AND s.is_active = true
         ORDER BY ST_Distance(
-            s.location,
-            ST_SetSRID(ST_Point(:longitude, :latitude), 4326)::geography
+            ST_SetSRID(ST_MakePoint(s.longitude, s.latitude), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography
         ) ASC
         """,
         countQuery = """
         SELECT COUNT(*) FROM stadiums s
         WHERE ST_DWithin(
-            s.location,
-            ST_SetSRID(ST_Point(:longitude, :latitude), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(s.longitude, s.latitude), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
             :radiusMeters
         )
         AND s.is_active = true

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumJpaRepository.kt
@@ -1,6 +1,8 @@
 package com.nextup.infrastructure.persistence.stadium
 
 import com.nextup.core.domain.stadium.Stadium
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -24,4 +26,36 @@ interface StadiumJpaRepository : JpaRepository<Stadium, Long> {
         longitude: Double,
         radiusMeters: Double,
     ): List<Stadium>
+
+    @Query(
+        value = """
+        SELECT s.* FROM stadiums s
+        WHERE ST_DWithin(
+            s.location,
+            ST_SetSRID(ST_Point(:longitude, :latitude), 4326)::geography,
+            :radiusMeters
+        )
+        AND s.is_active = true
+        ORDER BY ST_Distance(
+            s.location,
+            ST_SetSRID(ST_Point(:longitude, :latitude), 4326)::geography
+        ) ASC
+        """,
+        countQuery = """
+        SELECT COUNT(*) FROM stadiums s
+        WHERE ST_DWithin(
+            s.location,
+            ST_SetSRID(ST_Point(:longitude, :latitude), 4326)::geography,
+            :radiusMeters
+        )
+        AND s.is_active = true
+        """,
+        nativeQuery = true,
+    )
+    fun findNearbyOrderByDistance(
+        latitude: Double,
+        longitude: Double,
+        radiusMeters: Double,
+        pageable: Pageable,
+    ): Page<Stadium>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumRepositoryAdapter.kt
@@ -2,6 +2,8 @@ package com.nextup.infrastructure.persistence.stadium
 
 import com.nextup.core.domain.stadium.Stadium
 import com.nextup.core.port.repository.StadiumRepositoryPort
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
@@ -24,5 +26,15 @@ class StadiumRepositoryAdapter(
     ): List<Stadium> {
         val radiusMeters = radiusKm * 1000.0
         return jpaRepository.findNearby(latitude, longitude, radiusMeters)
+    }
+
+    override fun findNearbyStadiums(
+        latitude: Double,
+        longitude: Double,
+        radiusKm: Double,
+        pageable: Pageable,
+    ): Page<Stadium> {
+        val radiusMeters = radiusKm * 1000.0
+        return jpaRepository.findNearbyOrderByDistance(latitude, longitude, radiusMeters, pageable)
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumBookingRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumBookingRepositoryAdapterTest.kt
@@ -1,6 +1,7 @@
 package com.nextup.infrastructure.persistence.stadium
 
 import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.domain.stadium.Stadium
 import com.nextup.core.domain.stadium.StadiumBooking
 import com.nextup.core.domain.stadium.StadiumSlot
 import io.mockk.every
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
+import java.time.LocalTime
 
 @DisplayName("StadiumBookingRepositoryAdapter")
 class StadiumBookingRepositoryAdapterTest {
@@ -22,14 +25,6 @@ class StadiumBookingRepositoryAdapterTest {
     fun setUp() {
         jpaRepository = mockk()
         adapter = StadiumBookingRepositoryAdapter(jpaRepository)
-    }
-
-    private fun createBooking(
-        teamId: Long = 10L,
-        bookedBy: Long = 100L,
-    ): StadiumBooking {
-        val slot = mockk<StadiumSlot>(relaxed = true)
-        return StadiumBooking.create(slot = slot, teamId = teamId, bookedBy = bookedBy)
     }
 
     @Nested
@@ -69,10 +64,10 @@ class StadiumBookingRepositoryAdapterTest {
         @Test
         fun `should return null when not found`() {
             // given
-            every { jpaRepository.findByIdOrNull(99L) } returns null
+            every { jpaRepository.findByIdOrNull(999L) } returns null
 
             // when
-            val result = adapter.findByIdOrNull(99L)
+            val result = adapter.findByIdOrNull(999L)
 
             // then
             assertThat(result).isNull()
@@ -86,10 +81,10 @@ class StadiumBookingRepositoryAdapterTest {
         fun `should return bookings for given slot`() {
             // given
             val booking = createBooking()
-            every { jpaRepository.findBySlotId(5L) } returns listOf(booking)
+            every { jpaRepository.findBySlotId(1L) } returns listOf(booking)
 
             // when
-            val result = adapter.findBySlotId(5L)
+            val result = adapter.findBySlotId(1L)
 
             // then
             assertThat(result).hasSize(1)
@@ -114,15 +109,28 @@ class StadiumBookingRepositoryAdapterTest {
         @Test
         fun `should return bookings for given team`() {
             // given
-            val booking = createBooking(teamId = 10L)
-            every { jpaRepository.findByTeamId(10L) } returns listOf(booking)
+            val booking = createBooking()
+            every { jpaRepository.findByTeamId(100L) } returns listOf(booking)
 
             // when
-            val result = adapter.findByTeamId(10L)
+            val result = adapter.findByTeamId(100L)
 
             // then
             assertThat(result).hasSize(1)
-            assertThat(result[0].teamId).isEqualTo(10L)
+            assertThat(result[0].teamId).isEqualTo(100L)
+        }
+
+        @Test
+        fun `should return all bookings for team`() {
+            // given
+            val bookings = listOf(createBooking(), createBooking())
+            every { jpaRepository.findByTeamId(100L) } returns bookings
+
+            // when
+            val result = adapter.findByTeamId(100L)
+
+            // then
+            assertThat(result).hasSize(2)
         }
 
         @Test
@@ -144,11 +152,13 @@ class StadiumBookingRepositoryAdapterTest {
         @Test
         fun `should return confirmed bookings for given team`() {
             // given
-            val booking = createBooking(teamId = 10L)
-            every { jpaRepository.findByTeamIdAndStatus(10L, BookingStatus.CONFIRMED) } returns listOf(booking)
+            val booking = createBooking()
+            every {
+                jpaRepository.findByTeamIdAndStatus(100L, BookingStatus.CONFIRMED)
+            } returns listOf(booking)
 
             // when
-            val result = adapter.findByTeamIdAndStatus(10L, BookingStatus.CONFIRMED)
+            val result = adapter.findByTeamIdAndStatus(100L, BookingStatus.CONFIRMED)
 
             // then
             assertThat(result).hasSize(1)
@@ -158,10 +168,12 @@ class StadiumBookingRepositoryAdapterTest {
         @Test
         fun `should return empty list when no bookings match team and status`() {
             // given
-            every { jpaRepository.findByTeamIdAndStatus(10L, BookingStatus.CANCELLED) } returns emptyList()
+            every {
+                jpaRepository.findByTeamIdAndStatus(100L, BookingStatus.CANCELLED)
+            } returns emptyList()
 
             // when
-            val result = adapter.findByTeamIdAndStatus(10L, BookingStatus.CANCELLED)
+            val result = adapter.findByTeamIdAndStatus(100L, BookingStatus.CANCELLED)
 
             // then
             assertThat(result).isEmpty()
@@ -174,7 +186,9 @@ class StadiumBookingRepositoryAdapterTest {
         @Test
         fun `should return true when booking exists for slot and status`() {
             // given
-            every { jpaRepository.existsBySlotIdAndStatus(1L, BookingStatus.CONFIRMED) } returns true
+            every {
+                jpaRepository.existsBySlotIdAndStatus(1L, BookingStatus.CONFIRMED)
+            } returns true
 
             // when
             val result = adapter.existsBySlotIdAndStatus(1L, BookingStatus.CONFIRMED)
@@ -186,7 +200,9 @@ class StadiumBookingRepositoryAdapterTest {
         @Test
         fun `should return false when no booking exists for slot and status`() {
             // given
-            every { jpaRepository.existsBySlotIdAndStatus(99L, BookingStatus.CONFIRMED) } returns false
+            every {
+                jpaRepository.existsBySlotIdAndStatus(99L, BookingStatus.CONFIRMED)
+            } returns false
 
             // when
             val result = adapter.existsBySlotIdAndStatus(99L, BookingStatus.CONFIRMED)
@@ -194,5 +210,23 @@ class StadiumBookingRepositoryAdapterTest {
             // then
             assertThat(result).isFalse()
         }
+    }
+
+    private fun createBooking(): StadiumBooking {
+        val stadium =
+            Stadium.create(
+                name = "잠실 야구장",
+                address = "서울특별시",
+                latitude = 37.5121,
+                longitude = 127.0717,
+            )
+        val slot =
+            StadiumSlot.create(
+                stadium = stadium,
+                date = LocalDate.of(2024, 12, 25),
+                startTime = LocalTime.of(10, 0),
+                endTime = LocalTime.of(12, 0),
+            )
+        return StadiumBooking.create(slot = slot, teamId = 100L, bookedBy = 200L)
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumRepositoryAdapterTest.kt
@@ -1,0 +1,198 @@
+package com.nextup.infrastructure.persistence.stadium
+
+import com.nextup.core.domain.stadium.Stadium
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+
+@DisplayName("StadiumRepositoryAdapter")
+class StadiumRepositoryAdapterTest {
+    private lateinit var jpaRepository: StadiumJpaRepository
+    private lateinit var adapter: StadiumRepositoryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        jpaRepository = mockk()
+        adapter = StadiumRepositoryAdapter(jpaRepository)
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+        @Test
+        fun `should save and return stadium`() {
+            // given
+            val stadium = createStadium("잠실 야구장", 37.5121, 127.0717)
+            every { jpaRepository.save(stadium) } returns stadium
+
+            // when
+            val result = adapter.save(stadium)
+
+            // then
+            assertThat(result).isEqualTo(stadium)
+            verify { jpaRepository.save(stadium) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdOrNull")
+    inner class FindByIdOrNull {
+        @Test
+        fun `should return stadium when found`() {
+            // given
+            val stadium = createStadium("잠실 야구장", 37.5121, 127.0717)
+            every { jpaRepository.findByIdOrNull(1L) } returns stadium
+
+            // when
+            val result = adapter.findByIdOrNull(1L)
+
+            // then
+            assertThat(result).isEqualTo(stadium)
+        }
+
+        @Test
+        fun `should return null when not found`() {
+            // given
+            every { jpaRepository.findByIdOrNull(999L) } returns null
+
+            // when
+            val result = adapter.findByIdOrNull(999L)
+
+            // then
+            assertThat(result).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("findAll")
+    inner class FindAll {
+        @Test
+        fun `should return all stadiums`() {
+            // given
+            val stadiums =
+                listOf(
+                    createStadium("잠실 야구장", 37.5121, 127.0717),
+                    createStadium("고척 야구장", 37.4981, 126.8671),
+                )
+            every { jpaRepository.findAll() } returns stadiums
+
+            // when
+            val result = adapter.findAll()
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllActive")
+    inner class FindAllActive {
+        @Test
+        fun `should return only active stadiums`() {
+            // given
+            val activeStadium = createStadium("잠실 야구장", 37.5121, 127.0717)
+            every { jpaRepository.findByIsActiveTrue() } returns listOf(activeStadium)
+
+            // when
+            val result = adapter.findAllActive()
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].isActive).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("findNearby")
+    inner class FindNearby {
+        @Test
+        fun `should convert km to meters and call jpaRepository`() {
+            // given
+            val stadiums = listOf(createStadium("잠실 야구장", 37.5121, 127.0717))
+            // 10km -> 10000.0 meters
+            every { jpaRepository.findNearby(37.5, 127.0, 10000.0) } returns stadiums
+
+            // when
+            val result = adapter.findNearby(37.5, 127.0, 10.0)
+
+            // then
+            assertThat(result).hasSize(1)
+            verify { jpaRepository.findNearby(37.5, 127.0, 10000.0) }
+        }
+
+        @Test
+        fun `should convert 5km to 5000 meters`() {
+            // given
+            val stadiums = emptyList<Stadium>()
+            every { jpaRepository.findNearby(35.0, 129.0, 5000.0) } returns stadiums
+
+            // when
+            val result = adapter.findNearby(35.0, 129.0, 5.0)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findNearby(35.0, 129.0, 5000.0) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findNearbyStadiums")
+    inner class FindNearbyStadiums {
+        @Test
+        fun `should convert km to meters and return paged result`() {
+            // given
+            val stadiums = listOf(createStadium("잠실 야구장", 37.5121, 127.0717))
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(stadiums, pageable, 1)
+            // 10km -> 10000.0 meters
+            every {
+                jpaRepository.findNearbyOrderByDistance(37.5, 127.0, 10000.0, pageable)
+            } returns page
+
+            // when
+            val result = adapter.findNearbyStadiums(37.5, 127.0, 10.0, pageable)
+
+            // then
+            assertThat(result.content).hasSize(1)
+            assertThat(result.totalElements).isEqualTo(1)
+            verify { jpaRepository.findNearbyOrderByDistance(37.5, 127.0, 10000.0, pageable) }
+        }
+
+        @Test
+        fun `should return empty page when no stadiums found`() {
+            // given
+            val pageable = PageRequest.of(0, 20)
+            val emptyPage = PageImpl(emptyList<Stadium>(), pageable, 0)
+            every {
+                jpaRepository.findNearbyOrderByDistance(37.5, 127.0, 1000.0, pageable)
+            } returns emptyPage
+
+            // when
+            val result = adapter.findNearbyStadiums(37.5, 127.0, 1.0, pageable)
+
+            // then
+            assertThat(result.content).isEmpty()
+            assertThat(result.totalElements).isEqualTo(0)
+        }
+    }
+
+    private fun createStadium(
+        name: String,
+        latitude: Double,
+        longitude: Double,
+    ): Stadium =
+        Stadium.create(
+            name = name,
+            address = "서울특별시",
+            latitude = latitude,
+            longitude = longitude,
+        )
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumSlotRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumSlotRepositoryAdapterTest.kt
@@ -1,0 +1,193 @@
+package com.nextup.infrastructure.persistence.stadium
+
+import com.nextup.core.domain.stadium.SlotStatus
+import com.nextup.core.domain.stadium.Stadium
+import com.nextup.core.domain.stadium.StadiumSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
+import java.time.LocalTime
+
+@DisplayName("StadiumSlotRepositoryAdapter")
+class StadiumSlotRepositoryAdapterTest {
+    private lateinit var jpaRepository: StadiumSlotJpaRepository
+    private lateinit var adapter: StadiumSlotRepositoryAdapter
+
+    @BeforeEach
+    fun setUp() {
+        jpaRepository = mockk()
+        adapter = StadiumSlotRepositoryAdapter(jpaRepository)
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+        @Test
+        fun `should save and return slot`() {
+            // given
+            val stadium = createStadium()
+            val slot = createSlot(stadium, LocalDate.of(2024, 12, 25))
+            every { jpaRepository.save(slot) } returns slot
+
+            // when
+            val result = adapter.save(slot)
+
+            // then
+            assertThat(result).isEqualTo(slot)
+            verify { jpaRepository.save(slot) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdOrNull")
+    inner class FindByIdOrNull {
+        @Test
+        fun `should return slot when found`() {
+            // given
+            val stadium = createStadium()
+            val slot = createSlot(stadium, LocalDate.of(2024, 12, 25))
+            every { jpaRepository.findByIdOrNull(1L) } returns slot
+
+            // when
+            val result = adapter.findByIdOrNull(1L)
+
+            // then
+            assertThat(result).isEqualTo(slot)
+        }
+
+        @Test
+        fun `should return null when not found`() {
+            // given
+            every { jpaRepository.findByIdOrNull(999L) } returns null
+
+            // when
+            val result = adapter.findByIdOrNull(999L)
+
+            // then
+            assertThat(result).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("findByStadiumIdAndDate")
+    inner class FindByStadiumIdAndDate {
+        @Test
+        fun `should return slots for given stadium and date`() {
+            // given
+            val stadium = createStadium()
+            val date = LocalDate.of(2024, 12, 25)
+            val slots =
+                listOf(
+                    createSlot(stadium, date),
+                    createSlot(stadium, date),
+                )
+            every { jpaRepository.findByStadiumIdAndDate(1L, date) } returns slots
+
+            // when
+            val result = adapter.findByStadiumIdAndDate(1L, date)
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+
+        @Test
+        fun `should return empty list when no slots found`() {
+            // given
+            val date = LocalDate.of(2024, 12, 25)
+            every { jpaRepository.findByStadiumIdAndDate(1L, date) } returns emptyList()
+
+            // when
+            val result = adapter.findByStadiumIdAndDate(1L, date)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("findByStadiumIdAndDateBetween")
+    inner class FindByStadiumIdAndDateBetween {
+        @Test
+        fun `should return slots within date range`() {
+            // given
+            val stadium = createStadium()
+            val startDate = LocalDate.of(2024, 12, 1)
+            val endDate = LocalDate.of(2024, 12, 31)
+            val slots =
+                listOf(
+                    createSlot(stadium, LocalDate.of(2024, 12, 10)),
+                    createSlot(stadium, LocalDate.of(2024, 12, 20)),
+                )
+            every {
+                jpaRepository.findByStadiumIdAndDateBetween(1L, startDate, endDate)
+            } returns slots
+
+            // when
+            val result = adapter.findByStadiumIdAndDateBetween(1L, startDate, endDate)
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("findByStadiumIdAndStatus")
+    inner class FindByStadiumIdAndStatus {
+        @Test
+        fun `should return slots with given status`() {
+            // given
+            val stadium = createStadium()
+            val slot = createSlot(stadium, LocalDate.of(2024, 12, 25))
+            every {
+                jpaRepository.findByStadiumIdAndStatus(1L, SlotStatus.AVAILABLE)
+            } returns listOf(slot)
+
+            // when
+            val result = adapter.findByStadiumIdAndStatus(1L, SlotStatus.AVAILABLE)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].status).isEqualTo(SlotStatus.AVAILABLE)
+        }
+
+        @Test
+        fun `should return empty list when no slots with given status`() {
+            // given
+            every {
+                jpaRepository.findByStadiumIdAndStatus(1L, SlotStatus.BOOKED)
+            } returns emptyList()
+
+            // when
+            val result = adapter.findByStadiumIdAndStatus(1L, SlotStatus.BOOKED)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    private fun createStadium(): Stadium =
+        Stadium.create(
+            name = "잠실 야구장",
+            address = "서울특별시",
+            latitude = 37.5121,
+            longitude = 127.0717,
+        )
+
+    private fun createSlot(
+        stadium: Stadium,
+        date: LocalDate,
+    ): StadiumSlot =
+        StadiumSlot.create(
+            stadium = stadium,
+            date = date,
+            startTime = LocalTime.of(10, 0),
+            endTime = LocalTime.of(12, 0),
+        )
+}


### PR DESCRIPTION
## Summary

>- close #135

PostGIS의 ST_DWithin/ST_Distance를 활용한 **위치 기반 구장 검색** 기능을 구현합니다.

## Tasks

- StadiumRepositoryPort에 findNearbyStadiums() 메서드 추가
- Native Query로 ST_DWithin(반경 필터링) + ST_Distance(거리순 정렬) 구현
- StadiumService에 입력값 검증 로직 추가 (위도/경도/반경)
- API 엔드포인트 추가 (GET /api/v1/stadiums/nearby)
- StadiumServiceTest (5개) + StadiumControllerTest (5개) 단위 테스트

## To Reviewer

- 반경은 km 단위로 입력받아 내부에서 미터로 변환합니다.
- 페이징 지원 (기본 size=20).
- PostGIS extension이 DB에 설치되어 있어야 합니다.
- 빌드 성공 (87 tasks passed)