### PR TITLE
fix(#170,#177): ElectionController, AttendancePollController 권한 검증 추가

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/ElectionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/ElectionController.kt
@@ -44,6 +44,7 @@ class ElectionController(
      * 팀의 모든 선거를 조회합니다.
      */
     @GetMapping
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun getElectionsByTeam(
         @PathVariable teamId: Long,
     ): ApiResponse<List<ElectionResponse>> = ApiResponse.success(electionService.getElectionsByTeam(teamId))
@@ -52,6 +53,7 @@ class ElectionController(
      * 선거를 ID로 조회합니다.
      */
     @GetMapping("/{electionId}")
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun getElection(
         @PathVariable teamId: Long,
         @PathVariable electionId: Long,
@@ -91,6 +93,7 @@ class ElectionController(
      * 후보자를 등록합니다.
      */
     @PostMapping("/{electionId}/candidates")
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun registerCandidate(
         @PathVariable teamId: Long,
         @PathVariable electionId: Long,
@@ -106,6 +109,7 @@ class ElectionController(
      * 투표합니다.
      */
     @PostMapping("/{electionId}/votes")
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun castVote(
         @PathVariable teamId: Long,
         @PathVariable electionId: Long,
@@ -121,6 +125,7 @@ class ElectionController(
      * 선거 결과를 조회합니다.
      */
     @GetMapping("/{electionId}/results")
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun getResults(
         @PathVariable teamId: Long,
         @PathVariable electionId: Long,

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/TeamAttendancePollController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/TeamAttendancePollController.kt
@@ -7,6 +7,7 @@ import com.nextup.core.service.attendance.AttendanceService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import java.time.format.DateTimeFormatter
 
@@ -24,6 +25,7 @@ class TeamAttendancePollController(
      * 출석 투표를 생성합니다.
      */
     @PostMapping
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun createPoll(
         @PathVariable teamId: Long,
         @RequestBody @Valid request: CreatePollRequest,
@@ -45,6 +47,7 @@ class TeamAttendancePollController(
      * 팀의 출석 투표 목록을 조회합니다.
      */
     @GetMapping
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun listPolls(
         @PathVariable teamId: Long,
         @RequestParam(required = false) status: PollStatus?,
@@ -57,6 +60,7 @@ class TeamAttendancePollController(
      * 출석 투표를 조회합니다.
      */
     @GetMapping("/{pollId}")
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun getPoll(
         @PathVariable teamId: Long,
         @PathVariable pollId: Long,
@@ -69,6 +73,7 @@ class TeamAttendancePollController(
      * 출석 투표에 응답합니다.
      */
     @PutMapping("/{pollId}/vote")
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun submitVote(
         @PathVariable teamId: Long,
         @PathVariable pollId: Long,
@@ -90,6 +95,7 @@ class TeamAttendancePollController(
      * 출석 투표를 마감합니다.
      */
     @PutMapping("/{pollId}/close")
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun closePoll(
         @PathVariable teamId: Long,
         @PathVariable pollId: Long,
@@ -102,6 +108,7 @@ class TeamAttendancePollController(
      * 출석 투표의 응답 목록을 조회합니다.
      */
     @GetMapping("/{pollId}/votes")
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun listVotes(
         @PathVariable teamId: Long,
         @PathVariable pollId: Long,
@@ -114,6 +121,7 @@ class TeamAttendancePollController(
      * 출석 투표 통계를 조회합니다.
      */
     @GetMapping("/{pollId}/statistics")
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun getPollStatistics(
         @PathVariable teamId: Long,
         @PathVariable pollId: Long,


### PR DESCRIPTION
## Summary

>- close #170
>- close #177

ElectionController와 TeamAttendancePollController에 누락된 `@PreAuthorize` 권한 검증을 추가합니다.

- ElectionController: 5개 엔드포인트에 권한 추가
  - 조회(getElectionsByTeam, getElection, getResults): `isMember`
  - 투표/후보등록(castVote, registerCandidate): `isMember`
- TeamAttendancePollController: 7개 엔드포인트에 권한 추가
  - 생성/마감(createPoll, closePoll): `isOwnerOrManager`
  - 조회/투표/통계(listPolls, getPoll, submitVote, listVotes, getPollStatistics): `isMember`

## Tasks

- ElectionController 5개 엔드포인트 권한 추가
- TeamAttendancePollController 7개 엔드포인트 권한 추가
- 빌드 및 기존 테스트 통과 확인

## To Reviewer

- `@teamSecurity` 빈은 `TeamSecurityExpression`에서 `isMember`, `isOwnerOrManager`, `isOwner` 메서드를 제공합니다.
- 기존 ElectionController에 이미 있던 create/start/complete/cancel의 `isOwnerOrManager` 패턴과 동일하게 적용했습니다.
- `CastVoteApiRequest.voterId`, `SubmitVoteRequest.playerId`의 impersonation 이슈는 서비스 계층 변경이 필요하여 별도 이슈로 분리 권장합니다.