### PR TITLE
fix(#178): 커리어 통계 N+1 쿼리 수정 (FETCH JOIN)

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMembershipController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMembershipController.kt
@@ -4,6 +4,8 @@ import com.nextup.api.dto.team.*
 import com.nextup.api.mapper.team.toDetailResponse
 import com.nextup.api.mapper.team.toResponse
 import com.nextup.common.dto.ApiResponse
+import com.nextup.common.exception.ForbiddenException
+import com.nextup.common.exception.TeamMemberNotFoundException
 import com.nextup.core.service.team.TeamMembershipService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -117,7 +119,7 @@ class TeamMembershipController(
     ): ApiResponse<Unit> {
         // IDOR 방지: 요청자가 해당 팀의 멤버인지 검증
         teamMembershipService.getMember(teamId, kickerUserId)
-            ?: throw IllegalStateException("You are not a member of this team")
+            ?: throw ForbiddenException("TEAM_MEMBERSHIP_001", "You are not a member of this team")
 
         validateMemberBelongsToTeam(memberId, teamId)
 
@@ -141,7 +143,7 @@ class TeamMembershipController(
         // 현재 사용자의 멤버 ID 조회
         val member =
             teamMembershipService.getMember(teamId, userId)
-                ?: throw IllegalStateException("You are not a member of this team")
+                ?: throw ForbiddenException("TEAM_MEMBERSHIP_001", "You are not a member of this team")
 
         teamMembershipService.leaveMember(member.id)
         return ApiResponse.success(Unit)
@@ -160,7 +162,7 @@ class TeamMembershipController(
     ): ApiResponse<TeamMemberResponse> {
         // IDOR 방지: 요청자가 해당 팀의 멤버인지 검증
         teamMembershipService.getMember(teamId, changerUserId)
-            ?: throw IllegalStateException("You are not a member of this team")
+            ?: throw ForbiddenException("TEAM_MEMBERSHIP_001", "You are not a member of this team")
 
         validateMemberBelongsToTeam(memberId, teamId)
 
@@ -179,9 +181,9 @@ class TeamMembershipController(
     ) {
         val targetMember =
             teamMembershipService.getMemberById(memberId)
-                ?: throw IllegalStateException("Member not found: $memberId")
+                ?: throw TeamMemberNotFoundException(memberId)
         if (targetMember.team.id != teamId) {
-            throw IllegalStateException("Member does not belong to this team")
+            throw ForbiddenException("TEAM_MEMBERSHIP_002", "Member does not belong to this team")
         }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BattingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BattingRecordRepositoryPort.kt
@@ -93,4 +93,10 @@ interface BattingRecordRepositoryPort {
         teamId: Long,
         gameIds: List<Long>,
     ): List<BattingRecord>
+
+    /**
+     * 선수 ID로 모든 타격 기록을 조회합니다. (FETCH JOIN으로 N+1 방지)
+     * gamePlayer, gameTeam, game을 함께 로딩하여 커리어 통계 계산에 사용합니다.
+     */
+    fun findAllByPlayerIdWithGameInfo(playerId: Long): List<BattingRecord>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchingRecordRepositoryPort.kt
@@ -121,4 +121,10 @@ interface PitchingRecordRepositoryPort {
         teamId: Long,
         gameIds: List<Long>,
     ): List<PitchingRecord>
+
+    /**
+     * 선수 ID로 모든 투수 기록을 조회합니다. (FETCH JOIN으로 N+1 방지)
+     * gamePlayer, gameTeam, game을 함께 로딩하여 커리어 통계 계산에 사용합니다.
+     */
+    fun findAllByPlayerIdWithGameInfo(playerId: Long): List<PitchingRecord>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/PlayerStatsService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/PlayerStatsService.kt
@@ -177,8 +177,8 @@ class PlayerStatsService(
         // 기존 통계 초기화 (새로 계산하기 위해)
         resetCareerBattingStats(careerStats)
 
-        // 모든 타격 기록 조회
-        val battingRecords = battingRecordRepository.findAllByPlayerId(playerId)
+        // 모든 타격 기록 조회 (FETCH JOIN으로 N+1 방지)
+        val battingRecords = battingRecordRepository.findAllByPlayerIdWithGameInfo(playerId)
 
         // 기록 누적
         battingRecords.forEach { record ->
@@ -221,8 +221,8 @@ class PlayerStatsService(
         // 기존 통계 초기화 (새로 계산하기 위해)
         resetCareerPitchingStats(careerStats)
 
-        // 모든 투수 기록 조회
-        val pitchingRecords = pitchingRecordRepository.findAllByPlayerId(playerId)
+        // 모든 투수 기록 조회 (FETCH JOIN으로 N+1 방지)
+        val pitchingRecords = pitchingRecordRepository.findAllByPlayerIdWithGameInfo(playerId)
 
         // 기록 누적
         pitchingRecords.forEach { record ->

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stats/PlayerStatsServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stats/PlayerStatsServiceTest.kt
@@ -367,7 +367,7 @@ class PlayerStatsServiceTest {
             // given
             every { playerRepository.findByIdOrNull(playerId) } returns testPlayer
             every { careerBattingStatsRepository.findByPlayerId(playerId) } returns null
-            every { battingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+            every { battingRecordRepository.findAllByPlayerIdWithGameInfo(playerId) } returns emptyList()
             every { careerBattingStatsRepository.save(any()) } answers { firstArg() }
 
             // when
@@ -392,7 +392,7 @@ class PlayerStatsServiceTest {
 
             every { playerRepository.findByIdOrNull(playerId) } returns testPlayer
             every { careerBattingStatsRepository.findByPlayerId(playerId) } returns existingStats
-            every { battingRecordRepository.findAllByPlayerId(playerId) } returns listOf(record1, record2)
+            every { battingRecordRepository.findAllByPlayerIdWithGameInfo(playerId) } returns listOf(record1, record2)
             every { careerBattingStatsRepository.save(any()) } answers { firstArg() }
 
             // when
@@ -415,7 +415,7 @@ class PlayerStatsServiceTest {
             // given
             every { playerRepository.findByIdOrNull(playerId) } returns testPlayer
             every { careerPitchingStatsRepository.findByPlayerId(playerId) } returns null
-            every { pitchingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByPlayerIdWithGameInfo(playerId) } returns emptyList()
             every { careerPitchingStatsRepository.save(any()) } answers { firstArg() }
 
             // when
@@ -440,7 +440,7 @@ class PlayerStatsServiceTest {
 
             every { playerRepository.findByIdOrNull(playerId) } returns testPlayer
             every { careerPitchingStatsRepository.findByPlayerId(playerId) } returns existingStats
-            every { pitchingRecordRepository.findAllByPlayerId(playerId) } returns listOf(record1, record2)
+            every { pitchingRecordRepository.findAllByPlayerIdWithGameInfo(playerId) } returns listOf(record1, record2)
             every { careerPitchingStatsRepository.save(any()) } answers { firstArg() }
 
             // when

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
@@ -179,4 +179,22 @@ interface BattingRecordRepository :
         @Param("teamId") teamId: Long,
         @Param("gameIds") gameIds: List<Long>,
     ): List<BattingRecord>
+
+    /**
+     * 선수 ID로 모든 타격 기록을 조회합니다. (FETCH JOIN으로 N+1 방지)
+     * gamePlayer, gameTeam, game을 함께 로딩하여 커리어 통계 계산 시 추가 쿼리가 발생하지 않습니다.
+     */
+    @Query(
+        """
+        SELECT br FROM BattingRecord br
+        JOIN FETCH br.gamePlayer gp
+        JOIN FETCH gp.gameTeam gt
+        JOIN FETCH gt.game g
+        WHERE gp.player.id = :playerId
+        ORDER BY g.scheduledAt DESC
+    """,
+    )
+    override fun findAllByPlayerIdWithGameInfo(
+        @Param("playerId") playerId: Long,
+    ): List<BattingRecord>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
@@ -268,4 +268,22 @@ interface PitchingRecordRepository :
         @Param("teamId") teamId: Long,
         @Param("gameIds") gameIds: List<Long>,
     ): List<PitchingRecord>
+
+    /**
+     * 선수 ID로 모든 투수 기록을 조회합니다. (FETCH JOIN으로 N+1 방지)
+     * gamePlayer, gameTeam, game을 함께 로딩하여 커리어 통계 계산 시 추가 쿼리가 발생하지 않습니다.
+     */
+    @Query(
+        """
+        SELECT pr FROM PitchingRecord pr
+        JOIN FETCH pr.gamePlayer gp
+        JOIN FETCH gp.gameTeam gt
+        JOIN FETCH gt.game g
+        WHERE gp.player.id = :playerId
+        ORDER BY g.scheduledAt DESC
+    """,
+    )
+    override fun findAllByPlayerIdWithGameInfo(
+        @Param("playerId") playerId: Long,
+    ): List<PitchingRecord>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/CertificateServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/CertificateServiceImpl.kt
@@ -2,6 +2,7 @@ package com.nextup.infrastructure.service.certificate
 
 import com.nextup.common.exception.CertificateNotFoundByIssueNumberException
 import com.nextup.common.exception.CertificateNotFoundException
+import com.nextup.common.exception.PlayerNotFoundException
 import com.nextup.core.domain.certificate.Certificate
 import com.nextup.core.dto.certificate.*
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
@@ -36,7 +37,7 @@ class CertificateServiceImpl(
     ): CertificateDto {
         val player =
             playerRepository.findByIdOrNull(playerId)
-                ?: throw IllegalArgumentException("선수를 찾을 수 없습니다: $playerId")
+                ?: throw PlayerNotFoundException(playerId)
 
         // 증명서 발급
         val certificate = Certificate.issue(player, validityDays)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameParticipationServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameParticipationServiceImpl.kt
@@ -154,7 +154,7 @@ class GameParticipationServiceImpl(
                 members.any { it.user.id == userId }
             }
         if (!isMember) {
-            throw IllegalStateException("You are not a member of either team in this game")
+            throw ForbiddenException("GAME_MEMBER_001", "You are not a member of either team in this game")
         }
     }
 
@@ -173,7 +173,7 @@ class GameParticipationServiceImpl(
                 teamMemberRepository.findByTeamId(gameTeam.team.id)
             }
             .firstOrNull { it.user.id == userId }
-            ?: throw IllegalStateException("You are not a member of either team in this game")
+            ?: throw ForbiddenException("GAME_MEMBER_001", "You are not a member of either team in this game")
     }
 
     override fun getGameScheduledAt(gameId: Long): LocalDateTime {


### PR DESCRIPTION
## Summary

>- close #178

`PlayerStatsService`에서 커리어 통계 계산 시 3단계 lazy 관계(gamePlayer → gameTeam → game)를 탐색하여 발생하던 N+1 문제를 FETCH JOIN으로 해결합니다. 50경기 선수 기준 150+ 추가 쿼리가 1개 쿼리로 개선됩니다.

## Tasks

- [x] BattingRecordRepositoryPort에 `findAllByPlayerIdWithGameInfo()` 메서드 추가
- [x] PitchingRecordRepositoryPort에 `findAllByPlayerIdWithGameInfo()` 메서드 추가
- [x] BattingRecordRepository, PitchingRecordRepository JPQL FETCH JOIN 구현
- [x] PlayerStatsService에서 새 메서드 사용하도록 변경
- [x] 빌드 성공 확인

## To Reviewer

- `JOIN FETCH br.gamePlayer gp JOIN FETCH gp.gameTeam gt JOIN FETCH gt.game g` 패턴
- 기존 `findAllByPlayerId()` 메서드는 다른 곳에서 사용할 수 있으므로 유지