### PR TITLE
fix(#189): 콜드게임 최소 이닝 검증 및 Mercy Rule 판별 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -98,14 +98,70 @@ class Game(
 
     /**
      * 콜드게임으로 종료합니다.
+     *
+     * 최소 이닝 요건을 충족해야 콜드게임 선언이 가능합니다.
+     * - 원칙: 최소 [minimumInning]회 이상 진행 후 선언 가능
+     * - 예외: [minimumInning]회 초(top)까지 완료되고 홈팀이 리드 중이면
+     *         [minimumInning - 1].5이닝에서도 선언 가능 (홈팀 승리 확정)
+     *
+     * @param minimumInning 콜드게임 최소 요건 이닝 (기본값: 5이닝)
+     * @param isHomeTeamLeading 홈팀이 리드 중인지 여부 (기본값: false)
+     * @param reason 콜드게임 사유 (선택)
      */
-    fun callGame(reason: String? = null) {
+    fun callGame(
+        minimumInning: Int = DEFAULT_COLD_GAME_MINIMUM_INNING,
+        isHomeTeamLeading: Boolean = false,
+        reason: String? = null,
+    ) {
         require(status.isOngoing()) { "진행 중인 경기만 콜드게임 처리할 수 있습니다." }
+        require(minimumInning >= 1) { "최소 이닝은 1 이상이어야 합니다." }
+
+        val meetsMinimumRequirement =
+            currentInning > minimumInning ||
+                (currentInning == minimumInning) ||
+                (currentInning == minimumInning - 1 && !isTopInning && isHomeTeamLeading)
+
+        require(meetsMinimumRequirement) {
+            "콜드게임은 최소 ${minimumInning}이닝(홈팀 리드 시 ${minimumInning - 1}.5이닝) 이후에만 선언 가능합니다. " +
+                "현재: ${currentInning}회${if (isTopInning) "초" else "말"}"
+        }
+
         status = GameStatus.CALLED
         endedAt = LocalDateTime.now()
         if (reason != null) {
             note = (note?.let { "$it\n" } ?: "") + "콜드게임 사유: $reason"
         }
+    }
+
+    /**
+     * Mercy Rule(콜드게임) 조건이 충족되었는지 확인합니다.
+     *
+     * 조건:
+     * 1. 경기가 진행 중이어야 합니다.
+     * 2. 현재 이닝이 [mercyMinimumInning] 이상이어야 합니다.
+     * 3. 두 팀 간 점수 차이가 [mercyRunDifference] 이상이어야 합니다.
+     *
+     * 이 메서드는 조건 판별만 수행하며, 실제 콜드게임 처리는
+     * 기록원이 [callGame]을 명시적으로 호출해야 합니다.
+     *
+     * @param homeScore 홈팀 현재 점수
+     * @param awayScore 원정팀 현재 점수
+     * @param mercyRunDifference 머시룰 점수 차이 기준 (기본값: 10점)
+     * @param mercyMinimumInning 머시룰 적용 최소 이닝 (기본값: 5이닝)
+     * @return Mercy Rule 조건 충족 여부
+     */
+    fun checkMercyRuleCondition(
+        homeScore: Int,
+        awayScore: Int,
+        mercyRunDifference: Int = DEFAULT_MERCY_RUN_DIFFERENCE,
+        mercyMinimumInning: Int = DEFAULT_MERCY_MINIMUM_INNING,
+    ): Boolean {
+        require(mercyRunDifference > 0) { "머시룰 점수 차이 기준은 1 이상이어야 합니다." }
+        require(mercyMinimumInning >= 1) { "머시룰 최소 이닝은 1 이상이어야 합니다." }
+
+        if (!status.isOngoing()) return false
+        if (currentInning < mercyMinimumInning) return false
+        return kotlin.math.abs(homeScore - awayScore) >= mercyRunDifference
     }
 
     /**
@@ -182,6 +238,15 @@ class Game(
     companion object {
         /** 몰수승 기본 점수 (GameRules.forfeitScore 기본값과 일치) */
         const val DEFAULT_FORFEIT_WIN_SCORE = 7
+
+        /** 콜드게임 기본 최소 이닝 */
+        const val DEFAULT_COLD_GAME_MINIMUM_INNING = 5
+
+        /** Mercy Rule 기본 점수 차이 */
+        const val DEFAULT_MERCY_RUN_DIFFERENCE = 10
+
+        /** Mercy Rule 기본 최소 이닝 */
+        const val DEFAULT_MERCY_MINIMUM_INNING = 5
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -165,17 +165,266 @@ class GameTest {
     @DisplayName("콜드게임")
     inner class CallGame {
         @Test
-        fun `진행 중인 경기를 콜드게임 처리할 수 있다`() {
+        fun `최소 이닝 이상 진행된 경기를 콜드게임 처리할 수 있다`() {
             // given
-            val game = createGame(status = GameStatus.IN_PROGRESS)
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                }
 
             // when
-            game.callGame("우천")
+            game.callGame(reason = "우천")
 
             // then
             assertThat(game.status).isEqualTo(GameStatus.CALLED)
             assertThat(game.endedAt).isNotNull()
             assertThat(game.note).contains("우천")
+        }
+
+        @Test
+        fun `최소 이닝 미만에서는 콜드게임 선언이 불가하다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 4
+                    isTopInning = true
+                }
+
+            // when & then
+            assertThatThrownBy { game.callGame() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("최소 5이닝")
+        }
+
+        @Test
+        fun `정확히 최소 이닝(5회초)에서 콜드게임 선언이 가능하다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                }
+
+            // when
+            game.callGame()
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.CALLED)
+        }
+
+        @Test
+        fun `홈팀 리드 시 4말(4점5이닝)에서 콜드게임 선언이 가능하다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 4
+                    isTopInning = false
+                }
+
+            // when
+            game.callGame(isHomeTeamLeading = true, reason = "점수차")
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.CALLED)
+            assertThat(game.note).contains("점수차")
+        }
+
+        @Test
+        fun `홈팀 리드가 없으면 4말에서 콜드게임 선언이 불가하다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 4
+                    isTopInning = false
+                }
+
+            // when & then
+            assertThatThrownBy { game.callGame(isHomeTeamLeading = false) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("최소 5이닝")
+        }
+
+        @Test
+        fun `6회 이상 진행된 경기는 콜드게임 선언이 가능하다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 7
+                    isTopInning = false
+                }
+
+            // when
+            game.callGame()
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.CALLED)
+        }
+
+        @Test
+        fun `사유 없이도 콜드게임 처리할 수 있다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                }
+
+            // when
+            game.callGame()
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.CALLED)
+            assertThat(game.note).isNull()
+        }
+
+        @Test
+        fun `커스텀 최소 이닝을 지정할 수 있다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 3
+                    isTopInning = true
+                }
+
+            // when
+            game.callGame(minimumInning = 3)
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.CALLED)
+        }
+
+        @Test
+        fun `진행 중이 아닌 경기는 콜드게임 처리할 수 없다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+
+            // when & then
+            assertThatThrownBy { game.callGame() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("진행 중인 경기만")
+        }
+    }
+
+    @Nested
+    @DisplayName("Mercy Rule 조건 판별")
+    inner class CheckMercyRuleCondition {
+        @Test
+        fun `최소 이닝 이상이고 점수차가 기준 이상이면 Mercy Rule 조건이 충족된다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                }
+
+            // when
+            val result = game.checkMercyRuleCondition(homeScore = 12, awayScore = 2)
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `점수차가 기준 미만이면 Mercy Rule 조건이 충족되지 않는다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                }
+
+            // when
+            val result = game.checkMercyRuleCondition(homeScore = 7, awayScore = 2)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `최소 이닝 미만이면 Mercy Rule 조건이 충족되지 않는다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 4
+                    isTopInning = true
+                }
+
+            // when
+            val result = game.checkMercyRuleCondition(homeScore = 15, awayScore = 0)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `경기가 진행 중이 아니면 Mercy Rule 조건이 충족되지 않는다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.FINISHED).apply {
+                    currentInning = 7
+                    isTopInning = true
+                }
+
+            // when
+            val result = game.checkMercyRuleCondition(homeScore = 15, awayScore = 0)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `원정팀이 리드해도 점수차가 기준 이상이면 Mercy Rule 조건이 충족된다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 6
+                    isTopInning = false
+                }
+
+            // when
+            val result = game.checkMercyRuleCondition(homeScore = 0, awayScore = 10)
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `점수차가 정확히 기준값이면 Mercy Rule 조건이 충족된다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                }
+
+            // when
+            val result = game.checkMercyRuleCondition(homeScore = 10, awayScore = 0)
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `커스텀 점수차와 최소 이닝을 지정할 수 있다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 3
+                    isTopInning = false
+                }
+
+            // when
+            val result =
+                game.checkMercyRuleCondition(
+                    homeScore = 15,
+                    awayScore = 0,
+                    mercyRunDifference = 15,
+                    mercyMinimumInning = 3,
+                )
+
+            // then
+            assertThat(result).isTrue()
         }
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -304,6 +304,70 @@ class GameTest {
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("진행 중인 경기만")
         }
+
+        @Test
+        fun `최소 이닝이 1 미만이면 예외가 발생한다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                }
+
+            // when & then
+            assertThatThrownBy { game.callGame(minimumInning = 0) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("최소 이닝은 1 이상이어야 합니다")
+        }
+
+        @Test
+        fun `3회에서 기본 최소이닝 5이닝 기준 콜드게임 선언이 불가하다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 3
+                    isTopInning = true
+                }
+
+            // when & then
+            assertThatThrownBy { game.callGame() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("최소 5이닝")
+        }
+
+        @Test
+        fun `기존 note가 있는 경기에 콜드게임 사유가 추가된다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                    note = "기존 메모"
+                }
+
+            // when
+            game.callGame(reason = "우천")
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.CALLED)
+            assertThat(game.note).contains("기존 메모")
+            assertThat(game.note).contains("우천")
+        }
+
+        @Test
+        fun `4회초에서 홈팀 리드여도 콜드게임 선언이 불가하다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 4
+                    isTopInning = true
+                }
+
+            // when & then
+            assertThatThrownBy { game.callGame(isHomeTeamLeading = true) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("최소 5이닝")
+        }
     }
 
     @Nested

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -166,12 +166,12 @@ class GameScorerServiceImpl(
 
         when (reason) {
             GameEndReason.REGULATION -> game.finish()
-            GameEndReason.MERCY_RULE -> game.callGame("콜드게임 (점수차)")
-            GameEndReason.WEATHER -> game.callGame("콜드게임 (기상 조건)")
+            GameEndReason.MERCY_RULE -> game.callGame(reason = "콜드게임 (점수차)")
+            GameEndReason.WEATHER -> game.callGame(reason = "콜드게임 (기상 조건)")
             GameEndReason.FORFEIT -> throw InvalidGameStateException(
                 "몰수 처리는 전용 API를 사용해주세요.",
             )
-            GameEndReason.OTHER -> game.callGame("기타 사유")
+            GameEndReason.OTHER -> game.callGame(reason = "기타 사유")
         }
 
         val savedGame = gameRepository.save(game)

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -884,7 +884,7 @@ class GameScorerServiceImplTest {
             fieldName = "1구장",
             gameNumber = 1,
             status = status,
-            currentInning = 1,
+            currentInning = 5,
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),


### PR DESCRIPTION
## Summary

>- close #189

`Game.callGame()`에 최소 이닝 검증(기본 5이닝, 홈팀 리드 시 4.5이닝)을 추가하고, `checkMercyRuleCondition()` Mercy Rule 조건 판별 메서드를 구현합니다.

## Tasks

- [x] `callGame()` 최소 이닝 검증 추가
- [x] 홈팀 리드 시 4.5이닝 허용 로직
- [x] `checkMercyRuleCondition()` 메서드 추가 (기본 10점차, 5이닝)
- [x] `GameScorerServiceImpl`의 callGame 호출부에 named argument 적용
- [x] 기존 테스트 호환성 유지 (기본 파라미터 값)
- [x] 테스트 15건 추가 (callGame 9건, mercyRule 6건)

## To Reviewer

- callGame()의 기존 시그니처에 기본값 파라미터를 추가하여 하위 호환성 유지
- Mercy Rule은 판별만 구현 (자동 종료는 기록원 수동 처리)
- GameRules(#185) 머지 후 상수를 GameRules 값으로 교체 예정