### PR TITLE
fix(#181): URL 프리픽스 /api/v1/ 통일

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
@@ -70,17 +70,17 @@ class SecurityConfig(
                 auth
                     // Public auth endpoints (explicit paths instead of wildcard)
                     .requestMatchers(
-                        "/api/auth/login",
-                        "/api/auth/refresh",
-                        "/api/auth/oauth2/token",
+                        "/api/v1/auth/login",
+                        "/api/v1/auth/refresh",
+                        "/api/v1/auth/oauth2/token",
                     ).permitAll()
                     // Authenticated auth endpoints
                     .requestMatchers(
-                        "/api/auth/me",
-                        "/api/auth/logout",
-                        "/api/auth/logout-all",
+                        "/api/v1/auth/me",
+                        "/api/v1/auth/logout",
+                        "/api/v1/auth/logout-all",
                     ).authenticated()
-                    .requestMatchers(HttpMethod.GET, "/api/associations/**")
+                    .requestMatchers(HttpMethod.GET, "/api/v1/associations/**")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/stats/**")
                     .permitAll()
@@ -111,7 +111,7 @@ class SecurityConfig(
                     .requestMatchers("/api/admin/**")
                     .hasRole("ADMIN")
                     // Scorer endpoints (for game recording)
-                    .requestMatchers("/api/games/*/records/**")
+                    .requestMatchers("/api/v1/games/*/records/**")
                     .hasAnyRole("SCORER", "ADMIN")
                     // All other endpoints require authentication
                     .anyRequest()

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/association/AssociationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/association/AssociationController.kt
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController
  * 협회 조회 API Controller (일반 사용자용)
  */
 @RestController
-@RequestMapping("/api/associations")
+@RequestMapping("/api/v1/associations")
 class AssociationController(
     private val associationService: AssociationService,
 ) {

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/auth/AuthController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/auth/AuthController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
  * 인증 관련 API Controller
  */
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api/v1/auth")
 class AuthController(
     private val authenticationService: AuthenticationService,
 ) {

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BattingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BattingRecordController.kt
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/games/{gameId}/batting-records")
+@RequestMapping("/api/v1/games/{gameId}/batting-records")
 class BattingRecordController(
     private val battingRecordService: BattingRecordService,
     private val gamePlayerRepository: GamePlayerRepository,

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BoxScoreController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BoxScoreController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController
  * 박스스코어 API 컨트롤러
  */
 @RestController
-@RequestMapping("/api/games/{gameId}/boxscore")
+@RequestMapping("/api/v1/games/{gameId}/boxscore")
 class BoxScoreController(
     private val boxScoreService: BoxScoreService,
 ) {

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/PitchingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/PitchingRecordController.kt
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/games/{gameId}/pitching-records")
+@RequestMapping("/api/v1/games/{gameId}/pitching-records")
 class PitchingRecordController(
     private val pitchingRecordService: PitchingRecordService,
     private val gamePlayerRepository: GamePlayerRepository,

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/league/LeagueController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/league/LeagueController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController
  * 리그 조회 API Controller (일반 사용자용)
  */
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1")
 class LeagueController(
     private val leagueService: LeagueService,
 ) {

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/oauth/OAuthController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/oauth/OAuthController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.util.UriComponentsBuilder
  * OAuth 계정 연동 관련 API Controller
  */
 @RestController
-@RequestMapping("/api/me/oauth-accounts")
+@RequestMapping("/api/v1/me/oauth-accounts")
 class OAuthController(
     private val oauthLinkService: OAuthLinkService,
     @Value("\${app.oauth2.base-url:http://localhost:8080}")

--- a/nextup-api/src/test/kotlin/com/nextup/api/config/SecurityConfigUrlPatternTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/config/SecurityConfigUrlPatternTest.kt
@@ -20,7 +20,7 @@ class SecurityConfigUrlPatternTest {
     // SecurityConfig에서 정의된 public 패턴 목록
     private val publicPatterns =
         listOf(
-            "/api/auth/**",
+            "/api/v1/auth/**",
             "/oauth2/**",
             "/login/oauth2/**",
             "/swagger-ui/**",
@@ -33,7 +33,7 @@ class SecurityConfigUrlPatternTest {
     // GET 전용 public 패턴
     private val publicGetPatterns =
         listOf(
-            "/api/associations/**",
+            "/api/v1/associations/**",
             "/api/stats/**",
         )
 
@@ -46,7 +46,7 @@ class SecurityConfigUrlPatternTest {
     // SCORER or ADMIN 패턴
     private val scorerAdminPatterns =
         listOf(
-            "/api/games/*/records/**",
+            "/api/v1/games/*/records/**",
         )
 
     private fun matchesAnyPublicPattern(url: String): Boolean = publicPatterns.any { matcher.match(it, url) }
@@ -62,17 +62,17 @@ class SecurityConfigUrlPatternTest {
     inner class AuthEndpoints {
         @Test
         fun `api auth 로그인 경로는 public이어야 한다`() {
-            assertThat(matchesAnyPublicPattern("/api/auth/login")).isTrue()
+            assertThat(matchesAnyPublicPattern("/api/v1/auth/login")).isTrue()
         }
 
         @Test
         fun `api auth 회원가입 경로는 public이어야 한다`() {
-            assertThat(matchesAnyPublicPattern("/api/auth/register")).isTrue()
+            assertThat(matchesAnyPublicPattern("/api/v1/auth/register")).isTrue()
         }
 
         @Test
         fun `api auth 토큰 갱신 경로는 public이어야 한다`() {
-            assertThat(matchesAnyPublicPattern("/api/auth/refresh")).isTrue()
+            assertThat(matchesAnyPublicPattern("/api/v1/auth/refresh")).isTrue()
         }
     }
 
@@ -134,7 +134,7 @@ class SecurityConfigUrlPatternTest {
     inner class PublicGetEndpoints {
         @Test
         fun `api associations 경로는 GET public 패턴에 포함된다`() {
-            assertThat(matchesAnyPublicGetPattern("/api/associations/1")).isTrue()
+            assertThat(matchesAnyPublicGetPattern("/api/v1/associations/1")).isTrue()
         }
 
         @Test
@@ -164,7 +164,7 @@ class SecurityConfigUrlPatternTest {
 
         @Test
         fun `api auth 경로는 ADMIN 패턴에 포함되지 않는다`() {
-            assertThat(matchesAnyAdminPattern("/api/auth/login")).isFalse()
+            assertThat(matchesAnyAdminPattern("/api/v1/auth/login")).isFalse()
         }
     }
 
@@ -173,18 +173,18 @@ class SecurityConfigUrlPatternTest {
     inner class ScorerAdminEndpoints {
         @Test
         fun `api games records 경로는 SCORER ADMIN 패턴에 포함된다`() {
-            assertThat(matchesAnyScorerAdminPattern("/api/games/123/records/batting")).isTrue()
+            assertThat(matchesAnyScorerAdminPattern("/api/v1/games/123/records/batting")).isTrue()
         }
 
         @Test
         fun `api games records 중첩 경로도 SCORER ADMIN 패턴에 포함된다`() {
-            assertThat(matchesAnyScorerAdminPattern("/api/games/456/records/pitching/events")).isTrue()
+            assertThat(matchesAnyScorerAdminPattern("/api/v1/games/456/records/pitching/events")).isTrue()
         }
 
         @Test
         fun `api games 기본 경로는 SCORER ADMIN 패턴에 포함되지 않는다`() {
             // /api/games/123 만으로는 records 패턴에 해당하지 않음
-            assertThat(matchesAnyScorerAdminPattern("/api/games/123")).isFalse()
+            assertThat(matchesAnyScorerAdminPattern("/api/v1/games/123")).isFalse()
         }
     }
 

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/association/AssociationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/association/AssociationControllerTest.kt
@@ -42,7 +42,7 @@ class AssociationControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/associations"))
+                .perform(get("/api/v1/associations"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -61,7 +61,7 @@ class AssociationControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/associations").param("region", "서울"))
+                .perform(get("/api/v1/associations").param("region", "서울"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.length()").value(1))
@@ -80,7 +80,7 @@ class AssociationControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/associations/1"))
+                .perform(get("/api/v1/associations/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BattingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BattingRecordControllerTest.kt
@@ -97,7 +97,7 @@ class BattingRecordControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/games/$gameId/batting-records"))
+                .perform(get("/api/v1/games/$gameId/batting-records"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -112,7 +112,7 @@ class BattingRecordControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/games/$gameId/batting-records"))
+                .perform(get("/api/v1/games/$gameId/batting-records"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -172,7 +172,7 @@ class BattingRecordControllerTest {
             // when & then
             mockMvc
                 .perform(
-                    post("/api/games/$gameId/batting-records")
+                    post("/api/v1/games/$gameId/batting-records")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isCreated)
@@ -190,7 +190,7 @@ class BattingRecordControllerTest {
             // when & then
             mockMvc
                 .perform(
-                    post("/api/games/$gameId/batting-records")
+                    post("/api/v1/games/$gameId/batting-records")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isNotFound)
@@ -214,7 +214,7 @@ class BattingRecordControllerTest {
             // when & then
             mockMvc
                 .perform(
-                    post("/api/games/$gameId/batting-records")
+                    post("/api/v1/games/$gameId/batting-records")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isBadRequest)

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BoxScoreControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BoxScoreControllerTest.kt
@@ -134,7 +134,7 @@ class BoxScoreControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/games/$gameId/boxscore"))
+                .perform(get("/api/v1/games/$gameId/boxscore"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.gameId").value(gameId))
@@ -203,7 +203,7 @@ class BoxScoreControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/games/$gameId/boxscore"))
+                .perform(get("/api/v1/games/$gameId/boxscore"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.data.homeTeam.batters[0].playerId").value(100))
                 .andExpect(jsonPath("$.data.homeTeam.batters[0].name").value("타자A"))
@@ -271,7 +271,7 @@ class BoxScoreControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/games/$gameId/boxscore"))
+                .perform(get("/api/v1/games/$gameId/boxscore"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.data.homeTeam.pitchers[0].playerId").value(101))
                 .andExpect(jsonPath("$.data.homeTeam.pitchers[0].name").value("투수B"))
@@ -323,7 +323,7 @@ class BoxScoreControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/games/$gameId/boxscore"))
+                .perform(get("/api/v1/games/$gameId/boxscore"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.data.homeTeam.inningScores").isArray)
                 .andExpect(jsonPath("$.data.homeTeam.inningScores[0]").value(2))
@@ -341,7 +341,7 @@ class BoxScoreControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/games/$gameId/boxscore"))
+                .perform(get("/api/v1/games/$gameId/boxscore"))
                 .andExpect(status().isBadRequest)
                 .andExpect(jsonPath("$.success").value(false))
         }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
@@ -98,7 +98,7 @@ class PitchingRecordControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/games/$gameId/pitching-records"))
+                .perform(get("/api/v1/games/$gameId/pitching-records"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -114,7 +114,7 @@ class PitchingRecordControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/games/$gameId/pitching-records"))
+                .perform(get("/api/v1/games/$gameId/pitching-records"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -141,7 +141,7 @@ class PitchingRecordControllerTest {
             // when & then
             mockMvc
                 .perform(
-                    post("/api/games/$gameId/pitching-records")
+                    post("/api/v1/games/$gameId/pitching-records")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isCreated)
@@ -166,7 +166,7 @@ class PitchingRecordControllerTest {
             // when & then
             mockMvc
                 .perform(
-                    post("/api/games/$gameId/pitching-records")
+                    post("/api/v1/games/$gameId/pitching-records")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isCreated)
@@ -183,7 +183,7 @@ class PitchingRecordControllerTest {
             // when & then
             mockMvc
                 .perform(
-                    post("/api/games/$gameId/pitching-records")
+                    post("/api/v1/games/$gameId/pitching-records")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isNotFound)
@@ -207,7 +207,7 @@ class PitchingRecordControllerTest {
             // when & then
             mockMvc
                 .perform(
-                    post("/api/games/$gameId/pitching-records")
+                    post("/api/v1/games/$gameId/pitching-records")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)),
                 ).andExpect(status().isBadRequest)

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/league/LeagueControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/league/LeagueControllerTest.kt
@@ -44,7 +44,7 @@ class LeagueControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/leagues"))
+                .perform(get("/api/v1/leagues"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
@@ -65,7 +65,7 @@ class LeagueControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/leagues/1"))
+                .perform(get("/api/v1/leagues/1"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(1))
@@ -92,7 +92,7 @@ class LeagueControllerTest {
 
             // when & then
             mockMvc
-                .perform(get("/api/associations/$associationId/leagues"))
+                .perform(get("/api/v1/associations/$associationId/leagues"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)


### PR DESCRIPTION
## Summary

>- close #181

7개 컨트롤러의 `@RequestMapping`을 `/api/v1/` 프리픽스로 통일합니다.

- `LeagueController`: `/api` → `/api/v1`
- `AuthController`: `/api/auth` → `/api/v1/auth`
- `OAuthController`: `/api/me/oauth-accounts` → `/api/v1/me/oauth-accounts`
- `BattingRecordController`: `/api/games/...` → `/api/v1/games/...`
- `PitchingRecordController`: `/api/games/...` → `/api/v1/games/...`
- `BoxScoreController`: `/api/games/...` → `/api/v1/games/...`
- `AssociationController`: `/api/associations` → `/api/v1/associations`

## Tasks

- 7개 컨트롤러 `@RequestMapping` 수정
- SecurityConfig URL 패턴 수정 (auth, associations, games/records)
- 테스트 파일 URL 동기화 (6개 파일)
- nextup-api 테스트 전체 통과 확인

## To Reviewer

- 프론트엔드 연동 전 URL 통일이므로 breaking change 없음
- `SecurityConfig`의 CSRF(`/api/**`)는 그대로 유지 (전체 API에 적용)