### PR TITLE
feat(#185): 사회인 야구 규칙 설정 체계(GameRules) 구축

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/Competition.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/Competition.kt
@@ -47,6 +47,8 @@ class Competition(
     val maxTeams: Int? = null,
     @Column(name = "playoff_teams")
     var playoffTeams: Int? = null,
+    @Embedded
+    var gameRules: GameRules = GameRules(),
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
@@ -101,6 +103,17 @@ class Competition(
         }
         name?.let { this.name = it }
         description?.let { this.description = it }
+    }
+
+    /**
+     * 경기 규칙을 업데이트합니다.
+     * 첫 경기가 시작된 이후에는 규칙을 변경할 수 없습니다.
+     */
+    fun updateGameRules(newRules: GameRules) {
+        require(status == CompetitionStatus.SCHEDULED) {
+            "경기가 시작되기 전(예정 상태)에만 규칙을 변경할 수 있습니다."
+        }
+        this.gameRules = newRules
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/GameRules.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/GameRules.kt
@@ -1,0 +1,80 @@
+package com.nextup.core.domain.competition
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+
+/**
+ * 대회 경기 규칙 설정 (Value Object)
+ *
+ * Competition 단위로 설정되며, 사회인 야구 대회별로 다른 규칙을 지원합니다.
+ * 기본값은 일반적인 9이닝 야구 규칙을 따릅니다.
+ */
+@Embeddable
+data class GameRules(
+    /** 기본 이닝 수 (3~12 사이) */
+    @Column(name = "default_innings")
+    val defaultInnings: Int = 9,
+    /** 콜드게임(머시 룰) 활성화 여부 */
+    @Column(name = "mercy_rule_enabled")
+    val mercyRuleEnabled: Boolean = false,
+    /** 콜드게임 적용 득점 차이 (mercyRuleEnabled가 true일 때만 유효) */
+    @Column(name = "mercy_run_difference")
+    val mercyRunDifference: Int? = null,
+    /** 콜드게임 적용 최소 이닝 (mercyRuleEnabled가 true일 때만 유효) */
+    @Column(name = "mercy_minimum_inning")
+    val mercyMinimumInning: Int? = null,
+    /** 최대 연장 이닝 수 (null이면 무제한) */
+    @Column(name = "max_extra_innings")
+    val maxExtraInnings: Int? = null,
+    /** 동점 경기 처리 방법 */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tied_game_result")
+    val tiedGameResult: TiedGameResult = TiedGameResult.DRAW,
+    /** 타이브레이커(무사 2루 연장) 활성화 여부 */
+    @Column(name = "tiebreaker_enabled")
+    val tiebreakerEnabled: Boolean = false,
+    /** 몰수승 점수 */
+    @Column(name = "forfeit_score")
+    val forfeitScore: Int = 7,
+    /** 선발 투수 승리 자격 최소 아웃 수 (기본 15 = 5이닝) */
+    @Column(name = "starter_win_qualification_outs")
+    val starterWinQualificationOuts: Int = 15,
+    /** 규정 타석 배수 (팀당 경기 수 * 배수) */
+    @Column(name = "qualification_pa_multiplier")
+    val qualificationPAMultiplier: Double = 3.1,
+    /** 규정 이닝 배수 (팀당 경기 수 * 배수) */
+    @Column(name = "qualification_ip_multiplier")
+    val qualificationIPMultiplier: Double = 1.0,
+    /** 시간 제한 (분, null이면 무제한) */
+    @Column(name = "time_limit_minutes")
+    val timeLimitMinutes: Int? = null,
+) {
+    init {
+        require(defaultInnings in 3..12) { "기본 이닝은 3~12 사이여야 합니다." }
+        require(forfeitScore > 0) { "몰수승 점수는 양수여야 합니다." }
+        require(starterWinQualificationOuts > 0) { "선발 승리 자격 아웃 수는 양수여야 합니다." }
+        require(qualificationPAMultiplier > 0.0) { "규정 타석 배수는 양수여야 합니다." }
+        require(qualificationIPMultiplier > 0.0) { "규정 이닝 배수는 양수여야 합니다." }
+
+        if (mercyRuleEnabled) {
+            val diff =
+                requireNotNull(mercyRunDifference) { "콜드게임 활성화 시 득점 차이를 설정해야 합니다." }
+            require(diff > 0) { "콜드게임 적용 득점 차이는 양수여야 합니다." }
+            val minInning =
+                requireNotNull(mercyMinimumInning) { "콜드게임 활성화 시 최소 이닝을 설정해야 합니다." }
+            require(minInning in 1..defaultInnings) {
+                "콜드게임 최소 이닝은 1 이상 기본 이닝($defaultInnings) 이하여야 합니다."
+            }
+        }
+
+        maxExtraInnings?.let {
+            require(it > 0) { "최대 연장 이닝 수는 양수여야 합니다." }
+        }
+
+        timeLimitMinutes?.let {
+            require(it > 0) { "시간 제한은 양수여야 합니다." }
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/TiedGameResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/TiedGameResult.kt
@@ -1,0 +1,15 @@
+package com.nextup.core.domain.competition
+
+/**
+ * 동점 경기 처리 방법
+ */
+enum class TiedGameResult {
+    /** 무승부로 처리 */
+    DRAW,
+
+    /** 타이브레이커(연장전)로 승부 결정 */
+    TIEBREAKER,
+
+    /** 재경기로 승부 결정 */
+    RESCHEDULE,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -166,10 +166,11 @@ class Game(
         forfeitReason = reason
         note = (note?.let { "$it\n" } ?: "") + "몰수 사유: $reason"
 
-        // 승리팀 7:0 점수 반영
+        // 승리팀에 대회 규칙의 몰수승 점수 반영
+        val forfeitWinScore = competition.gameRules.forfeitScore
         gameTeams.forEach { gameTeam ->
             if (gameTeam.team.id == winnerTeamId) {
-                gameTeam.updateScore(totalScore = FORFEIT_WIN_SCORE, totalHits = 0, totalErrors = 0)
+                gameTeam.updateScore(totalScore = forfeitWinScore, totalHits = 0, totalErrors = 0)
                 gameTeam.updateResult(GameResult.WIN)
             } else {
                 gameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
@@ -179,8 +180,8 @@ class Game(
     }
 
     companion object {
-        /** 몰수승 점수 */
-        const val FORFEIT_WIN_SCORE = 7
+        /** 몰수승 기본 점수 (GameRules.forfeitScore 기본값과 일치) */
+        const val DEFAULT_FORFEIT_WIN_SCORE = 7
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/CompetitionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/CompetitionTest.kt
@@ -376,4 +376,96 @@ class CompetitionTest {
             assertThat(competition.isActiveAt(LocalDate.of(2025, 4, 15))).isFalse()
         }
     }
+
+    @Nested
+    @DisplayName("경기 규칙 업데이트")
+    inner class UpdateGameRules {
+        @Test
+        fun `기본 GameRules가 설정된다`() {
+            // given
+            val competition = createCompetition()
+
+            // then
+            assertThat(competition.gameRules.defaultInnings).isEqualTo(9)
+            assertThat(competition.gameRules.forfeitScore).isEqualTo(7)
+        }
+
+        @Test
+        fun `예정 상태의 대회는 규칙을 변경할 수 있다`() {
+            // given
+            val competition = createCompetition(status = CompetitionStatus.SCHEDULED)
+            val newRules = GameRules(defaultInnings = 7, forfeitScore = 9)
+
+            // when
+            competition.updateGameRules(newRules)
+
+            // then
+            assertThat(competition.gameRules.defaultInnings).isEqualTo(7)
+            assertThat(competition.gameRules.forfeitScore).isEqualTo(9)
+        }
+
+        @Test
+        fun `진행 중인 대회는 규칙을 변경할 수 없다`() {
+            // given
+            val competition = createCompetition(status = CompetitionStatus.IN_PROGRESS)
+            val newRules = GameRules(defaultInnings = 7)
+
+            // when & then
+            assertThatThrownBy { competition.updateGameRules(newRules) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("예정 상태")
+        }
+
+        @Test
+        fun `완료된 대회는 규칙을 변경할 수 없다`() {
+            // given
+            val competition = createCompetition(status = CompetitionStatus.COMPLETED)
+            val newRules = GameRules(defaultInnings = 7)
+
+            // when & then
+            assertThatThrownBy { competition.updateGameRules(newRules) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("예정 상태")
+        }
+
+        @Test
+        fun `취소된 대회는 규칙을 변경할 수 없다`() {
+            // given
+            val competition = createCompetition(status = CompetitionStatus.CANCELLED)
+            val newRules = GameRules(defaultInnings = 7)
+
+            // when & then
+            assertThatThrownBy { competition.updateGameRules(newRules) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("예정 상태")
+        }
+
+        @Test
+        fun `사용자 정의 GameRules로 대회를 생성할 수 있다`() {
+            // given
+            val customRules =
+                GameRules(
+                    defaultInnings = 7,
+                    mercyRuleEnabled = true,
+                    mercyRunDifference = 10,
+                    mercyMinimumInning = 5,
+                    forfeitScore = 9,
+                )
+            val competition =
+                Competition(
+                    league = league,
+                    name = "2025 사회인 대회",
+                    year = 2025,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    gameRules = customRules,
+                )
+
+            // then
+            assertThat(competition.gameRules.defaultInnings).isEqualTo(7)
+            assertThat(competition.gameRules.mercyRuleEnabled).isTrue()
+            assertThat(competition.gameRules.forfeitScore).isEqualTo(9)
+        }
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/GameRulesTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/GameRulesTest.kt
@@ -1,0 +1,327 @@
+package com.nextup.core.domain.competition
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("GameRules 값 객체 테스트")
+class GameRulesTest {
+    @Nested
+    @DisplayName("기본값 검증")
+    inner class DefaultValues {
+        @Test
+        fun `기본 GameRules는 9이닝 규칙을 따른다`() {
+            val rules = GameRules()
+
+            assertThat(rules.defaultInnings).isEqualTo(9)
+            assertThat(rules.mercyRuleEnabled).isFalse()
+            assertThat(rules.tiedGameResult).isEqualTo(TiedGameResult.DRAW)
+            assertThat(rules.tiebreakerEnabled).isFalse()
+            assertThat(rules.forfeitScore).isEqualTo(7)
+            assertThat(rules.starterWinQualificationOuts).isEqualTo(15)
+            assertThat(rules.qualificationPAMultiplier).isEqualTo(3.1)
+            assertThat(rules.qualificationIPMultiplier).isEqualTo(1.0)
+            assertThat(rules.timeLimitMinutes).isNull()
+            assertThat(rules.maxExtraInnings).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("기본 이닝 검증")
+    inner class DefaultInningsValidation {
+        @Test
+        fun `3이닝도 유효하다`() {
+            val rules = GameRules(defaultInnings = 3)
+
+            assertThat(rules.defaultInnings).isEqualTo(3)
+        }
+
+        @Test
+        fun `12이닝도 유효하다`() {
+            val rules = GameRules(defaultInnings = 12)
+
+            assertThat(rules.defaultInnings).isEqualTo(12)
+        }
+
+        @Test
+        fun `7이닝 단축 경기를 설정할 수 있다`() {
+            val rules = GameRules(defaultInnings = 7)
+
+            assertThat(rules.defaultInnings).isEqualTo(7)
+        }
+
+        @Test
+        fun `2이닝은 유효하지 않다`() {
+            assertThatThrownBy { GameRules(defaultInnings = 2) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("기본 이닝은 3~12 사이여야 합니다")
+        }
+
+        @Test
+        fun `13이닝은 유효하지 않다`() {
+            assertThatThrownBy { GameRules(defaultInnings = 13) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("기본 이닝은 3~12 사이여야 합니다")
+        }
+    }
+
+    @Nested
+    @DisplayName("몰수승 점수 검증")
+    inner class ForfeitScoreValidation {
+        @Test
+        fun `몰수승 점수를 사용자 정의할 수 있다`() {
+            val rules = GameRules(forfeitScore = 9)
+
+            assertThat(rules.forfeitScore).isEqualTo(9)
+        }
+
+        @Test
+        fun `몰수승 점수가 0이면 예외가 발생한다`() {
+            assertThatThrownBy { GameRules(forfeitScore = 0) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("몰수승 점수는 양수여야 합니다")
+        }
+
+        @Test
+        fun `몰수승 점수가 음수이면 예외가 발생한다`() {
+            assertThatThrownBy { GameRules(forfeitScore = -1) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("몰수승 점수는 양수여야 합니다")
+        }
+    }
+
+    @Nested
+    @DisplayName("콜드게임(머시 룰) 검증")
+    inner class MercyRuleValidation {
+        @Test
+        fun `콜드게임을 활성화할 수 있다`() {
+            val rules =
+                GameRules(
+                    mercyRuleEnabled = true,
+                    mercyRunDifference = 10,
+                    mercyMinimumInning = 5,
+                )
+
+            assertThat(rules.mercyRuleEnabled).isTrue()
+            assertThat(rules.mercyRunDifference).isEqualTo(10)
+            assertThat(rules.mercyMinimumInning).isEqualTo(5)
+        }
+
+        @Test
+        fun `콜드게임 활성화 시 득점 차이가 없으면 예외가 발생한다`() {
+            assertThatThrownBy {
+                GameRules(
+                    mercyRuleEnabled = true,
+                    mercyRunDifference = null,
+                    mercyMinimumInning = 5,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("득점 차이를 설정해야 합니다")
+        }
+
+        @Test
+        fun `콜드게임 활성화 시 최소 이닝이 없으면 예외가 발생한다`() {
+            assertThatThrownBy {
+                GameRules(
+                    mercyRuleEnabled = true,
+                    mercyRunDifference = 10,
+                    mercyMinimumInning = null,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("최소 이닝을 설정해야 합니다")
+        }
+
+        @Test
+        fun `콜드게임 득점 차이가 0이면 예외가 발생한다`() {
+            assertThatThrownBy {
+                GameRules(
+                    mercyRuleEnabled = true,
+                    mercyRunDifference = 0,
+                    mercyMinimumInning = 5,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("득점 차이는 양수여야 합니다")
+        }
+
+        @Test
+        fun `콜드게임 최소 이닝이 기본 이닝보다 크면 예외가 발생한다`() {
+            assertThatThrownBy {
+                GameRules(
+                    defaultInnings = 7,
+                    mercyRuleEnabled = true,
+                    mercyRunDifference = 10,
+                    mercyMinimumInning = 8,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("콜드게임 최소 이닝은 1 이상 기본 이닝")
+        }
+
+        @Test
+        fun `콜드게임 비활성화 시 관련 값이 null이어도 유효하다`() {
+            val rules =
+                GameRules(
+                    mercyRuleEnabled = false,
+                    mercyRunDifference = null,
+                    mercyMinimumInning = null,
+                )
+
+            assertThat(rules.mercyRuleEnabled).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("선발 승리 자격 검증")
+    inner class StarterWinQualificationValidation {
+        @Test
+        fun `선발 승리 자격 아웃 수를 사용자 정의할 수 있다`() {
+            // 5이닝(15아웃) 대신 4이닝(12아웃)으로 설정
+            val rules = GameRules(starterWinQualificationOuts = 12)
+
+            assertThat(rules.starterWinQualificationOuts).isEqualTo(12)
+        }
+
+        @Test
+        fun `선발 승리 자격 아웃 수가 0이면 예외가 발생한다`() {
+            assertThatThrownBy { GameRules(starterWinQualificationOuts = 0) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("선발 승리 자격 아웃 수는 양수여야 합니다")
+        }
+    }
+
+    @Nested
+    @DisplayName("규정 배수 검증")
+    inner class QualificationMultiplierValidation {
+        @Test
+        fun `규정 타석 배수를 사용자 정의할 수 있다`() {
+            val rules = GameRules(qualificationPAMultiplier = 2.7)
+
+            assertThat(rules.qualificationPAMultiplier).isEqualTo(2.7)
+        }
+
+        @Test
+        fun `규정 타석 배수가 0이면 예외가 발생한다`() {
+            assertThatThrownBy { GameRules(qualificationPAMultiplier = 0.0) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("규정 타석 배수는 양수여야 합니다")
+        }
+
+        @Test
+        fun `규정 이닝 배수가 0이면 예외가 발생한다`() {
+            assertThatThrownBy { GameRules(qualificationIPMultiplier = 0.0) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("규정 이닝 배수는 양수여야 합니다")
+        }
+    }
+
+    @Nested
+    @DisplayName("연장 이닝 설정")
+    inner class MaxExtraInningsValidation {
+        @Test
+        fun `최대 연장 이닝을 설정할 수 있다`() {
+            val rules = GameRules(maxExtraInnings = 2)
+
+            assertThat(rules.maxExtraInnings).isEqualTo(2)
+        }
+
+        @Test
+        fun `최대 연장 이닝이 0이면 예외가 발생한다`() {
+            assertThatThrownBy { GameRules(maxExtraInnings = 0) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("최대 연장 이닝 수는 양수여야 합니다")
+        }
+
+        @Test
+        fun `최대 연장 이닝을 null로 설정하면 무제한이다`() {
+            val rules = GameRules(maxExtraInnings = null)
+
+            assertThat(rules.maxExtraInnings).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("시간 제한 설정")
+    inner class TimeLimitValidation {
+        @Test
+        fun `시간 제한을 설정할 수 있다`() {
+            val rules = GameRules(timeLimitMinutes = 90)
+
+            assertThat(rules.timeLimitMinutes).isEqualTo(90)
+        }
+
+        @Test
+        fun `시간 제한이 0이면 예외가 발생한다`() {
+            assertThatThrownBy { GameRules(timeLimitMinutes = 0) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("시간 제한은 양수여야 합니다")
+        }
+
+        @Test
+        fun `시간 제한을 null로 설정하면 무제한이다`() {
+            val rules = GameRules(timeLimitMinutes = null)
+
+            assertThat(rules.timeLimitMinutes).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("동점 처리 설정")
+    inner class TiedGameResultSetting {
+        @Test
+        fun `무승부로 처리할 수 있다`() {
+            val rules = GameRules(tiedGameResult = TiedGameResult.DRAW)
+
+            assertThat(rules.tiedGameResult).isEqualTo(TiedGameResult.DRAW)
+        }
+
+        @Test
+        fun `타이브레이커로 처리할 수 있다`() {
+            val rules = GameRules(tiedGameResult = TiedGameResult.TIEBREAKER)
+
+            assertThat(rules.tiedGameResult).isEqualTo(TiedGameResult.TIEBREAKER)
+        }
+
+        @Test
+        fun `재경기로 처리할 수 있다`() {
+            val rules = GameRules(tiedGameResult = TiedGameResult.RESCHEDULE)
+
+            assertThat(rules.tiedGameResult).isEqualTo(TiedGameResult.RESCHEDULE)
+        }
+    }
+
+    @Nested
+    @DisplayName("사회인 야구 대표 규칙 설정")
+    inner class CommonAmateurBaseballRules {
+        @Test
+        fun `7이닝 단축 콜드게임 규칙을 설정할 수 있다`() {
+            val rules =
+                GameRules(
+                    defaultInnings = 7,
+                    mercyRuleEnabled = true,
+                    mercyRunDifference = 10,
+                    mercyMinimumInning = 5,
+                    forfeitScore = 9,
+                )
+
+            assertThat(rules.defaultInnings).isEqualTo(7)
+            assertThat(rules.mercyRuleEnabled).isTrue()
+            assertThat(rules.mercyRunDifference).isEqualTo(10)
+            assertThat(rules.mercyMinimumInning).isEqualTo(5)
+            assertThat(rules.forfeitScore).isEqualTo(9)
+        }
+
+        @Test
+        fun `시간 제한 있는 경기 규칙을 설정할 수 있다`() {
+            val rules =
+                GameRules(
+                    defaultInnings = 7,
+                    timeLimitMinutes = 100,
+                    maxExtraInnings = 1,
+                )
+
+            assertThat(rules.timeLimitMinutes).isEqualTo(100)
+            assertThat(rules.maxExtraInnings).isEqualTo(1)
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V022__add_game_rules_to_competitions.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V022__add_game_rules_to_competitions.sql
@@ -1,0 +1,17 @@
+-- #185: 사회인 야구 규칙 설정 체계(GameRules) 구축
+-- competitions 테이블에 경기 규칙 관련 컬럼 추가
+-- 기존 데이터 호환성을 위해 모든 컬럼에 DEFAULT 값 설정
+
+ALTER TABLE competitions
+    ADD COLUMN IF NOT EXISTS default_innings                  INT            NOT NULL DEFAULT 9,
+    ADD COLUMN IF NOT EXISTS mercy_rule_enabled               BOOLEAN        NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS mercy_run_difference             INT            NULL,
+    ADD COLUMN IF NOT EXISTS mercy_minimum_inning             INT            NULL,
+    ADD COLUMN IF NOT EXISTS max_extra_innings                INT            NULL,
+    ADD COLUMN IF NOT EXISTS tied_game_result                 VARCHAR(20)    NOT NULL DEFAULT 'DRAW',
+    ADD COLUMN IF NOT EXISTS tiebreaker_enabled               BOOLEAN        NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS forfeit_score                    INT            NOT NULL DEFAULT 7,
+    ADD COLUMN IF NOT EXISTS starter_win_qualification_outs   INT            NOT NULL DEFAULT 15,
+    ADD COLUMN IF NOT EXISTS qualification_pa_multiplier      DOUBLE PRECISION NOT NULL DEFAULT 3.1,
+    ADD COLUMN IF NOT EXISTS qualification_ip_multiplier      DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    ADD COLUMN IF NOT EXISTS time_limit_minutes               INT            NULL;


### PR DESCRIPTION
## Summary

>- close #185

사회인 야구 규칙을 대회(Competition) 단위로 설정할 수 있는 `GameRules` @Embeddable Value Object를 생성하고, 하드코딩된 규칙 값들을 설정 기반으로 변경합니다.

## Tasks

- [x] `GameRules` @Embeddable 생성 (이닝, 콜드게임, 연장전, 몰수승, 규정타석/이닝 등 12개 설정)
- [x] `TiedGameResult` enum 생성 (DRAW, TIEBREAKER, RESCHEDULE)
- [x] `Competition` 엔티티에 `@Embedded gameRules` 추가
- [x] `Game.forfeit()`에서 하드코딩된 점수를 `competition.gameRules.forfeitScore` 사용으로 변경
- [x] Competition 규칙 수정 불가 검증 (SCHEDULED 상태에서만 변경 허용)
- [x] Flyway V022 마이그레이션
- [x] GameRules 유효성 검증 테스트 + Competition 규칙 변경 테스트

## To Reviewer

- Phase 1 범위: 엔티티/설정 체계만 구축. Mercy Rule 자동 감지, 시간 제한 enforcement 등은 Phase 2
- 기존 기본값(9이닝, 15아웃 등) 유지하여 하위 호환성 보장
- V022 마이그레이션이 #179(Stats 테이블)과 충돌 가능 - 머지 시 번호 조정 필요