### PR TITLE
feat(#173): PagedResponse 인프라 구축 및 알림 목록 API 적용

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
@@ -1,5 +1,6 @@
 package com.nextup.api.controller.notification
 
+import com.nextup.api.dto.common.PagedResponse
 import com.nextup.api.dto.notification.DeviceTokenResponse
 import com.nextup.api.dto.notification.NotificationPreferenceResponse
 import com.nextup.api.dto.notification.NotificationResponse
@@ -67,9 +68,9 @@ class NotificationController(
     fun getNotifications(
         @AuthenticationPrincipal userId: Long,
         @PageableDefault(size = 20) pageable: Pageable,
-    ): ApiResponse<List<NotificationResponse>> {
+    ): ApiResponse<PagedResponse<NotificationResponse>> {
         val notifications = notificationService.getUserNotifications(userId, pageable)
-        return ApiResponse.success(notifications.content.map { NotificationResponse.from(it) })
+        return ApiResponse.success(PagedResponse.from(notifications.map { NotificationResponse.from(it) }))
     }
 
     /**

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/common/PagedResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/common/PagedResponse.kt
@@ -1,0 +1,40 @@
+package com.nextup.api.dto.common
+
+import org.springframework.data.domain.Page
+
+/**
+ * 페이징된 목록 응답 래퍼
+ *
+ * Spring Data [Page]를 클라이언트 친화적인 형태로 변환합니다.
+ *
+ * @param T 응답 데이터 원소 타입
+ * @property content 현재 페이지의 데이터 목록
+ * @property totalElements 전체 데이터 수
+ * @property totalPages 전체 페이지 수
+ * @property currentPage 현재 페이지 번호 (0-based)
+ * @property size 페이지당 데이터 수
+ * @property hasNext 다음 페이지 존재 여부
+ */
+data class PagedResponse<T>(
+    val content: List<T>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+    val size: Int,
+    val hasNext: Boolean,
+) {
+    companion object {
+        /**
+         * Spring Data [Page]로부터 [PagedResponse]를 생성합니다.
+         */
+        fun <T> from(page: Page<T>): PagedResponse<T> =
+            PagedResponse(
+                content = page.content,
+                totalElements = page.totalElements,
+                totalPages = page.totalPages,
+                currentPage = page.number,
+                size = page.size,
+                hasNext = page.hasNext(),
+            )
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/notification/NotificationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/notification/NotificationControllerTest.kt
@@ -187,11 +187,16 @@ class NotificationControllerTest {
             )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data").isArray)
-            .andExpect(jsonPath("$.data[0].id").value(1))
-            .andExpect(jsonPath("$.data[0].userId").value(authenticatedUserId))
-            .andExpect(jsonPath("$.data[0].type").value("GAME_START"))
-            .andExpect(jsonPath("$.data[0].title").value("경기 시작"))
+            .andExpect(jsonPath("$.data.content").isArray)
+            .andExpect(jsonPath("$.data.content[0].id").value(1))
+            .andExpect(jsonPath("$.data.content[0].userId").value(authenticatedUserId))
+            .andExpect(jsonPath("$.data.content[0].type").value("GAME_START"))
+            .andExpect(jsonPath("$.data.content[0].title").value("경기 시작"))
+            .andExpect(jsonPath("$.data.totalElements").value(1))
+            .andExpect(jsonPath("$.data.totalPages").value(1))
+            .andExpect(jsonPath("$.data.currentPage").value(0))
+            .andExpect(jsonPath("$.data.size").value(20))
+            .andExpect(jsonPath("$.data.hasNext").value(false))
 
         verify(exactly = 1) { notificationService.getUserNotifications(authenticatedUserId, any()) }
     }

--- a/nextup-api/src/test/kotlin/com/nextup/api/dto/common/PagedResponseTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/dto/common/PagedResponseTest.kt
@@ -1,0 +1,99 @@
+package com.nextup.api.dto.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+@DisplayName("PagedResponse")
+class PagedResponseTest {
+    @Nested
+    @DisplayName("from(page)")
+    inner class From {
+        @Test
+        fun `단일 페이지 데이터를 올바르게 변환한다`() {
+            // given
+            val pageable = PageRequest.of(0, 20)
+            val content = listOf("item1", "item2", "item3")
+            val page = PageImpl(content, pageable, 3L)
+
+            // when
+            val result = PagedResponse.from(page)
+
+            // then
+            assertThat(result.content).isEqualTo(content)
+            assertThat(result.totalElements).isEqualTo(3L)
+            assertThat(result.totalPages).isEqualTo(1)
+            assertThat(result.currentPage).isEqualTo(0)
+            assertThat(result.size).isEqualTo(20)
+            assertThat(result.hasNext).isFalse()
+        }
+
+        @Test
+        fun `다음 페이지가 존재하는 경우 hasNext가 true이다`() {
+            // given
+            val pageable = PageRequest.of(0, 2)
+            val content = listOf("item1", "item2")
+            val page = PageImpl(content, pageable, 5L)
+
+            // when
+            val result = PagedResponse.from(page)
+
+            // then
+            assertThat(result.hasNext).isTrue()
+            assertThat(result.totalPages).isEqualTo(3)
+            assertThat(result.totalElements).isEqualTo(5L)
+        }
+
+        @Test
+        fun `마지막 페이지인 경우 hasNext가 false이다`() {
+            // given
+            val pageable = PageRequest.of(2, 2)
+            val content = listOf("item5")
+            val page = PageImpl(content, pageable, 5L)
+
+            // when
+            val result = PagedResponse.from(page)
+
+            // then
+            assertThat(result.hasNext).isFalse()
+            assertThat(result.currentPage).isEqualTo(2)
+        }
+
+        @Test
+        fun `빈 페이지를 올바르게 변환한다`() {
+            // given
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(emptyList<String>(), pageable, 0L)
+
+            // when
+            val result = PagedResponse.from(page)
+
+            // then
+            assertThat(result.content).isEmpty()
+            assertThat(result.totalElements).isEqualTo(0L)
+            assertThat(result.totalPages).isEqualTo(0)
+            assertThat(result.currentPage).isEqualTo(0)
+            assertThat(result.size).isEqualTo(20)
+            assertThat(result.hasNext).isFalse()
+        }
+
+        @Test
+        fun `두 번째 페이지의 currentPage가 1이다`() {
+            // given
+            val pageable = PageRequest.of(1, 10)
+            val content = listOf("item11")
+            val page = PageImpl(content, pageable, 11L)
+
+            // when
+            val result = PagedResponse.from(page)
+
+            // then
+            assertThat(result.currentPage).isEqualTo(1)
+            assertThat(result.size).isEqualTo(10)
+            assertThat(result.hasNext).isFalse()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #173

`PagedResponse<T>` 공통 DTO를 생성하고 NotificationController에 적용하여 페이징 메타데이터(totalElements, totalPages, currentPage, size, hasNext)를 복원합니다.

## Tasks

- [x] `PagedResponse<T>` DTO 생성 + `from(Page<T>)` 팩토리 메서드
- [x] NotificationController 페이징 메타데이터 복원
- [x] 단위 테스트 작성 (5건)
- [x] 빌드 성공 확인

## To Reviewer

- 다른 Controller들은 Service가 `List<T>`를 반환하여 `Page<T>` 전환이 필요하므로, 이번 PR에서는 이미 Page를 반환하는 NotificationController만 적용
- 향후 Service/Repository 수정과 함께 점진적 적용 예정