### PR TITLE
fix(#197): 표준 Java 예외를 BusinessException 계열로 교체

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMembershipController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMembershipController.kt
@@ -4,6 +4,8 @@ import com.nextup.api.dto.team.*
 import com.nextup.api.mapper.team.toDetailResponse
 import com.nextup.api.mapper.team.toResponse
 import com.nextup.common.dto.ApiResponse
+import com.nextup.common.exception.ForbiddenException
+import com.nextup.common.exception.TeamMemberNotFoundException
 import com.nextup.core.service.team.TeamMembershipService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -117,7 +119,7 @@ class TeamMembershipController(
     ): ApiResponse<Unit> {
         // IDOR 방지: 요청자가 해당 팀의 멤버인지 검증
         teamMembershipService.getMember(teamId, kickerUserId)
-            ?: throw IllegalStateException("You are not a member of this team")
+            ?: throw ForbiddenException("TEAM_MEMBERSHIP_001", "You are not a member of this team")
 
         validateMemberBelongsToTeam(memberId, teamId)
 
@@ -141,7 +143,7 @@ class TeamMembershipController(
         // 현재 사용자의 멤버 ID 조회
         val member =
             teamMembershipService.getMember(teamId, userId)
-                ?: throw IllegalStateException("You are not a member of this team")
+                ?: throw ForbiddenException("TEAM_MEMBERSHIP_001", "You are not a member of this team")
 
         teamMembershipService.leaveMember(member.id)
         return ApiResponse.success(Unit)
@@ -160,7 +162,7 @@ class TeamMembershipController(
     ): ApiResponse<TeamMemberResponse> {
         // IDOR 방지: 요청자가 해당 팀의 멤버인지 검증
         teamMembershipService.getMember(teamId, changerUserId)
-            ?: throw IllegalStateException("You are not a member of this team")
+            ?: throw ForbiddenException("TEAM_MEMBERSHIP_001", "You are not a member of this team")
 
         validateMemberBelongsToTeam(memberId, teamId)
 
@@ -179,9 +181,9 @@ class TeamMembershipController(
     ) {
         val targetMember =
             teamMembershipService.getMemberById(memberId)
-                ?: throw IllegalStateException("Member not found: $memberId")
+                ?: throw TeamMemberNotFoundException(memberId)
         if (targetMember.team.id != teamId) {
-            throw IllegalStateException("Member does not belong to this team")
+            throw ForbiddenException("TEAM_MEMBERSHIP_002", "Member does not belong to this team")
         }
     }
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamMembershipControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamMembershipControllerTest.kt
@@ -1,6 +1,8 @@
 package com.nextup.api.controller.team
 
 import com.nextup.api.dto.team.*
+import com.nextup.common.exception.ForbiddenException
+import com.nextup.common.exception.TeamMemberNotFoundException
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.team.*
@@ -238,7 +240,7 @@ class TeamMembershipControllerTest {
             every { teamMembershipService.getMember(1L, 10L) } returns null
 
             // when & then
-            assertThrows<IllegalStateException> {
+            assertThrows<ForbiddenException> {
                 controller.kickMember(teamId = 1L, memberId = 50L, request = request, kickerUserId = 10L)
             }
         }
@@ -252,7 +254,7 @@ class TeamMembershipControllerTest {
             every { teamMembershipService.getMemberById(50L) } returns null
 
             // when & then
-            assertThrows<IllegalStateException> {
+            assertThrows<TeamMemberNotFoundException> {
                 controller.kickMember(teamId = 1L, memberId = 50L, request = request, kickerUserId = 10L)
             }
         }
@@ -272,7 +274,7 @@ class TeamMembershipControllerTest {
             every { teamMembershipService.getMemberById(50L) } returns wrongTeamMember
 
             // when & then
-            assertThrows<IllegalStateException> {
+            assertThrows<ForbiddenException> {
                 controller.kickMember(teamId = 1L, memberId = 50L, request = request, kickerUserId = 10L)
             }
         }
@@ -302,7 +304,7 @@ class TeamMembershipControllerTest {
             every { teamMembershipService.getMember(1L, 10L) } returns null
 
             // when & then
-            assertThrows<IllegalStateException> {
+            assertThrows<ForbiddenException> {
                 controller.leaveTeam(teamId = 1L, userId = 10L)
             }
         }
@@ -341,7 +343,7 @@ class TeamMembershipControllerTest {
             every { teamMembershipService.getMember(1L, 10L) } returns null
 
             // when & then
-            assertThrows<IllegalStateException> {
+            assertThrows<ForbiddenException> {
                 controller.changeRole(teamId = 1L, memberId = 50L, request = request, changerUserId = 10L)
             }
         }
@@ -355,7 +357,7 @@ class TeamMembershipControllerTest {
             every { teamMembershipService.getMemberById(50L) } returns null
 
             // when & then
-            assertThrows<IllegalStateException> {
+            assertThrows<TeamMemberNotFoundException> {
                 controller.changeRole(teamId = 1L, memberId = 50L, request = request, changerUserId = 10L)
             }
         }
@@ -375,7 +377,7 @@ class TeamMembershipControllerTest {
             every { teamMembershipService.getMemberById(50L) } returns wrongTeamMember
 
             // when & then
-            assertThrows<IllegalStateException> {
+            assertThrows<ForbiddenException> {
                 controller.changeRole(teamId = 1L, memberId = 50L, request = request, changerUserId = 10L)
             }
         }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/CertificateServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/CertificateServiceImpl.kt
@@ -2,6 +2,7 @@ package com.nextup.infrastructure.service.certificate
 
 import com.nextup.common.exception.CertificateNotFoundByIssueNumberException
 import com.nextup.common.exception.CertificateNotFoundException
+import com.nextup.common.exception.PlayerNotFoundException
 import com.nextup.core.domain.certificate.Certificate
 import com.nextup.core.dto.certificate.*
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
@@ -36,7 +37,7 @@ class CertificateServiceImpl(
     ): CertificateDto {
         val player =
             playerRepository.findByIdOrNull(playerId)
-                ?: throw IllegalArgumentException("선수를 찾을 수 없습니다: $playerId")
+                ?: throw PlayerNotFoundException(playerId)
 
         // 증명서 발급
         val certificate = Certificate.issue(player, validityDays)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameParticipationServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameParticipationServiceImpl.kt
@@ -154,7 +154,7 @@ class GameParticipationServiceImpl(
                 members.any { it.user.id == userId }
             }
         if (!isMember) {
-            throw IllegalStateException("You are not a member of either team in this game")
+            throw ForbiddenException("GAME_MEMBER_001", "You are not a member of either team in this game")
         }
     }
 
@@ -173,7 +173,7 @@ class GameParticipationServiceImpl(
                 teamMemberRepository.findByTeamId(gameTeam.team.id)
             }
             .firstOrNull { it.user.id == userId }
-            ?: throw IllegalStateException("You are not a member of either team in this game")
+            ?: throw ForbiddenException("GAME_MEMBER_001", "You are not a member of either team in this game")
     }
 
     override fun getGameScheduledAt(gameId: Long): LocalDateTime {

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/certificate/CertificateServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/certificate/CertificateServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.nextup.infrastructure.service.certificate
 
 import com.nextup.common.exception.CertificateNotFoundByIssueNumberException
 import com.nextup.common.exception.CertificateNotFoundException
+import com.nextup.common.exception.PlayerNotFoundException
 import com.nextup.core.domain.certificate.Certificate
 import com.nextup.core.domain.certificate.CertificateStatus
 import com.nextup.core.domain.player.BattingHand
@@ -88,7 +89,7 @@ class CertificateServiceImplTest {
         every { playerRepository.findByIdOrNull(playerId) } returns null
 
         // when & then
-        assertThrows<IllegalArgumentException> {
+        assertThrows<PlayerNotFoundException> {
             certificateService.issueCertificate(playerId)
         }
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameParticipationServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameParticipationServiceImplTest.kt
@@ -335,7 +335,7 @@ class GameParticipationServiceImplTest {
             // when & then
             assertThatThrownBy {
                 service.verifyGameTeamMember(100L, 999L)
-            }.isInstanceOf(IllegalStateException::class.java)
+            }.isInstanceOf(ForbiddenException::class.java)
                 .hasMessage("You are not a member of either team in this game")
         }
     }
@@ -392,7 +392,7 @@ class GameParticipationServiceImplTest {
             // when & then
             assertThatThrownBy {
                 service.findMemberInGame(100L, 999L)
-            }.isInstanceOf(IllegalStateException::class.java)
+            }.isInstanceOf(ForbiddenException::class.java)
                 .hasMessage("You are not a member of either team in this game")
         }
     }


### PR DESCRIPTION
## Summary

>- close #197

프로덕션 코드에서 사용되던 `IllegalStateException`, `IllegalArgumentException`을 프로젝트 커스텀 예외(`ForbiddenException`, `PlayerNotFoundException`, `TeamMemberNotFoundException`)로 교체합니다.

## Tasks

- `TeamMembershipController`: 팀 미소속 검증 `IllegalStateException` → `ForbiddenException`, 멤버 미존재 → `TeamMemberNotFoundException`
- `CertificateServiceImpl`: 선수 미존재 `IllegalArgumentException` → `PlayerNotFoundException`
- `GameParticipationServiceImpl`: 팀 미소속 검증 `IllegalStateException` → `ForbiddenException`
- 테스트 코드 예외 타입 동기화 (`TeamMembershipControllerTest`, `CertificateServiceImplTest`, `GameParticipationServiceImplTest`)

## To Reviewer

- verify-custom-exception 스킬 실행 결과 발견된 위반사항을 모두 수정했습니다
- 기존 동작 로직은 동일하며, 예외 타입만 BusinessException 계열로 변경되었습니다