### PR TITLE
fix(#176): BattingRecord/PitchingRecord revert 시 음수 값 방지

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
@@ -291,30 +291,48 @@ class BattingRecord(
         result: PlateAppearanceResult,
         rbis: Int = 0,
     ) {
+        require(plateAppearances > 0) { "롤백할 타석 기록이 없습니다." }
+        require(rbis >= 0) { "타점은 0 이상이어야 합니다." }
+        require(runsBattedIn >= rbis) { "롤백할 타점($rbis)이 현재 타점($runsBattedIn)보다 클 수 없습니다." }
+
         plateAppearances--
 
         when (result) {
             PlateAppearanceResult.SINGLE -> {
+                require(atBats > 0) { "롤백할 타수 기록이 없습니다." }
+                require(hits > 0) { "롤백할 안타 기록이 없습니다." }
                 atBats--
                 hits--
             }
             PlateAppearanceResult.DOUBLE -> {
+                require(atBats > 0) { "롤백할 타수 기록이 없습니다." }
+                require(hits > 0) { "롤백할 안타 기록이 없습니다." }
+                require(doubles > 0) { "롤백할 2루타 기록이 없습니다." }
                 atBats--
                 hits--
                 doubles--
             }
             PlateAppearanceResult.TRIPLE -> {
+                require(atBats > 0) { "롤백할 타수 기록이 없습니다." }
+                require(hits > 0) { "롤백할 안타 기록이 없습니다." }
+                require(triples > 0) { "롤백할 3루타 기록이 없습니다." }
                 atBats--
                 hits--
                 triples--
             }
             PlateAppearanceResult.HOME_RUN -> {
+                require(atBats > 0) { "롤백할 타수 기록이 없습니다." }
+                require(hits > 0) { "롤백할 안타 기록이 없습니다." }
+                require(homeRuns > 0) { "롤백할 홈런 기록이 없습니다." }
+                require(runs > 0) { "롤백할 득점 기록이 없습니다." }
                 atBats--
                 hits--
                 homeRuns--
                 runs--
             }
             PlateAppearanceResult.STRIKEOUT -> {
+                require(atBats > 0) { "롤백할 타수 기록이 없습니다." }
+                require(strikeouts > 0) { "롤백할 삼진 기록이 없습니다." }
                 atBats--
                 strikeouts--
             }
@@ -324,26 +342,34 @@ class BattingRecord(
             PlateAppearanceResult.FIELDERS_CHOICE,
             PlateAppearanceResult.ERROR,
             -> {
+                require(atBats > 0) { "롤백할 타수 기록이 없습니다." }
                 atBats--
             }
             PlateAppearanceResult.WALK -> {
+                require(walks > 0) { "롤백할 볼넷 기록이 없습니다." }
                 walks--
             }
             PlateAppearanceResult.INTENTIONAL_WALK -> {
+                require(intentionalWalks > 0) { "롤백할 고의사구 기록이 없습니다." }
                 intentionalWalks--
             }
             PlateAppearanceResult.HIT_BY_PITCH -> {
+                require(hitByPitch > 0) { "롤백할 사구 기록이 없습니다." }
                 hitByPitch--
             }
             PlateAppearanceResult.SACRIFICE_FLY -> {
+                require(sacrificeFlies > 0) { "롤백할 희생플라이 기록이 없습니다." }
                 sacrificeFlies--
             }
             PlateAppearanceResult.SACRIFICE_BUNT -> {
+                require(sacrificeBunts > 0) { "롤백할 희생번트 기록이 없습니다." }
                 sacrificeBunts--
             }
             PlateAppearanceResult.DOUBLE_PLAY,
             PlateAppearanceResult.TRIPLE_PLAY,
             -> {
+                require(atBats > 0) { "롤백할 타수 기록이 없습니다." }
+                require(groundedIntoDoublePlays > 0) { "롤백할 병살타 기록이 없습니다." }
                 atBats--
                 groundedIntoDoublePlays--
             }
@@ -367,6 +393,23 @@ class BattingRecord(
      * 기록 유효성을 검증합니다.
      */
     fun validate() {
+        require(plateAppearances >= 0) { "타석($plateAppearances)은 음수일 수 없습니다." }
+        require(atBats >= 0) { "타수($atBats)는 음수일 수 없습니다." }
+        require(hits >= 0) { "안타($hits)는 음수일 수 없습니다." }
+        require(doubles >= 0) { "2루타($doubles)는 음수일 수 없습니다." }
+        require(triples >= 0) { "3루타($triples)는 음수일 수 없습니다." }
+        require(homeRuns >= 0) { "홈런($homeRuns)은 음수일 수 없습니다." }
+        require(runs >= 0) { "득점($runs)은 음수일 수 없습니다." }
+        require(runsBattedIn >= 0) { "타점($runsBattedIn)은 음수일 수 없습니다." }
+        require(walks >= 0) { "볼넷($walks)은 음수일 수 없습니다." }
+        require(intentionalWalks >= 0) { "고의사구($intentionalWalks)는 음수일 수 없습니다." }
+        require(hitByPitch >= 0) { "사구($hitByPitch)는 음수일 수 없습니다." }
+        require(strikeouts >= 0) { "삼진($strikeouts)은 음수일 수 없습니다." }
+        require(sacrificeBunts >= 0) { "희생번트($sacrificeBunts)는 음수일 수 없습니다." }
+        require(sacrificeFlies >= 0) { "희생플라이($sacrificeFlies)는 음수일 수 없습니다." }
+        require(stolenBases >= 0) { "도루($stolenBases)는 음수일 수 없습니다." }
+        require(caughtStealing >= 0) { "도루실패($caughtStealing)는 음수일 수 없습니다." }
+        require(groundedIntoDoublePlays >= 0) { "병살타($groundedIntoDoublePlays)는 음수일 수 없습니다." }
         require(hits <= atBats) {
             "안타 수($hits)가 타수($atBats)보다 클 수 없습니다."
         }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
@@ -421,6 +421,7 @@ class PitchingRecord(
      * applyBatterFaced의 역연산입니다.
      */
     fun revertBatterFaced(result: PlateAppearanceResult) {
+        require(battersFaced > 0) { "롤백할 대면 타자 기록이 없습니다." }
         battersFaced--
 
         when (result) {
@@ -428,21 +429,27 @@ class PitchingRecord(
             PlateAppearanceResult.DOUBLE,
             PlateAppearanceResult.TRIPLE,
             -> {
+                require(hitsAllowed > 0) { "롤백할 피안타 기록이 없습니다." }
                 hitsAllowed--
             }
             PlateAppearanceResult.HOME_RUN -> {
+                require(hitsAllowed > 0) { "롤백할 피안타 기록이 없습니다." }
+                require(homeRunsAllowed > 0) { "롤백할 피홈런 기록이 없습니다." }
                 hitsAllowed--
                 homeRunsAllowed--
             }
             PlateAppearanceResult.STRIKEOUT -> {
+                require(strikeouts > 0) { "롤백할 삼진 기록이 없습니다." }
                 strikeouts--
             }
             PlateAppearanceResult.WALK,
             PlateAppearanceResult.INTENTIONAL_WALK,
             -> {
+                require(walksAllowed > 0) { "롤백할 볼넷 기록이 없습니다." }
                 walksAllowed--
             }
             PlateAppearanceResult.HIT_BY_PITCH -> {
+                require(hitBatsmen > 0) { "롤백할 사구 기록이 없습니다." }
                 hitBatsmen--
             }
             else -> {
@@ -464,6 +471,8 @@ class PitchingRecord(
      */
     fun revertEarnedRun(runs: Int) {
         require(runs >= 0) { "롤백할 자책점은 0 이상이어야 합니다." }
+        require(earnedRuns >= runs) { "롤백할 자책점($runs)이 현재 자책점($earnedRuns)보다 클 수 없습니다." }
+        require(runsAllowed >= runs) { "롤백할 실점($runs)이 현재 실점($runsAllowed)보다 클 수 없습니다." }
         earnedRuns -= runs
         runsAllowed -= runs
     }
@@ -472,6 +481,17 @@ class PitchingRecord(
      * 기록 유효성을 검증합니다.
      */
     fun validate() {
+        require(inningsPitchedOuts >= 0) { "이닝 아웃 수($inningsPitchedOuts)는 음수일 수 없습니다." }
+        require(earnedRuns >= 0) { "자책점($earnedRuns)은 음수일 수 없습니다." }
+        require(runsAllowed >= 0) { "실점($runsAllowed)은 음수일 수 없습니다." }
+        require(hitsAllowed >= 0) { "피안타($hitsAllowed)는 음수일 수 없습니다." }
+        require(walksAllowed >= 0) { "볼넷 허용($walksAllowed)은 음수일 수 없습니다." }
+        require(strikeouts >= 0) { "삼진($strikeouts)은 음수일 수 없습니다." }
+        require(homeRunsAllowed >= 0) { "피홈런($homeRunsAllowed)은 음수일 수 없습니다." }
+        require(hitBatsmen >= 0) { "사구($hitBatsmen)는 음수일 수 없습니다." }
+        require(wildPitches >= 0) { "와일드피치($wildPitches)는 음수일 수 없습니다." }
+        require(balks >= 0) { "보크($balks)는 음수일 수 없습니다." }
+        require(battersFaced >= 0) { "대면 타자 수($battersFaced)는 음수일 수 없습니다." }
         require(earnedRuns <= runsAllowed) {
             "자책점($earnedRuns)이 실점($runsAllowed)보다 클 수 없습니다."
         }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
@@ -998,4 +998,153 @@ class BattingRecordTest {
                 .hasMessageContaining("롤백할 병살타 기록이 없습니다")
         }
     }
+
+    @Nested
+    @DisplayName("validate - 음수 필드 검증")
+    inner class ValidateNonNegativeFieldTest {
+        private fun setField(
+            fieldName: String,
+            value: Int,
+        ) {
+            val field = BattingRecord::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            field.setInt(battingRecord, value)
+        }
+
+        @Test
+        fun `타석이 음수이면 검증에 실패한다`() {
+            setField("plateAppearances", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("타석")
+        }
+
+        @Test
+        fun `타수가 음수이면 검증에 실패한다`() {
+            setField("atBats", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("타수")
+        }
+
+        @Test
+        fun `안타가 음수이면 검증에 실패한다`() {
+            setField("hits", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("안타")
+        }
+
+        @Test
+        fun `2루타가 음수이면 검증에 실패한다`() {
+            setField("doubles", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("2루타")
+        }
+
+        @Test
+        fun `3루타가 음수이면 검증에 실패한다`() {
+            setField("triples", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("3루타")
+        }
+
+        @Test
+        fun `홈런이 음수이면 검증에 실패한다`() {
+            setField("homeRuns", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("홈런")
+        }
+
+        @Test
+        fun `득점이 음수이면 검증에 실패한다`() {
+            setField("runs", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("득점")
+        }
+
+        @Test
+        fun `타점이 음수이면 검증에 실패한다`() {
+            setField("runsBattedIn", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("타점")
+        }
+
+        @Test
+        fun `볼넷이 음수이면 검증에 실패한다`() {
+            setField("walks", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("볼넷")
+        }
+
+        @Test
+        fun `고의사구가 음수이면 검증에 실패한다`() {
+            setField("intentionalWalks", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("고의사구")
+        }
+
+        @Test
+        fun `사구가 음수이면 검증에 실패한다`() {
+            setField("hitByPitch", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("사구")
+        }
+
+        @Test
+        fun `삼진이 음수이면 검증에 실패한다`() {
+            setField("strikeouts", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("삼진")
+        }
+
+        @Test
+        fun `희생번트가 음수이면 검증에 실패한다`() {
+            setField("sacrificeBunts", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("희생번트")
+        }
+
+        @Test
+        fun `희생플라이가 음수이면 검증에 실패한다`() {
+            setField("sacrificeFlies", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("희생플라이")
+        }
+
+        @Test
+        fun `도루가 음수이면 검증에 실패한다`() {
+            setField("stolenBases", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("도루")
+        }
+
+        @Test
+        fun `도루실패가 음수이면 검증에 실패한다`() {
+            setField("caughtStealing", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("도루실패")
+        }
+
+        @Test
+        fun `병살타가 음수이면 검증에 실패한다`() {
+            setField("groundedIntoDoublePlays", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("병살타")
+        }
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
@@ -905,4 +905,97 @@ class BattingRecordTest {
             assertThat(battingRecord.atBats).isEqualTo(1)
         }
     }
+
+    @Nested
+    @DisplayName("revertPlateAppearanceResult - 음수 값 방지 가드")
+    inner class RevertNegativeGuardTest {
+        @Test
+        fun `타석 기록이 없을 때 롤백하면 예외가 발생한다`() {
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 타석 기록이 없습니다")
+        }
+
+        @Test
+        fun `단타 기록이 없을 때 단타를 롤백하면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 타수 기록이 없습니다")
+        }
+
+        @Test
+        fun `2루타 기록이 없을 때 2루타를 롤백하면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.DOUBLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 2루타 기록이 없습니다")
+        }
+
+        @Test
+        fun `3루타 기록이 없을 때 3루타를 롤백하면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.TRIPLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 3루타 기록이 없습니다")
+        }
+
+        @Test
+        fun `홈런 기록이 없을 때 홈런을 롤백하면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.HOME_RUN)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 홈런 기록이 없습니다")
+        }
+
+        @Test
+        fun `삼진 기록이 없을 때 삼진을 롤백하면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 삼진 기록이 없습니다")
+        }
+
+        @Test
+        fun `볼넷 기록이 없을 때 볼넷을 롤백하면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+            battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.WALK)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.WALK)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 타석 기록이 없습니다")
+        }
+
+        @Test
+        fun `롤백할 타점이 현재 타점보다 크면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE, rbis = 1)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.SINGLE, rbis = 2)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 타점")
+        }
+
+        @Test
+        fun `병살타 기록이 없을 때 병살타를 롤백하면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.DOUBLE_PLAY)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 병살타 기록이 없습니다")
+        }
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
@@ -1000,6 +1000,190 @@ class BattingRecordTest {
     }
 
     @Nested
+    @DisplayName("revertPlateAppearanceResult - 중간 가드 커버리지")
+    inner class RevertIntermediateGuardTest {
+        private fun setField(
+            fieldName: String,
+            value: Int,
+        ) {
+            val field = BattingRecord::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            field.setInt(battingRecord, value)
+        }
+
+        @Test
+        fun `롤백 시 음수 타점은 허용되지 않는다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE, rbis = 1)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.SINGLE, rbis = -1)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("타점은 0 이상이어야 합니다")
+        }
+
+        @Test
+        fun `단타 롤백 시 안타가 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 안타 기록이 없습니다")
+        }
+
+        @Test
+        fun `2루타 롤백 시 타수가 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.DOUBLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 타수 기록이 없습니다")
+        }
+
+        @Test
+        fun `2루타 롤백 시 안타가 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.DOUBLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 안타 기록이 없습니다")
+        }
+
+        @Test
+        fun `3루타 롤백 시 타수가 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.TRIPLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 타수 기록이 없습니다")
+        }
+
+        @Test
+        fun `3루타 롤백 시 안타가 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.TRIPLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 안타 기록이 없습니다")
+        }
+
+        @Test
+        fun `홈런 롤백 시 타수가 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.HOME_RUN)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 타수 기록이 없습니다")
+        }
+
+        @Test
+        fun `홈런 롤백 시 안타가 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.HOME_RUN)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 안타 기록이 없습니다")
+        }
+
+        @Test
+        fun `홈런 롤백 시 득점이 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+            setField("homeRuns", 1)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.HOME_RUN)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 득점 기록이 없습니다")
+        }
+
+        @Test
+        fun `삼진 롤백 시 타수가 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.STRIKEOUT)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 타수 기록이 없습니다")
+        }
+
+        @Test
+        fun `땅볼아웃 롤백 시 타수가 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 타수 기록이 없습니다")
+        }
+
+        @Test
+        fun `볼넷 롤백 시 볼넷 기록이 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.WALK)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 볼넷 기록이 없습니다")
+        }
+
+        @Test
+        fun `고의사구 롤백 시 고의사구 기록이 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.INTENTIONAL_WALK)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 고의사구 기록이 없습니다")
+        }
+
+        @Test
+        fun `사구 롤백 시 사구 기록이 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.HIT_BY_PITCH)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 사구 기록이 없습니다")
+        }
+
+        @Test
+        fun `희생플라이 롤백 시 희생플라이 기록이 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.SACRIFICE_FLY)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 희생플라이 기록이 없습니다")
+        }
+
+        @Test
+        fun `희생번트 롤백 시 희생번트 기록이 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.SACRIFICE_BUNT)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 희생번트 기록이 없습니다")
+        }
+
+        @Test
+        fun `병살타 롤백 시 타수가 없으면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.WALK)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.DOUBLE_PLAY)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 타수 기록이 없습니다")
+        }
+    }
+
+    @Nested
     @DisplayName("validate - 음수 필드 검증")
     inner class ValidateNonNegativeFieldTest {
         private fun setField(

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -759,4 +759,106 @@ class PitchingRecordTest {
             assertThat(pitchingRecord.unearnedRuns).isEqualTo(1)
         }
     }
+
+    @Nested
+    @DisplayName("revertBatterFaced - 음수 값 방지 가드")
+    inner class RevertBatterFacedNegativeGuardTest {
+        @Test
+        fun `대면 타자 기록이 없을 때 롤백하면 예외가 발생한다`() {
+            assertThatThrownBy {
+                pitchingRecord.revertBatterFaced(PlateAppearanceResult.SINGLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 대면 타자 기록이 없습니다")
+        }
+
+        @Test
+        fun `피안타 기록이 없을 때 단타 롤백하면 예외가 발생한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.STRIKEOUT)
+
+            assertThatThrownBy {
+                pitchingRecord.revertBatterFaced(PlateAppearanceResult.SINGLE)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 피안타 기록이 없습니다")
+        }
+
+        @Test
+        fun `피홈런 기록이 없을 때 홈런 롤백하면 예외가 발생한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.SINGLE)
+
+            assertThatThrownBy {
+                pitchingRecord.revertBatterFaced(PlateAppearanceResult.HOME_RUN)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 피홈런 기록이 없습니다")
+        }
+
+        @Test
+        fun `삼진 기록이 없을 때 삼진 롤백하면 예외가 발생한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.GROUND_OUT)
+
+            assertThatThrownBy {
+                pitchingRecord.revertBatterFaced(PlateAppearanceResult.STRIKEOUT)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 삼진 기록이 없습니다")
+        }
+
+        @Test
+        fun `볼넷 기록이 없을 때 볼넷 롤백하면 예외가 발생한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.GROUND_OUT)
+
+            assertThatThrownBy {
+                pitchingRecord.revertBatterFaced(PlateAppearanceResult.WALK)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 볼넷 기록이 없습니다")
+        }
+
+        @Test
+        fun `사구 기록이 없을 때 사구 롤백하면 예외가 발생한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.GROUND_OUT)
+
+            assertThatThrownBy {
+                pitchingRecord.revertBatterFaced(PlateAppearanceResult.HIT_BY_PITCH)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 사구 기록이 없습니다")
+        }
+
+        @Test
+        fun `단타 롤백이 정상적으로 동작한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.SINGLE)
+            pitchingRecord.revertBatterFaced(PlateAppearanceResult.SINGLE)
+
+            assertThat(pitchingRecord.battersFaced).isEqualTo(0)
+            assertThat(pitchingRecord.hitsAllowed).isEqualTo(0)
+        }
+    }
+
+    @Nested
+    @DisplayName("revertEarnedRun - 음수 값 방지 가드")
+    inner class RevertEarnedRunNegativeGuardTest {
+        @Test
+        fun `롤백할 자책점이 현재 자책점보다 크면 예외가 발생한다`() {
+            pitchingRecord.recordEarnedRun(1)
+
+            assertThatThrownBy {
+                pitchingRecord.revertEarnedRun(2)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 자책점")
+        }
+
+        @Test
+        fun `자책점 롤백이 정상적으로 동작한다`() {
+            pitchingRecord.recordEarnedRun(3)
+            pitchingRecord.revertEarnedRun(2)
+
+            assertThat(pitchingRecord.earnedRuns).isEqualTo(1)
+            assertThat(pitchingRecord.runsAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `음수 롤백 값은 허용되지 않는다`() {
+            assertThatThrownBy {
+                pitchingRecord.revertEarnedRun(-1)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 자책점은 0 이상이어야 합니다")
+        }
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -861,4 +861,247 @@ class PitchingRecordTest {
                 .hasMessageContaining("롤백할 자책점은 0 이상이어야 합니다")
         }
     }
+
+    @Nested
+    @DisplayName("revertOut - 아웃 카운트 롤백")
+    inner class RevertOutTest {
+        @Test
+        fun `아웃 카운트를 롤백할 수 있다`() {
+            pitchingRecord.recordOut()
+            assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(1)
+
+            pitchingRecord.revertOut()
+            assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(0)
+        }
+
+        @Test
+        fun `롤백할 아웃 카운트가 없으면 예외가 발생한다`() {
+            assertThatThrownBy {
+                pitchingRecord.revertOut()
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 아웃 카운트가 없습니다")
+        }
+    }
+
+    @Nested
+    @DisplayName("revertBatterFaced - 결과별 롤백 정상 동작")
+    inner class RevertBatterFacedHappyPathTest {
+        @Test
+        fun `2루타 롤백이 정상적으로 동작한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.DOUBLE)
+            pitchingRecord.revertBatterFaced(PlateAppearanceResult.DOUBLE)
+
+            assertThat(pitchingRecord.battersFaced).isEqualTo(0)
+            assertThat(pitchingRecord.hitsAllowed).isEqualTo(0)
+        }
+
+        @Test
+        fun `3루타 롤백이 정상적으로 동작한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.TRIPLE)
+            pitchingRecord.revertBatterFaced(PlateAppearanceResult.TRIPLE)
+
+            assertThat(pitchingRecord.battersFaced).isEqualTo(0)
+            assertThat(pitchingRecord.hitsAllowed).isEqualTo(0)
+        }
+
+        @Test
+        fun `홈런 롤백이 정상적으로 동작한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.HOME_RUN)
+            pitchingRecord.revertBatterFaced(PlateAppearanceResult.HOME_RUN)
+
+            assertThat(pitchingRecord.battersFaced).isEqualTo(0)
+            assertThat(pitchingRecord.hitsAllowed).isEqualTo(0)
+            assertThat(pitchingRecord.homeRunsAllowed).isEqualTo(0)
+        }
+
+        @Test
+        fun `삼진 롤백이 정상적으로 동작한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.STRIKEOUT)
+            pitchingRecord.revertBatterFaced(PlateAppearanceResult.STRIKEOUT)
+
+            assertThat(pitchingRecord.battersFaced).isEqualTo(0)
+            assertThat(pitchingRecord.strikeouts).isEqualTo(0)
+        }
+
+        @Test
+        fun `볼넷 롤백이 정상적으로 동작한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.WALK)
+            pitchingRecord.revertBatterFaced(PlateAppearanceResult.WALK)
+
+            assertThat(pitchingRecord.battersFaced).isEqualTo(0)
+            assertThat(pitchingRecord.walksAllowed).isEqualTo(0)
+        }
+
+        @Test
+        fun `고의4구 롤백이 정상적으로 동작한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.INTENTIONAL_WALK)
+            pitchingRecord.revertBatterFaced(PlateAppearanceResult.INTENTIONAL_WALK)
+
+            assertThat(pitchingRecord.battersFaced).isEqualTo(0)
+            assertThat(pitchingRecord.walksAllowed).isEqualTo(0)
+        }
+
+        @Test
+        fun `사구 롤백이 정상적으로 동작한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.HIT_BY_PITCH)
+            pitchingRecord.revertBatterFaced(PlateAppearanceResult.HIT_BY_PITCH)
+
+            assertThat(pitchingRecord.battersFaced).isEqualTo(0)
+            assertThat(pitchingRecord.hitBatsmen).isEqualTo(0)
+        }
+
+        @Test
+        fun `땅볼아웃 롤백이 정상적으로 동작한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.GROUND_OUT)
+            pitchingRecord.revertBatterFaced(PlateAppearanceResult.GROUND_OUT)
+
+            assertThat(pitchingRecord.battersFaced).isEqualTo(0)
+        }
+    }
+
+    @Nested
+    @DisplayName("validate - 음수 필드 검증")
+    inner class ValidateNonNegativeFieldTest {
+        private fun setField(
+            fieldName: String,
+            value: Int,
+        ) {
+            val field = PitchingRecord::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            field.setInt(pitchingRecord, value)
+        }
+
+        @Test
+        fun `이닝 아웃 수가 음수이면 검증에 실패한다`() {
+            setField("inningsPitchedOuts", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이닝 아웃 수")
+        }
+
+        @Test
+        fun `자책점이 음수이면 검증에 실패한다`() {
+            setField("earnedRuns", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("자책점")
+        }
+
+        @Test
+        fun `실점이 음수이면 검증에 실패한다`() {
+            setField("runsAllowed", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("실점")
+        }
+
+        @Test
+        fun `피안타가 음수이면 검증에 실패한다`() {
+            setField("hitsAllowed", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("피안타")
+        }
+
+        @Test
+        fun `볼넷 허용이 음수이면 검증에 실패한다`() {
+            setField("walksAllowed", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("볼넷 허용")
+        }
+
+        @Test
+        fun `삼진이 음수이면 검증에 실패한다`() {
+            setField("strikeouts", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("삼진")
+        }
+
+        @Test
+        fun `피홈런이 음수이면 검증에 실패한다`() {
+            setField("homeRunsAllowed", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("피홈런")
+        }
+
+        @Test
+        fun `사구가 음수이면 검증에 실패한다`() {
+            setField("hitBatsmen", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("사구")
+        }
+
+        @Test
+        fun `와일드피치가 음수이면 검증에 실패한다`() {
+            setField("wildPitches", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("와일드피치")
+        }
+
+        @Test
+        fun `보크가 음수이면 검증에 실패한다`() {
+            setField("balks", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("보크")
+        }
+
+        @Test
+        fun `대면 타자 수가 음수이면 검증에 실패한다`() {
+            setField("battersFaced", -1)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("대면 타자 수")
+        }
+    }
+
+    @Nested
+    @DisplayName("validate - 관계형 제약 검증")
+    inner class ValidateRelationalTest {
+        private fun setField(
+            fieldName: String,
+            value: Int,
+        ) {
+            val field = PitchingRecord::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            field.setInt(pitchingRecord, value)
+        }
+
+        @Test
+        fun `자책점이 실점보다 크면 검증에 실패한다`() {
+            setField("earnedRuns", 3)
+            setField("runsAllowed", 2)
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("자책점")
+        }
+
+        @Test
+        fun `스트라이크가 투구 수보다 크면 검증에 실패한다`() {
+            pitchingRecord.recordPitchCount(totalPitches = 50, strikes = 30)
+            val strikesField = PitchingRecord::class.java.getDeclaredField("strikesThrown")
+            strikesField.isAccessible = true
+            strikesField.set(pitchingRecord, 60)
+
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("스트라이크 수")
+        }
+
+        @Test
+        fun `선발 투수가 승리 자격 미달인데 승리 결정이면 검증에 실패한다`() {
+            pitchingRecord.setAsStartingPitcher()
+            repeat(14) { pitchingRecord.recordOut() } // 4.2이닝 (5이닝 미만)
+            pitchingRecord.assignWin()
+
+            assertThatThrownBy { pitchingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("선발 승리 자격")
+        }
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -960,6 +960,44 @@ class PitchingRecordTest {
     }
 
     @Nested
+    @DisplayName("revertBatterFaced - 중간 가드 커버리지")
+    inner class RevertBatterFacedIntermediateGuardTest {
+        @Test
+        fun `홈런 롤백 시 피안타가 없으면 예외가 발생한다`() {
+            pitchingRecord.applyBatterFaced(PlateAppearanceResult.STRIKEOUT)
+
+            assertThatThrownBy {
+                pitchingRecord.revertBatterFaced(PlateAppearanceResult.HOME_RUN)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 피안타 기록이 없습니다")
+        }
+    }
+
+    @Nested
+    @DisplayName("revertEarnedRun - 중간 가드 커버리지")
+    inner class RevertEarnedRunIntermediateGuardTest {
+        private fun setField(
+            fieldName: String,
+            value: Int,
+        ) {
+            val field = PitchingRecord::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            field.setInt(pitchingRecord, value)
+        }
+
+        @Test
+        fun `자책점 롤백 시 실점이 부족하면 예외가 발생한다`() {
+            setField("earnedRuns", 3)
+            setField("runsAllowed", 1)
+
+            assertThatThrownBy {
+                pitchingRecord.revertEarnedRun(2)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 실점")
+        }
+    }
+
+    @Nested
     @DisplayName("validate - 음수 필드 검증")
     inner class ValidateNonNegativeFieldTest {
         private fun setField(


### PR DESCRIPTION
## Summary

>- close #176

BattingRecord와 PitchingRecord의 revert 메서드에 음수 방지 가드를 추가합니다.

## Tasks

- BattingRecord.revertPlateAppearanceResult()에 require 가드 추가 (plateAppearances, hits, doubles, homeRuns 등)
- PitchingRecord.revertBatterFaced()에 require 가드 추가 (battersFaced, hitsAllowed, strikeouts 등)
- PitchingRecord.revertEarnedRun()에 require 가드 추가
- BattingRecord.validate()에 17개 카운터 필드 비음수 검증 추가
- PitchingRecord.validate()에 11개 카운터 필드 비음수 검증 추가
- BattingRecordTest: RevertNegativeGuardTest 8개 테스트 추가
- PitchingRecordTest: RevertBatterFacedNegativeGuardTest 7개 + RevertEarnedRunNegativeGuardTest 3개 테스트 추가

## To Reviewer

음수 통계 발생 시 AVG, ERA 등 계산 결과가 왜곡되는 CRITICAL 이슈 수정입니다.
기존 revertOut()의 require 패턴을 다른 revert 메서드에도 일관되게 적용했습니다.