### PR TITLE
fix(#171): 백오피스 평문 비밀번호 해싱 및 SecurityConfig CORS 설정 (#172)

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
@@ -24,6 +24,9 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 /**
  * Spring Security 설정
@@ -42,10 +45,13 @@ class SecurityConfig(
     private val oAuth2AuthenticationFailureHandler: OAuth2AuthenticationFailureHandler,
     @Value("\${springdoc.swagger-ui.enabled:true}")
     private val swaggerEnabled: Boolean,
+    @Value("\${app.cors.allowed-origins:http://localhost:3000}")
+    private val allowedOrigins: String,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain =
         http
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .csrf { csrf ->
                 csrf.ignoringRequestMatchers("/api/**")
             }.headers { headers ->
@@ -62,9 +68,18 @@ class SecurityConfig(
                 it.accessDeniedHandler(customAccessDeniedHandler)
             }.authorizeHttpRequests { auth ->
                 auth
-                    // Public endpoints
-                    .requestMatchers("/api/auth/**")
-                    .permitAll()
+                    // Public auth endpoints (explicit paths instead of wildcard)
+                    .requestMatchers(
+                        "/api/auth/login",
+                        "/api/auth/refresh",
+                        "/api/auth/oauth2/token",
+                    ).permitAll()
+                    // Authenticated auth endpoints
+                    .requestMatchers(
+                        "/api/auth/me",
+                        "/api/auth/logout",
+                        "/api/auth/logout-all",
+                    ).authenticated()
                     .requestMatchers(HttpMethod.GET, "/api/associations/**")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/stats/**")
@@ -114,4 +129,18 @@ class SecurityConfig(
     @Bean
     fun authenticationManager(authenticationConfiguration: AuthenticationConfiguration): AuthenticationManager =
         authenticationConfiguration.authenticationManager
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        configuration.allowedOrigins = allowedOrigins.split(",").map { it.trim() }
+        configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
+        configuration.maxAge = 3600L
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
+    }
 }

--- a/nextup-api/src/main/resources/application.yml
+++ b/nextup-api/src/main/resources/application.yml
@@ -69,6 +69,8 @@ app:
   oauth2:
     base-url: ${APP_BASE_URL:http://localhost:8080}
     redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/oauth2/callback}
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/config/SecurityConfig.kt
@@ -13,9 +13,14 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 /**
  * Backoffice Security 설정
@@ -34,10 +39,13 @@ class SecurityConfig(
     private val customAccessDeniedHandler: CustomAccessDeniedHandler,
     @Value("\${springdoc.swagger-ui.enabled:true}")
     private val swaggerEnabled: Boolean,
+    @Value("\${app.cors.allowed-origins:http://localhost:3000}")
+    private val allowedOrigins: String,
 ) {
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain =
         http
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .csrf { csrf ->
                 csrf.ignoringRequestMatchers("/api/**")
             }.headers { headers ->
@@ -78,4 +86,21 @@ class SecurityConfig(
             }.addFilterBefore(rateLimitFilter, JwtAuthenticationFilter::class.java)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        configuration.allowedOrigins = allowedOrigins.split(",").map { it.trim() }
+        configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
+        configuration.maxAge = 3600L
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
+    }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/user/UserAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/user/UserAdminController.kt
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.web.bind.annotation.*
 
 /**
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/backoffice/users")
 class UserAdminController(
     private val userService: UserService,
+    private val passwordEncoder: PasswordEncoder,
 ) {
     /**
      * 모든 사용자 목록을 페이징으로 조회합니다.
@@ -76,20 +78,16 @@ class UserAdminController(
 
     /**
      * 사용자를 생성합니다 (관리자용 - 비밀번호 직접 설정).
-     *
-     * 주의: 실제 운영에서는 PasswordEncoder를 사용해야 합니다.
-     * Security 모듈 구현 후 수정 필요.
      */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun createUser(
         @Valid @RequestBody request: CreateUserRequest,
     ): ApiResponse<UserAdminResponse> {
-        // TODO: PasswordEncoder 적용 필요 (Issue #26)
         val user =
             userService.createLocalUser(
                 email = request.email,
-                encodedPassword = request.password, // 임시: 실제로는 인코딩 필요
+                encodedPassword = passwordEncoder.encode(request.password),
                 nickname = request.nickname,
             )
 

--- a/nextup-backoffice/src/main/resources/application.yml
+++ b/nextup-backoffice/src/main/resources/application.yml
@@ -24,6 +24,10 @@ spring:
     property-naming-strategy: SNAKE_CASE
     default-property-inclusion: non_null
 
+app:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION:1800000}

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/user/UserAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/user/UserAdminControllerTest.kt
@@ -18,6 +18,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.http.MediaType
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -31,13 +32,16 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 class UserAdminControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var userService: UserService
+    private lateinit var passwordEncoder: PasswordEncoder
     private lateinit var controller: UserAdminController
     private lateinit var objectMapper: ObjectMapper
 
     @BeforeEach
     fun setUp() {
         userService = mockk()
-        controller = UserAdminController(userService)
+        passwordEncoder = mockk()
+        every { passwordEncoder.encode(any()) } answers { "encoded_${firstArg<String>()}" }
+        controller = UserAdminController(userService, passwordEncoder)
         mockMvc =
             MockMvcBuilders
                 .standaloneSetup(controller)
@@ -188,7 +192,7 @@ class UserAdminControllerTest {
             every {
                 userService.createLocalUser(
                     email = "newuser@example.com",
-                    encodedPassword = "password123",
+                    encodedPassword = "encoded_password123",
                     nickname = "새사용자",
                 )
             } returns user
@@ -208,7 +212,7 @@ class UserAdminControllerTest {
             verify(exactly = 1) {
                 userService.createLocalUser(
                     email = "newuser@example.com",
-                    encodedPassword = "password123",
+                    encodedPassword = "encoded_password123",
                     nickname = "새사용자",
                 )
             }
@@ -229,7 +233,7 @@ class UserAdminControllerTest {
             every {
                 userService.createLocalUser(
                     email = "admin@example.com",
-                    encodedPassword = "password123",
+                    encodedPassword = "encoded_password123",
                     nickname = "관리자",
                 )
             } returns user

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/SecurityConfig.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/SecurityConfig.kt
@@ -16,6 +16,9 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 /**
  * Scorer Security 설정
@@ -33,11 +36,14 @@ class SecurityConfig(
     private val customAccessDeniedHandler: CustomAccessDeniedHandler,
     @Value("\${springdoc.swagger-ui.enabled:true}")
     private val swaggerEnabled: Boolean,
+    @Value("\${app.cors.allowed-origins:\${app.websocket.allowed-origins:http://localhost:3000}}")
+    private val allowedOrigins: String,
 ) {
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         return http
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .csrf { csrf ->
                 csrf.ignoringRequestMatchers("/api/**", "/ws/**")
             }.headers { headers ->
@@ -82,5 +88,19 @@ class SecurityConfig(
             .addFilterBefore(rateLimitFilter, JwtAuthenticationFilter::class.java)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        configuration.allowedOrigins = allowedOrigins.split(",").map { it.trim() }
+        configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
+        configuration.maxAge = 3600L
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
     }
 }


### PR DESCRIPTION
## Summary

>- close #171
>- close #172

백오피스 사용자 생성 시 평문 비밀번호를 BCrypt로 해싱하도록 수정하고, 전체 API 모듈의 SecurityConfig에 CORS 설정을 추가합니다.

## Tasks

- UserAdminController에 PasswordEncoder 주입 및 비밀번호 해싱 적용 (#171)
- Backoffice SecurityConfig에 BCryptPasswordEncoder Bean 추가 (#171)
- API SecurityConfig `/api/auth/**` 와일드카드를 명시적 경로로 축소 (#172)
- `/api/auth/me`, `/api/auth/logout`, `/api/auth/logout-all`에 authenticated 적용 (#172)
- API/Backoffice/Scorer 3개 모듈에 CorsConfigurationSource Bean 추가 (#172)
- application.yml에 `app.cors.allowed-origins` 환경변수 설정 추가 (#172)

## To Reviewer

보안 관련 수정입니다.
- #171: 평문 비밀번호 저장은 OWASP A02 (Cryptographic Failures) 위반
- #172: CORS 미설정 시 프론트엔드 연동 불가, 와일드카드 permitAll은 인증 우회 가능성