### PR TITLE
feat(#174): Player 검색/목록 API 추가

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
@@ -69,6 +69,8 @@ class SecurityConfig(
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/stats/**")
                     .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/players/**")
+                    .permitAll()
                     // OAuth2 endpoints
                     .requestMatchers("/oauth2/**")
                     .permitAll()

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/player/PlayerController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/player/PlayerController.kt
@@ -1,0 +1,85 @@
+package com.nextup.api.controller.player
+
+import com.nextup.api.dto.player.PlayerDetailResponse
+import com.nextup.api.dto.player.PlayerSearchResponse
+import com.nextup.api.dto.player.toDetailResponse
+import com.nextup.api.dto.player.toSearchResponse
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.player.PlayerService
+import com.nextup.core.service.player.PlayerTeamService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 선수 검색/조회 API Controller
+ *
+ * GET /api/v1/players         - 선수 검색/목록 (name, teamId, position 필터, Pageable)
+ * GET /api/v1/players/{id}    - 선수 단건 상세 조회
+ */
+@RestController
+@RequestMapping("/api/v1/players")
+class PlayerController(
+    private val playerService: PlayerService,
+    private val playerTeamService: PlayerTeamService,
+) {
+    /**
+     * 선수 검색/목록 조회
+     *
+     * GET /api/v1/players?name={name}&teamId={teamId}&position={position}
+     *
+     * @param name 이름 부분 검색 (선택)
+     * @param teamId 팀 ID 필터 (선택)
+     * @param position 포지션 필터 (선택, Position enum 이름)
+     * @param pageable 페이징 정보 (기본: size=20, sort=name,asc)
+     * @return 선수 검색 결과 페이지
+     */
+    @GetMapping
+    fun searchPlayers(
+        @RequestParam(required = false) name: String?,
+        @RequestParam(required = false) teamId: Long?,
+        @RequestParam(required = false) position: Position?,
+        @PageableDefault(size = 20, sort = ["name"], direction = Sort.Direction.ASC)
+        pageable: Pageable,
+    ): ApiResponse<Page<PlayerSearchResponse>> {
+        val players =
+            playerService.search(
+                name = name,
+                teamId = teamId,
+                position = position,
+                pageable = pageable,
+            )
+        val result =
+            players.map { player ->
+                val currentHistory =
+                    playerTeamService.getActiveAffiliationsByPlayer(player.id).firstOrNull()
+                player.toSearchResponse(currentHistory)
+            }
+        return ApiResponse.success(result)
+    }
+
+    /**
+     * 선수 단건 상세 조회
+     *
+     * GET /api/v1/players/{playerId}
+     *
+     * @param playerId 선수 ID
+     * @return 선수 상세 정보
+     */
+    @GetMapping("/{playerId}")
+    fun getPlayer(
+        @PathVariable playerId: Long,
+    ): ApiResponse<PlayerDetailResponse> {
+        val player = playerService.getById(playerId)
+        val currentHistory =
+            playerTeamService.getActiveAffiliationsByPlayer(playerId).firstOrNull()
+        return ApiResponse.success(player.toDetailResponse(currentHistory))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/player/PlayerDetailResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/player/PlayerDetailResponse.kt
@@ -1,0 +1,51 @@
+package com.nextup.api.dto.player
+
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.PlayerTeamHistory
+import java.time.LocalDate
+
+/**
+ * 선수 단건 상세 조회 응답 DTO
+ *
+ * GET /api/v1/players/{playerId} 에서 사용됩니다.
+ */
+data class PlayerDetailResponse(
+    val id: Long,
+    val name: String,
+    val backNumber: Int?,
+    val position: String?,
+    val teamName: String?,
+    val profileImageUrl: String?,
+    val birthDate: LocalDate?,
+    val birthPlace: String?,
+    val nationality: String?,
+    val height: Int?,
+    val weight: Int?,
+    val throwingHand: String?,
+    val battingHand: String?,
+    val debutYear: Int?,
+    val isActive: Boolean,
+)
+
+/**
+ * Player 엔티티를 PlayerDetailResponse로 변환합니다.
+ * currentHistory가 있으면 팀 정보와 등번호/포지션을 포함합니다.
+ */
+fun Player.toDetailResponse(currentHistory: PlayerTeamHistory? = null): PlayerDetailResponse =
+    PlayerDetailResponse(
+        id = this.id,
+        name = this.name,
+        backNumber = currentHistory?.uniformNumber,
+        position = currentHistory?.position?.displayName ?: this.primaryPosition.displayName,
+        teamName = currentHistory?.team?.name,
+        profileImageUrl = this.profileImageUrl,
+        birthDate = this.birthDate,
+        birthPlace = this.birthPlace,
+        nationality = this.nationality,
+        height = this.height,
+        weight = this.weight,
+        throwingHand = this.throwingHand?.name,
+        battingHand = this.battingHand?.name,
+        debutYear = this.debutYear,
+        isActive = this.isActive,
+    )

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/player/PlayerSearchResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/player/PlayerSearchResponse.kt
@@ -1,0 +1,32 @@
+package com.nextup.api.dto.player
+
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.PlayerTeamHistory
+
+/**
+ * 선수 검색/목록 응답 DTO
+ *
+ * GET /api/v1/players 에서 사용됩니다.
+ */
+data class PlayerSearchResponse(
+    val id: Long,
+    val name: String,
+    val backNumber: Int?,
+    val position: String?,
+    val teamName: String?,
+    val profileImageUrl: String?,
+)
+
+/**
+ * Player 엔티티를 PlayerSearchResponse로 변환합니다.
+ * currentHistory가 있으면 팀 정보와 등번호/포지션을 포함합니다.
+ */
+fun Player.toSearchResponse(currentHistory: PlayerTeamHistory? = null): PlayerSearchResponse =
+    PlayerSearchResponse(
+        id = this.id,
+        name = this.name,
+        backNumber = currentHistory?.uniformNumber,
+        position = currentHistory?.position?.displayName ?: this.primaryPosition.displayName,
+        teamName = currentHistory?.team?.name,
+        profileImageUrl = this.profileImageUrl,
+    )

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/player/PlayerControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/player/PlayerControllerTest.kt
@@ -13,11 +13,11 @@ import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @DisplayName("PlayerController")

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/player/PlayerControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/player/PlayerControllerTest.kt
@@ -1,0 +1,141 @@
+package com.nextup.api.controller.player
+
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.player.PlayerService
+import com.nextup.core.service.player.PlayerTeamService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("PlayerController")
+class PlayerControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var playerService: PlayerService
+    private lateinit var playerTeamService: PlayerTeamService
+    private lateinit var controller: PlayerController
+
+    @BeforeEach
+    fun setUp() {
+        playerService = mockk()
+        playerTeamService = mockk()
+        controller = PlayerController(playerService, playerTeamService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(PageableHandlerMethodArgumentResolver())
+                .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/players")
+    inner class SearchPlayers {
+        @Test
+        fun `should return paginated player search results`() {
+            // given
+            val players =
+                listOf(
+                    createPlayer(1L, "김철수", Position.STARTING_PITCHER),
+                    createPlayer(2L, "이영희", Position.CATCHER),
+                )
+            val pageable =
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "name"))
+            val page = PageImpl(players, pageable, 2)
+
+            every {
+                playerService.search(
+                    name = null,
+                    teamId = null,
+                    position = null,
+                    pageable = any(),
+                )
+            } returns page
+            every { playerTeamService.getActiveAffiliationsByPlayer(any()) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content").isArray)
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.content[0].name").value("김철수"))
+        }
+
+        @Test
+        fun `should filter by name parameter`() {
+            // given
+            val players =
+                listOf(
+                    createPlayer(1L, "김철수", Position.STARTING_PITCHER),
+                )
+            val pageable =
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "name"))
+            val page = PageImpl(players, pageable, 1)
+
+            every {
+                playerService.search(
+                    name = "김철수",
+                    teamId = null,
+                    position = null,
+                    pageable = any(),
+                )
+            } returns page
+            every { playerTeamService.getActiveAffiliationsByPlayer(any()) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players").param("name", "김철수"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].name").value("김철수"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/players/{playerId}")
+    inner class GetPlayer {
+        @Test
+        fun `should return player detail when found`() {
+            // given
+            val player = createPlayer(1L, "김철수", Position.STARTING_PITCHER)
+            every { playerService.getById(1L) } returns player
+            every { playerTeamService.getActiveAffiliationsByPlayer(1L) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.name").value("김철수"))
+        }
+    }
+
+    private fun createPlayer(
+        id: Long,
+        name: String,
+        position: Position,
+    ): Player =
+        Player(
+            name = name,
+            primaryPosition = position,
+        ).apply {
+            val idField = Player::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PlayerRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PlayerRepositoryPort.kt
@@ -1,6 +1,9 @@
 package com.nextup.core.port.repository
 
 import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import java.time.LocalDate
 
 /**
@@ -32,4 +35,15 @@ interface PlayerRepositoryPort {
         teamId: Long,
         date: LocalDate,
     ): List<Player>
+
+    /**
+     * 이름(부분 일치), 팀 ID, 포지션 필터로 선수를 검색합니다.
+     * null 파라미터는 해당 조건을 무시합니다.
+     */
+    fun search(
+        name: String?,
+        teamId: Long?,
+        position: Position?,
+        pageable: Pageable,
+    ): Page<Player>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/player/PlayerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/player/PlayerService.kt
@@ -2,7 +2,10 @@ package com.nextup.core.service.player
 
 import com.nextup.common.exception.PlayerNotFoundException
 import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
 import com.nextup.core.port.repository.PlayerRepositoryPort
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -42,4 +45,26 @@ class PlayerService(
      * 활성 선수 목록을 조회합니다.
      */
     fun getActivePlayers(): List<Player> = playerRepository.findActivePlayers()
+
+    /**
+     * 이름(부분 일치), 팀 ID, 포지션으로 선수를 검색합니다.
+     *
+     * @param name 이름 부분 검색 (null이면 조건 무시)
+     * @param teamId 팀 ID 필터 (null이면 조건 무시)
+     * @param position 포지션 필터 (null이면 조건 무시)
+     * @param pageable 페이징 정보
+     * @return 검색 결과 페이지
+     */
+    fun search(
+        name: String?,
+        teamId: Long?,
+        position: Position?,
+        pageable: Pageable,
+    ): Page<Player> =
+        playerRepository.search(
+            name = name,
+            teamId = teamId,
+            position = position,
+            pageable = pageable,
+        )
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/player/PlayerServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/player/PlayerServiceTest.kt
@@ -1,0 +1,109 @@
+package com.nextup.core.service.player
+
+import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+@DisplayName("PlayerService")
+class PlayerServiceTest {
+    private lateinit var playerRepository: PlayerRepositoryPort
+    private lateinit var playerService: PlayerService
+
+    @BeforeEach
+    fun setUp() {
+        playerRepository = mockk()
+        playerService = PlayerService(playerRepository)
+    }
+
+    @Nested
+    @DisplayName("search")
+    inner class Search {
+        @Test
+        fun `should return paginated results`() {
+            // given
+            val player =
+                Player(
+                    name = "김철수",
+                    primaryPosition = Position.STARTING_PITCHER,
+                )
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(listOf(player), pageable, 1)
+
+            every {
+                playerRepository.search(
+                    name = "김",
+                    teamId = null,
+                    position = null,
+                    pageable = pageable,
+                )
+            } returns page
+
+            // when
+            val result =
+                playerService.search(
+                    name = "김",
+                    teamId = null,
+                    position = null,
+                    pageable = pageable,
+                )
+
+            // then
+            assertThat(result.content).hasSize(1)
+            assertThat(result.content[0].name).isEqualTo("김철수")
+        }
+
+        @Test
+        fun `should pass all filter parameters to repository`() {
+            // given
+            val pageable = PageRequest.of(0, 10)
+            val page = PageImpl<Player>(emptyList(), pageable, 0)
+
+            every {
+                playerRepository.search(
+                    name = "이",
+                    teamId = 5L,
+                    position = Position.SHORTSTOP,
+                    pageable = pageable,
+                )
+            } returns page
+
+            // when
+            val result =
+                playerService.search(
+                    name = "이",
+                    teamId = 5L,
+                    position = Position.SHORTSTOP,
+                    pageable = pageable,
+                )
+
+            // then
+            assertThat(result.content).isEmpty()
+            assertThat(result.totalElements).isEqualTo(0)
+        }
+    }
+
+    @Nested
+    @DisplayName("getById")
+    inner class GetById {
+        @Test
+        fun `should throw PlayerNotFoundException when player not found`() {
+            // given
+            every { playerRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy { playerService.getById(999L) }
+                .isInstanceOf(PlayerNotFoundException::class.java)
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerRepository.kt
@@ -1,9 +1,13 @@
 package com.nextup.infrastructure.repository
 
 import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
 import com.nextup.core.port.repository.PlayerRepositoryPort
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.LocalDate
 
 interface PlayerRepository :
@@ -38,4 +42,20 @@ interface PlayerRepository :
         teamId: Long,
         date: LocalDate,
     ): List<Player>
+
+    @Query(
+        """
+        SELECT DISTINCT p FROM Player p
+        LEFT JOIN PlayerTeamHistory h ON h.player.id = p.id AND h.endDate IS NULL
+        WHERE (:name IS NULL OR p.name LIKE %:name%)
+        AND (:teamId IS NULL OR h.team.id = :teamId)
+        AND (:position IS NULL OR p.primaryPosition = :position)
+    """,
+    )
+    override fun search(
+        @Param("name") name: String?,
+        @Param("teamId") teamId: Long?,
+        @Param("position") position: Position?,
+        pageable: Pageable,
+    ): Page<Player>
 }


### PR DESCRIPTION
## Summary

>- close #174

선수 검색 및 목록 조회 API를 추가합니다. 프론트엔드에서 선수 검색, 선수 프로필 화면을 구현하기 위해 필요합니다.

## Tasks

- PlayerController 생성 (nextup-api)
- GET /api/v1/players - 검색/목록 (name, teamId, position 필터, Pageable)
- GET /api/v1/players/{playerId} - 단건 상세 조회
- PlayerSearchResponse, PlayerDetailResponse DTO 생성
- PlayerRepositoryPort에 search 메서드 추가 (nextup-core)
- PlayerService에 search 메서드 추가 (nextup-core)
- PlayerRepository에 JPQL 검색 쿼리 구현 (nextup-infrastructure)
- SecurityConfig에 /api/v1/players/** GET 퍼블릭 허용 추가

## To Reviewer

프론트엔드 개발 착수를 위한 필수 API입니다. 기존 PlayerStatsController와 URL이 겹치지 않도록 구성했습니다.
PlayerTeamHistory LEFT JOIN으로 현재 소속팀 정보를 함께 조회합니다.