### PR TITLE
fix(#226): IndividualRankingService N+1 쿼리 개선

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamMemberRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamMemberRepositoryPort.kt
@@ -59,6 +59,8 @@ interface TeamMemberRepositoryPort {
 
     fun findByPlayerIdActive(playerId: Long): List<TeamMember>
 
+    fun findByPlayerIdsActive(playerIds: List<Long>): List<TeamMember>
+
     fun countByTeamIdAndStatus(
         teamId: Long,
         status: TeamMemberStatus,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepository.kt
@@ -75,6 +75,9 @@ interface TeamMemberRepository : JpaRepository<TeamMember, Long> {
     @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.player.id = :playerId AND tm.status = 'ACTIVE'")
     fun findByPlayerIdActive(playerId: Long): List<TeamMember>
 
+    @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.player.id IN :playerIds AND tm.status = 'ACTIVE'")
+    fun findByPlayerIdsActive(playerIds: List<Long>): List<TeamMember>
+
     @Query("SELECT COUNT(tm) FROM TeamMember tm WHERE tm.team.id = :teamId AND tm.status = :status")
     fun countByTeamIdAndStatus(
         teamId: Long,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapter.kt
@@ -69,6 +69,11 @@ class TeamMemberRepositoryAdapter(
 
     override fun findByPlayerIdActive(playerId: Long): List<TeamMember> = jpaRepository.findByPlayerIdActive(playerId)
 
+    override fun findByPlayerIdsActive(playerIds: List<Long>): List<TeamMember> {
+        if (playerIds.isEmpty()) return emptyList()
+        return jpaRepository.findByPlayerIdsActive(playerIds)
+    }
+
     override fun countByTeamIdAndStatus(
         teamId: Long,
         status: TeamMemberStatus,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/IndividualRankingServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/IndividualRankingServiceImpl.kt
@@ -66,8 +66,10 @@ class IndividualRankingServiceImpl(
                     seasonBattingStatsRepository.findTopByStolenBases(year, limit)
             }
 
+        val teamNameMap = resolveTeamNames(stats.map { it.player.id })
+
         return stats.mapIndexed { index, stat ->
-            stat.toBattingLeaderDto(index + 1, category)
+            stat.toBattingLeaderDto(index + 1, category, teamNameMap)
         }
     }
 
@@ -97,16 +99,19 @@ class IndividualRankingServiceImpl(
                     seasonPitchingStatsRepository.findTopByStrikeouts(year, limit)
             }
 
+        val teamNameMap = resolveTeamNames(stats.map { it.player.id })
+
         return stats.mapIndexed { index, stat ->
-            stat.toPitchingLeaderDto(index + 1, category)
+            stat.toPitchingLeaderDto(index + 1, category, teamNameMap)
         }
     }
 
     private fun SeasonBattingStats.toBattingLeaderDto(
         rank: Int,
         category: BattingCategory,
+        teamNameMap: Map<Long, String>,
     ): BattingLeaderDto {
-        val teamName = resolveTeamName(this.player.id)
+        val teamName = teamNameMap[this.player.id] ?: "-"
         val value =
             when (category) {
                 BattingCategory.BATTING_AVG -> this.battingAverage.toDouble()
@@ -132,8 +137,9 @@ class IndividualRankingServiceImpl(
     private fun SeasonPitchingStats.toPitchingLeaderDto(
         rank: Int,
         category: PitchingCategory,
+        teamNameMap: Map<Long, String>,
     ): PitchingLeaderDto {
-        val teamName = resolveTeamName(this.player.id)
+        val teamName = teamNameMap[this.player.id] ?: "-"
         val value =
             when (category) {
                 PitchingCategory.ERA -> this.earnedRunAverage?.toDouble() ?: Double.MAX_VALUE
@@ -153,8 +159,17 @@ class IndividualRankingServiceImpl(
         )
     }
 
-    private fun resolveTeamName(playerId: Long): String {
-        val members = teamMemberRepository.findByPlayerIdActive(playerId)
-        return members.firstOrNull()?.team?.name ?: "-"
+    /**
+     * 선수 ID 목록에 대한 활성 팀명을 한 번의 IN 쿼리로 일괄 조회한다.
+     * N+1 문제 방지: 랭킹 리스트 크기와 무관하게 단 1번의 쿼리만 실행된다.
+     *
+     * @param playerIds 조회할 선수 ID 목록
+     * @return 선수 ID -> 팀명 맵 (활성 팀이 없으면 해당 ID 없음)
+     */
+    private fun resolveTeamNames(playerIds: List<Long>): Map<Long, String> {
+        if (playerIds.isEmpty()) return emptyMap()
+        return teamMemberRepository.findByPlayerIdsActive(playerIds)
+            .groupBy { it.player.id }
+            .mapValues { (_, members) -> members.first().team.name }
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapterTest.kt
@@ -269,6 +269,33 @@ class TeamMemberRepositoryAdapterTest {
     }
 
     @Test
+    @DisplayName("findByPlayerIdsActive - 선수 ID 목록으로 활성 멤버 일괄 조회 시 JPA repository에 위임한다")
+    fun `should delegate findByPlayerIdsActive to jpa repository`() {
+        // given
+        val members = listOf(mockk<TeamMember>(), mockk<TeamMember>())
+        every { jpaRepository.findByPlayerIdsActive(listOf(10L, 20L)) } returns members
+
+        // when
+        val result = adapter.findByPlayerIdsActive(listOf(10L, 20L))
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result).isEqualTo(members)
+        verify(exactly = 1) { jpaRepository.findByPlayerIdsActive(listOf(10L, 20L)) }
+    }
+
+    @Test
+    @DisplayName("findByPlayerIdsActive - 빈 목록 전달 시 JPA 호출 없이 빈 리스트를 반환한다")
+    fun `should return empty list without jpa call when playerIds is empty`() {
+        // when
+        val result = adapter.findByPlayerIdsActive(emptyList())
+
+        // then
+        assertThat(result).isEmpty()
+        verify(exactly = 0) { jpaRepository.findByPlayerIdsActive(any()) }
+    }
+
+    @Test
     @DisplayName("countByTeamIdAndStatus - 팀 상태별 멤버 수 조회 시 JPA repository에 위임한다")
     fun `should delegate countByTeamIdAndStatus to jpa repository`() {
         // given

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/IndividualRankingServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/IndividualRankingServiceImplTest.kt
@@ -19,6 +19,7 @@ import com.nextup.core.service.stats.dto.BattingCategory
 import com.nextup.core.service.stats.dto.PitchingCategory
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -109,10 +110,12 @@ class IndividualRankingServiceImplTest {
                     IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
-            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, qualifyingPA, 10) } returns
-                listOf(stats1, stats2)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
-            every { teamMemberRepository.findByPlayerIdActive(20L) } returns listOf(createTeamMember(player2))
+            every {
+                seasonBattingStatsRepository.findTopByBattingAverage(2026, qualifyingPA, 10)
+            } returns listOf(stats1, stats2)
+            every {
+                teamMemberRepository.findByPlayerIdsActive(listOf(10L, 20L))
+            } returns listOf(createTeamMember(player1), createTeamMember(player2))
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.BATTING_AVG)
@@ -133,7 +136,7 @@ class IndividualRankingServiceImplTest {
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
             every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.HOME_RUNS)
@@ -150,7 +153,7 @@ class IndividualRankingServiceImplTest {
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
             every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.RBI)
@@ -167,7 +170,7 @@ class IndividualRankingServiceImplTest {
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
             every { seasonBattingStatsRepository.findTopByHits(2026, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.HITS)
@@ -185,7 +188,7 @@ class IndividualRankingServiceImplTest {
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
             every { seasonBattingStatsRepository.findTopByStolenBases(2026, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.STOLEN_BASES)
@@ -204,9 +207,10 @@ class IndividualRankingServiceImplTest {
                     IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
-            every { seasonBattingStatsRepository.findTopByOnBasePercentage(2026, qualifyingPA, 10) } returns
-                listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every {
+                seasonBattingStatsRepository.findTopByOnBasePercentage(2026, qualifyingPA, 10)
+            } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.OBP)
@@ -225,7 +229,7 @@ class IndividualRankingServiceImplTest {
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
             every { seasonBattingStatsRepository.findTopBySlugging(2026, qualifyingPA, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.SLG)
@@ -244,7 +248,7 @@ class IndividualRankingServiceImplTest {
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
             every { seasonBattingStatsRepository.findTopByOps(2026, qualifyingPA, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.OPS)
@@ -261,7 +265,9 @@ class IndividualRankingServiceImplTest {
                     IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
-            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, qualifyingPA, 10) } returns emptyList()
+            every {
+                seasonBattingStatsRepository.findTopByBattingAverage(2026, qualifyingPA, 10)
+            } returns emptyList()
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.BATTING_AVG)
@@ -279,9 +285,10 @@ class IndividualRankingServiceImplTest {
                     IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
-            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, qualifyingPA, 10) } returns
-                listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns emptyList()
+            every {
+                seasonBattingStatsRepository.findTopByBattingAverage(2026, qualifyingPA, 10)
+            } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns emptyList()
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.BATTING_AVG)
@@ -298,13 +305,38 @@ class IndividualRankingServiceImplTest {
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
             every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 5) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getBattingLeaders(1L, BattingCategory.HOME_RUNS, limit = 5)
 
             // then
             assertThat(result).hasSize(1)
+        }
+
+        @Test
+        fun `should call findByPlayerIdsActive only once for multiple players`() {
+            // given: N+1 방지 검증 - 선수 2명에 대해 단 1번의 배치 쿼리만 실행되어야 함
+            val stats1 = createBattingStats(player1, 2026, atBats = 50, hits = 18, pa = 55, games = 12)
+            val stats2 = createBattingStats(player2, 2026, atBats = 45, hits = 14, pa = 50, games = 10)
+            val qualifyingPA =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_PA_FACTOR).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every {
+                seasonBattingStatsRepository.findTopByBattingAverage(2026, qualifyingPA, 10)
+            } returns listOf(stats1, stats2)
+            every {
+                teamMemberRepository.findByPlayerIdsActive(listOf(10L, 20L))
+            } returns listOf(createTeamMember(player1), createTeamMember(player2))
+
+            // when
+            service.getBattingLeaders(1L, BattingCategory.BATTING_AVG)
+
+            // then: 배치 메서드가 정확히 1번 호출되고, 단건 메서드는 호출되지 않아야 함
+            verify(exactly = 1) { teamMemberRepository.findByPlayerIdsActive(listOf(10L, 20L)) }
+            verify(exactly = 0) { teamMemberRepository.findByPlayerIdActive(any()) }
         }
     }
 
@@ -333,10 +365,12 @@ class IndividualRankingServiceImplTest {
                     3).toInt()
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
-            every { seasonPitchingStatsRepository.findTopByEra(2026, qualifyingIPOuts, 10) } returns
-                listOf(stats1, stats2)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
-            every { teamMemberRepository.findByPlayerIdActive(20L) } returns listOf(createTeamMember(player2))
+            every {
+                seasonPitchingStatsRepository.findTopByEra(2026, qualifyingIPOuts, 10)
+            } returns listOf(stats1, stats2)
+            every {
+                teamMemberRepository.findByPlayerIdsActive(listOf(10L, 20L))
+            } returns listOf(createTeamMember(player1), createTeamMember(player2))
 
             // when
             val result = service.getPitchingLeaders(1L, PitchingCategory.ERA)
@@ -359,8 +393,10 @@ class IndividualRankingServiceImplTest {
                     3).toInt()
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
-            every { seasonPitchingStatsRepository.findTopByEra(2026, qualifyingIPOuts, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every {
+                seasonPitchingStatsRepository.findTopByEra(2026, qualifyingIPOuts, 10)
+            } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getPitchingLeaders(1L, PitchingCategory.ERA)
@@ -377,7 +413,7 @@ class IndividualRankingServiceImplTest {
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
             every { seasonPitchingStatsRepository.findTopByWins(2026, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getPitchingLeaders(1L, PitchingCategory.WINS)
@@ -394,7 +430,7 @@ class IndividualRankingServiceImplTest {
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
             every { seasonPitchingStatsRepository.findTopBySaves(2026, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getPitchingLeaders(1L, PitchingCategory.SAVES)
@@ -411,7 +447,7 @@ class IndividualRankingServiceImplTest {
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
             every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getPitchingLeaders(1L, PitchingCategory.STRIKEOUTS)
@@ -431,8 +467,10 @@ class IndividualRankingServiceImplTest {
                     3).toInt()
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
-            every { seasonPitchingStatsRepository.findTopByWhip(2026, qualifyingIPOuts, 10) } returns listOf(stats1)
-            every { teamMemberRepository.findByPlayerIdActive(10L) } returns listOf(createTeamMember(player1))
+            every {
+                seasonPitchingStatsRepository.findTopByWhip(2026, qualifyingIPOuts, 10)
+            } returns listOf(stats1)
+            every { teamMemberRepository.findByPlayerIdsActive(listOf(10L)) } returns listOf(createTeamMember(player1))
 
             // when
             val result = service.getPitchingLeaders(1L, PitchingCategory.WHIP)
@@ -450,13 +488,41 @@ class IndividualRankingServiceImplTest {
                     3).toInt()
 
             every { competitionRepository.findByIdOrNull(1L) } returns competition
-            every { seasonPitchingStatsRepository.findTopByEra(2026, qualifyingIPOuts, 10) } returns emptyList()
+            every {
+                seasonPitchingStatsRepository.findTopByEra(2026, qualifyingIPOuts, 10)
+            } returns emptyList()
 
             // when
             val result = service.getPitchingLeaders(1L, PitchingCategory.ERA)
 
             // then
             assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `should call findByPlayerIdsActive only once for multiple pitchers`() {
+            // given: N+1 방지 검증 - 투수 2명에 대해 단 1번의 배치 쿼리만 실행되어야 함
+            val stats1 = createPitchingStats(player1, 2026, ipOuts = 36, earnedRuns = 3, games = 10)
+            val stats2 = createPitchingStats(player2, 2026, ipOuts = 30, earnedRuns = 5, games = 8)
+            val qualifyingIPOuts =
+                (IndividualRankingServiceImpl.DEFAULT_TEAM_GAMES *
+                    IndividualRankingServiceImpl.QUALIFYING_IP_FACTOR *
+                    3).toInt()
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every {
+                seasonPitchingStatsRepository.findTopByEra(2026, qualifyingIPOuts, 10)
+            } returns listOf(stats1, stats2)
+            every {
+                teamMemberRepository.findByPlayerIdsActive(listOf(10L, 20L))
+            } returns listOf(createTeamMember(player1), createTeamMember(player2))
+
+            // when
+            service.getPitchingLeaders(1L, PitchingCategory.ERA)
+
+            // then: 배치 메서드가 정확히 1번 호출되고, 단건 메서드는 호출되지 않아야 함
+            verify(exactly = 1) { teamMemberRepository.findByPlayerIdsActive(listOf(10L, 20L)) }
+            verify(exactly = 0) { teamMemberRepository.findByPlayerIdActive(any()) }
         }
     }
 
@@ -511,6 +577,7 @@ class IndividualRankingServiceImplTest {
     private fun createTeamMember(player: Player): TeamMember {
         val member =
             mockk<TeamMember> {
+                every { this@mockk.player } returns player
                 every { this@mockk.team } returns this@IndividualRankingServiceImplTest.team
                 every { role } returns TeamMemberRole.MEMBER
             }
@@ -520,7 +587,7 @@ class IndividualRankingServiceImplTest {
     private fun setField(
         target: Any,
         fieldName: String,
-        value: Any
+        value: Any,
     ) {
         val field = target::class.java.getDeclaredField(fieldName)
         field.isAccessible = true
@@ -530,7 +597,7 @@ class IndividualRankingServiceImplTest {
     private fun <T> setId(
         target: T,
         clazz: Class<T>,
-        id: Long
+        id: Long,
     ) {
         val idField = clazz.getDeclaredField("id")
         idField.isAccessible = true


### PR DESCRIPTION
## Summary

> - close #226

`IndividualRankingServiceImpl.resolveTeamName(playerId)`이 랭킹 리스트의 각 선수마다 개별 쿼리 실행하는 N+1 문제를 배치 조회로 개선합니다.

## Tasks

- `TeamMemberRepositoryPort`에 `findByPlayerIdsActive(playerIds)` 배치 메서드 추가
- JPA Repository에 `JOIN FETCH` + `IN` 쿼리 구현
- `resolveTeamName(단건)` → `resolveTeamNames(배치)` 리팩토링
- `getBattingLeaders`, `getPitchingLeaders` 모두 한 번의 IN 쿼리로 처리
- N+1 방지 검증 테스트 추가

## To Reviewer

- Top-10 조회 기준 10번의 추가 쿼리 → 1번의 IN 쿼리로 개선
- `BUILD SUCCESSFUL` 확인
- 5개 verify 스킬 모두 PASS (entity-leak, dependency, api-response, custom-exception, url-prefix)