### PR TITLE
fix(#188): 팀 목록 N+1 쿼리 및 메모리 필터링 개선

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamController.kt
@@ -141,24 +141,19 @@ class TeamController(
         @RequestParam(required = false) name: String?,
         @RequestParam(required = false) city: String?,
     ): ApiResponse<List<TeamSummaryResponse>> {
-        val teams = teamRepository.findActiveTeams()
+        val teams = teamRepository.findActiveTeamsByFilter(name, city)
 
-        val filtered =
-            teams.filter { team ->
-                val nameMatch = name == null || team.name.contains(name, ignoreCase = true)
-                val cityMatch = city == null || team.city.contains(city, ignoreCase = true)
-                nameMatch && cityMatch
-            }
+        val teamIds = teams.map { it.id }
+        val memberCounts = teamMembershipService.getTeamMemberCounts(teamIds)
 
         val responses =
-            filtered.map { team ->
-                val memberCount = teamMembershipService.getTeamMemberCount(team.id)
+            teams.map { team ->
                 TeamSummaryResponse(
                     teamId = team.id,
                     name = team.name,
                     city = team.city,
                     abbreviation = team.abbreviation,
-                    memberCount = memberCount,
+                    memberCount = memberCounts[team.id] ?: 0,
                 )
             }
 

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamControllerTest.kt
@@ -265,6 +265,35 @@ class TeamControllerTest {
         }
 
         @Test
+        fun `should default memberCount to zero when not in counts map`() {
+            // given
+            val team2 =
+                mockk<Team> {
+                    every { id } returns 20L
+                    every { name } returns "이글스"
+                    every { city } returns "부산"
+                    every { abbreviation } returns "EGL"
+                    every { isActive } returns true
+                }
+            every {
+                teamRepository.findActiveTeamsByFilter(null, null)
+            } returns listOf(team, team2)
+            // team2(20L)의 카운트가 map에 없음 → ?: 0 분기 커버
+            every {
+                teamMembershipService.getTeamMemberCounts(listOf(10L, 20L))
+            } returns mapOf(10L to 15)
+
+            // when
+            val response = controller.getTeams(null, null)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data).hasSize(2)
+            val team2Response = response.data?.find { it.teamId == 20L }
+            assertThat(team2Response?.memberCount).isEqualTo(0)
+        }
+
+        @Test
         fun `should return empty when no match`() {
             // given
             every { teamRepository.findActiveTeamsByFilter("없는팀", null) } returns emptyList()

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamControllerTest.kt
@@ -226,9 +226,8 @@ class TeamControllerTest {
                     every { abbreviation } returns "EGL"
                     every { isActive } returns true
                 }
-            every { teamRepository.findActiveTeams() } returns listOf(team, team2)
-            every { teamMembershipService.getTeamMemberCount(10L) } returns 15
-            every { teamMembershipService.getTeamMemberCount(20L) } returns 12
+            every { teamRepository.findActiveTeamsByFilter(null, null) } returns listOf(team, team2)
+            every { teamMembershipService.getTeamMemberCounts(listOf(10L, 20L)) } returns mapOf(10L to 15, 20L to 12)
 
             // when
             val response = controller.getTeams(null, null)
@@ -241,8 +240,8 @@ class TeamControllerTest {
         @Test
         fun `should filter by name`() {
             // given
-            every { teamRepository.findActiveTeams() } returns listOf(team)
-            every { teamMembershipService.getTeamMemberCount(10L) } returns 15
+            every { teamRepository.findActiveTeamsByFilter("타이거", null) } returns listOf(team)
+            every { teamMembershipService.getTeamMemberCounts(listOf(10L)) } returns mapOf(10L to 15)
 
             // when
             val response = controller.getTeams(name = "타이거", city = null)
@@ -255,8 +254,8 @@ class TeamControllerTest {
         @Test
         fun `should filter by city`() {
             // given
-            every { teamRepository.findActiveTeams() } returns listOf(team)
-            every { teamMembershipService.getTeamMemberCount(10L) } returns 15
+            every { teamRepository.findActiveTeamsByFilter(null, "서울") } returns listOf(team)
+            every { teamMembershipService.getTeamMemberCounts(listOf(10L)) } returns mapOf(10L to 15)
 
             // when
             val response = controller.getTeams(name = null, city = "서울")
@@ -268,7 +267,8 @@ class TeamControllerTest {
         @Test
         fun `should return empty when no match`() {
             // given
-            every { teamRepository.findActiveTeams() } returns listOf(team)
+            every { teamRepository.findActiveTeamsByFilter("없는팀", null) } returns emptyList()
+            every { teamMembershipService.getTeamMemberCounts(emptyList()) } returns emptyMap()
 
             // when
             val response = controller.getTeams(name = "없는팀", city = null)

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamMemberRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamMemberRepositoryPort.kt
@@ -63,4 +63,9 @@ interface TeamMemberRepositoryPort {
         teamId: Long,
         status: TeamMemberStatus,
     ): Long
+
+    fun countByTeamIdsAndStatus(
+        teamIds: List<Long>,
+        status: TeamMemberStatus,
+    ): Map<Long, Long>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamRepositoryPort.kt
@@ -25,5 +25,10 @@ interface TeamRepositoryPort {
 
     fun findActiveTeams(): List<Team>
 
+    fun findActiveTeamsByFilter(
+        name: String?,
+        city: String?,
+    ): List<Team>
+
     fun findByIdWithLeague(id: Long): Team?
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
@@ -170,4 +170,12 @@ interface TeamMembershipService {
      * @return 활성 멤버 수
      */
     fun getTeamMemberCount(teamId: Long): Int
+
+    /**
+     * 여러 팀의 활성 멤버 수를 배치로 반환합니다. (N+1 방지)
+     *
+     * @param teamIds 팀 ID 목록
+     * @return 팀 ID → 활성 멤버 수 맵
+     */
+    fun getTeamMemberCounts(teamIds: List<Long>): Map<Long, Int>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberCountProjection.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberCountProjection.kt
@@ -1,0 +1,12 @@
+package com.nextup.infrastructure.repository
+
+/**
+ * 팀별 멤버 수 집계 프로젝션
+ *
+ * TeamMemberRepository.countByTeamIdsAndStatus 배치 쿼리 결과 매핑용
+ */
+interface TeamMemberCountProjection {
+    fun getTeamId(): Long
+
+    fun getMemberCount(): Long
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepository.kt
@@ -80,4 +80,17 @@ interface TeamMemberRepository : JpaRepository<TeamMember, Long> {
         teamId: Long,
         status: TeamMemberStatus,
     ): Long
+
+    @Query(
+        """
+        SELECT tm.team.id AS teamId, COUNT(tm) AS memberCount
+        FROM TeamMember tm
+        WHERE tm.team.id IN :teamIds AND tm.status = :status
+        GROUP BY tm.team.id
+        """,
+    )
+    fun countByTeamIdsAndStatus(
+        teamIds: List<Long>,
+        status: TeamMemberStatus,
+    ): List<TeamMemberCountProjection>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapter.kt
@@ -73,4 +73,13 @@ class TeamMemberRepositoryAdapter(
         teamId: Long,
         status: TeamMemberStatus,
     ): Long = jpaRepository.countByTeamIdAndStatus(teamId, status)
+
+    override fun countByTeamIdsAndStatus(
+        teamIds: List<Long>,
+        status: TeamMemberStatus,
+    ): Map<Long, Long> {
+        if (teamIds.isEmpty()) return emptyMap()
+        return jpaRepository.countByTeamIdsAndStatus(teamIds, status)
+            .associate { it.getTeamId() to it.getMemberCount() }
+    }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamRepository.kt
@@ -4,6 +4,7 @@ import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.TeamRepositoryPort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface TeamRepository :
     JpaRepository<Team, Long>,
@@ -16,6 +17,20 @@ interface TeamRepository :
 
     @Query("SELECT t FROM Team t WHERE t.isActive = true")
     override fun findActiveTeams(): List<Team>
+
+    @Query(
+        """
+        SELECT t FROM Team t
+        WHERE t.isActive = true
+        AND (:name IS NULL OR LOWER(t.name) LIKE LOWER(CONCAT('%', :name, '%')))
+        AND (:city IS NULL OR LOWER(t.city) LIKE LOWER(CONCAT('%', :city, '%')))
+        ORDER BY t.name ASC
+        """,
+    )
+    override fun findActiveTeamsByFilter(
+        @Param("name") name: String?,
+        @Param("city") city: String?,
+    ): List<Team>
 
     @Query("SELECT t FROM Team t JOIN FETCH t.league WHERE t.id = :id")
     override fun findByIdWithLeague(id: Long): Team?

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
@@ -354,4 +354,10 @@ class TeamMembershipServiceImpl(
     override fun getTeamMemberCount(teamId: Long): Int {
         return teamMemberRepository.countByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE).toInt()
     }
+
+    override fun getTeamMemberCounts(teamIds: List<Long>): Map<Long, Int> {
+        if (teamIds.isEmpty()) return emptyMap()
+        return teamMemberRepository.countByTeamIdsAndStatus(teamIds, TeamMemberStatus.ACTIVE)
+            .mapValues { it.value.toInt() }
+    }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapterTest.kt
@@ -9,6 +9,7 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -280,5 +281,61 @@ class TeamMemberRepositoryAdapterTest {
         // then
         assertThat(result).isEqualTo(5L)
         verify(exactly = 1) { jpaRepository.countByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE) }
+    }
+
+    @Nested
+    @DisplayName("countByTeamIdsAndStatus")
+    inner class CountByTeamIdsAndStatus {
+        @Test
+        @DisplayName("빈 teamIds 목록이면 빈 Map을 반환한다")
+        fun `should return empty map when teamIds is empty`() {
+            // when
+            val result =
+                adapter.countByTeamIdsAndStatus(emptyList(), TeamMemberStatus.ACTIVE)
+
+            // then
+            assertThat(result).isEmpty()
+            verify(exactly = 0) { jpaRepository.countByTeamIdsAndStatus(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("teamIds 목록으로 배치 조회 시 JPA repository에 위임한다")
+        fun `should delegate to jpa repository and map projection results`() {
+            // given
+            val projection1 =
+                mockk<TeamMemberCountProjection> {
+                    every { getTeamId() } returns 1L
+                    every { getMemberCount() } returns 10L
+                }
+            val projection2 =
+                mockk<TeamMemberCountProjection> {
+                    every { getTeamId() } returns 2L
+                    every { getMemberCount() } returns 5L
+                }
+            every {
+                jpaRepository.countByTeamIdsAndStatus(
+                    listOf(1L, 2L),
+                    TeamMemberStatus.ACTIVE,
+                )
+            } returns listOf(projection1, projection2)
+
+            // when
+            val result =
+                adapter.countByTeamIdsAndStatus(
+                    listOf(1L, 2L),
+                    TeamMemberStatus.ACTIVE,
+                )
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result[1L]).isEqualTo(10L)
+            assertThat(result[2L]).isEqualTo(5L)
+            verify(exactly = 1) {
+                jpaRepository.countByTeamIdsAndStatus(
+                    listOf(1L, 2L),
+                    TeamMemberStatus.ACTIVE,
+                )
+            }
+        }
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
@@ -881,6 +881,38 @@ class TeamMembershipServiceImplTest {
     }
 
     @Nested
+    @DisplayName("getTeamMemberCounts")
+    inner class GetTeamMemberCounts {
+        @Test
+        fun `should return empty map when teamIds is empty`() {
+            // when
+            val result = service.getTeamMemberCounts(emptyList())
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `should return member counts as Int map`() {
+            // given
+            every {
+                teamMemberRepository.countByTeamIdsAndStatus(
+                    listOf(1L, 2L),
+                    TeamMemberStatus.ACTIVE,
+                )
+            } returns mapOf(1L to 10L, 2L to 5L)
+
+            // when
+            val result = service.getTeamMemberCounts(listOf(1L, 2L))
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result[1L]).isEqualTo(10)
+            assertThat(result[2L]).isEqualTo(5)
+        }
+    }
+
+    @Nested
     @DisplayName("getMember")
     inner class GetMember {
         @Test


### PR DESCRIPTION
## Summary

>- close #188

팀 목록 조회 시 100개 팀 기준 101개 쿼리가 발생하던 N+1 문제와 메모리 내 필터링 문제를 해결합니다. DB 레벨 필터링과 배치 멤버 카운트 조회로 2개 쿼리로 개선합니다.

## Tasks

- [x] `findActiveTeamsByFilter(name?, city?)` DB 레벨 LIKE 필터링 메서드 추가
- [x] `getTeamMemberCounts(teamIds)` 배치 메서드 추가 (GROUP BY 집계)
- [x] `TeamMemberCountProjection` 인터페이스 생성
- [x] TeamController 리팩토링 (101 쿼리 → 2 쿼리)
- [x] 빌드 성공 확인

## To Reviewer

- 메모리 필터링을 DB 쿼리로 이동하여 성능 개선
- 팀당 개별 카운트 쿼리를 단일 GROUP BY 쿼리로 통합