### PR TITLE
feat(#228): 순위 캐싱 및 대회 자동 완료 처리

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
@@ -40,4 +40,15 @@ interface GameRepositoryPort {
      * Game을 GameTeam과 함께 조회합니다. (N+1 방지)
      */
     fun findByIdWithTeams(id: Long): Game?
+
+    /**
+     * 대회의 전체 경기 수를 반환합니다.
+     */
+    fun countByCompetitionId(competitionId: Long): Long
+
+    /**
+     * 대회에서 완료된 경기 수를 반환합니다.
+     * 완료 상태: FINISHED, CALLED, FORFEITED, CANCELLED
+     */
+    fun countCompletedOrCancelledByCompetitionId(competitionId: Long): Long
 }

--- a/nextup-infrastructure/build.gradle.kts
+++ b/nextup-infrastructure/build.gradle.kts
@@ -54,8 +54,11 @@ dependencies {
     // Rate Limiting
     implementation("com.bucket4j:bucket4j-core:8.10.1")
 
-    // Caffeine Cache (for bounded rate limit buckets)
+    // Caffeine Cache (for bounded rate limit buckets + Spring Cache)
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
+
+    // Spring Cache
+    implementation("org.springframework.boot:spring-boot-starter-cache")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/CacheConfig.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/CacheConfig.kt
@@ -1,0 +1,35 @@
+package com.nextup.infrastructure.config
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
+
+/**
+ * Spring Cache 설정
+ *
+ * Caffeine 기반 인메모리 캐시를 구성합니다.
+ * - standings: 대회 순위표 캐시 (10분 TTL)
+ */
+@Configuration
+@EnableCaching
+class CacheConfig {
+
+    companion object {
+        const val STANDINGS_CACHE = "standings"
+    }
+
+    @Bean
+    fun cacheManager(): CacheManager {
+        val cacheManager = CaffeineCacheManager(STANDINGS_CACHE)
+        cacheManager.setCaffeine(
+            Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .maximumSize(200),
+        )
+        return cacheManager
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameResultEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameResultEventListener.kt
@@ -1,0 +1,101 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.event.GameResultConfirmedEvent
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.infrastructure.config.CacheConfig
+import org.slf4j.LoggerFactory
+import org.springframework.cache.CacheManager
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * 경기 결과 확정 이벤트 리스너
+ *
+ * GameResultConfirmedEvent 수신 시:
+ * 1. 해당 대회의 순위 캐시를 무효화합니다.
+ * 2. 대회의 모든 경기가 완료되었으면 Competition.complete()를 자동 호출합니다.
+ */
+@Component
+class GameResultEventListener(
+    private val gameRepository: GameRepositoryPort,
+    private val competitionRepository: CompetitionRepositoryPort,
+    private val cacheManager: CacheManager,
+) {
+    private val logger = LoggerFactory.getLogger(GameResultEventListener::class.java)
+
+    /**
+     * 경기 결과 확정 이벤트를 처리합니다.
+     *
+     * BEFORE_COMMIT 단계에서 실행하여 대회 자동 완료를 동일 트랜잭션 내에서 처리합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @Transactional
+    fun onGameResultConfirmed(event: GameResultConfirmedEvent) {
+        val game =
+            gameRepository.findByIdOrNull(event.gameId)
+                ?: throw GameNotFoundException(event.gameId)
+
+        val competition = game.competition
+        val competitionId = competition.id
+
+        logger.debug(
+            "경기 결과 확정 이벤트 수신 (gameId={}, competitionId={})",
+            event.gameId,
+            competitionId,
+        )
+
+        // 대회 자동 완료 처리
+        if (competition.status == CompetitionStatus.IN_PROGRESS) {
+            val totalGames = gameRepository.countByCompetitionId(competitionId)
+            val completedOrCancelledGames =
+                gameRepository.countCompletedOrCancelledByCompetitionId(competitionId)
+
+            logger.debug(
+                "대회 경기 현황 (competitionId={}, total={}, completedOrCancelled={})",
+                competitionId,
+                totalGames,
+                completedOrCancelledGames,
+            )
+
+            if (totalGames > 0 && totalGames == completedOrCancelledGames) {
+                competition.complete()
+                competitionRepository.save(competition)
+                logger.info(
+                    "대회 자동 완료 처리 (competitionId={}, name={})",
+                    competitionId,
+                    competition.name,
+                )
+            }
+        }
+    }
+
+    /**
+     * 경기 결과 확정 후 순위 캐시를 무효화합니다.
+     *
+     * AFTER_COMMIT 단계에서 실행하여 DB 커밋 이후 캐시를 제거합니다.
+     * competitionId 기준으로 캐시 키를 직접 제거합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun evictStandingsCache(event: GameResultConfirmedEvent) {
+        val game =
+            gameRepository.findByIdOrNull(event.gameId)
+                ?: run {
+                    logger.warn("캐시 무효화 중 경기를 찾을 수 없음 (gameId={})", event.gameId)
+                    return
+                }
+
+        val competitionId = game.competition.id
+        cacheManager.getCache(CacheConfig.STANDINGS_CACHE)?.evict(competitionId)
+
+        logger.debug(
+            "순위 캐시 무효화 완료 (competitionId={}, gameId={})",
+            competitionId,
+            event.gameId,
+        )
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
@@ -33,4 +33,18 @@ interface GameRepository :
     override fun findByIdWithTeams(
         @Param("id") id: Long,
     ): Game?
+
+    @Query("SELECT COUNT(g) FROM Game g WHERE g.competition.id = :competitionId")
+    override fun countByCompetitionId(
+        @Param("competitionId") competitionId: Long,
+    ): Long
+
+    @Query(
+        "SELECT COUNT(g) FROM Game g " +
+            "WHERE g.competition.id = :competitionId " +
+            "AND g.status IN ('FINISHED', 'CALLED', 'FORFEITED', 'CANCELLED')",
+    )
+    override fun countCompletedOrCancelledByCompetitionId(
+        @Param("competitionId") competitionId: Long,
+    ): Long
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/standings/StandingsServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/standings/StandingsServiceImpl.kt
@@ -8,6 +8,8 @@ import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.service.standings.StandingsService
 import com.nextup.core.service.standings.dto.StandingsDto
 import com.nextup.core.service.standings.dto.TeamStandingDto
+import com.nextup.infrastructure.config.CacheConfig
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -23,6 +25,7 @@ class StandingsServiceImpl(
     private val competitionRepository: CompetitionRepositoryPort,
     private val gameTeamRepository: GameTeamRepositoryPort,
 ) : StandingsService {
+    @Cacheable(cacheNames = [CacheConfig.STANDINGS_CACHE], key = "#competitionId")
     override fun getStandings(competitionId: Long): StandingsDto {
         // 1. 대회 조회
         val competition =

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameResultEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameResultEventListenerTest.kt
@@ -1,0 +1,255 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.event.GameResultConfirmedEvent
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.infrastructure.config.CacheConfig
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameResultEventListener 테스트")
+class GameResultEventListenerTest {
+    private val gameRepository = mockk<GameRepositoryPort>()
+    private val competitionRepository = mockk<CompetitionRepositoryPort>()
+    private val cacheManager = mockk<CacheManager>()
+    private val standingsCache = mockk<Cache>()
+
+    private val listener =
+        GameResultEventListener(gameRepository, competitionRepository, cacheManager)
+
+    private lateinit var competition: Competition
+    private lateinit var game: Game
+
+    @BeforeEach
+    fun setUp() {
+        competition = createCompetition(1L, CompetitionStatus.IN_PROGRESS)
+        game = createGame(10L, competition, GameStatus.FINISHED)
+
+        every { cacheManager.getCache(CacheConfig.STANDINGS_CACHE) } returns standingsCache
+        every { standingsCache.evict(any<Long>()) } returns Unit
+    }
+
+    @Nested
+    @DisplayName("onGameResultConfirmed - 경기 결과 확정 이벤트 처리")
+    inner class OnGameResultConfirmed {
+        @Test
+        fun `경기가 존재하지 않으면 GameNotFoundException 발생`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+
+            val event =
+                GameResultConfirmedEvent(
+                    gameId = 999L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    homeScore = 5,
+                    awayScore = 3,
+                )
+
+            // when & then
+            assertThrows<GameNotFoundException> {
+                listener.onGameResultConfirmed(event)
+            }
+        }
+
+        @Test
+        fun `모든 경기가 완료되면 대회를 자동 완료 처리`() {
+            // given
+            every { gameRepository.findByIdOrNull(10L) } returns game
+            every { gameRepository.countByCompetitionId(1L) } returns 5L
+            every { gameRepository.countCompletedOrCancelledByCompetitionId(1L) } returns 5L
+            every { competitionRepository.save(any()) } returnsArgument 0
+
+            val event =
+                GameResultConfirmedEvent(
+                    gameId = 10L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    homeScore = 5,
+                    awayScore = 3,
+                )
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then
+            assertThat(competition.status).isEqualTo(CompetitionStatus.COMPLETED)
+            verify { competitionRepository.save(competition) }
+        }
+
+        @Test
+        fun `아직 완료되지 않은 경기가 있으면 대회를 완료하지 않음`() {
+            // given
+            every { gameRepository.findByIdOrNull(10L) } returns game
+            every { gameRepository.countByCompetitionId(1L) } returns 5L
+            every { gameRepository.countCompletedOrCancelledByCompetitionId(1L) } returns 4L
+
+            val event =
+                GameResultConfirmedEvent(
+                    gameId = 10L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    homeScore = 5,
+                    awayScore = 3,
+                )
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then
+            assertThat(competition.status).isEqualTo(CompetitionStatus.IN_PROGRESS)
+            verify(exactly = 0) { competitionRepository.save(any()) }
+        }
+
+        @Test
+        fun `대회가 IN_PROGRESS 상태가 아니면 자동 완료 처리 건너뜀`() {
+            // given
+            val scheduledCompetition = createCompetition(2L, CompetitionStatus.SCHEDULED)
+            val scheduledGame = createGame(20L, scheduledCompetition, GameStatus.FINISHED)
+
+            every { gameRepository.findByIdOrNull(20L) } returns scheduledGame
+
+            val event =
+                GameResultConfirmedEvent(
+                    gameId = 20L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    homeScore = 3,
+                    awayScore = 1,
+                )
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then
+            verify(exactly = 0) { gameRepository.countByCompetitionId(any()) }
+            verify(exactly = 0) { competitionRepository.save(any()) }
+        }
+
+        @Test
+        fun `대회에 경기가 없으면 자동 완료 처리 건너뜀`() {
+            // given
+            every { gameRepository.findByIdOrNull(10L) } returns game
+            every { gameRepository.countByCompetitionId(1L) } returns 0L
+            every { gameRepository.countCompletedOrCancelledByCompetitionId(1L) } returns 0L
+
+            val event =
+                GameResultConfirmedEvent(
+                    gameId = 10L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    homeScore = 5,
+                    awayScore = 3,
+                )
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then
+            assertThat(competition.status).isEqualTo(CompetitionStatus.IN_PROGRESS)
+            verify(exactly = 0) { competitionRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("evictStandingsCache - 순위 캐시 무효화")
+    inner class EvictStandingsCache {
+        @Test
+        fun `경기 결과 확정 후 해당 대회의 순위 캐시를 무효화`() {
+            // given
+            every { gameRepository.findByIdOrNull(10L) } returns game
+
+            val event =
+                GameResultConfirmedEvent(
+                    gameId = 10L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    homeScore = 5,
+                    awayScore = 3,
+                )
+
+            // when
+            listener.evictStandingsCache(event)
+
+            // then
+            verify { cacheManager.getCache(CacheConfig.STANDINGS_CACHE) }
+            verify { standingsCache.evict(1L) }
+        }
+
+        @Test
+        fun `경기를 찾을 수 없으면 캐시 무효화 없이 반환`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+
+            val event =
+                GameResultConfirmedEvent(
+                    gameId = 999L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    homeScore = 5,
+                    awayScore = 3,
+                )
+
+            // when
+            listener.evictStandingsCache(event)
+
+            // then
+            verify(exactly = 0) { standingsCache.evict(any<Long>()) }
+        }
+    }
+
+    // Helper methods
+    private fun createCompetition(
+        id: Long,
+        status: CompetitionStatus,
+    ): Competition {
+        val competition =
+            Competition(
+                league = mockk(relaxed = true),
+                name = "테스트 대회 $id",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = status,
+            )
+        val idField = Competition::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(competition, id)
+        return competition
+    }
+
+    private fun createGame(
+        id: Long,
+        competition: Competition,
+        status: GameStatus,
+    ): Game {
+        val game =
+            Game(
+                competition = competition,
+                scheduledAt = LocalDateTime.of(2025, 5, 10, 14, 0),
+                status = status,
+            )
+        val idField = Game::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(game, id)
+        return game
+    }
+}


### PR DESCRIPTION
## Summary

> - Closes #228

Spring Cache(Caffeine)를 활용한 순위표 캐싱과 경기 결과 확정 이벤트 기반 대회 자동 완료 처리를 구현합니다.

## Tasks

- \`CacheConfig\`: \`@EnableCaching\` + Caffeine 기반 \`CacheManager\` 설정 (standings 캐시 10분 TTL, 최대 200개)
- \`StandingsServiceImpl.getStandings()\`: \`@Cacheable("standings", key = "#competitionId")\` 적용
- \`GameResultEventListener\` 신규 생성:
  - \`BEFORE_COMMIT\` 단계: 대회의 모든 경기가 완료/취소된 경우 \`Competition.complete()\` 자동 호출
  - \`AFTER_COMMIT\` 단계: 해당 대회의 standings 캐시를 \`CacheManager\`로 직접 무효화
- \`GameRepositoryPort\` / \`GameRepository\`: \`countByCompetitionId\`, \`countCompletedOrCancelledByCompetitionId\` 메서드 추가
- \`GameResultEventListenerTest\`: 7개 단위 테스트 작성 (자동완료, 캐시 무효화, 예외처리 검증)
- \`build.gradle.kts\`: \`spring-boot-starter-cache\` 의존성 추가

## To Reviewer

- \`BEFORE_COMMIT\` 단계에서 대회 자동 완료를 처리하여 동일 트랜잭션 내 DB 반영을 보장합니다.
- \`AFTER_COMMIT\` 단계에서 캐시 무효화를 처리하여 커밋 확정 후에만 캐시가 제거됩니다.
- 완료 조건: \`FINISHED\`, \`CALLED\`, \`FORFEITED\`, \`CANCELLED\` 상태 경기의 합이 전체 경기 수와 같을 때.
- \`@CacheEvict\` 어노테이션 대신 \`CacheManager.getCache().evict(competitionId)\` 직접 호출 방식 사용 (이벤트 객체에서 competitionId를 동적으로 조회해야 하므로).