### PR TITLE
feat(#223): 야구 규칙 검증 강화 (투수 교체 제한, 연장전 타이브레이크)

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -74,9 +74,34 @@ class Game(
 
     /**
      * 다음 이닝으로 진행합니다.
+     *
+     * 연장전 타이브레이크 활성화 시 초(원정팀 공격) 시작마다 무사 1,2루 상태를 자동 설정합니다.
+     * 최대 연장 이닝 도달 시 무승부로 경기를 종료합니다.
+     *
+     * @param tiebreakerFirstRunnerId  타이브레이크 1루 배치 주자 GamePlayer ID
+     * @param tiebreakerSecondRunnerId 타이브레이크 2루 배치 주자 GamePlayer ID
+     * @param gameTeams 무승부 자동 처리용 GameTeam 목록 (최대 연장 이닝 도달 시 DRAW 설정)
+     * @return [TiebreakerResult] 이닝 전환 처리 결과
      */
-    fun nextHalfInning() {
+    fun nextHalfInning(
+        tiebreakerFirstRunnerId: Long? = null,
+        tiebreakerSecondRunnerId: Long? = null,
+        gameTeams: List<GameTeam> = emptyList(),
+    ): TiebreakerResult {
         require(status.isOngoing()) { "진행 중인 경기만 이닝을 진행할 수 있습니다." }
+
+        val rules = competition.gameRules
+
+        // 말(홈팀 공격) 종료 후 다음 이닝으로 넘어가기 전에 최대 연장 이닝 제한 확인
+        if (!isTopInning) {
+            val maxExtra = rules.maxExtraInnings
+            if (maxExtra != null && currentInning >= totalInnings + maxExtra) {
+                status = GameStatus.FINISHED
+                endedAt = LocalDateTime.now()
+                gameTeams.forEach { it.updateResult(GameResult.DRAW) }
+                return TiebreakerResult.DRAW_BY_INNINGS_LIMIT
+            }
+        }
 
         if (isTopInning) {
             isTopInning = false
@@ -85,6 +110,48 @@ class Game(
             isTopInning = true
         }
         gameState.resetForNewInning()
+
+        // 연장전 타이브레이크: 초(원정팀 공격) 시작 시에만 적용
+        if (rules.tiebreakerEnabled && isTopInning && currentInning > totalInnings) {
+            gameState.setupTiebreaker(
+                firstRunnerId = tiebreakerFirstRunnerId,
+                secondRunnerId = tiebreakerSecondRunnerId,
+            )
+            return TiebreakerResult.TIEBREAKER_APPLIED
+        }
+
+        return TiebreakerResult.NORMAL
+    }
+
+    /**
+     * 투수 교체 가능 여부를 검증합니다 (한 타자 최소 대면 규칙).
+     *
+     * 사회인 야구 유연성을 위해 규칙 위반 시 예외를 던지지 않고 경고를 반환합니다.
+     * - 이닝이 종료된 경우(아웃 3개) 교체는 자유롭습니다.
+     * - 현재 투수의 대면 타자 수([battersFaced])가 [minBattersFaced] 미만이면 경고를 반환합니다.
+     *
+     * @param currentPitcherBattersFaced 현재 투수의 이번 경기 대면 타자 수
+     * @param minBattersFaced 최소 대면 타자 수 (기본값 1)
+     * @return [PitcherChangeWarning] 교체 가능 시 null, 경고 시 해당 경고 객체
+     */
+    fun checkPitcherChangeAllowed(
+        currentPitcherBattersFaced: Int,
+        minBattersFaced: Int = DEFAULT_MIN_BATTERS_FACED,
+    ): PitcherChangeWarning? {
+        require(status.isOngoing()) { "진행 중인 경기에서만 투수 교체를 확인할 수 있습니다." }
+        require(minBattersFaced >= 1) { "최소 대면 타자 수는 1 이상이어야 합니다." }
+
+        // 이닝 종료 후(아웃 3개) 교체는 항상 허용
+        if (gameState.outs >= 3) return null
+
+        return if (currentPitcherBattersFaced < minBattersFaced) {
+            PitcherChangeWarning(
+                currentBattersFaced = currentPitcherBattersFaced,
+                minBattersFaced = minBattersFaced,
+            )
+        } else {
+            null
+        }
     }
 
     /**
@@ -247,6 +314,9 @@ class Game(
 
         /** Mercy Rule 기본 최소 이닝 */
         const val DEFAULT_MERCY_MINIMUM_INNING = 5
+
+        /** 투수 교체 시 최소 대면 타자 수 기본값 */
+        const val DEFAULT_MIN_BATTERS_FACED = 1
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
@@ -279,6 +279,24 @@ class GameState(
     fun isBasesLoaded(): Boolean = runnerOnFirstId != null && runnerOnSecondId != null && runnerOnThirdId != null
 
     /**
+     * 연장전 타이브레이크 주자를 배치합니다 (무사 1,2루).
+     *
+     * 사회인 야구 타이브레이크 규칙에 따라 이닝 시작 시 자동으로
+     * 1루와 2루에 주자를 배치합니다.
+     *
+     * @param firstRunnerId  1루에 배치할 주자 GamePlayer ID (null 허용)
+     * @param secondRunnerId 2루에 배치할 주자 GamePlayer ID (null 허용)
+     */
+    fun setupTiebreaker(
+        firstRunnerId: Long? = null,
+        secondRunnerId: Long? = null,
+    ) {
+        runnerOnFirstId = firstRunnerId
+        runnerOnSecondId = secondRunnerId
+        runnerOnThirdId = null
+    }
+
+    /**
      * 현재 볼카운트 문자열을 반환합니다 (예: "2B-1S").
      */
     val countDisplay: String

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitcherChangeWarning.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitcherChangeWarning.kt
@@ -1,0 +1,21 @@
+package com.nextup.core.domain.game
+
+/**
+ * 투수 교체 제한 경고 (한 타자 최소 대면 규칙)
+ *
+ * 사회인 야구의 유연성을 위해 규칙 위반 시 예외가 아닌 경고를 반환합니다.
+ * 호출 측에서 이 경고를 무시하거나 사용자에게 확인을 요청할 수 있습니다.
+ *
+ * @param currentBattersFaced 현재 투수의 대면 타자 수
+ * @param minBattersFaced 최소 대면 타자 수 요건
+ */
+data class PitcherChangeWarning(
+    val currentBattersFaced: Int,
+    val minBattersFaced: Int,
+) {
+    val message: String
+        get() =
+            "현재 투수가 ${currentBattersFaced}명의 타자만 대면했습니다. " +
+                "최소 ${minBattersFaced}명의 타자를 대면해야 합니다. " +
+                "사회인 야구 규칙에 따라 교체는 허용되나 경고가 발생합니다."
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/TiebreakerResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/TiebreakerResult.kt
@@ -1,0 +1,15 @@
+package com.nextup.core.domain.game
+
+/**
+ * 이닝 전환 시 타이브레이크/이닝 제한 처리 결과
+ */
+enum class TiebreakerResult {
+    /** 일반 이닝 전환 (타이브레이크 미적용) */
+    NORMAL,
+
+    /** 연장전 타이브레이크 적용 (무사 1,2루 자동 배치) */
+    TIEBREAKER_APPLIED,
+
+    /** 최대 연장 이닝 도달로 인한 무승부 처리 */
+    DRAW_BY_INNINGS_LIMIT,
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitcherChangeWarningTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitcherChangeWarningTest.kt
@@ -1,0 +1,199 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.competition.GameRules
+import com.nextup.core.domain.league.League
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("투수 교체 제한 규칙 (한 타자 최소 대면)")
+class PitcherChangeWarningTest {
+    private lateinit var competition: Competition
+    private lateinit var league: League
+
+    @BeforeEach
+    fun setUp() {
+        val association = Association(name = "서울시야구협회", region = "서울")
+        league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+                gameRules = GameRules(),
+            )
+    }
+
+    private fun createInProgressGame(outs: Int = 0): Game {
+        val game =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                status = GameStatus.IN_PROGRESS,
+                currentInning = 3,
+                isTopInning = true,
+            )
+        repeat(outs) { game.recordOut() }
+        return game
+    }
+
+    @Nested
+    @DisplayName("이닝 중 투수 교체")
+    inner class MidInningChange {
+
+        @Test
+        fun `이닝 중 0명 대면한 투수 교체 시 경고를 반환한다`() {
+            // given
+            val game = createInProgressGame(outs = 0)
+
+            // when
+            val warning = game.checkPitcherChangeAllowed(currentPitcherBattersFaced = 0)
+
+            // then
+            assertThat(warning).isNotNull
+            assertThat(warning!!.currentBattersFaced).isEqualTo(0)
+            assertThat(warning.minBattersFaced).isEqualTo(Game.DEFAULT_MIN_BATTERS_FACED)
+            assertThat(warning.message).contains("0명")
+            assertThat(warning.message).contains("최소 1명")
+        }
+
+        @Test
+        fun `이닝 중 1명 이상 대면한 투수 교체 시 경고 없음`() {
+            // given
+            val game = createInProgressGame(outs = 0)
+
+            // when
+            val warning = game.checkPitcherChangeAllowed(currentPitcherBattersFaced = 1)
+
+            // then
+            assertThat(warning).isNull()
+        }
+
+        @Test
+        fun `최소 대면 타자 수를 2명으로 설정 시 1명 대면 투수 교체는 경고`() {
+            // given
+            val game = createInProgressGame(outs = 0)
+
+            // when
+            val warning =
+                game.checkPitcherChangeAllowed(
+                    currentPitcherBattersFaced = 1,
+                    minBattersFaced = 2,
+                )
+
+            // then
+            assertThat(warning).isNotNull
+            assertThat(warning!!.currentBattersFaced).isEqualTo(1)
+            assertThat(warning.minBattersFaced).isEqualTo(2)
+        }
+
+        @Test
+        fun `최소 대면 타자 수를 2명으로 설정 시 2명 이상 대면하면 경고 없음`() {
+            // given
+            val game = createInProgressGame(outs = 0)
+
+            // when
+            val warning =
+                game.checkPitcherChangeAllowed(
+                    currentPitcherBattersFaced = 2,
+                    minBattersFaced = 2,
+                )
+
+            // then
+            assertThat(warning).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("이닝 완료 후 투수 교체")
+    inner class EndOfInningChange {
+
+        @Test
+        fun `3아웃 후 투수 교체는 대면 타자 수와 관계없이 항상 허용된다`() {
+            // given - 3아웃 (이닝 종료)
+            val game = createInProgressGame(outs = 3)
+
+            // when: 0명 대면했어도 경고 없음
+            val warning = game.checkPitcherChangeAllowed(currentPitcherBattersFaced = 0)
+
+            // then
+            assertThat(warning).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("잘못된 입력 처리")
+    inner class InvalidInput {
+
+        @Test
+        fun `최소 대면 타자 수가 0 이하이면 예외가 발생한다`() {
+            // given
+            val game = createInProgressGame()
+
+            // when & then
+            assertThatThrownBy {
+                game.checkPitcherChangeAllowed(currentPitcherBattersFaced = 0, minBattersFaced = 0)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("최소 대면 타자 수는 1 이상이어야 합니다")
+        }
+
+        @Test
+        fun `진행 중이 아닌 경기에서 투수 교체 확인 시 예외가 발생한다`() {
+            // given
+            val game =
+                Game(
+                    competition = competition,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                    status = GameStatus.SCHEDULED,
+                )
+
+            // when & then
+            assertThatThrownBy {
+                game.checkPitcherChangeAllowed(currentPitcherBattersFaced = 0)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("진행 중인 경기에서만")
+        }
+    }
+
+    @Nested
+    @DisplayName("PitcherChangeWarning 데이터 클래스")
+    inner class WarningDataClass {
+
+        @Test
+        fun `경고 메시지에 현재 대면 타자 수와 최소 요건을 포함한다`() {
+            // given
+            val warning =
+                PitcherChangeWarning(
+                    currentBattersFaced = 0,
+                    minBattersFaced = 1,
+                )
+
+            // then
+            assertThat(warning.message).contains("0명")
+            assertThat(warning.message).contains("1명")
+        }
+
+        @Test
+        fun `경고는 데이터 클래스로 동등 비교가 가능하다`() {
+            // given
+            val warning1 = PitcherChangeWarning(currentBattersFaced = 0, minBattersFaced = 1)
+            val warning2 = PitcherChangeWarning(currentBattersFaced = 0, minBattersFaced = 1)
+
+            // then
+            assertThat(warning1).isEqualTo(warning2)
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/TiebreakerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/TiebreakerTest.kt
@@ -1,0 +1,356 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.competition.GameRules
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("연장전 타이브레이크 및 이닝 제한 규칙")
+class TiebreakerTest {
+    private lateinit var league: League
+    private lateinit var team1: Team
+    private lateinit var team2: Team
+
+    @BeforeEach
+    fun setUp() {
+        val association = Association(name = "서울시야구협회", region = "서울")
+        league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        team1 = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        team2 = Team(league = league, name = "원정팀", city = "서울", foundedYear = 2020, id = 2L)
+    }
+
+    private fun createCompetition(rules: GameRules): Competition =
+        Competition(
+            league = league,
+            name = "2025 춘계대회",
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            status = CompetitionStatus.IN_PROGRESS,
+            gameRules = rules,
+        )
+
+    private fun createGame(
+        competition: Competition,
+        currentInning: Int,
+        isTopInning: Boolean,
+        totalInnings: Int = 9,
+    ): Game =
+        Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            status = GameStatus.IN_PROGRESS,
+            currentInning = currentInning,
+            isTopInning = isTopInning,
+            totalInnings = totalInnings,
+        )
+
+    // ─── GameTeam 목 생성 헬퍼 ───────────────────────────────────────────────────
+    private fun mockGameTeam(
+        game: Game,
+        team: Team,
+        homeAway: HomeAway
+    ): GameTeam {
+        val gt = mockk<GameTeam>(relaxed = true)
+        every { gt.team } returns team
+        every { gt.homeAway } returns homeAway
+        every { gt.game } returns game
+        return gt
+    }
+
+    @Nested
+    @DisplayName("타이브레이크 미적용 (일반 이닝 전환)")
+    inner class NoTiebreaker {
+
+        @Test
+        fun `타이브레이커가 비활성화된 경우 연장전에서도 NORMAL을 반환한다`() {
+            // given: 타이브레이커 비활성화
+            val competition =
+                createCompetition(
+                    GameRules(tiebreakerEnabled = false, maxExtraInnings = null),
+                )
+            // 9말 종료 후 다음 이닝(10회초)으로 전환
+            val game = createGame(competition, currentInning = 9, isTopInning = false)
+
+            // when
+            val result = game.nextHalfInning()
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.NORMAL)
+            assertThat(game.currentInning).isEqualTo(10)
+            assertThat(game.isTopInning).isTrue()
+            assertThat(game.gameState.runnerOnFirstId).isNull()
+            assertThat(game.gameState.runnerOnSecondId).isNull()
+        }
+
+        @Test
+        fun `정규 이닝 중 초에서 말로 전환 시 NORMAL을 반환한다`() {
+            // given
+            val competition = createCompetition(GameRules())
+            val game = createGame(competition, currentInning = 5, isTopInning = true)
+
+            // when
+            val result = game.nextHalfInning()
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.NORMAL)
+            assertThat(game.currentInning).isEqualTo(5)
+            assertThat(game.isTopInning).isFalse()
+        }
+
+        @Test
+        fun `타이브레이커가 활성화되어도 정규 이닝에서는 NORMAL을 반환한다`() {
+            // given: 타이브레이커 활성화, 하지만 정규 이닝 중
+            val competition = createCompetition(GameRules(tiebreakerEnabled = true))
+            val game = createGame(competition, currentInning = 8, isTopInning = false)
+
+            // when: 8말 → 9회초 (정규 이닝)
+            val result = game.nextHalfInning()
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.NORMAL)
+            assertThat(game.currentInning).isEqualTo(9)
+            assertThat(game.gameState.runnerOnFirstId).isNull()
+            assertThat(game.gameState.runnerOnSecondId).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("타이브레이크 적용 (연장전 무사 1,2루)")
+    inner class WithTiebreaker {
+
+        @Test
+        fun `타이브레이커 활성화 시 연장 이닝 초 시작에서 TIEBREAKER_APPLIED를 반환한다`() {
+            // given: 9말 → 10회초 (연장전 시작)
+            val competition = createCompetition(GameRules(tiebreakerEnabled = true))
+            val game = createGame(competition, currentInning = 9, isTopInning = false)
+
+            // when
+            val result =
+                game.nextHalfInning(
+                    tiebreakerFirstRunnerId = 101L,
+                    tiebreakerSecondRunnerId = 102L,
+                )
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.TIEBREAKER_APPLIED)
+            assertThat(game.currentInning).isEqualTo(10)
+            assertThat(game.isTopInning).isTrue()
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(101L)
+            assertThat(game.gameState.runnerOnSecondId).isEqualTo(102L)
+            assertThat(game.gameState.runnerOnThirdId).isNull()
+            assertThat(game.gameState.outs).isEqualTo(0)
+        }
+
+        @Test
+        fun `타이브레이커 주자 ID가 null이어도 기본 무사 주자 배치 상태로 적용된다`() {
+            // given
+            val competition = createCompetition(GameRules(tiebreakerEnabled = true))
+            val game = createGame(competition, currentInning = 9, isTopInning = false)
+
+            // when: 주자 ID 없이 타이브레이커 적용
+            val result = game.nextHalfInning()
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.TIEBREAKER_APPLIED)
+            assertThat(game.gameState.runnerOnFirstId).isNull()
+            assertThat(game.gameState.runnerOnSecondId).isNull()
+            assertThat(game.gameState.outs).isEqualTo(0)
+        }
+
+        @Test
+        fun `타이브레이커 연장 이닝 말 전환은 NORMAL을 반환한다`() {
+            // given: 이미 10회초인 상태에서 말로 전환
+            val competition = createCompetition(GameRules(tiebreakerEnabled = true))
+            val game = createGame(competition, currentInning = 10, isTopInning = true)
+
+            // when: 10회초 → 10회말 (말은 타이브레이커 미적용)
+            val result =
+                game.nextHalfInning(
+                    tiebreakerFirstRunnerId = 101L,
+                    tiebreakerSecondRunnerId = 102L,
+                )
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.NORMAL)
+            assertThat(game.currentInning).isEqualTo(10)
+            assertThat(game.isTopInning).isFalse()
+            // 말에는 타이브레이커 주자 배치 안 함
+            assertThat(game.gameState.runnerOnFirstId).isNull()
+            assertThat(game.gameState.runnerOnSecondId).isNull()
+        }
+
+        @Test
+        fun `연속 연장 이닝에서 매 초마다 타이브레이커가 적용된다`() {
+            // given
+            val competition = createCompetition(GameRules(tiebreakerEnabled = true))
+            val game = createGame(competition, currentInning = 9, isTopInning = false)
+
+            // when: 9말 → 10회초 (타이브레이커)
+            val result1 =
+                game.nextHalfInning(
+                    tiebreakerFirstRunnerId = 101L,
+                    tiebreakerSecondRunnerId = 102L,
+                )
+            assertThat(result1).isEqualTo(TiebreakerResult.TIEBREAKER_APPLIED)
+
+            // when: 10회초 → 10회말 (일반)
+            val result2 = game.nextHalfInning()
+            assertThat(result2).isEqualTo(TiebreakerResult.NORMAL)
+
+            // when: 10회말 → 11회초 (타이브레이커 재적용)
+            val result3 =
+                game.nextHalfInning(
+                    tiebreakerFirstRunnerId = 201L,
+                    tiebreakerSecondRunnerId = 202L,
+                )
+            assertThat(result3).isEqualTo(TiebreakerResult.TIEBREAKER_APPLIED)
+            assertThat(game.currentInning).isEqualTo(11)
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(201L)
+            assertThat(game.gameState.runnerOnSecondId).isEqualTo(202L)
+        }
+    }
+
+    @Nested
+    @DisplayName("최대 연장 이닝 제한 (무승부 처리)")
+    inner class MaxExtraInnings {
+
+        @Test
+        fun `최대 연장 이닝 도달 후 말 종료 시 DRAW_BY_INNINGS_LIMIT을 반환한다`() {
+            // given: 최대 연장 이닝 = 2 (9+2=11이닝까지 허용, 11말 종료 시 무승부)
+            val competition =
+                createCompetition(
+                    GameRules(tiebreakerEnabled = true, maxExtraInnings = 2),
+                )
+            // 11회말 (9 + 2 = 11이닝, 이 말이 끝나면 무승부)
+            val game = createGame(competition, currentInning = 11, isTopInning = false)
+
+            val homeGameTeam = mockGameTeam(game, team1, HomeAway.HOME)
+            val awayGameTeam = mockGameTeam(game, team2, HomeAway.AWAY)
+
+            // when
+            val result = game.nextHalfInning(gameTeams = listOf(homeGameTeam, awayGameTeam))
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.DRAW_BY_INNINGS_LIMIT)
+            assertThat(game.status).isEqualTo(GameStatus.FINISHED)
+            assertThat(game.endedAt).isNotNull()
+        }
+
+        @Test
+        fun `최대 연장 이닝 미도달 시 DRAW_BY_INNINGS_LIMIT이 반환되지 않는다`() {
+            // given: 최대 연장 이닝 = 2, 현재 10회말 (11이닝 미도달)
+            val competition =
+                createCompetition(
+                    GameRules(tiebreakerEnabled = true, maxExtraInnings = 2),
+                )
+            val game = createGame(competition, currentInning = 10, isTopInning = false)
+
+            // when: 10회말 → 11회초 (아직 제한 아님)
+            val result =
+                game.nextHalfInning(
+                    tiebreakerFirstRunnerId = 101L,
+                    tiebreakerSecondRunnerId = 102L,
+                )
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.TIEBREAKER_APPLIED)
+            assertThat(game.status).isEqualTo(GameStatus.IN_PROGRESS)
+        }
+
+        @Test
+        fun `maxExtraInnings가 null이면 연장 이닝 제한이 없다`() {
+            // given: 최대 연장 이닝 미설정
+            val competition =
+                createCompetition(
+                    GameRules(tiebreakerEnabled = false, maxExtraInnings = null),
+                )
+            // 매우 높은 이닝도 무승부 처리 안 함
+            val game = createGame(competition, currentInning = 20, isTopInning = false)
+
+            // when
+            val result = game.nextHalfInning()
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.NORMAL)
+            assertThat(game.status).isEqualTo(GameStatus.IN_PROGRESS)
+            assertThat(game.currentInning).isEqualTo(21)
+        }
+
+        @Test
+        fun `무승부 처리 시 gameTeams 미전달 시에도 경기는 FINISHED 상태가 된다`() {
+            // given
+            val competition =
+                createCompetition(
+                    GameRules(tiebreakerEnabled = true, maxExtraInnings = 1),
+                )
+            // 10회말 (9+1=10이닝 제한)
+            val game = createGame(competition, currentInning = 10, isTopInning = false)
+
+            // when: gameTeams 빈 리스트 전달
+            val result = game.nextHalfInning(gameTeams = emptyList())
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.DRAW_BY_INNINGS_LIMIT)
+            assertThat(game.status).isEqualTo(GameStatus.FINISHED)
+        }
+    }
+
+    @Nested
+    @DisplayName("GameState 타이브레이크 주자 배치")
+    inner class GameStateSetupTiebreaker {
+
+        @Test
+        fun `setupTiebreaker 호출 시 1루와 2루에 주자가 배치된다`() {
+            // given
+            val state = GameState()
+
+            // when
+            state.setupTiebreaker(firstRunnerId = 10L, secondRunnerId = 20L)
+
+            // then
+            assertThat(state.runnerOnFirstId).isEqualTo(10L)
+            assertThat(state.runnerOnSecondId).isEqualTo(20L)
+            assertThat(state.runnerOnThirdId).isNull()
+        }
+
+        @Test
+        fun `setupTiebreaker 호출 시 기존 3루 주자는 제거된다`() {
+            // given: 이전에 3루 주자 있었던 경우
+            val state = GameState()
+            state.setRunner(Base.THIRD, 99L)
+            assertThat(state.runnerOnThirdId).isEqualTo(99L)
+
+            // when
+            state.setupTiebreaker(firstRunnerId = 10L, secondRunnerId = 20L)
+
+            // then
+            assertThat(state.runnerOnThirdId).isNull()
+        }
+
+        @Test
+        fun `setupTiebreaker 후 아웃 카운트는 0이다`() {
+            // given
+            val state = GameState()
+
+            // when
+            state.setupTiebreaker(firstRunnerId = 10L, secondRunnerId = 20L)
+
+            // then
+            assertThat(state.outs).isEqualTo(0)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImplTest.kt
@@ -3,7 +3,6 @@ package com.nextup.infrastructure.service.game.correction
 import com.nextup.common.exception.BattingRecordNotFoundByIdException
 import com.nextup.common.exception.GameNotFoundException
 import com.nextup.common.exception.PitchingRecordNotFoundByIdException
-import com.nextup.core.domain.audit.AuditLog
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.domain.game.Game


### PR DESCRIPTION
## Summary

>- close #223

투수 교체 제한(한 타자 최소 대면 규칙)과 연장전 타이브레이크(무사 1,2루 시작) 도메인 로직을 `nextup-core` Entity에 구현합니다.

## Tasks

- `Game.checkPitcherChangeAllowed()`: 이닝 중 투수 교체 시 한 타자 최소 대면 규칙 검증
  - 이닝 종료(3아웃) 후 교체는 항상 허용
  - 위반 시 예외가 아닌 `PitcherChangeWarning` 반환 (사회인 야구 유연성 보장)
- `Game.nextHalfInning()`: 연장전 타이브레이크 및 이닝 제한 처리
  - `GameRules.tiebreakerEnabled` 활성화 시 연장 이닝 초 시작마다 무사 1,2루 자동 배치
  - `GameRules.maxExtraInnings` 도달 시 무승부(`DRAW`) 자동 처리
  - `TiebreakerResult` enum으로 처리 결과 반환 (`NORMAL`/`TIEBREAKER_APPLIED`/`DRAW_BY_INNINGS_LIMIT`)
- `GameState.setupTiebreaker()`: 타이브레이크 주자 배치 메서드 추가
- `PitcherChangeWarning` 데이터 클래스 추가
- `TiebreakerResult` enum 추가
- `PitcherChangeWarningTest`, `TiebreakerTest` 단위 테스트 작성

## To Reviewer

- Rich Domain Model 원칙: 모든 규칙 검증 로직이 Entity 내부에 캡슐화되어 있습니다.
- `nextHalfInning()`은 모든 파라미터에 기본값이 있어 기존 호출부(`GameScorerServiceImpl`)와 완전히 하위 호환됩니다.
- 사회인 야구 특성상 투수 교체 제한은 예외 발생 대신 경고 반환 방식으로 구현했습니다 (유연성 우선).
- 기존 `GameRules` 에 이미 `tiebreakerEnabled`, `maxExtraInnings` 필드가 존재하여 별도 DB 마이그레이션이 불필요합니다.