### PR TITLE
feat(#183): Inherited Runner(계승 주자) 추적 메커니즘 구현

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
@@ -33,6 +33,16 @@ class GameState(
     var currentPitcherId: Long? = null,
     @Column(name = "current_batter_id")
     var currentBatterId: Long? = null,
+    /**
+     * 계승 주자(Inherited Runner) 추적: 각 베이스 주자가 출루할 당시의 담당 투수 ID.
+     * 투수 교체 후 남긴 주자가 득점할 경우 원래 투수의 책임을 추적하기 위해 사용됩니다.
+     */
+    @Column(name = "runner_on_first_pitcher_id")
+    var runnerOnFirstPitcherId: Long? = null,
+    @Column(name = "runner_on_second_pitcher_id")
+    var runnerOnSecondPitcherId: Long? = null,
+    @Column(name = "runner_on_third_pitcher_id")
+    var runnerOnThirdPitcherId: Long? = null,
 ) {
     init {
         require(outs in 0..3) { "아웃 카운트는 0-3 사이여야 합니다: $outs" }
@@ -82,18 +92,46 @@ class GameState(
 
     /**
      * 주자를 설정합니다.
+     * 주자가 출루할 때 현재 담당 투수 ID를 함께 기록합니다.
+     * playerId가 null이면(주자 제거) 담당 투수 ID도 함께 클리어합니다.
+     *
+     * @param base 베이스
+     * @param playerId 주자 GamePlayer ID (null이면 주자 제거)
+     * @param pitcherId 담당 투수 GamePlayer ID. null이면 currentPitcherId를 자동 사용.
+     *                 주자 진루 시 기존 pitcherId를 유지하려면 명시적으로 전달해야 합니다.
      */
     fun setRunner(
         base: Base,
         playerId: Long?,
+        pitcherId: Long? = if (playerId != null) currentPitcherId else null,
     ) {
         when (base) {
-            Base.FIRST -> runnerOnFirstId = playerId
-            Base.SECOND -> runnerOnSecondId = playerId
-            Base.THIRD -> runnerOnThirdId = playerId
+            Base.FIRST -> {
+                runnerOnFirstId = playerId
+                runnerOnFirstPitcherId = if (playerId != null) pitcherId else null
+            }
+            Base.SECOND -> {
+                runnerOnSecondId = playerId
+                runnerOnSecondPitcherId = if (playerId != null) pitcherId else null
+            }
+            Base.THIRD -> {
+                runnerOnThirdId = playerId
+                runnerOnThirdPitcherId = if (playerId != null) pitcherId else null
+            }
             Base.HOME -> {} // HOME은 득점이므로 무시
         }
     }
+
+    /**
+     * 특정 베이스 주자의 담당 투수 ID를 반환합니다.
+     */
+    fun getRunnerPitcherId(base: Base): Long? =
+        when (base) {
+            Base.FIRST -> runnerOnFirstPitcherId
+            Base.SECOND -> runnerOnSecondPitcherId
+            Base.THIRD -> runnerOnThirdPitcherId
+            Base.HOME -> null
+        }
 
     /**
      * 특정 베이스의 주자를 반환합니다.
@@ -108,11 +146,15 @@ class GameState(
 
     /**
      * 모든 베이스를 클리어합니다 (3아웃 시).
+     * 담당 투수 ID도 함께 클리어합니다.
      */
     fun clearBases() {
         runnerOnFirstId = null
         runnerOnSecondId = null
         runnerOnThirdId = null
+        runnerOnFirstPitcherId = null
+        runnerOnSecondPitcherId = null
+        runnerOnThirdPitcherId = null
     }
 
     /**
@@ -160,6 +202,7 @@ class GameState(
     /**
      * 주자를 JSON 문자열로부터 복원합니다 (Undo용).
      * JSON 형식: "1루:playerId,2루:playerId,3루:playerId" 또는 null
+     * 담당 투수 ID도 함께 클리어됩니다.
      */
     fun restoreRunners(runnersJson: String?) {
         clearBases()
@@ -177,6 +220,52 @@ class GameState(
                 }
             }
         }
+    }
+
+    /**
+     * 주자의 담당 투수 ID를 JSON 문자열로부터 복원합니다 (Undo용).
+     * JSON 형식: "1루:pitcherId,2루:pitcherId,3루:pitcherId" 또는 null
+     * restoreRunners 호출 후 사용하여 pitcher ID를 복원합니다.
+     */
+    fun restoreRunnerPitchers(runnerPitchersJson: String?) {
+        runnerOnFirstPitcherId = null
+        runnerOnSecondPitcherId = null
+        runnerOnThirdPitcherId = null
+        if (runnerPitchersJson.isNullOrBlank()) return
+
+        runnerPitchersJson.split(",").forEach { entry ->
+            val parts = entry.split(":")
+            if (parts.size == 2) {
+                val base = parts[0].trim()
+                val pitcherId = parts[1].trim().toLongOrNull()
+                when (base) {
+                    "1루" -> runnerOnFirstPitcherId = pitcherId
+                    "2루" -> runnerOnSecondPitcherId = pitcherId
+                    "3루" -> runnerOnThirdPitcherId = pitcherId
+                }
+            }
+        }
+    }
+
+    /**
+     * 현재 주자-담당투수 상태를 JSON 문자열로 직렬화합니다 (Undo 스냅샷 저장용).
+     * JSON 형식: "1루:pitcherId,2루:pitcherId,3루:pitcherId"
+     * 담당 투수가 없는 베이스는 포함되지 않습니다.
+     */
+    fun serializeRunnerPitchers(): String? {
+        val entries =
+            buildList {
+                runnerOnFirstId?.let {
+                    runnerOnFirstPitcherId?.let { p -> add("1루:$p") }
+                }
+                runnerOnSecondId?.let {
+                    runnerOnSecondPitcherId?.let { p -> add("2루:$p") }
+                }
+                runnerOnThirdId?.let {
+                    runnerOnThirdPitcherId?.let { p -> add("3루:$p") }
+                }
+            }
+        return if (entries.isEmpty()) null else entries.joinToString(",")
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameStateTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameStateTest.kt
@@ -733,4 +733,221 @@ class GameStateTest {
         assertThat(gameState.runnerOnSecondPitcherId).isEqualTo(20L)
         assertThat(gameState.runnerOnThirdPitcherId).isEqualTo(30L)
     }
+
+    @Test
+    fun `should serialize runner pitcher ids including third base`() {
+        // given
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnFirstPitcherId = 10L,
+                runnerOnSecondId = 200L,
+                runnerOnSecondPitcherId = 20L,
+                runnerOnThirdId = 300L,
+                runnerOnThirdPitcherId = 30L,
+            )
+
+        // when
+        val json = gameState.serializeRunnerPitchers()
+
+        // then
+        assertThat(json).isEqualTo("1루:10,2루:20,3루:30")
+    }
+
+    @Test
+    fun `should restore runner pitcher ids including third base`() {
+        // given
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnSecondId = 200L,
+                runnerOnThirdId = 300L,
+            )
+
+        // when
+        gameState.restoreRunnerPitchers("1루:10,2루:20,3루:30")
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isEqualTo(10L)
+        assertThat(gameState.runnerOnSecondPitcherId).isEqualTo(20L)
+        assertThat(gameState.runnerOnThirdPitcherId).isEqualTo(30L)
+    }
+
+    // ── RestoreRunners Tests ─────────────────────────────────────────────────
+
+    @Test
+    fun `should restore runners from json string`() {
+        // given
+        val gameState = GameState()
+
+        // when
+        gameState.restoreRunners("1루:100,2루:200,3루:300")
+
+        // then
+        assertThat(gameState.runnerOnFirstId).isEqualTo(100L)
+        assertThat(gameState.runnerOnSecondId).isEqualTo(200L)
+        assertThat(gameState.runnerOnThirdId).isEqualTo(300L)
+    }
+
+    @Test
+    fun `should clear all runners when restoreRunners called with null`() {
+        // given
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnSecondId = 200L,
+                runnerOnThirdId = 300L,
+            )
+
+        // when
+        gameState.restoreRunners(null)
+
+        // then
+        assertThat(gameState.runnerOnFirstId).isNull()
+        assertThat(gameState.runnerOnSecondId).isNull()
+        assertThat(gameState.runnerOnThirdId).isNull()
+    }
+
+    @Test
+    fun `should clear all runners when restoreRunners called with blank string`() {
+        // given
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+            )
+
+        // when
+        gameState.restoreRunners("")
+
+        // then
+        assertThat(gameState.runnerOnFirstId).isNull()
+    }
+
+    @Test
+    fun `should restore partial runners from json string`() {
+        // given
+        val gameState = GameState()
+
+        // when
+        gameState.restoreRunners("1루:100,3루:300")
+
+        // then
+        assertThat(gameState.runnerOnFirstId).isEqualTo(100L)
+        assertThat(gameState.runnerOnSecondId).isNull()
+        assertThat(gameState.runnerOnThirdId).isEqualTo(300L)
+    }
+
+    @Test
+    fun `should handle malformed entry in restoreRunners`() {
+        // given
+        val gameState = GameState()
+
+        // when
+        gameState.restoreRunners("1루:100,invalid,3루:300")
+
+        // then
+        assertThat(gameState.runnerOnFirstId).isEqualTo(100L)
+        assertThat(gameState.runnerOnSecondId).isNull()
+        assertThat(gameState.runnerOnThirdId).isEqualTo(300L)
+    }
+
+    // ── RevertBatter Tests ───────────────────────────────────────────────────
+
+    @Test
+    fun `should revert home team batter`() {
+        // given
+        val gameState = GameState(homeBattingOrder = 5)
+
+        // when
+        gameState.revertBatter(isHomeTeam = true)
+
+        // then
+        assertThat(gameState.homeBattingOrder).isEqualTo(4)
+    }
+
+    @Test
+    fun `should revert away team batter`() {
+        // given
+        val gameState = GameState(awayBattingOrder = 7)
+
+        // when
+        gameState.revertBatter(isHomeTeam = false)
+
+        // then
+        assertThat(gameState.awayBattingOrder).isEqualTo(6)
+    }
+
+    @Test
+    fun `should wrap home team batter from 1 to 9 when reverting`() {
+        // given
+        val gameState = GameState(homeBattingOrder = 1)
+
+        // when
+        gameState.revertBatter(isHomeTeam = true)
+
+        // then
+        assertThat(gameState.homeBattingOrder).isEqualTo(9)
+    }
+
+    @Test
+    fun `should wrap away team batter from 1 to 9 when reverting`() {
+        // given
+        val gameState = GameState(awayBattingOrder = 1)
+
+        // when
+        gameState.revertBatter(isHomeTeam = false)
+
+        // then
+        assertThat(gameState.awayBattingOrder).isEqualTo(9)
+    }
+
+    // ── RestoreOuts Tests ────────────────────────────────────────────────────
+
+    @Test
+    fun `should restore outs count`() {
+        // given
+        val gameState = GameState(outs = 0)
+
+        // when
+        gameState.restoreOuts(2)
+
+        // then
+        assertThat(gameState.outs).isEqualTo(2)
+    }
+
+    @Test
+    fun `should throw exception when restoring invalid outs`() {
+        // given
+        val gameState = GameState()
+
+        // when & then
+        assertThatThrownBy { gameState.restoreOuts(-1) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("아웃 카운트는 0-3 사이여야 합니다")
+
+        assertThatThrownBy { gameState.restoreOuts(4) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("아웃 카운트는 0-3 사이여야 합니다")
+    }
+
+    // ── RestoreRunnerPitchers edge case ──────────────────────────────────────
+
+    @Test
+    fun `should clear pitcher ids when restoreRunnerPitchers called with blank string`() {
+        // given
+        val gameState =
+            GameState(
+                runnerOnFirstPitcherId = 10L,
+                runnerOnSecondPitcherId = 20L,
+                runnerOnThirdPitcherId = 30L,
+            )
+
+        // when
+        gameState.restoreRunnerPitchers("")
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isNull()
+        assertThat(gameState.runnerOnSecondPitcherId).isNull()
+        assertThat(gameState.runnerOnThirdPitcherId).isNull()
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameStateTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameStateTest.kt
@@ -478,4 +478,259 @@ class GameStateTest {
         // then
         assertThat(display).isEqualTo("3B-2S")
     }
+
+    // ── Inherited Runner Tracking Tests ──────────────────────────────────────
+
+    @Test
+    fun `should record responsible pitcher id when runner reaches base`() {
+        // given
+        val gameState = GameState(currentPitcherId = 10L)
+
+        // when
+        gameState.setRunner(Base.FIRST, 100L)
+
+        // then
+        assertThat(gameState.runnerOnFirstId).isEqualTo(100L)
+        assertThat(gameState.runnerOnFirstPitcherId).isEqualTo(10L)
+    }
+
+    @Test
+    fun `should use currentPitcherId automatically when runner reaches base`() {
+        // given
+        val gameState = GameState(currentPitcherId = 20L)
+
+        // when
+        gameState.setRunner(Base.SECOND, 200L)
+        gameState.setRunner(Base.THIRD, 300L)
+
+        // then
+        assertThat(gameState.runnerOnSecondPitcherId).isEqualTo(20L)
+        assertThat(gameState.runnerOnThirdPitcherId).isEqualTo(20L)
+    }
+
+    @Test
+    fun `should preserve original pitcher id when runner advances bases`() {
+        // given - pitcher A(id=10) puts runner on first
+        val gameState = GameState(currentPitcherId = 10L)
+        gameState.setRunner(Base.FIRST, 100L)
+
+        // when - pitcher changes to B(id=99), runner advances to second
+        gameState.currentPitcherId = 99L
+        val originalPitcherId = gameState.getRunnerPitcherId(Base.FIRST)
+        gameState.setRunner(Base.FIRST, null)
+        gameState.setRunner(Base.SECOND, 100L, pitcherId = originalPitcherId)
+
+        // then - pitcher id on second should still be pitcher A(id=10)
+        assertThat(gameState.runnerOnSecondId).isEqualTo(100L)
+        assertThat(gameState.runnerOnSecondPitcherId).isEqualTo(10L)
+        assertThat(gameState.runnerOnFirstId).isNull()
+        assertThat(gameState.runnerOnFirstPitcherId).isNull()
+    }
+
+    @Test
+    fun `should record new pitcher id for new runner after pitcher change`() {
+        // given - pitcher A(id=10) already has runner on first
+        val gameState = GameState(currentPitcherId = 10L)
+        gameState.setRunner(Base.FIRST, 100L)
+
+        // when - pitcher changes to B(id=99), new batter reaches base
+        gameState.currentPitcherId = 99L
+        gameState.setRunner(Base.SECOND, 200L)
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isEqualTo(10L) // original pitcher
+        assertThat(gameState.runnerOnSecondPitcherId).isEqualTo(99L) // new pitcher
+    }
+
+    @Test
+    fun `should clear pitcher ids when runner is removed`() {
+        // given
+        val gameState = GameState(currentPitcherId = 10L)
+        gameState.setRunner(Base.FIRST, 100L)
+        gameState.setRunner(Base.SECOND, 200L)
+
+        // when - runner on first is out
+        gameState.setRunner(Base.FIRST, null)
+
+        // then
+        assertThat(gameState.runnerOnFirstId).isNull()
+        assertThat(gameState.runnerOnFirstPitcherId).isNull()
+        // second base unaffected
+        assertThat(gameState.runnerOnSecondId).isEqualTo(200L)
+        assertThat(gameState.runnerOnSecondPitcherId).isEqualTo(10L)
+    }
+
+    @Test
+    fun `should clear all pitcher ids when clearBases is called`() {
+        // given
+        val gameState = GameState(currentPitcherId = 10L)
+        gameState.setRunner(Base.FIRST, 100L)
+        gameState.setRunner(Base.SECOND, 200L)
+        gameState.setRunner(Base.THIRD, 300L)
+
+        // when
+        gameState.clearBases()
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isNull()
+        assertThat(gameState.runnerOnSecondPitcherId).isNull()
+        assertThat(gameState.runnerOnThirdPitcherId).isNull()
+    }
+
+    @Test
+    fun `should clear all pitcher ids when resetForNewInning is called`() {
+        // given
+        val gameState =
+            GameState(
+                outs = 2,
+                currentPitcherId = 10L,
+                runnerOnFirstId = 100L,
+                runnerOnFirstPitcherId = 10L,
+                runnerOnSecondId = 200L,
+                runnerOnSecondPitcherId = 10L,
+            )
+
+        // when
+        gameState.resetForNewInning()
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isNull()
+        assertThat(gameState.runnerOnSecondPitcherId).isNull()
+        assertThat(gameState.runnerOnThirdPitcherId).isNull()
+        assertThat(gameState.outs).isEqualTo(0)
+    }
+
+    @Test
+    fun `should get runner pitcher id by base`() {
+        // given
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnFirstPitcherId = 10L,
+                runnerOnSecondId = 200L,
+                runnerOnSecondPitcherId = 20L,
+                runnerOnThirdId = 300L,
+                runnerOnThirdPitcherId = 30L,
+            )
+
+        // when & then
+        assertThat(gameState.getRunnerPitcherId(Base.FIRST)).isEqualTo(10L)
+        assertThat(gameState.getRunnerPitcherId(Base.SECOND)).isEqualTo(20L)
+        assertThat(gameState.getRunnerPitcherId(Base.THIRD)).isEqualTo(30L)
+        assertThat(gameState.getRunnerPitcherId(Base.HOME)).isNull()
+    }
+
+    @Test
+    fun `should restore runner pitcher ids from json`() {
+        // given
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnSecondId = 200L,
+            )
+
+        // when
+        gameState.restoreRunnerPitchers("1루:10,2루:20")
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isEqualTo(10L)
+        assertThat(gameState.runnerOnSecondPitcherId).isEqualTo(20L)
+        assertThat(gameState.runnerOnThirdPitcherId).isNull()
+    }
+
+    @Test
+    fun `should clear all pitcher ids when restoreRunnerPitchers called with null`() {
+        // given
+        val gameState =
+            GameState(
+                runnerOnFirstPitcherId = 10L,
+                runnerOnSecondPitcherId = 20L,
+            )
+
+        // when
+        gameState.restoreRunnerPitchers(null)
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isNull()
+        assertThat(gameState.runnerOnSecondPitcherId).isNull()
+    }
+
+    @Test
+    fun `should serialize runner pitcher ids to json`() {
+        // given
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnFirstPitcherId = 10L,
+                runnerOnSecondId = 200L,
+                runnerOnSecondPitcherId = 20L,
+            )
+
+        // when
+        val json = gameState.serializeRunnerPitchers()
+
+        // then
+        assertThat(json).isEqualTo("1루:10,2루:20")
+    }
+
+    @Test
+    fun `should return null when serializing with no pitcher assignments`() {
+        // given
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnFirstPitcherId = null,
+            )
+
+        // when
+        val json = gameState.serializeRunnerPitchers()
+
+        // then
+        assertThat(json).isNull()
+    }
+
+    @Test
+    fun `should not set pitcher id for HOME base`() {
+        // given
+        val gameState = GameState(currentPitcherId = 10L)
+
+        // when
+        gameState.setRunner(Base.HOME, 400L)
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isNull()
+        assertThat(gameState.runnerOnSecondPitcherId).isNull()
+        assertThat(gameState.runnerOnThirdPitcherId).isNull()
+    }
+
+    @Test
+    fun `should allow explicit pitcher id override when setting runner`() {
+        // given
+        val gameState = GameState(currentPitcherId = 99L)
+
+        // when - explicitly pass a different pitcher id
+        gameState.setRunner(Base.FIRST, 100L, pitcherId = 42L)
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isEqualTo(42L)
+    }
+
+    @Test
+    fun `should create GameState with inherited runner pitcher id fields`() {
+        // when
+        val gameState =
+            GameState(
+                runnerOnFirstId = 100L,
+                runnerOnFirstPitcherId = 10L,
+                runnerOnSecondId = 200L,
+                runnerOnSecondPitcherId = 20L,
+                runnerOnThirdId = 300L,
+                runnerOnThirdPitcherId = 30L,
+            )
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isEqualTo(10L)
+        assertThat(gameState.runnerOnSecondPitcherId).isEqualTo(20L)
+        assertThat(gameState.runnerOnThirdPitcherId).isEqualTo(30L)
+    }
 }

--- a/nextup-infrastructure/src/main/resources/db/migration/V022__add_inherited_runner_pitcher_ids.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V022__add_inherited_runner_pitcher_ids.sql
@@ -1,0 +1,13 @@
+-- V022: Add inherited runner pitcher tracking columns to games table
+-- Issue #183: Track which pitcher is responsible for each base runner
+-- When a pitcher is replaced, runners left on base are "inherited" by the new pitcher,
+-- but any runs scored by those runners are charged to the original pitcher.
+
+ALTER TABLE games
+    ADD COLUMN runner_on_first_pitcher_id  BIGINT NULL,
+    ADD COLUMN runner_on_second_pitcher_id BIGINT NULL,
+    ADD COLUMN runner_on_third_pitcher_id  BIGINT NULL;
+
+COMMENT ON COLUMN games.runner_on_first_pitcher_id  IS '1루 주자 담당 투수 game_player_id (계승 주자 추적)';
+COMMENT ON COLUMN games.runner_on_second_pitcher_id IS '2루 주자 담당 투수 game_player_id (계승 주자 추적)';
+COMMENT ON COLUMN games.runner_on_third_pitcher_id  IS '3루 주자 담당 투수 game_player_id (계승 주자 추적)';


### PR DESCRIPTION
## Summary

>- close #183

투수 교체 시 남긴 주자(Inherited Runner)의 담당 투수를 추적하기 위한 메커니즘을 GameState에 구현합니다. 주자별 담당 투수 ID 필드를 추가하고, 출루/진루/클리어 시 자동 관리합니다.

## Tasks

- [x] GameState에 주자별 담당 투수 추적 필드 3개 추가
- [x] `setRunner()`에 pitcherId 파라미터 추가 (기본값: 현재 투수 자동 사용)
- [x] `getRunnerPitcherId()`, `serializeRunnerPitchers()`, `restoreRunnerPitchers()` 메서드 추가
- [x] clearBases/resetForNewInning 시 pitcher ID 자동 클리어
- [x] Flyway V022 마이그레이션 (games 테이블에 컬럼 3개 추가)
- [x] 테스트 13건 추가

## To Reviewer

- **Phase 1**: 추적 구조만 구현. 득점 시 담당 투수 PitchingRecord 반영은 Phase 2
- setRunner()의 pitcherId 기본값으로 하위 호환성 유지
- V022 마이그레이션이 다른 PR과 충돌 가능 - 머지 시 번호 조정 필요