### PR TITLE
fix(#180): TRIPLE_PLAY를 별도 triplePlays 필드로 분리

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
@@ -95,6 +95,10 @@ class BattingRecord(
     var groundedIntoDoublePlays: Int = 0
         protected set
 
+    @Column(name = "triple_plays", nullable = false)
+    var triplePlays: Int = 0
+        protected set
+
     // Calculated properties
 
     /**
@@ -248,11 +252,13 @@ class BattingRecord(
             PlateAppearanceResult.SACRIFICE_BUNT -> {
                 sacrificeBunts++
             }
-            PlateAppearanceResult.DOUBLE_PLAY,
-            PlateAppearanceResult.TRIPLE_PLAY,
-            -> {
+            PlateAppearanceResult.DOUBLE_PLAY -> {
                 atBats++
                 groundedIntoDoublePlays++
+            }
+            PlateAppearanceResult.TRIPLE_PLAY -> {
+                atBats++
+                triplePlays++
             }
             PlateAppearanceResult.INTERFERENCE -> {
                 // 방해는 타수에 포함되지 않음
@@ -365,13 +371,17 @@ class BattingRecord(
                 require(sacrificeBunts > 0) { "롤백할 희생번트 기록이 없습니다." }
                 sacrificeBunts--
             }
-            PlateAppearanceResult.DOUBLE_PLAY,
-            PlateAppearanceResult.TRIPLE_PLAY,
-            -> {
+            PlateAppearanceResult.DOUBLE_PLAY -> {
                 require(atBats > 0) { "롤백할 타수 기록이 없습니다." }
                 require(groundedIntoDoublePlays > 0) { "롤백할 병살타 기록이 없습니다." }
                 atBats--
                 groundedIntoDoublePlays--
+            }
+            PlateAppearanceResult.TRIPLE_PLAY -> {
+                require(atBats > 0) { "롤백할 타수 기록이 없습니다." }
+                require(triplePlays > 0) { "롤백할 삼중살 기록이 없습니다." }
+                atBats--
+                triplePlays--
             }
             PlateAppearanceResult.INTERFERENCE -> {
                 // 방해는 타수에 포함되지 않음
@@ -410,6 +420,7 @@ class BattingRecord(
         require(stolenBases >= 0) { "도루($stolenBases)는 음수일 수 없습니다." }
         require(caughtStealing >= 0) { "도루실패($caughtStealing)는 음수일 수 없습니다." }
         require(groundedIntoDoublePlays >= 0) { "병살타($groundedIntoDoublePlays)는 음수일 수 없습니다." }
+        require(triplePlays >= 0) { "삼중살($triplePlays)은 음수일 수 없습니다." }
         require(hits <= atBats) {
             "안타 수($hits)가 타수($atBats)보다 클 수 없습니다."
         }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
@@ -619,12 +619,13 @@ class BattingRecordTest {
         }
 
         @Test
-        fun `삼중살을 적용하면 타수와 groundedIntoDoublePlays가 증가한다`() {
+        fun `삼중살을 적용하면 타수와 triplePlays가 증가한다`() {
             battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.TRIPLE_PLAY)
 
             assertThat(battingRecord.plateAppearances).isEqualTo(1)
             assertThat(battingRecord.atBats).isEqualTo(1)
-            assertThat(battingRecord.groundedIntoDoublePlays).isEqualTo(1)
+            assertThat(battingRecord.triplePlays).isEqualTo(1)
+            assertThat(battingRecord.groundedIntoDoublePlays).isEqualTo(0)
         }
     }
 
@@ -801,13 +802,14 @@ class BattingRecordTest {
         }
 
         @Test
-        fun `삼중살을 롤백하면 타수와 groundedIntoDoublePlays가 감소한다`() {
+        fun `삼중살을 롤백하면 타수와 triplePlays가 감소한다`() {
             battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.TRIPLE_PLAY)
 
             battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.TRIPLE_PLAY)
 
             assertThat(battingRecord.plateAppearances).isEqualTo(0)
             assertThat(battingRecord.atBats).isEqualTo(0)
+            assertThat(battingRecord.triplePlays).isEqualTo(0)
             assertThat(battingRecord.groundedIntoDoublePlays).isEqualTo(0)
         }
 
@@ -898,11 +900,22 @@ class BattingRecordTest {
     @DisplayName("applyPlateAppearanceResult - 삼중살 기록")
     inner class RecordTriplePlayTest {
         @Test
-        fun `삼중살을 기록하면 groundedIntoDoublePlays가 증가한다`() {
+        fun `삼중살을 기록하면 triplePlays가 증가한다`() {
             battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.TRIPLE_PLAY)
 
-            assertThat(battingRecord.groundedIntoDoublePlays).isEqualTo(1)
+            assertThat(battingRecord.triplePlays).isEqualTo(1)
             assertThat(battingRecord.atBats).isEqualTo(1)
+            assertThat(battingRecord.groundedIntoDoublePlays).isEqualTo(0)
+        }
+
+        @Test
+        fun `삼중살 롤백 시 triplePlays가 감소한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.TRIPLE_PLAY)
+
+            battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.TRIPLE_PLAY)
+
+            assertThat(battingRecord.triplePlays).isEqualTo(0)
+            assertThat(battingRecord.atBats).isEqualTo(0)
         }
     }
 
@@ -996,6 +1009,16 @@ class BattingRecordTest {
                 battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.DOUBLE_PLAY)
             }.isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("롤백할 병살타 기록이 없습니다")
+        }
+
+        @Test
+        fun `삼중살 기록이 없을 때 삼중살을 롤백하면 예외가 발생한다`() {
+            battingRecord.applyPlateAppearanceResult(PlateAppearanceResult.GROUND_OUT)
+
+            assertThatThrownBy {
+                battingRecord.revertPlateAppearanceResult(PlateAppearanceResult.TRIPLE_PLAY)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("롤백할 삼중살 기록이 없습니다")
         }
     }
 
@@ -1329,6 +1352,14 @@ class BattingRecordTest {
             assertThatThrownBy { battingRecord.validate() }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("병살타")
+        }
+
+        @Test
+        fun `삼중살이 음수이면 검증에 실패한다`() {
+            setField("triplePlays", -1)
+            assertThatThrownBy { battingRecord.validate() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("삼중살")
         }
     }
 }

--- a/nextup-infrastructure/src/main/resources/db/migration/V021__add_triple_plays_column.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V021__add_triple_plays_column.sql
@@ -1,0 +1,2 @@
+-- batting_records 테이블에 triple_plays 컬럼 추가
+ALTER TABLE batting_records ADD COLUMN triple_plays INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

>- close #180

`BattingRecord`에서 `TRIPLE_PLAY` 결과가 `groundedIntoDoublePlays`에 합산되던 버그를 수정합니다. 삼중살 전용 `triplePlays` 필드를 추가하고 apply/revert/validate 로직을 분리합니다.

## Tasks

- `triplePlays` 필드 추가 (`@Column(name = "triple_plays")`)
- `applyPlateAppearanceResult()`에서 TRIPLE_PLAY 분리
- `revertPlateAppearanceResult()`에서 TRIPLE_PLAY 분리
- `validate()`에 triplePlays 검증 추가
- Flyway V021 마이그레이션 작성
- 단위 테스트 추가/수정

## To Reviewer

- 야구 규칙상 삼중살은 병살과 별도로 집계되어야 합니다
- 기존 DOUBLE_PLAY 테스트는 영향 없음