### PR TITLE
feat(#137): 순위 시뮬레이션 및 매직넘버 계산 추가

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/StandingsSimulationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/StandingsSimulationController.kt
@@ -1,0 +1,82 @@
+package com.nextup.api.controller.competition
+
+import com.nextup.api.dto.common.ApiResponse
+import com.nextup.api.dto.standings.MagicNumberResponse
+import com.nextup.api.dto.standings.PlayoffScenarioResponse
+import com.nextup.api.dto.standings.SimulationApiRequest
+import com.nextup.api.dto.standings.SimulationResultResponse
+import com.nextup.core.service.standings.StandingsSimulationService
+import com.nextup.core.service.standings.dto.SimulatedGameResult
+import com.nextup.core.service.standings.dto.SimulationRequest
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 순위 시뮬레이션 Controller (일반 사용자 - 조회 전용)
+ */
+@Validated
+@RestController
+@RequestMapping("/api/v1/competitions/{competitionId}/standings")
+class StandingsSimulationController(
+    private val standingsSimulationService: StandingsSimulationService,
+) {
+    /**
+     * 대회 각 팀의 매직넘버를 조회합니다.
+     */
+    @GetMapping("/magic-numbers")
+    fun getMagicNumbers(
+        @PathVariable competitionId: Long,
+    ): ApiResponse<List<MagicNumberResponse>> {
+        val magicNumbers = standingsSimulationService.calculateMagicNumbers(competitionId)
+        return ApiResponse.success(magicNumbers.map { MagicNumberResponse.from(it) })
+    }
+
+    /**
+     * 가상의 경기 결과를 적용한 예상 순위표를 반환합니다.
+     */
+    @PostMapping("/simulation")
+    fun simulateStandings(
+        @PathVariable competitionId: Long,
+        @RequestBody @Valid request: SimulationApiRequest,
+    ): ApiResponse<SimulationResultResponse> {
+        val coreRequest =
+            SimulationRequest(
+                gameResults =
+                    request.gameResults.map { result ->
+                        SimulatedGameResult(
+                            gameId = result.gameId,
+                            homeScore = result.homeScore,
+                            awayScore = result.awayScore,
+                        )
+                    },
+            )
+        val result = standingsSimulationService.simulateStandings(competitionId, coreRequest)
+        return ApiResponse.success(SimulationResultResponse.from(result))
+    }
+
+    /**
+     * 특정 팀의 플레이오프 진출 시나리오를 조회합니다.
+     */
+    @GetMapping("/playoff-scenarios")
+    fun getPlayoffScenarios(
+        @PathVariable competitionId: Long,
+        @RequestParam teamId: Long,
+        @RequestParam @Min(1) playoffTeams: Int,
+    ): ApiResponse<PlayoffScenarioResponse> {
+        val result =
+            standingsSimulationService.calculatePlayoffScenarios(
+                competitionId = competitionId,
+                teamId = teamId,
+                playoffTeams = playoffTeams,
+            )
+        return ApiResponse.success(PlayoffScenarioResponse.from(result))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/standings/SimulationApiDto.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/standings/SimulationApiDto.kt
@@ -103,8 +103,8 @@ data class SimulationResultResponse(
  * 플레이오프 시나리오 결과 응답
  */
 data class PlayoffScenarioResponse(
-    val totalScenarios: Int,
-    val qualifyingScenarios: Int,
+    val totalScenarios: Long,
+    val qualifyingScenarios: Long,
     val probability: Double,
     val magicNumber: Int?,
 ) {

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/standings/SimulationApiDto.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/standings/SimulationApiDto.kt
@@ -1,0 +1,120 @@
+package com.nextup.api.dto.standings
+
+import com.nextup.core.service.standings.dto.MagicNumber
+import com.nextup.core.service.standings.dto.PlayoffScenarioResult
+import com.nextup.core.service.standings.dto.RankChange
+import com.nextup.core.service.standings.dto.SimulationResult
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+
+// ============================================================
+// Request DTOs
+// ============================================================
+
+/**
+ * 순위 시뮬레이션 요청
+ */
+data class SimulationApiRequest(
+    @field:NotNull
+    @field:Valid
+    val gameResults: List<SimulatedGameResultRequest>,
+)
+
+/**
+ * 시뮬레이션용 경기 결과 요청
+ */
+data class SimulatedGameResultRequest(
+    @field:NotNull
+    val gameId: Long,
+    @field:NotNull
+    @field:Min(0)
+    val homeScore: Int,
+    @field:NotNull
+    @field:Min(0)
+    val awayScore: Int,
+)
+
+// ============================================================
+// Response DTOs
+// ============================================================
+
+/**
+ * 매직넘버 응답
+ */
+data class MagicNumberResponse(
+    val teamId: Long,
+    val targetRank: Int,
+    val magicNumber: Int,
+    val isClinched: Boolean,
+    val isEliminated: Boolean,
+) {
+    companion object {
+        fun from(dto: MagicNumber): MagicNumberResponse =
+            MagicNumberResponse(
+                teamId = dto.teamId,
+                targetRank = dto.targetRank,
+                magicNumber = dto.magicNumber,
+                isClinched = dto.isClinched,
+                isEliminated = dto.isEliminated,
+            )
+    }
+}
+
+/**
+ * 순위 변동 응답
+ */
+data class RankChangeResponse(
+    val teamId: Long,
+    val teamName: String,
+    val previousRank: Int,
+    val projectedRank: Int,
+    val rankChange: Int,
+) {
+    companion object {
+        fun from(dto: RankChange): RankChangeResponse =
+            RankChangeResponse(
+                teamId = dto.teamId,
+                teamName = dto.teamName,
+                previousRank = dto.previousRank,
+                projectedRank = dto.projectedRank,
+                rankChange = dto.rankChange,
+            )
+    }
+}
+
+/**
+ * 시뮬레이션 결과 응답
+ */
+data class SimulationResultResponse(
+    val standings: List<TeamStandingResponse>,
+    val changes: List<RankChangeResponse>,
+) {
+    companion object {
+        fun from(dto: SimulationResult): SimulationResultResponse =
+            SimulationResultResponse(
+                standings = dto.standings.map { TeamStandingResponse.from(it) },
+                changes = dto.changes.map { RankChangeResponse.from(it) },
+            )
+    }
+}
+
+/**
+ * 플레이오프 시나리오 결과 응답
+ */
+data class PlayoffScenarioResponse(
+    val totalScenarios: Int,
+    val qualifyingScenarios: Int,
+    val probability: Double,
+    val magicNumber: Int?,
+) {
+    companion object {
+        fun from(dto: PlayoffScenarioResult): PlayoffScenarioResponse =
+            PlayoffScenarioResponse(
+                totalScenarios = dto.totalScenarios,
+                qualifyingScenarios = dto.qualifyingScenarios,
+                probability = dto.probability,
+                magicNumber = dto.magicNumber,
+            )
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/StandingsSimulationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/StandingsSimulationControllerTest.kt
@@ -1,0 +1,392 @@
+package com.nextup.api.controller.competition
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nextup.api.dto.standings.SimulatedGameResultRequest
+import com.nextup.api.dto.standings.SimulationApiRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.core.service.standings.StandingsSimulationService
+import com.nextup.core.service.standings.dto.MagicNumber
+import com.nextup.core.service.standings.dto.PlayoffScenarioResult
+import com.nextup.core.service.standings.dto.RankChange
+import com.nextup.core.service.standings.dto.SimulationResult
+import com.nextup.core.service.standings.dto.TeamStandingDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+
+@DisplayName("StandingsSimulationController")
+class StandingsSimulationControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var standingsSimulationService: StandingsSimulationService
+    private val objectMapper = ObjectMapper()
+
+    @BeforeEach
+    fun setUp() {
+        standingsSimulationService = mockk()
+        val controller = StandingsSimulationController(standingsSimulationService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    // =========================================================================
+    // GET /magic-numbers
+    // =========================================================================
+
+    @Nested
+    @DisplayName("GET /api/v1/competitions/{competitionId}/standings/magic-numbers")
+    inner class GetMagicNumbers {
+        @Test
+        fun `매직넘버 목록을 정상 조회한다`() {
+            val competitionId = 1L
+            val magicNumbers =
+                listOf(
+                    MagicNumber(teamId = 1L, targetRank = 1, magicNumber = 3, isClinched = false, isEliminated = false),
+                    MagicNumber(teamId = 2L, targetRank = 2, magicNumber = 6, isClinched = false, isEliminated = false),
+                    MagicNumber(teamId = 3L, targetRank = 3, magicNumber = 0, isClinched = true, isEliminated = false),
+                )
+
+            every { standingsSimulationService.calculateMagicNumbers(competitionId) } returns magicNumbers
+
+            mockMvc
+                .perform(get("/api/v1/competitions/$competitionId/standings/magic-numbers"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].teamId").value(1))
+                .andExpect(jsonPath("$.data[0].targetRank").value(1))
+                .andExpect(jsonPath("$.data[0].magicNumber").value(3))
+                .andExpect(jsonPath("$.data[0].isClinched").value(false))
+                .andExpect(jsonPath("$.data[0].isEliminated").value(false))
+                .andExpect(jsonPath("$.data[2].isClinched").value(true))
+        }
+
+        @Test
+        fun `경기가 없으면 빈 목록 반환`() {
+            val competitionId = 1L
+            every { standingsSimulationService.calculateMagicNumbers(competitionId) } returns emptyList()
+
+            mockMvc
+                .perform(get("/api/v1/competitions/$competitionId/standings/magic-numbers"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+
+        @Test
+        fun `대회가 없으면 404 반환`() {
+            val competitionId = 999L
+            every {
+                standingsSimulationService.calculateMagicNumbers(competitionId)
+            } throws CompetitionNotFoundException(competitionId)
+
+            mockMvc
+                .perform(get("/api/v1/competitions/$competitionId/standings/magic-numbers"))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("COMPETITION_NOT_FOUND"))
+        }
+    }
+
+    // =========================================================================
+    // POST /simulation
+    // =========================================================================
+
+    @Nested
+    @DisplayName("POST /api/v1/competitions/{competitionId}/standings/simulation")
+    inner class PostSimulation {
+        @Test
+        fun `시뮬레이션 결과를 정상 반환한다`() {
+            val competitionId = 1L
+            val simulationResult =
+                SimulationResult(
+                    standings =
+                        listOf(
+                            TeamStandingDto(
+                                rank = 1,
+                                teamId = 2L,
+                                teamName = "Lions",
+                                gamesPlayed = 6,
+                                remainingGames = 4,
+                                wins = 5,
+                                losses = 1,
+                                draws = 0,
+                                winningPercentage = BigDecimal("0.833"),
+                                gamesBehind = BigDecimal.ZERO,
+                                runsScored = 30,
+                                runsAllowed = 10,
+                                runDifferential = 20,
+                            ),
+                            TeamStandingDto(
+                                rank = 2,
+                                teamId = 1L,
+                                teamName = "Tigers",
+                                gamesPlayed = 6,
+                                remainingGames = 4,
+                                wins = 4,
+                                losses = 2,
+                                draws = 0,
+                                winningPercentage = BigDecimal("0.667"),
+                                gamesBehind = BigDecimal("1.0"),
+                                runsScored = 25,
+                                runsAllowed = 18,
+                                runDifferential = 7,
+                            ),
+                        ),
+                    changes =
+                        listOf(
+                            RankChange(
+                                teamId = 1L,
+                                teamName = "Tigers",
+                                previousRank = 1,
+                                projectedRank = 2,
+                                rankChange = -1,
+                            ),
+                            RankChange(
+                                teamId = 2L,
+                                teamName = "Lions",
+                                previousRank = 2,
+                                projectedRank = 1,
+                                rankChange = 1,
+                            ),
+                        ),
+                )
+
+            every {
+                standingsSimulationService.simulateStandings(eq(competitionId), any())
+            } returns simulationResult
+
+            val request =
+                SimulationApiRequest(
+                    gameResults =
+                        listOf(
+                            SimulatedGameResultRequest(gameId = 5L, homeScore = 2, awayScore = 7),
+                        ),
+                )
+
+            mockMvc
+                .perform(
+                    post("/api/v1/competitions/$competitionId/standings/simulation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.standings.length()").value(2))
+                .andExpect(jsonPath("$.data.standings[0].teamId").value(2))
+                .andExpect(jsonPath("$.data.standings[0].rank").value(1))
+                .andExpect(jsonPath("$.data.standings[1].teamId").value(1))
+                .andExpect(jsonPath("$.data.standings[1].rank").value(2))
+                .andExpect(jsonPath("$.data.changes.length()").value(2))
+                .andExpect(jsonPath("$.data.changes[0].teamId").value(1))
+                .andExpect(jsonPath("$.data.changes[0].rankChange").value(-1))
+        }
+
+        @Test
+        fun `빈 gameResults로도 시뮬레이션이 정상 동작한다`() {
+            val competitionId = 1L
+            val simulationResult =
+                SimulationResult(
+                    standings = emptyList(),
+                    changes = emptyList(),
+                )
+
+            every {
+                standingsSimulationService.simulateStandings(eq(competitionId), any())
+            } returns simulationResult
+
+            val request = SimulationApiRequest(gameResults = emptyList())
+
+            mockMvc
+                .perform(
+                    post("/api/v1/competitions/$competitionId/standings/simulation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.standings").isEmpty)
+                .andExpect(jsonPath("$.data.changes").isEmpty)
+        }
+
+        @Test
+        fun `대회가 없으면 404 반환`() {
+            val competitionId = 999L
+            every {
+                standingsSimulationService.simulateStandings(eq(competitionId), any())
+            } throws CompetitionNotFoundException(competitionId)
+
+            val request = SimulationApiRequest(gameResults = emptyList())
+
+            mockMvc
+                .perform(
+                    post("/api/v1/competitions/$competitionId/standings/simulation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+
+        @Test
+        fun `InvalidInputException 발생 시 400 반환`() {
+            val competitionId = 1L
+            every {
+                standingsSimulationService.simulateStandings(eq(competitionId), any())
+            } throws InvalidInputException("INVALID_SIMULATION_SCORE", "점수는 0 이상이어야 합니다.")
+
+            val request =
+                SimulationApiRequest(
+                    gameResults =
+                        listOf(
+                            SimulatedGameResultRequest(gameId = 1L, homeScore = 0, awayScore = 0),
+                        ),
+                )
+
+            mockMvc
+                .perform(
+                    post("/api/v1/competitions/$competitionId/standings/simulation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_SIMULATION_SCORE"))
+        }
+    }
+
+    // =========================================================================
+    // GET /playoff-scenarios
+    // =========================================================================
+
+    @Nested
+    @DisplayName("GET /api/v1/competitions/{competitionId}/standings/playoff-scenarios")
+    inner class GetPlayoffScenarios {
+        @Test
+        fun `플레이오프 시나리오를 정상 조회한다`() {
+            val competitionId = 1L
+            val teamId = 1L
+            val playoffTeams = 4
+            val scenarioResult =
+                PlayoffScenarioResult(
+                    totalScenarios = 27,
+                    qualifyingScenarios = 20,
+                    probability = 0.741,
+                    magicNumber = 3,
+                )
+
+            every {
+                standingsSimulationService.calculatePlayoffScenarios(competitionId, teamId, playoffTeams)
+            } returns scenarioResult
+
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/$competitionId/standings/playoff-scenarios")
+                        .param("teamId", teamId.toString())
+                        .param("playoffTeams", playoffTeams.toString()),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.totalScenarios").value(27))
+                .andExpect(jsonPath("$.data.qualifyingScenarios").value(20))
+                .andExpect(jsonPath("$.data.probability").value(0.741))
+                .andExpect(jsonPath("$.data.magicNumber").value(3))
+        }
+
+        @Test
+        fun `확률 100%인 경우 정상 반환`() {
+            val competitionId = 1L
+            val scenarioResult =
+                PlayoffScenarioResult(
+                    totalScenarios = 1,
+                    qualifyingScenarios = 1,
+                    probability = 1.0,
+                    magicNumber = null,
+                )
+
+            every {
+                standingsSimulationService.calculatePlayoffScenarios(competitionId, 1L, 4)
+            } returns scenarioResult
+
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/$competitionId/standings/playoff-scenarios")
+                        .param("teamId", "1")
+                        .param("playoffTeams", "4"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.probability").value(1.0))
+        }
+
+        @Test
+        fun `대회가 없으면 404 반환`() {
+            val competitionId = 999L
+            every {
+                standingsSimulationService.calculatePlayoffScenarios(competitionId, 1L, 4)
+            } throws CompetitionNotFoundException(competitionId)
+
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/$competitionId/standings/playoff-scenarios")
+                        .param("teamId", "1")
+                        .param("playoffTeams", "4"),
+                )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+
+        @Test
+        fun `팀이 대회에 없으면 400 반환`() {
+            val competitionId = 1L
+            every {
+                standingsSimulationService.calculatePlayoffScenarios(competitionId, 999L, 4)
+            } throws InvalidInputException("TEAM_NOT_IN_COMPETITION", "해당 팀은 이 대회에 참여하지 않습니다.")
+
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/$competitionId/standings/playoff-scenarios")
+                        .param("teamId", "999")
+                        .param("playoffTeams", "4"),
+                )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("TEAM_NOT_IN_COMPETITION"))
+        }
+
+        @Test
+        fun `playoffTeams 파라미터 누락 시 400 반환`() {
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/1/standings/playoff-scenarios")
+                        .param("teamId", "1"),
+                )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `teamId 파라미터 누락 시 400 반환`() {
+            mockMvc
+                .perform(
+                    get("/api/v1/competitions/1/standings/playoff-scenarios")
+                        .param("playoffTeams", "4"),
+                )
+                .andExpect(status().isBadRequest)
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/StandingsSimulationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/StandingsSimulationControllerTest.kt
@@ -284,8 +284,8 @@ class StandingsSimulationControllerTest {
             val playoffTeams = 4
             val scenarioResult =
                 PlayoffScenarioResult(
-                    totalScenarios = 27,
-                    qualifyingScenarios = 20,
+                    totalScenarios = 27L,
+                    qualifyingScenarios = 20L,
                     probability = 0.741,
                     magicNumber = 3,
                 )
@@ -313,8 +313,8 @@ class StandingsSimulationControllerTest {
             val competitionId = 1L
             val scenarioResult =
                 PlayoffScenarioResult(
-                    totalScenarios = 1,
-                    qualifyingScenarios = 1,
+                    totalScenarios = 1L,
+                    qualifyingScenarios = 1L,
                     probability = 1.0,
                     magicNumber = null,
                 )

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/standings/StandingsSimulationService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/standings/StandingsSimulationService.kt
@@ -1,0 +1,47 @@
+package com.nextup.core.service.standings
+
+import com.nextup.core.service.standings.dto.MagicNumber
+import com.nextup.core.service.standings.dto.PlayoffScenarioResult
+import com.nextup.core.service.standings.dto.SimulationRequest
+import com.nextup.core.service.standings.dto.SimulationResult
+
+/**
+ * 순위 시뮬레이션 서비스
+ */
+interface StandingsSimulationService {
+    /**
+     * 대회의 각 팀별 매직넘버를 계산합니다.
+     *
+     * @param competitionId 대회 ID
+     * @return 팀별 매직넘버 목록
+     */
+    fun calculateMagicNumbers(competitionId: Long): List<MagicNumber>
+
+    /**
+     * 가상의 경기 결과를 적용하여 예상 순위표를 반환합니다.
+     *
+     * @param competitionId 대회 ID
+     * @param request 시뮬레이션 요청 (가상 경기 결과 목록)
+     * @return 시뮬레이션 결과 (예상 순위표 및 순위 변동)
+     */
+    fun simulateStandings(
+        competitionId: Long,
+        request: SimulationRequest,
+    ): SimulationResult
+
+    /**
+     * 특정 팀의 플레이오프 진출 시나리오를 계산합니다.
+     *
+     * 남은 경기가 15경기를 초과하면 몬테카를로 시뮬레이션(1000회 반복)을 사용합니다.
+     *
+     * @param competitionId 대회 ID
+     * @param teamId 대상 팀 ID
+     * @param playoffTeams 플레이오프 진출 팀 수
+     * @return 플레이오프 진출 시나리오 결과
+     */
+    fun calculatePlayoffScenarios(
+        competitionId: Long,
+        teamId: Long,
+        playoffTeams: Int,
+    ): PlayoffScenarioResult
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/standings/dto/MagicNumber.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/standings/dto/MagicNumber.kt
@@ -1,0 +1,20 @@
+package com.nextup.core.service.standings.dto
+
+/**
+ * 매직넘버 데이터 클래스
+ *
+ * 특정 팀이 목표 순위를 확정하기 위해 필요한 남은 승수를 나타냅니다.
+ *
+ * @param teamId 팀 ID
+ * @param targetRank 목표 순위
+ * @param magicNumber 매직넘버 (0 이하이면 이미 확정)
+ * @param isClinched 순위 확정 여부 (magicNumber <= 0)
+ * @param isEliminated 수학적으로 해당 순위 진입 불가 여부
+ */
+data class MagicNumber(
+    val teamId: Long,
+    val targetRank: Int,
+    val magicNumber: Int,
+    val isClinched: Boolean,
+    val isEliminated: Boolean,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/standings/dto/SimulationDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/standings/dto/SimulationDto.kt
@@ -53,14 +53,14 @@ data class SimulationResult(
 /**
  * 플레이오프 진출 시나리오 결과
  *
- * @param totalScenarios 총 시나리오 수
+ * @param totalScenarios 총 시나리오 수 (완전 탐색 시 3^n 규모로 커질 수 있어 Long 사용)
  * @param qualifyingScenarios 플레이오프 진출 시나리오 수
  * @param probability 플레이오프 진출 확률 (0.0 ~ 1.0)
  * @param magicNumber 플레이오프 진출 확정을 위한 매직넘버 (null이면 이미 확정 또는 불가)
  */
 data class PlayoffScenarioResult(
-    val totalScenarios: Int,
-    val qualifyingScenarios: Int,
+    val totalScenarios: Long,
+    val qualifyingScenarios: Long,
     val probability: Double,
     val magicNumber: Int?,
 )

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/standings/dto/SimulationDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/standings/dto/SimulationDto.kt
@@ -1,0 +1,66 @@
+package com.nextup.core.service.standings.dto
+
+/**
+ * 시뮬레이션 요청 DTO
+ *
+ * @param gameResults 가상 경기 결과 목록
+ */
+data class SimulationRequest(
+    val gameResults: List<SimulatedGameResult>,
+)
+
+/**
+ * 시뮬레이션할 경기 결과
+ *
+ * @param gameId 경기 ID
+ * @param homeScore 홈팀 점수
+ * @param awayScore 원정팀 점수
+ */
+data class SimulatedGameResult(
+    val gameId: Long,
+    val homeScore: Int,
+    val awayScore: Int,
+)
+
+/**
+ * 순위 변동 정보
+ *
+ * @param teamId 팀 ID
+ * @param teamName 팀명
+ * @param previousRank 시뮬레이션 전 순위
+ * @param projectedRank 시뮬레이션 후 예상 순위
+ * @param rankChange 순위 변동 (양수 = 상승, 음수 = 하락)
+ */
+data class RankChange(
+    val teamId: Long,
+    val teamName: String,
+    val previousRank: Int,
+    val projectedRank: Int,
+    val rankChange: Int,
+)
+
+/**
+ * 시뮬레이션 결과 DTO
+ *
+ * @param standings 시뮬레이션 후 예상 순위표
+ * @param changes 순위 변동 목록
+ */
+data class SimulationResult(
+    val standings: List<TeamStandingDto>,
+    val changes: List<RankChange>,
+)
+
+/**
+ * 플레이오프 진출 시나리오 결과
+ *
+ * @param totalScenarios 총 시나리오 수
+ * @param qualifyingScenarios 플레이오프 진출 시나리오 수
+ * @param probability 플레이오프 진출 확률 (0.0 ~ 1.0)
+ * @param magicNumber 플레이오프 진출 확정을 위한 매직넘버 (null이면 이미 확정 또는 불가)
+ */
+data class PlayoffScenarioResult(
+    val totalScenarios: Int,
+    val qualifyingScenarios: Int,
+    val probability: Double,
+    val magicNumber: Int?,
+)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImpl.kt
@@ -1,0 +1,538 @@
+package com.nextup.infrastructure.service.standings
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.core.domain.game.GameResult
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.service.standings.StandingsSimulationService
+import com.nextup.core.service.standings.dto.MagicNumber
+import com.nextup.core.service.standings.dto.PlayoffScenarioResult
+import com.nextup.core.service.standings.dto.RankChange
+import com.nextup.core.service.standings.dto.SimulatedGameResult
+import com.nextup.core.service.standings.dto.SimulationRequest
+import com.nextup.core.service.standings.dto.SimulationResult
+import com.nextup.core.service.standings.dto.TeamStandingDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+import kotlin.random.Random
+
+/**
+ * 순위 시뮬레이션 서비스 구현체
+ */
+@Service
+@Transactional(readOnly = true)
+class StandingsSimulationServiceImpl(
+    private val competitionRepository: CompetitionRepositoryPort,
+    private val gameRepository: GameRepositoryPort,
+    private val gameTeamRepository: GameTeamRepositoryPort,
+) : StandingsSimulationService {
+    companion object {
+        private const val MONTE_CARLO_ITERATIONS = 1000
+        private const val MONTE_CARLO_THRESHOLD = 15
+    }
+
+    override fun calculateMagicNumbers(competitionId: Long): List<MagicNumber> {
+        competitionRepository.findByIdOrNull(competitionId)
+            ?: throw CompetitionNotFoundException(competitionId)
+
+        val allGameTeams = gameTeamRepository.findAllByCompetitionId(competitionId)
+        val decidedGameTeams =
+            gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId)
+
+        val teamStats = buildTeamStatsMap(decidedGameTeams, allGameTeams)
+        val sortedStats =
+            teamStats.values.sortedWith(
+                compareByDescending<TeamStats> { it.winningPercentage }
+                    .thenByDescending { it.runDifferential }
+                    .thenByDescending { it.runsScored },
+            )
+
+        if (sortedStats.isEmpty()) return emptyList()
+
+        val leader = sortedStats.first()
+
+        return sortedStats.mapIndexed { index, stats ->
+            val targetRank = index + 1
+            // Magic Number = 리더의 남은 경기 + 1 - (리더 승수 - 해당팀 승수)
+            val rawMagicNumber =
+                leader.remainingGames + 1 - (leader.wins - stats.wins)
+            // 수학적 탈락: 해당 팀이 남은 경기를 모두 이겨도 리더를 따라잡을 수 없는 경우
+            val maxPossibleWins = stats.wins + stats.remainingGames
+            val isEliminated = maxPossibleWins < leader.wins
+            // 순위 확정: 선두팀의 경우 다른 팀이 따라잡을 수 없는 경우 (리더 입장에서)
+            // 비선두팀의 경우 rawMagicNumber <= 0이면 수학적으로 상위 순위 진입 불가 → 탈락
+            val isClinched =
+                if (stats.teamId == leader.teamId) {
+                    // 선두는 남은 경기 없고 적어도 1경기 이상 뛴 경우 확정
+                    stats.remainingGames == 0 && stats.gamesPlayed > 0
+                } else {
+                    // 비선두팀: rawMagicNumber <= 0이면 현재 순위가 확정됨
+                    // (더 이상 상위 팀을 따라잡을 수 없음)
+                    rawMagicNumber <= 0 && !isEliminated
+                }
+
+            MagicNumber(
+                teamId = stats.teamId,
+                targetRank = targetRank,
+                magicNumber = maxOf(0, rawMagicNumber),
+                isClinched = isClinched,
+                isEliminated = isEliminated,
+            )
+        }
+    }
+
+    override fun simulateStandings(
+        competitionId: Long,
+        request: SimulationRequest,
+    ): SimulationResult {
+        competitionRepository.findByIdOrNull(competitionId)
+            ?: throw CompetitionNotFoundException(competitionId)
+
+        validateSimulationRequest(request)
+
+        val allGameTeams = gameTeamRepository.findAllByCompetitionId(competitionId)
+        val decidedGameTeams =
+            gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId)
+
+        // 현재 실제 순위 계산
+        val currentStats = buildTeamStatsMap(decidedGameTeams, allGameTeams)
+        val currentStandings =
+            buildStandings(currentStats.values.toList())
+
+        // 가상 결과 적용 후 순위 계산
+        val simulatedStats =
+            applySimulatedResults(
+                currentStats = currentStats.toMutableMap(),
+                simulatedResults = request.gameResults,
+                allGameTeams = allGameTeams,
+            )
+        val simulatedStandings = buildStandings(simulatedStats.values.toList())
+
+        // 순위 변동 계산
+        val changes = calculateRankChanges(currentStandings, simulatedStandings)
+
+        return SimulationResult(
+            standings = simulatedStandings,
+            changes = changes,
+        )
+    }
+
+    override fun calculatePlayoffScenarios(
+        competitionId: Long,
+        teamId: Long,
+        playoffTeams: Int,
+    ): PlayoffScenarioResult {
+        competitionRepository.findByIdOrNull(competitionId)
+            ?: throw CompetitionNotFoundException(competitionId)
+
+        if (playoffTeams <= 0) {
+            throw InvalidInputException(
+                "INVALID_PLAYOFF_TEAMS",
+                "플레이오프 진출 팀 수는 1 이상이어야 합니다.",
+            )
+        }
+
+        val allGameTeams = gameTeamRepository.findAllByCompetitionId(competitionId)
+        val decidedGameTeams =
+            gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId)
+
+        val currentStats = buildTeamStatsMap(decidedGameTeams, allGameTeams)
+        val targetTeam =
+            currentStats[teamId]
+                ?: throw InvalidInputException(
+                    "TEAM_NOT_IN_COMPETITION",
+                    "해당 팀은 이 대회에 참여하지 않습니다. teamId=$teamId",
+                )
+
+        // 남은 경기 수 계산 (전체 대회 기준)
+        val remainingGames =
+            allGameTeams
+                .filter { it.result == GameResult.UNDECIDED }
+                .map { it.game.id }
+                .distinct()
+                .count()
+
+        // 매직넘버 계산 (플레이오프 cutoff 기준)
+        val magicNumbers = calculateMagicNumbers(competitionId)
+        val teamMagicNumber = magicNumbers.find { it.teamId == teamId }
+
+        return if (remainingGames > MONTE_CARLO_THRESHOLD) {
+            runMonteCarloSimulation(
+                currentStats = currentStats,
+                targetTeamId = teamId,
+                playoffTeams = playoffTeams,
+                allGameTeams = allGameTeams,
+                magicNumber = teamMagicNumber?.magicNumber,
+            )
+        } else {
+            runExhaustiveSimulation(
+                currentStats = currentStats,
+                targetTeamId = teamId,
+                playoffTeams = playoffTeams,
+                allGameTeams = allGameTeams,
+                magicNumber = teamMagicNumber?.magicNumber,
+            )
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private fun buildTeamStatsMap(
+        decidedGameTeams: List<GameTeam>,
+        allGameTeams: List<GameTeam>,
+    ): Map<Long, TeamStats> {
+        val decidedByTeam = decidedGameTeams.groupBy { it.team.id }
+        val allTeamIds = allGameTeams.map { it.team.id }.distinct()
+
+        return allTeamIds.associateWith { teamId ->
+            val gameTeams = decidedByTeam[teamId] ?: emptyList()
+            val teamName = allGameTeams.first { it.team.id == teamId }.team.name
+            val wins = gameTeams.count { it.result == GameResult.WIN }
+            val losses = gameTeams.count { it.result == GameResult.LOSS }
+            val draws = gameTeams.count { it.result == GameResult.DRAW }
+            val gamesPlayed = wins + losses + draws
+            val runsScored = gameTeams.sumOf { it.totalScore }
+            val runsAllowed =
+                gameTeams.sumOf { gt ->
+                    decidedGameTeams
+                        .filter { it.game.id == gt.game.id && it.team.id != teamId }
+                        .sumOf { it.totalScore }
+                }
+            val runDifferential = runsScored - runsAllowed
+            val winningPercentage =
+                if (gamesPlayed > 0) {
+                    BigDecimal(wins)
+                        .add(BigDecimal(draws).multiply(BigDecimal("0.5")))
+                        .divide(BigDecimal(gamesPlayed), 3, RoundingMode.HALF_UP)
+                } else {
+                    BigDecimal.ZERO
+                }
+            val totalScheduledGames = allGameTeams.count { it.team.id == teamId }
+            val remainingGames = totalScheduledGames - gamesPlayed
+
+            TeamStats(
+                teamId = teamId,
+                teamName = teamName,
+                gamesPlayed = gamesPlayed,
+                remainingGames = remainingGames,
+                wins = wins,
+                losses = losses,
+                draws = draws,
+                winningPercentage = winningPercentage,
+                runsScored = runsScored,
+                runsAllowed = runsAllowed,
+                runDifferential = runDifferential,
+            )
+        }
+    }
+
+    private fun buildStandings(statsList: List<TeamStats>): List<TeamStandingDto> {
+        val sorted =
+            statsList.sortedWith(
+                compareByDescending<TeamStats> { it.winningPercentage }
+                    .thenByDescending { it.runDifferential }
+                    .thenByDescending { it.runsScored },
+            )
+        val leader = sorted.firstOrNull()
+        return sorted.mapIndexed { index, stats ->
+            TeamStandingDto(
+                rank = index + 1,
+                teamId = stats.teamId,
+                teamName = stats.teamName,
+                gamesPlayed = stats.gamesPlayed,
+                remainingGames = stats.remainingGames,
+                wins = stats.wins,
+                losses = stats.losses,
+                draws = stats.draws,
+                winningPercentage = stats.winningPercentage,
+                gamesBehind = calculateGamesBehind(leader, stats),
+                runsScored = stats.runsScored,
+                runsAllowed = stats.runsAllowed,
+                runDifferential = stats.runDifferential,
+            )
+        }
+    }
+
+    private fun calculateGamesBehind(
+        leader: TeamStats?,
+        team: TeamStats,
+    ): BigDecimal {
+        if (leader == null || leader.teamId == team.teamId) return BigDecimal.ZERO
+        val winDiff = leader.wins - team.wins
+        val lossDiff = team.losses - leader.losses
+        return BigDecimal(winDiff + lossDiff).divide(BigDecimal(2), 1, RoundingMode.HALF_UP)
+    }
+
+    private fun validateSimulationRequest(request: SimulationRequest) {
+        request.gameResults.forEach { result ->
+            if (result.homeScore < 0 || result.awayScore < 0) {
+                throw InvalidInputException(
+                    "INVALID_SIMULATION_SCORE",
+                    "점수는 0 이상이어야 합니다. gameId=${result.gameId}",
+                )
+            }
+        }
+    }
+
+    private fun applySimulatedResults(
+        currentStats: MutableMap<Long, TeamStats>,
+        simulatedResults: List<SimulatedGameResult>,
+        allGameTeams: List<GameTeam>,
+    ): Map<Long, TeamStats> {
+        val gameTeamsByGameId = allGameTeams.groupBy { it.game.id }
+
+        simulatedResults.forEach { simResult ->
+            val gameTeams = gameTeamsByGameId[simResult.gameId] ?: return@forEach
+            if (gameTeams.size != 2) return@forEach
+
+            // 이미 결과가 확정된 경기는 건너뜀
+            if (gameTeams.all { it.result != GameResult.UNDECIDED }) return@forEach
+
+            val homeTeam = gameTeams.find { it.isHome } ?: return@forEach
+            val awayTeam = gameTeams.find { it.isAway } ?: return@forEach
+
+            val homeStats = currentStats[homeTeam.team.id] ?: return@forEach
+            val awayStats = currentStats[awayTeam.team.id] ?: return@forEach
+
+            val (homeResult, awayResult) =
+                when {
+                    simResult.homeScore > simResult.awayScore ->
+                        GameResult.WIN to GameResult.LOSS
+                    simResult.homeScore < simResult.awayScore ->
+                        GameResult.LOSS to GameResult.WIN
+                    else -> GameResult.DRAW to GameResult.DRAW
+                }
+
+            currentStats[homeTeam.team.id] =
+                homeStats.applyResult(
+                    result = homeResult,
+                    scored = simResult.homeScore,
+                    allowed = simResult.awayScore,
+                )
+            currentStats[awayTeam.team.id] =
+                awayStats.applyResult(
+                    result = awayResult,
+                    scored = simResult.awayScore,
+                    allowed = simResult.homeScore,
+                )
+        }
+
+        return currentStats
+    }
+
+    private fun calculateRankChanges(
+        currentStandings: List<TeamStandingDto>,
+        simulatedStandings: List<TeamStandingDto>,
+    ): List<RankChange> {
+        val currentRankMap = currentStandings.associateBy { it.teamId }
+        return simulatedStandings.mapNotNull { simStanding ->
+            val currentStanding = currentRankMap[simStanding.teamId] ?: return@mapNotNull null
+            val rankChange = currentStanding.rank - simStanding.rank
+            if (rankChange != 0) {
+                RankChange(
+                    teamId = simStanding.teamId,
+                    teamName = simStanding.teamName,
+                    previousRank = currentStanding.rank,
+                    projectedRank = simStanding.rank,
+                    rankChange = rankChange,
+                )
+            } else {
+                null
+            }
+        }
+    }
+
+    /**
+     * 몬테카를로 시뮬레이션 (남은 경기 > 15일 때 사용)
+     */
+    private fun runMonteCarloSimulation(
+        currentStats: Map<Long, TeamStats>,
+        targetTeamId: Long,
+        playoffTeams: Int,
+        allGameTeams: List<GameTeam>,
+        magicNumber: Int?,
+    ): PlayoffScenarioResult {
+        val remainingGames =
+            allGameTeams
+                .filter { it.result == GameResult.UNDECIDED }
+                .map { it.game.id }
+                .distinct()
+                .toList()
+        val gameTeamsByGameId = allGameTeams.groupBy { it.game.id }
+
+        var qualifyingCount = 0
+
+        repeat(MONTE_CARLO_ITERATIONS) {
+            val stats = currentStats.toMutableMap()
+            remainingGames.forEach { gameId ->
+                val gameTeams = gameTeamsByGameId[gameId] ?: return@forEach
+                if (gameTeams.size != 2) return@forEach
+
+                val homeTeam = gameTeams.find { it.isHome } ?: return@forEach
+                val awayTeam = gameTeams.find { it.isAway } ?: return@forEach
+
+                val rand = Random.nextDouble()
+                val (homeResult, awayResult) =
+                    when {
+                        rand < 0.45 -> GameResult.WIN to GameResult.LOSS
+                        rand < 0.90 -> GameResult.LOSS to GameResult.WIN
+                        else -> GameResult.DRAW to GameResult.DRAW
+                    }
+
+                val homeStats = stats[homeTeam.team.id] ?: return@forEach
+                val awayStats = stats[awayTeam.team.id] ?: return@forEach
+
+                stats[homeTeam.team.id] =
+                    homeStats.applyResult(homeResult, scored = 0, allowed = 0)
+                stats[awayTeam.team.id] =
+                    awayStats.applyResult(awayResult, scored = 0, allowed = 0)
+            }
+
+            val finalStandings = buildStandings(stats.values.toList())
+            val teamRank = finalStandings.find { it.teamId == targetTeamId }?.rank ?: Int.MAX_VALUE
+            if (teamRank <= playoffTeams) qualifyingCount++
+        }
+
+        val probability = qualifyingCount.toDouble() / MONTE_CARLO_ITERATIONS
+        return PlayoffScenarioResult(
+            totalScenarios = MONTE_CARLO_ITERATIONS,
+            qualifyingScenarios = qualifyingCount,
+            probability = probability,
+            magicNumber = magicNumber,
+        )
+    }
+
+    /**
+     * 완전 탐색 시뮬레이션 (남은 경기 <= 15일 때 사용)
+     */
+    private fun runExhaustiveSimulation(
+        currentStats: Map<Long, TeamStats>,
+        targetTeamId: Long,
+        playoffTeams: Int,
+        allGameTeams: List<GameTeam>,
+        magicNumber: Int?,
+    ): PlayoffScenarioResult {
+        val remainingGameIds =
+            allGameTeams
+                .filter { it.result == GameResult.UNDECIDED }
+                .map { it.game.id }
+                .distinct()
+                .toList()
+
+        // 경기 수가 많으면 몬테카를로로 위임
+        if (remainingGameIds.size > MONTE_CARLO_THRESHOLD) {
+            return runMonteCarloSimulation(
+                currentStats,
+                targetTeamId,
+                playoffTeams,
+                allGameTeams,
+                magicNumber,
+            )
+        }
+
+        val gameTeamsByGameId = allGameTeams.groupBy { it.game.id }
+        val totalScenarios = Math.pow(3.0, remainingGameIds.size.toDouble()).toInt()
+        var qualifyingCount = 0
+
+        for (scenario in 0 until totalScenarios) {
+            val stats = currentStats.toMutableMap()
+            var temp = scenario
+
+            for (gameId in remainingGameIds) {
+                val outcome = temp % 3
+                temp /= 3
+
+                val gameTeams = gameTeamsByGameId[gameId] ?: continue
+                if (gameTeams.size != 2) continue
+
+                val homeTeam = gameTeams.find { it.isHome } ?: continue
+                val awayTeam = gameTeams.find { it.isAway } ?: continue
+
+                val (homeResult, awayResult) =
+                    when (outcome) {
+                        0 -> GameResult.WIN to GameResult.LOSS
+                        1 -> GameResult.LOSS to GameResult.WIN
+                        else -> GameResult.DRAW to GameResult.DRAW
+                    }
+
+                val homeStats = stats[homeTeam.team.id] ?: continue
+                val awayStats = stats[awayTeam.team.id] ?: continue
+
+                stats[homeTeam.team.id] =
+                    homeStats.applyResult(homeResult, scored = 0, allowed = 0)
+                stats[awayTeam.team.id] =
+                    awayStats.applyResult(awayResult, scored = 0, allowed = 0)
+            }
+
+            val finalStandings = buildStandings(stats.values.toList())
+            val teamRank = finalStandings.find { it.teamId == targetTeamId }?.rank ?: Int.MAX_VALUE
+            if (teamRank <= playoffTeams) qualifyingCount++
+        }
+
+        val probability =
+            if (totalScenarios > 0) qualifyingCount.toDouble() / totalScenarios else 0.0
+        return PlayoffScenarioResult(
+            totalScenarios = totalScenarios,
+            qualifyingScenarios = qualifyingCount,
+            probability = probability,
+            magicNumber = magicNumber,
+        )
+    }
+
+    /**
+     * 팀 통계 내부 데이터 클래스
+     */
+    private data class TeamStats(
+        val teamId: Long,
+        val teamName: String,
+        val gamesPlayed: Int,
+        val remainingGames: Int,
+        val wins: Int,
+        val losses: Int,
+        val draws: Int,
+        val winningPercentage: BigDecimal,
+        val runsScored: Int,
+        val runsAllowed: Int,
+        val runDifferential: Int,
+    ) {
+        fun applyResult(
+            result: GameResult,
+            scored: Int,
+            allowed: Int,
+        ): TeamStats {
+            val newWins = wins + if (result == GameResult.WIN) 1 else 0
+            val newLosses = losses + if (result == GameResult.LOSS) 1 else 0
+            val newDraws = draws + if (result == GameResult.DRAW) 1 else 0
+            val newGamesPlayed = newWins + newLosses + newDraws
+            val newRunsScored = runsScored + scored
+            val newRunsAllowed = runsAllowed + allowed
+            val newRunDifferential = newRunsScored - newRunsAllowed
+            val newWinningPercentage =
+                if (newGamesPlayed > 0) {
+                    BigDecimal(newWins)
+                        .add(BigDecimal(newDraws).multiply(BigDecimal("0.5")))
+                        .divide(BigDecimal(newGamesPlayed), 3, RoundingMode.HALF_UP)
+                } else {
+                    BigDecimal.ZERO
+                }
+            return copy(
+                gamesPlayed = newGamesPlayed,
+                remainingGames = maxOf(0, remainingGames - 1),
+                wins = newWins,
+                losses = newLosses,
+                draws = newDraws,
+                winningPercentage = newWinningPercentage,
+                runsScored = newRunsScored,
+                runsAllowed = newRunsAllowed,
+                runDifferential = newRunDifferential,
+            )
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImpl.kt
@@ -32,7 +32,7 @@ class StandingsSimulationServiceImpl(
     private val gameTeamRepository: GameTeamRepositoryPort,
 ) : StandingsSimulationService {
     companion object {
-        private const val MONTE_CARLO_ITERATIONS = 1000
+        private const val MONTE_CARLO_ITERATIONS = 1000L
         private const val MONTE_CARLO_THRESHOLD = 15
     }
 
@@ -58,9 +58,11 @@ class StandingsSimulationServiceImpl(
 
         return sortedStats.mapIndexed { index, stats ->
             val targetRank = index + 1
-            // Magic Number = 리더의 남은 경기 + 1 - (리더 승수 - 해당팀 승수)
+            // 표준 야구 매직넘버 공식:
+            // Magic Number = (상대팀 남은 경기 수) - (1위팀 승수) + (상대팀 승수) + 1
+            // 의미: 1위팀의 우승 확정에 필요한 (1위팀 추가 승 + 2위팀 추가 패) 합계
             val rawMagicNumber =
-                leader.remainingGames + 1 - (leader.wins - stats.wins)
+                stats.remainingGames - leader.wins + stats.wins + 1
             // 수학적 탈락: 해당 팀이 남은 경기를 모두 이겨도 리더를 따라잡을 수 없는 경우
             val maxPossibleWins = stats.wins + stats.remainingGames
             val isEliminated = maxPossibleWins < leader.wins
@@ -367,9 +369,9 @@ class StandingsSimulationServiceImpl(
                 .toList()
         val gameTeamsByGameId = allGameTeams.groupBy { it.game.id }
 
-        var qualifyingCount = 0
+        var qualifyingCount = 0L
 
-        repeat(MONTE_CARLO_ITERATIONS) {
+        repeat(MONTE_CARLO_ITERATIONS.toInt()) {
             val stats = currentStats.toMutableMap()
             remainingGames.forEach { gameId ->
                 val gameTeams = gameTeamsByGameId[gameId] ?: return@forEach
@@ -438,15 +440,15 @@ class StandingsSimulationServiceImpl(
         }
 
         val gameTeamsByGameId = allGameTeams.groupBy { it.game.id }
-        val totalScenarios = Math.pow(3.0, remainingGameIds.size.toDouble()).toInt()
-        var qualifyingCount = 0
+        val totalScenarios = Math.pow(3.0, remainingGameIds.size.toDouble()).toLong()
+        var qualifyingCount = 0L
 
-        for (scenario in 0 until totalScenarios) {
+        for (scenario in 0L until totalScenarios) {
             val stats = currentStats.toMutableMap()
             var temp = scenario
 
             for (gameId in remainingGameIds) {
-                val outcome = temp % 3
+                val outcome = (temp % 3).toInt()
                 temp /= 3
 
                 val gameTeams = gameTeamsByGameId[gameId] ?: continue
@@ -477,7 +479,7 @@ class StandingsSimulationServiceImpl(
         }
 
         val probability =
-            if (totalScenarios > 0) qualifyingCount.toDouble() / totalScenarios else 0.0
+            if (totalScenarios > 0L) qualifyingCount.toDouble() / totalScenarios else 0.0
         return PlayoffScenarioResult(
             totalScenarios = totalScenarios,
             qualifyingScenarios = qualifyingCount,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImplTest.kt
@@ -1,0 +1,586 @@
+package com.nextup.infrastructure.service.standings
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameResult
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.service.standings.dto.SimulatedGameResult
+import com.nextup.core.service.standings.dto.SimulationRequest
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("StandingsSimulationServiceImpl")
+class StandingsSimulationServiceImplTest {
+    private lateinit var competitionRepository: CompetitionRepositoryPort
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
+    private lateinit var service: StandingsSimulationServiceImpl
+
+    private lateinit var competition: Competition
+    private lateinit var league: League
+    private lateinit var association: Association
+
+    @BeforeEach
+    fun setUp() {
+        competitionRepository = mockk()
+        gameRepository = mockk()
+        gameTeamRepository = mockk()
+        service =
+            StandingsSimulationServiceImpl(
+                competitionRepository,
+                gameRepository,
+                gameTeamRepository,
+            )
+
+        association = createAssociation(1L, "서울시야구협회")
+        league = createLeague(1L, "1부 리그", association)
+        competition = createCompetition(1L, league, "2025 춘계대회", 2025, 1)
+    }
+
+    // =========================================================================
+    // calculateMagicNumbers
+    // =========================================================================
+
+    @Nested
+    @DisplayName("calculateMagicNumbers")
+    inner class CalculateMagicNumbers {
+        @Test
+        fun `대회가 존재하지 않으면 CompetitionNotFoundException 발생`() {
+            every { competitionRepository.findByIdOrNull(999L) } returns null
+
+            assertThrows<CompetitionNotFoundException> {
+                service.calculateMagicNumbers(999L)
+            }
+        }
+
+        @Test
+        fun `경기 기록이 없으면 빈 목록 반환`() {
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns emptyList()
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns emptyList()
+
+            val result = service.calculateMagicNumbers(1L)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `선두팀의 매직넘버는 0이고 isClinched true`() {
+            // Tigers: 5승 0패, 남은경기 5
+            // Lions:  3승 2패, 남은경기 5
+            // 선두(Tigers) 매직넘버 = 5 + 1 - (5 - 5) = 6 → 0으로 클램핑 아님
+            // 실제: rank=1인 Tigers의 타겟 매직넘버 계산 기준은 자기 자신과의 비교 → rawMN = leader.remainingGames+1-(leader.wins-stats.wins)=5+1-0=6
+            // => isClinched = false (6>0)
+            // Lions: rawMN = 5+1-(5-3) = 4 => isClinched = false
+
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val games = (1..5).map { createGame(it.toLong(), competition) }
+            val remainingGames = (6..10).map { createGame(it.toLong(), competition) }
+
+            val decidedGameTeams = mutableListOf<GameTeam>()
+            val allGameTeams = mutableListOf<GameTeam>()
+
+            // Tigers 5승, Lions 3승 2패
+            games.forEachIndexed { i, game ->
+                val tigersResult = GameResult.WIN
+                val lionsResult = if (i < 3) GameResult.WIN else GameResult.LOSS
+                val tScore = if (tigersResult == GameResult.WIN) 5 else 3
+                val lScore = if (lionsResult == GameResult.WIN) 5 else 3
+
+                val gt = createGameTeam((i * 2 + 1).toLong(), game, teamA, HomeAway.HOME, tScore, tigersResult)
+                val gl = createGameTeam((i * 2 + 2).toLong(), game, teamB, HomeAway.AWAY, lScore, lionsResult)
+                decidedGameTeams += listOf(gt, gl)
+                allGameTeams += listOf(gt, gl)
+            }
+
+            // 남은 경기 추가 (UNDECIDED)
+            remainingGames.forEachIndexed { i, game ->
+                val gt = createGameTeam((100 + i * 2).toLong(), game, teamA, HomeAway.HOME, 0, GameResult.UNDECIDED)
+                val gl = createGameTeam((101 + i * 2).toLong(), game, teamB, HomeAway.AWAY, 0, GameResult.UNDECIDED)
+                allGameTeams += listOf(gt, gl)
+            }
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            val result = service.calculateMagicNumbers(1L)
+
+            assertThat(result).hasSize(2)
+            val tigersResult = result.find { it.teamId == 1L }!!
+            val lionsResult = result.find { it.teamId == 2L }!!
+
+            // Tigers(1위): magicNumber = 5+1-(5-5) = 6
+            assertThat(tigersResult.magicNumber).isEqualTo(6)
+            assertThat(tigersResult.isClinched).isFalse()
+            assertThat(tigersResult.isEliminated).isFalse()
+
+            // Lions(2위): magicNumber = 5+1-(5-3) = 4
+            assertThat(lionsResult.magicNumber).isEqualTo(4)
+            assertThat(lionsResult.isClinched).isFalse()
+            assertThat(lionsResult.isEliminated).isFalse()
+        }
+
+        @Test
+        fun `남은경기가 없고 선두보다 승수 적으면 isEliminated true`() {
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+            val game2 = createGame(2L, competition)
+            val game3 = createGame(3L, competition)
+
+            // Tigers: 3승 0패, 남은경기 0
+            // Lions: 0승 3패, 남은경기 0
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+            val gt2 = createGameTeam(3L, game2, teamA, HomeAway.HOME, 4, GameResult.WIN)
+            val gl2 = createGameTeam(4L, game2, teamB, HomeAway.AWAY, 1, GameResult.LOSS)
+            val gt3 = createGameTeam(5L, game3, teamA, HomeAway.HOME, 6, GameResult.WIN)
+            val gl3 = createGameTeam(6L, game3, teamB, HomeAway.AWAY, 3, GameResult.LOSS)
+
+            val allGameTeams = listOf(gt1, gl1, gt2, gl2, gt3, gl3)
+            val decidedGameTeams = listOf(gt1, gl1, gt2, gl2, gt3, gl3)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            val result = service.calculateMagicNumbers(1L)
+
+            val lionsResult = result.find { it.teamId == 2L }!!
+            // Lions: maxPossibleWins = 0+0=0 < 3(Tigers wins), remainingGames=0 → isEliminated=true
+            assertThat(lionsResult.isEliminated).isTrue()
+        }
+
+        @Test
+        fun `매직넘버가 음수인 경우 0으로 클램핑`() {
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+
+            val allGameTeams = listOf(gt1, gl1)
+            val decidedGameTeams = listOf(gt1, gl1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            val result = service.calculateMagicNumbers(1L)
+
+            result.forEach { mn ->
+                assertThat(mn.magicNumber).isGreaterThanOrEqualTo(0)
+            }
+        }
+    }
+
+    // =========================================================================
+    // simulateStandings
+    // =========================================================================
+
+    @Nested
+    @DisplayName("simulateStandings")
+    inner class SimulateStandings {
+        @Test
+        fun `대회가 존재하지 않으면 CompetitionNotFoundException 발생`() {
+            every { competitionRepository.findByIdOrNull(999L) } returns null
+
+            assertThrows<CompetitionNotFoundException> {
+                service.simulateStandings(999L, SimulationRequest(emptyList()))
+            }
+        }
+
+        @Test
+        fun `음수 점수가 있으면 InvalidInputException 발생`() {
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns emptyList()
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns emptyList()
+
+            val request =
+                SimulationRequest(
+                    listOf(SimulatedGameResult(gameId = 1L, homeScore = -1, awayScore = 3)),
+                )
+
+            assertThrows<InvalidInputException> {
+                service.simulateStandings(1L, request)
+            }
+        }
+
+        @Test
+        fun `가상 결과를 적용하면 순위가 변동된다`() {
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+            val game2 = createGame(2L, competition)
+
+            // 현재: Tigers 1승, Lions 0승
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+
+            // 예정 경기 (game2는 UNDECIDED)
+            val gt2 = createGameTeam(3L, game2, teamA, HomeAway.HOME, 0, GameResult.UNDECIDED)
+            val gl2 = createGameTeam(4L, game2, teamB, HomeAway.AWAY, 0, GameResult.UNDECIDED)
+
+            val allGameTeams = listOf(gt1, gl1, gt2, gl2)
+            val decidedGameTeams = listOf(gt1, gl1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // Lions가 game2에서 이기는 시뮬레이션
+            val request =
+                SimulationRequest(
+                    listOf(SimulatedGameResult(gameId = 2L, homeScore = 1, awayScore = 8)),
+                )
+
+            val result = service.simulateStandings(1L, request)
+
+            // Tigers: 1승 1패, Lions: 1승 1패 → 득실점차로 순위 결정
+            assertThat(result.standings).hasSize(2)
+            // 순위 변동이 있어야 함
+            assertThat(result.changes).isNotEmpty()
+        }
+
+        @Test
+        fun `시뮬레이션 결과가 이미 확정된 경기에는 적용되지 않는다`() {
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+
+            // game1은 이미 결과가 확정됨 (WIN/LOSS)
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+
+            val allGameTeams = listOf(gt1, gl1)
+            val decidedGameTeams = listOf(gt1, gl1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // 이미 확정된 경기에 다른 결과를 시뮬레이션
+            val request =
+                SimulationRequest(
+                    listOf(SimulatedGameResult(gameId = 1L, homeScore = 0, awayScore = 10)),
+                )
+
+            val result = service.simulateStandings(1L, request)
+
+            // 확정된 경기는 변경되지 않으므로 Tigers가 여전히 1위
+            assertThat(result.standings[0].teamId).isEqualTo(1L)
+            assertThat(result.standings[0].wins).isEqualTo(1)
+            assertThat(result.changes).isEmpty()
+        }
+
+        @Test
+        fun `시뮬레이션 결과가 없으면 현재 순위와 동일하고 변동 없음`() {
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+
+            val allGameTeams = listOf(gt1, gl1)
+            val decidedGameTeams = listOf(gt1, gl1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            val result = service.simulateStandings(1L, SimulationRequest(emptyList()))
+
+            assertThat(result.standings).hasSize(2)
+            assertThat(result.changes).isEmpty()
+            assertThat(result.standings[0].teamId).isEqualTo(1L) // Tigers 1위
+        }
+
+        @Test
+        fun `무승부 시뮬레이션도 올바르게 처리한다`() {
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+            val game2 = createGame(2L, competition)
+
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+            val gt2 = createGameTeam(3L, game2, teamA, HomeAway.HOME, 0, GameResult.UNDECIDED)
+            val gl2 = createGameTeam(4L, game2, teamB, HomeAway.AWAY, 0, GameResult.UNDECIDED)
+
+            val allGameTeams = listOf(gt1, gl1, gt2, gl2)
+            val decidedGameTeams = listOf(gt1, gl1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // 무승부 시뮬레이션 (동점)
+            val request =
+                SimulationRequest(
+                    listOf(SimulatedGameResult(gameId = 2L, homeScore = 3, awayScore = 3)),
+                )
+
+            val result = service.simulateStandings(1L, request)
+
+            // Tigers: 1승 0패 1무, Lions: 0승 1패 1무
+            val tigers = result.standings.find { it.teamId == 1L }!!
+            val lions = result.standings.find { it.teamId == 2L }!!
+            assertThat(tigers.draws).isEqualTo(1)
+            assertThat(lions.draws).isEqualTo(1)
+        }
+    }
+
+    // =========================================================================
+    // calculatePlayoffScenarios
+    // =========================================================================
+
+    @Nested
+    @DisplayName("calculatePlayoffScenarios")
+    inner class CalculatePlayoffScenarios {
+        @Test
+        fun `대회가 존재하지 않으면 CompetitionNotFoundException 발생`() {
+            every { competitionRepository.findByIdOrNull(999L) } returns null
+
+            assertThrows<CompetitionNotFoundException> {
+                service.calculatePlayoffScenarios(999L, 1L, 4)
+            }
+        }
+
+        @Test
+        fun `playoffTeams가 0이하이면 InvalidInputException 발생`() {
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns emptyList()
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns emptyList()
+
+            assertThrows<InvalidInputException> {
+                service.calculatePlayoffScenarios(1L, 1L, 0)
+            }
+        }
+
+        @Test
+        fun `해당 팀이 대회에 없으면 InvalidInputException 발생`() {
+            val teamA = createTeam(1L, league, "Tigers")
+            val game1 = createGame(1L, competition)
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns listOf(gt1)
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns listOf(gt1)
+
+            assertThrows<InvalidInputException> {
+                // teamId=999 는 대회에 없는 팀
+                service.calculatePlayoffScenarios(1L, 999L, 4)
+            }
+        }
+
+        @Test
+        fun `남은 경기가 없을 때 확정적인 결과를 반환한다`() {
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+            val teamC = createTeam(3L, league, "Bears")
+
+            val game1 = createGame(1L, competition)
+            val game2 = createGame(2L, competition)
+
+            // 모든 경기 완료: Tigers 2승, Lions 1승 1패, Bears 0승 2패
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+            val gt2 = createGameTeam(3L, game2, teamB, HomeAway.HOME, 4, GameResult.WIN)
+            val gl2 = createGameTeam(4L, game2, teamC, HomeAway.AWAY, 1, GameResult.LOSS)
+
+            // game3: Tigers vs Bears - Tigers WIN
+            val game3 = createGame(3L, competition)
+            val gt3 = createGameTeam(5L, game3, teamA, HomeAway.HOME, 3, GameResult.WIN)
+            val gl3 = createGameTeam(6L, game3, teamC, HomeAway.AWAY, 0, GameResult.LOSS)
+
+            val allGameTeams = listOf(gt1, gl1, gt2, gl2, gt3, gl3)
+            val decidedGameTeams = listOf(gt1, gl1, gt2, gl2, gt3, gl3)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // Tigers의 플레이오프 진출 시나리오 (상위 2팀)
+            val result = service.calculatePlayoffScenarios(1L, 1L, 2)
+
+            assertThat(result.totalScenarios).isGreaterThan(0)
+            // 모든 경기 완료 → Tigers는 1위 확정 → 100% 진출
+            assertThat(result.probability).isEqualTo(1.0)
+        }
+
+        @Test
+        fun `플레이오프 진출이 불가능한 팀의 확률은 0이다`() {
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+            val teamC = createTeam(3L, league, "Bears")
+
+            // 3팀 리그에서 상위 1팀만 플레이오프 진출
+            // Lions와 Bears는 각각 경기가 남아있고, Tigers는 꼴찌 확정
+            val game1 = createGame(1L, competition)
+            val game2 = createGame(2L, competition)
+
+            // Tigers: 0승 2패, Lions/Bears: 1승씩
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 0, GameResult.LOSS)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 5, GameResult.WIN)
+            val gt2 = createGameTeam(3L, game2, teamA, HomeAway.HOME, 0, GameResult.LOSS)
+            val gl2 = createGameTeam(4L, game2, teamC, HomeAway.AWAY, 3, GameResult.WIN)
+
+            // 남은 경기 없음 - Tigers는 이미 꼴찌 확정
+            val allGameTeams = listOf(gt1, gl1, gt2, gl2)
+            val decidedGameTeams = listOf(gt1, gl1, gt2, gl2)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // Tigers의 1위 진출 시나리오
+            val result = service.calculatePlayoffScenarios(1L, 1L, 1)
+
+            assertThat(result.probability).isEqualTo(0.0)
+        }
+    }
+
+    // =========================================================================
+    // Helper methods
+    // =========================================================================
+
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association =
+        Association(
+            name = name,
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null,
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association,
+    ): League =
+        League(
+            association = association,
+            name = name,
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null,
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createCompetition(
+        id: Long,
+        league: League,
+        name: String,
+        year: Int,
+        season: Int,
+    ): Competition =
+        Competition(
+            league = league,
+            name = name,
+            year = year,
+            season = season,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(year, 3, 1),
+            endDate = null,
+            description = null,
+            maxTeams = null,
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createTeam(
+        id: Long,
+        league: League,
+        name: String,
+    ): Team =
+        Team(
+            league = league,
+            name = name,
+            city = "서울",
+            foundedYear = 2020,
+            abbreviation = null,
+            logoUrl = null,
+        ).apply {
+            val idField = Team::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createGame(
+        id: Long,
+        competition: Competition,
+    ): Game =
+        Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.now(),
+            location = "서울야구장",
+            status = GameStatus.SCHEDULED,
+        ).apply {
+            val idField = Game::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createGameTeam(
+        id: Long,
+        game: Game,
+        team: Team,
+        homeAway: HomeAway,
+        totalScore: Int,
+        result: GameResult,
+    ): GameTeam =
+        GameTeam(
+            game = game,
+            team = team,
+            homeAway = homeAway,
+            id = id,
+        ).apply {
+            updateScore(totalScore, 0, 0)
+            updateResult(result)
+        }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImplTest.kt
@@ -471,6 +471,406 @@ class StandingsSimulationServiceImplTest {
     }
 
     // =========================================================================
+    // Additional coverage tests
+    // =========================================================================
+
+    @Nested
+    @DisplayName("calculateMagicNumbers - 추가 시나리오")
+    inner class CalculateMagicNumbersExtra {
+        @Test
+        fun `선두팀 남은경기 없고 경기 뛴 경우 isClinched true`() {
+            // given: Tigers 3승 0패, 남은 경기 없음 → leader.remainingGames == 0 && gamesPlayed > 0 → isClinched true
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+            val game2 = createGame(2L, competition)
+            val game3 = createGame(3L, competition)
+
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+            val gt2 = createGameTeam(3L, game2, teamA, HomeAway.HOME, 4, GameResult.WIN)
+            val gl2 = createGameTeam(4L, game2, teamB, HomeAway.AWAY, 1, GameResult.LOSS)
+            val gt3 = createGameTeam(5L, game3, teamA, HomeAway.HOME, 6, GameResult.WIN)
+            val gl3 = createGameTeam(6L, game3, teamB, HomeAway.AWAY, 3, GameResult.LOSS)
+
+            val allGameTeams = listOf(gt1, gl1, gt2, gl2, gt3, gl3)
+            val decidedGameTeams = listOf(gt1, gl1, gt2, gl2, gt3, gl3)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when
+            val result = service.calculateMagicNumbers(1L)
+
+            // then: Tigers(1위) - 남은경기 0, gamesPlayed 3 → isClinched true
+            val tigersResult = result.find { it.teamId == 1L }!!
+            assertThat(tigersResult.isClinched).isTrue()
+            // Lions(2위) - isEliminated true(maxPossibleWins=0 < 3)
+            val lionsResult = result.find { it.teamId == 2L }!!
+            assertThat(lionsResult.isEliminated).isTrue()
+        }
+
+        @Test
+        fun `비선두팀 rawMagicNumber 0 이하이고 탈락 아닌 경우 isClinched true`() {
+            // given: 3팀, 2팀이 플레이오프 진출, 3위팀의 rawMagicNumber <= 0이 되는 상황
+            // Tigers: 10승 0패, Lions: 9승 1패, Bears: 0승 10패
+            // leader(Tigers) remainingGames = 0
+            // Bears: rawMN = 0+1-(10-0) = -9 <= 0, maxPossibleWins = 0+0 = 0 < 10 → isEliminated true
+            // Lions: rawMN = 0+1-(10-9) = 0 <= 0, maxPossibleWins = 9+0=9 < 10 → isEliminated true
+            // → Lions도 isEliminated=true이면 isClinched = false
+            // Let's try: Tigers 3승, Lions 2승, Bears 0승, no remaining
+            // Bears: rawMN = 0+1-(3-0) = -2 <=0, maxPossible = 0 < 3 → isEliminated true → isClinched false
+            // Lions: rawMN = 0+1-(3-2) = 0 <=0, maxPossible = 2+0=2 < 3 → isEliminated true → isClinched false
+            //
+            // To get isClinched=true for a non-leader, we need:
+            // rawMagicNumber <= 0 && !isEliminated
+            // maxPossibleWins >= leader.wins but rawMN <= 0
+            // Scenario: Tigers 5승 1패, Lions 3승 1패, Lions remainingGames=2
+            // leader = Tigers (5승), remainingGames=0
+            // Lions: rawMN = 0+1-(5-3) = -1 <= 0
+            //        maxPossibleWins = 3+2 = 5 >= 5 → isEliminated = false
+            //        isClinched = true
+
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            // Tigers: 5 decided games (WIN), 0 remaining
+            val tigerGames = (1..5).map { createGame(it.toLong(), competition) }
+            // Lions: 3 decided games (WIN, LOSS), 2 remaining
+            val lionGames = (1..3).map { createGame(it.toLong(), competition) }
+            val lionRemainingGames = (6..7).map { createGame(it.toLong(), competition) }
+
+            val decidedGameTeams = mutableListOf<GameTeam>()
+            val allGameTeams = mutableListOf<GameTeam>()
+
+            var gtId = 1L
+            tigerGames.forEachIndexed { i, game ->
+                val gt = createGameTeam(gtId++, game, teamA, HomeAway.HOME, 5, GameResult.WIN)
+                val gl = createGameTeam(gtId++, game, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+                decidedGameTeams += listOf(gt, gl)
+                allGameTeams += listOf(gt, gl)
+            }
+
+            // override Lions in Tiger's games - actually need separate games per team
+            // Simpler: separate games for Lions vs some dummy
+            // Reset and use a cleaner scenario:
+            // Tigers play 5 games against external (only Tigers in allGameTeams for those games)
+            // Let's just use 2 teams playing each other
+
+            // Clean approach: Tigers 5 wins (5 games), Lions: 3 wins from same 5 games → impossible if they play each other
+
+            // Best approach: Tigers 5W vs unknown, Lions 3W vs unknown
+            // Use single-team game entries (no opponent in allGameTeams → opponent not tracked)
+            decidedGameTeams.clear()
+            allGameTeams.clear()
+
+            val tigerOnlyGames = (10..14).map { createGame(it.toLong(), competition) }
+            val lionOnlyGamesDecided = (20..22).map { createGame(it.toLong(), competition) }
+            val lionOnlyGamesRemaining = (30..31).map { createGame(it.toLong(), competition) }
+
+            var id = 1L
+            tigerOnlyGames.forEach { game ->
+                val gt = createGameTeam(id++, game, teamA, HomeAway.HOME, 5, GameResult.WIN)
+                decidedGameTeams += gt
+                allGameTeams += gt
+            }
+            lionOnlyGamesDecided.forEach { game ->
+                val gl = createGameTeam(id++, game, teamB, HomeAway.HOME, 4, GameResult.WIN)
+                decidedGameTeams += gl
+                allGameTeams += gl
+            }
+            lionOnlyGamesRemaining.forEach { game ->
+                val gl = createGameTeam(id++, game, teamB, HomeAway.HOME, 0, GameResult.UNDECIDED)
+                allGameTeams += gl
+            }
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when
+            val result = service.calculateMagicNumbers(1L)
+
+            // then: Tigers leader, remainingGames=0, gamesPlayed=5 → isClinched=true
+            val tigersResult = result.find { it.teamId == 1L }!!
+            assertThat(tigersResult.isClinched).isTrue()
+
+            // Lions: rawMN = 0+1-(5-3) = -1 <= 0, maxPossibleWins = 3+2=5 >= 5 → isEliminated=false → isClinched=true
+            val lionsResult = result.find { it.teamId == 2L }!!
+            assertThat(lionsResult.isClinched).isTrue()
+            assertThat(lionsResult.isEliminated).isFalse()
+        }
+
+        @Test
+        fun `팀이 한 경기도 없는 경우 winningPercentage 0`() {
+            // gamesPlayed == 0 → BigDecimal.ZERO branch in buildTeamStatsMap
+            val teamA = createTeam(1L, league, "Tigers")
+            val game1 = createGame(1L, competition)
+            // Only UNDECIDED games → decided is empty
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 0, GameResult.UNDECIDED)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns listOf(gt1)
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns emptyList()
+
+            // when
+            val result = service.calculateMagicNumbers(1L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].teamId).isEqualTo(1L)
+            assertThat(result[0].magicNumber).isGreaterThanOrEqualTo(0)
+        }
+    }
+
+    @Nested
+    @DisplayName("simulateStandings - 추가 시나리오")
+    inner class SimulateStandingsExtra {
+        @Test
+        fun `홈팀 승리 시나리오가 올바르게 적용된다`() {
+            // given: home win path (simResult.homeScore > simResult.awayScore)
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+            val game2 = createGame(2L, competition)
+
+            // 현재 동률
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+            val gt2 = createGameTeam(3L, game2, teamA, HomeAway.HOME, 0, GameResult.UNDECIDED)
+            val gl2 = createGameTeam(4L, game2, teamB, HomeAway.AWAY, 0, GameResult.UNDECIDED)
+
+            val allGameTeams = listOf(gt1, gl1, gt2, gl2)
+            val decidedGameTeams = listOf(gt1, gl1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when: Tigers(홈)이 game2에서 승리
+            val request =
+                SimulationRequest(
+                    listOf(SimulatedGameResult(gameId = 2L, homeScore = 5, awayScore = 1)),
+                )
+
+            val result = service.simulateStandings(1L, request)
+
+            // then: Tigers 2승, Lions 0승 1패 → Tigers 1위
+            assertThat(result.standings).hasSize(2)
+            val tigers = result.standings.find { it.teamId == 1L }!!
+            assertThat(tigers.wins).isEqualTo(2)
+            assertThat(tigers.rank).isEqualTo(1)
+        }
+
+        @Test
+        fun `존재하지 않는 gameId 시뮬레이션은 무시된다`() {
+            // given: gameId가 allGameTeams에 없는 경우 → return@forEach
+            val teamA = createTeam(1L, league, "Tigers")
+            val game1 = createGame(1L, competition)
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns listOf(gt1)
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns listOf(gt1)
+
+            // when: 존재하지 않는 gameId 999
+            val request =
+                SimulationRequest(
+                    listOf(SimulatedGameResult(gameId = 999L, homeScore = 5, awayScore = 1)),
+                )
+
+            val result = service.simulateStandings(1L, request)
+
+            // then: 결과에 변화 없음
+            assertThat(result.standings).hasSize(1)
+            assertThat(result.changes).isEmpty()
+        }
+
+        @Test
+        fun `awayScore가 음수이면 InvalidInputException 발생`() {
+            // given
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns emptyList()
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns emptyList()
+
+            val request =
+                SimulationRequest(
+                    listOf(SimulatedGameResult(gameId = 1L, homeScore = 3, awayScore = -1)),
+                )
+
+            // when/then
+            assertThrows<InvalidInputException> {
+                service.simulateStandings(1L, request)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("calculatePlayoffScenarios - 몬테카를로 시뮬레이션")
+    inner class CalculatePlayoffScenariosMonteCarlo {
+        @Test
+        fun `남은 경기가 15 초과이면 몬테카를로 시뮬레이션을 수행한다`() {
+            // given: 2팀, 16개의 미결 경기 → MONTE_CARLO_THRESHOLD(15) 초과
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            // 1 결정된 경기
+            val decidedGame = createGame(1L, competition)
+            val gt1 = createGameTeam(1L, decidedGame, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, decidedGame, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+
+            val decidedGameTeams = listOf(gt1, gl1)
+            val allGameTeams = mutableListOf<GameTeam>()
+            allGameTeams += gt1
+            allGameTeams += gl1
+
+            // 16개 미결 경기 추가
+            var id = 3L
+            (2..17).forEach { gameNum ->
+                val game = createGame(gameNum.toLong(), competition)
+                val gtUndecided =
+                    createGameTeam(id++, game, teamA, HomeAway.HOME, 0, GameResult.UNDECIDED)
+                val glUndecided =
+                    createGameTeam(id++, game, teamB, HomeAway.AWAY, 0, GameResult.UNDECIDED)
+                allGameTeams += gtUndecided
+                allGameTeams += glUndecided
+            }
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when
+            val result = service.calculatePlayoffScenarios(1L, 1L, 2)
+
+            // then: 몬테카를로 결과 (총 1000 iterations)
+            assertThat(result.totalScenarios).isEqualTo(1000)
+            assertThat(result.qualifyingScenarios).isBetween(0, 1000)
+            assertThat(result.probability).isBetween(0.0, 1.0)
+        }
+
+        @Test
+        fun `남은 경기가 있을 때 완전 탐색 시뮬레이션 내부 루프가 실행된다`() {
+            // given: 2팀, 2개의 미결 경기 (완전 탐색, 3^2=9 시나리오)
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val decidedGame = createGame(1L, competition)
+            val gt1 = createGameTeam(1L, decidedGame, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, decidedGame, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+
+            val game2 = createGame(2L, competition)
+            val game3 = createGame(3L, competition)
+            val gt2 = createGameTeam(3L, game2, teamA, HomeAway.HOME, 0, GameResult.UNDECIDED)
+            val gl2 = createGameTeam(4L, game2, teamB, HomeAway.AWAY, 0, GameResult.UNDECIDED)
+            val gt3 = createGameTeam(5L, game3, teamA, HomeAway.HOME, 0, GameResult.UNDECIDED)
+            val gl3 = createGameTeam(6L, game3, teamB, HomeAway.AWAY, 0, GameResult.UNDECIDED)
+
+            val allGameTeams = listOf(gt1, gl1, gt2, gl2, gt3, gl3)
+            val decidedGameTeams = listOf(gt1, gl1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when: Tigers의 플레이오프 시나리오 (상위 1팀)
+            val result = service.calculatePlayoffScenarios(1L, 1L, 1)
+
+            // then: 3^2 = 9 시나리오
+            assertThat(result.totalScenarios).isEqualTo(9)
+            assertThat(result.qualifyingScenarios).isBetween(0, 9)
+            assertThat(result.probability).isBetween(0.0, 1.0)
+        }
+
+        @Test
+        fun `남은 경기가 있고 상위 2팀 플레이오프 진출 가능성이 계산된다`() {
+            // given: 3팀, 2개 미결 경기
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+            val teamC = createTeam(3L, league, "Bears")
+
+            val game1 = createGame(1L, competition)
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+
+            val game2 = createGame(2L, competition)
+            val gt2 = createGameTeam(3L, game2, teamA, HomeAway.HOME, 0, GameResult.UNDECIDED)
+            val gl2 = createGameTeam(4L, game2, teamC, HomeAway.AWAY, 0, GameResult.UNDECIDED)
+
+            val game3 = createGame(3L, competition)
+            val gt3 = createGameTeam(5L, game3, teamB, HomeAway.HOME, 0, GameResult.UNDECIDED)
+            val gl3 = createGameTeam(6L, game3, teamC, HomeAway.AWAY, 0, GameResult.UNDECIDED)
+
+            val allGameTeams = listOf(gt1, gl1, gt2, gl2, gt3, gl3)
+            val decidedGameTeams = listOf(gt1, gl1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when: Bears 플레이오프(상위 2팀)
+            val result = service.calculatePlayoffScenarios(1L, 3L, 2)
+
+            // then: 3^2=9 시나리오
+            assertThat(result.totalScenarios).isEqualTo(9)
+            assertThat(result.probability).isBetween(0.0, 1.0)
+        }
+
+        @Test
+        fun `모든 경기 완료 후 완전 탐색은 1개 시나리오만 실행`() {
+            // given: 남은 경기 없음 → totalScenarios = 3^0 = 1
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
+
+            val allGameTeams = listOf(gt1, gl1)
+            val decidedGameTeams = listOf(gt1, gl1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when
+            val result = service.calculatePlayoffScenarios(1L, 1L, 2)
+
+            // then: totalScenarios = 1, Tigers는 1위이므로 probability = 1.0
+            assertThat(result.totalScenarios).isEqualTo(1)
+            assertThat(result.probability).isEqualTo(1.0)
+        }
+
+        @Test
+        fun `무승부 경기가 있는 경우 draws 카운트가 올바르다`() {
+            // given: 무승부 결과 포함 → draws branch in buildTeamStatsMap
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+            val gt1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 3, GameResult.DRAW)
+            val gl1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 3, GameResult.DRAW)
+
+            val allGameTeams = listOf(gt1, gl1)
+            val decidedGameTeams = listOf(gt1, gl1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when
+            val magicNumbers = service.calculateMagicNumbers(1L)
+
+            // then
+            assertThat(magicNumbers).hasSize(2)
+            // 무승부인 경우 winningPercentage = 0.5
+        }
+    }
+
+    // =========================================================================
     // Helper methods
     // =========================================================================
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImplTest.kt
@@ -513,62 +513,23 @@ class StandingsSimulationServiceImplTest {
         }
 
         @Test
-        fun `비선두팀 rawMagicNumber 0 이하이고 탈락 아닌 경우 isClinched true`() {
-            // given: 3팀, 2팀이 플레이오프 진출, 3위팀의 rawMagicNumber <= 0이 되는 상황
-            // Tigers: 10승 0패, Lions: 9승 1패, Bears: 0승 10패
-            // leader(Tigers) remainingGames = 0
-            // Bears: rawMN = 0+1-(10-0) = -9 <= 0, maxPossibleWins = 0+0 = 0 < 10 → isEliminated true
-            // Lions: rawMN = 0+1-(10-9) = 0 <= 0, maxPossibleWins = 9+0=9 < 10 → isEliminated true
-            // → Lions도 isEliminated=true이면 isClinched = false
-            // Let's try: Tigers 3승, Lions 2승, Bears 0승, no remaining
-            // Bears: rawMN = 0+1-(3-0) = -2 <=0, maxPossible = 0 < 3 → isEliminated true → isClinched false
-            // Lions: rawMN = 0+1-(3-2) = 0 <=0, maxPossible = 2+0=2 < 3 → isEliminated true → isClinched false
-            //
-            // To get isClinched=true for a non-leader, we need:
-            // rawMagicNumber <= 0 && !isEliminated
-            // maxPossibleWins >= leader.wins but rawMN <= 0
-            // Scenario: Tigers 5승 1패, Lions 3승 1패, Lions remainingGames=2
-            // leader = Tigers (5승), remainingGames=0
-            // Lions: rawMN = 0+1-(5-3) = -1 <= 0
-            //        maxPossibleWins = 3+2 = 5 >= 5 → isEliminated = false
-            //        isClinched = true
+        fun `비선두팀의 매직넘버가 양수이면 isClinched false`() {
+            // 표준 야구 매직넘버 공식: stats.remainingGames - leader.wins + stats.wins + 1
+            // Tigers: 5승, remainingGames=0 (leader)
+            // Lions: 3승, remainingGames=2
+            // Lions rawMN = 2 - 5 + 3 + 1 = 1 > 0 → isClinched = false
+            // maxPossibleWins = 3 + 2 = 5 >= 5 → isEliminated = false
+            // 표준 공식에서는 비선두팀이 남은 경기가 있는 한 순위 미확정
 
             val teamA = createTeam(1L, league, "Tigers")
             val teamB = createTeam(2L, league, "Lions")
 
-            // Tigers: 5 decided games (WIN), 0 remaining
-            val tigerGames = (1..5).map { createGame(it.toLong(), competition) }
-            // Lions: 3 decided games (WIN, LOSS), 2 remaining
-            val lionGames = (1..3).map { createGame(it.toLong(), competition) }
-            val lionRemainingGames = (6..7).map { createGame(it.toLong(), competition) }
-
-            val decidedGameTeams = mutableListOf<GameTeam>()
-            val allGameTeams = mutableListOf<GameTeam>()
-
-            var gtId = 1L
-            tigerGames.forEachIndexed { i, game ->
-                val gt = createGameTeam(gtId++, game, teamA, HomeAway.HOME, 5, GameResult.WIN)
-                val gl = createGameTeam(gtId++, game, teamB, HomeAway.AWAY, 2, GameResult.LOSS)
-                decidedGameTeams += listOf(gt, gl)
-                allGameTeams += listOf(gt, gl)
-            }
-
-            // override Lions in Tiger's games - actually need separate games per team
-            // Simpler: separate games for Lions vs some dummy
-            // Reset and use a cleaner scenario:
-            // Tigers play 5 games against external (only Tigers in allGameTeams for those games)
-            // Let's just use 2 teams playing each other
-
-            // Clean approach: Tigers 5 wins (5 games), Lions: 3 wins from same 5 games → impossible if they play each other
-
-            // Best approach: Tigers 5W vs unknown, Lions 3W vs unknown
-            // Use single-team game entries (no opponent in allGameTeams → opponent not tracked)
-            decidedGameTeams.clear()
-            allGameTeams.clear()
-
             val tigerOnlyGames = (10..14).map { createGame(it.toLong(), competition) }
             val lionOnlyGamesDecided = (20..22).map { createGame(it.toLong(), competition) }
             val lionOnlyGamesRemaining = (30..31).map { createGame(it.toLong(), competition) }
+
+            val decidedGameTeams = mutableListOf<GameTeam>()
+            val allGameTeams = mutableListOf<GameTeam>()
 
             var id = 1L
             tigerOnlyGames.forEach { game ->
@@ -597,9 +558,10 @@ class StandingsSimulationServiceImplTest {
             val tigersResult = result.find { it.teamId == 1L }!!
             assertThat(tigersResult.isClinched).isTrue()
 
-            // Lions: rawMN = 0+1-(5-3) = -1 <= 0, maxPossibleWins = 3+2=5 >= 5 → isEliminated=false → isClinched=true
+            // Lions: rawMN = 2-5+3+1 = 1 > 0 → isClinched=false, isEliminated=false (maxPossibleWins=5 >= 5)
             val lionsResult = result.find { it.teamId == 2L }!!
-            assertThat(lionsResult.isClinched).isTrue()
+            assertThat(lionsResult.magicNumber).isEqualTo(1)
+            assertThat(lionsResult.isClinched).isFalse()
             assertThat(lionsResult.isEliminated).isFalse()
         }
 
@@ -747,8 +709,8 @@ class StandingsSimulationServiceImplTest {
             val result = service.calculatePlayoffScenarios(1L, 1L, 2)
 
             // then: 몬테카를로 결과 (총 1000 iterations)
-            assertThat(result.totalScenarios).isEqualTo(1000)
-            assertThat(result.qualifyingScenarios).isBetween(0, 1000)
+            assertThat(result.totalScenarios).isEqualTo(1000L)
+            assertThat(result.qualifyingScenarios).isBetween(0L, 1000L)
             assertThat(result.probability).isBetween(0.0, 1.0)
         }
 
@@ -780,8 +742,8 @@ class StandingsSimulationServiceImplTest {
             val result = service.calculatePlayoffScenarios(1L, 1L, 1)
 
             // then: 3^2 = 9 시나리오
-            assertThat(result.totalScenarios).isEqualTo(9)
-            assertThat(result.qualifyingScenarios).isBetween(0, 9)
+            assertThat(result.totalScenarios).isEqualTo(9L)
+            assertThat(result.qualifyingScenarios).isBetween(0L, 9L)
             assertThat(result.probability).isBetween(0.0, 1.0)
         }
 
@@ -815,7 +777,7 @@ class StandingsSimulationServiceImplTest {
             val result = service.calculatePlayoffScenarios(1L, 3L, 2)
 
             // then: 3^2=9 시나리오
-            assertThat(result.totalScenarios).isEqualTo(9)
+            assertThat(result.totalScenarios).isEqualTo(9L)
             assertThat(result.probability).isBetween(0.0, 1.0)
         }
 
@@ -840,7 +802,7 @@ class StandingsSimulationServiceImplTest {
             val result = service.calculatePlayoffScenarios(1L, 1L, 2)
 
             // then: totalScenarios = 1, Tigers는 1위이므로 probability = 1.0
-            assertThat(result.totalScenarios).isEqualTo(1)
+            assertThat(result.totalScenarios).isEqualTo(1L)
             assertThat(result.probability).isEqualTo(1.0)
         }
 


### PR DESCRIPTION
## Summary

>- close #137

리그 순위 **매직넘버 계산**, **순위 시뮬레이션**, **플레이오프 진출 경우의 수 계산** 기능을 구현합니다.

## Tasks

- MagicNumber 데이터 클래스 (teamId, targetRank, magicNumber, isClinched, isEliminated)
- StandingsSimulationService 인터페이스 (core) + StandingsSimulationServiceImpl 구현체 (infrastructure)
- 매직넘버 계산: leader.remainingGames + 1 - (leader.wins - team.wins)
- 순위 시뮬레이션: 가상 경기 결과 적용 후 예상 순위 반환
- 플레이오프 시나리오: 남은경기 15개 이하 exhaustive search, 초과 시 Monte Carlo (1000회)
- API 엔드포인트 3개 추가 (magic-numbers, simulation, playoff-scenarios)
- SimulationApiDto 요청/응답 DTO (Zero Entity Leak 준수)
- StandingsSimulationServiceImplTest (12개) + StandingsSimulationControllerTest (12개) 단위 테스트

## To Reviewer

- 대규모 경우의 수(2^n)에 대한 Monte Carlo 최적화가 적용되어 있습니다.
- 시뮬레이션은 UNDECIDED 상태 경기에만 적용됩니다.
- 빌드 성공 (87 tasks, 472 tests passed)