### PR TITLE
fix(#214): 경기 종료 시 시즌/커리어 스탯 자동 집계 파이프라인 구축

### DIFF
--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
@@ -1,10 +1,19 @@
 package com.nextup.infrastructure.listener
 
 import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlateAppearanceUndoneEvent
+import com.nextup.core.domain.stats.CareerBattingStats
+import com.nextup.core.domain.stats.CareerPitchingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -15,11 +24,17 @@ import org.springframework.transaction.event.TransactionalEventListener
  * 실시간 통계 갱신 이벤트 리스너
  *
  * 경기 중 타석 이벤트를 수신하여 시즌 타격 통계를 즉시 갱신합니다.
+ * 경기 종료 이벤트를 수신하여 투수 스탯 및 커리어 스탯을 집계합니다.
  * Infrastructure 계층에 위치하여 Core의 Port를 통해 데이터에 접근합니다.
  */
 @Component
 class StatsEventListener(
     private val seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort,
+    private val seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort,
+    private val careerBattingStatsRepository: CareerBattingStatsRepositoryPort,
+    private val careerPitchingStatsRepository: CareerPitchingStatsRepositoryPort,
+    private val battingRecordRepository: BattingRecordRepositoryPort,
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
     private val gameRepository: GameRepositoryPort,
 ) {
     private val logger = LoggerFactory.getLogger(StatsEventListener::class.java)
@@ -85,6 +100,101 @@ class StatsEventListener(
             event.playerId,
             year,
             event.result,
+        )
+    }
+
+    /**
+     * 경기 결과 확정 이벤트를 처리합니다.
+     *
+     * 경기 종료 시점에 다음 통계를 일괄 집계합니다:
+     * - SeasonPitchingStats: 경기별 투수 기록 누적 (신규)
+     * - CareerBattingStats: 커리어 타격 기록 누적 (신규)
+     * - CareerPitchingStats: 커리어 투수 기록 누적 (신규)
+     *
+     * SeasonBattingStats는 PlateAppearanceRecordedEvent를 통해 실시간 반영되므로
+     * 여기서는 처리하지 않습니다.
+     *
+     * 처리 순서:
+     * 1. 투수 스탯: isFirstSeasonRecord 확인 → SeasonPitchingStats 갱신 → CareerPitchingStats 갱신
+     * 2. 타자 스탯: isFirstSeasonRecord 확인 → CareerBattingStats 갱신
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional
+    fun onGameResultConfirmed(event: GameResultConfirmedEvent) {
+        val gameId = event.gameId
+        val year = resolveYear(gameId)
+
+        logger.info("경기 결과 확정 스탯 집계 시작 (gameId={}, year={})", gameId, year)
+
+        val battingRecords = battingRecordRepository.findAllByGameId(gameId)
+        val pitchingRecords = pitchingRecordRepository.findAllByGameId(gameId)
+
+        // 투수 스탯 집계: SeasonPitchingStats + CareerPitchingStats
+        // isFirstSeasonRecord를 SeasonPitchingStats 저장 전에 확인해야 올바른 값이 반환됩니다.
+        for (pitchingRecord in pitchingRecords) {
+            val player = pitchingRecord.gamePlayer.player
+            val playerId = player.id
+
+            val existingSeasonPitching =
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year)
+            val isFirstPitchingSeason = existingSeasonPitching == null
+
+            // SeasonPitchingStats 갱신
+            val seasonPitchingStats = existingSeasonPitching ?: SeasonPitchingStats.create(player = player, year = year)
+            seasonPitchingStats.addGameRecord(pitchingRecord)
+            seasonPitchingStatsRepository.save(seasonPitchingStats)
+
+            // CareerPitchingStats 갱신
+            val careerPitchingStats =
+                careerPitchingStatsRepository.findByPlayerId(playerId)
+                    ?: CareerPitchingStats.create(player = player)
+
+            if (isFirstPitchingSeason) {
+                careerPitchingStats.addSeason()
+            }
+            careerPitchingStats.addGameRecord(pitchingRecord)
+            careerPitchingStatsRepository.save(careerPitchingStats)
+
+            logger.debug(
+                "투수 통계 갱신 완료 (playerId={}, year={}, isFirstSeason={})",
+                playerId,
+                year,
+                isFirstPitchingSeason,
+            )
+        }
+
+        // 커리어 타격 스탯 집계: CareerBattingStats
+        // SeasonBattingStats는 PlateAppearanceRecordedEvent로 실시간 갱신되므로
+        // 해당 시즌 통계 존재 여부로 첫 시즌인지 판단합니다.
+        for (battingRecord in battingRecords) {
+            val player = battingRecord.gamePlayer.player
+            val playerId = player.id
+
+            val isFirstBattingSeason =
+                seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year) == null
+
+            val careerBattingStats =
+                careerBattingStatsRepository.findByPlayerId(playerId)
+                    ?: CareerBattingStats.create(player = player)
+
+            if (isFirstBattingSeason) {
+                careerBattingStats.addSeason()
+            }
+            careerBattingStats.addGameRecord(battingRecord)
+            careerBattingStatsRepository.save(careerBattingStats)
+
+            logger.debug(
+                "커리어 타격 통계 갱신 완료 (playerId={}, isFirstSeason={})",
+                playerId,
+                isFirstBattingSeason,
+            )
+        }
+
+        logger.info(
+            "경기 결과 확정 스탯 집계 완료 (gameId={}, battingRecords={}, pitchingRecords={})",
+            gameId,
+            battingRecords.size,
+            pitchingRecords.size,
         )
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
@@ -1,17 +1,29 @@
 package com.nextup.infrastructure.listener
 
 import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlateAppearanceUndoneEvent
+import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.player.BattingHand
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.domain.stats.CareerBattingStats
+import com.nextup.core.domain.stats.CareerPitchingStats
 import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -26,9 +38,23 @@ import java.time.LocalDateTime
 @DisplayName("StatsEventListener 테스트")
 class StatsEventListenerTest {
     private val seasonBattingStatsRepository = mockk<SeasonBattingStatsRepositoryPort>()
+    private val seasonPitchingStatsRepository = mockk<SeasonPitchingStatsRepositoryPort>()
+    private val careerBattingStatsRepository = mockk<CareerBattingStatsRepositoryPort>()
+    private val careerPitchingStatsRepository = mockk<CareerPitchingStatsRepositoryPort>()
+    private val battingRecordRepository = mockk<BattingRecordRepositoryPort>()
+    private val pitchingRecordRepository = mockk<PitchingRecordRepositoryPort>()
     private val gameRepository = mockk<GameRepositoryPort>()
 
-    private val listener = StatsEventListener(seasonBattingStatsRepository, gameRepository)
+    private val listener =
+        StatsEventListener(
+            seasonBattingStatsRepository = seasonBattingStatsRepository,
+            seasonPitchingStatsRepository = seasonPitchingStatsRepository,
+            careerBattingStatsRepository = careerBattingStatsRepository,
+            careerPitchingStatsRepository = careerPitchingStatsRepository,
+            battingRecordRepository = battingRecordRepository,
+            pitchingRecordRepository = pitchingRecordRepository,
+            gameRepository = gameRepository,
+        )
 
     private val testPlayer =
         Player(
@@ -37,6 +63,15 @@ class StatsEventListenerTest {
             throwingHand = ThrowingHand.RIGHT,
             battingHand = BattingHand.RIGHT,
             id = 1L,
+        )
+
+    private val testPitcher =
+        Player(
+            name = "박투수",
+            primaryPosition = Position.STARTING_PITCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 2L,
         )
 
     private val mockGame = mockk<Game>()
@@ -283,6 +318,250 @@ class StatsEventListenerTest {
             // when & then
             assertThrows<GameNotFoundException> {
                 listener.onPlateAppearanceUndone(event)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("onGameResultConfirmed - 경기 결과 확정 이벤트 처리")
+    inner class OnGameResultConfirmed {
+        private val mockBattingRecord = mockk<BattingRecord>(relaxed = true)
+        private val mockPitchingRecord = mockk<PitchingRecord>(relaxed = true)
+        private val mockGamePlayer = mockk<GamePlayer>()
+        private val mockPitcherGamePlayer = mockk<GamePlayer>()
+
+        private val gameId = 10L
+        private val event =
+            GameResultConfirmedEvent(
+                gameId = gameId,
+                homeTeamId = 1L,
+                awayTeamId = 2L,
+                homeScore = 3,
+                awayScore = 1,
+            )
+
+        @BeforeEach
+        fun setUpRecords() {
+            every { mockBattingRecord.gamePlayer } returns mockGamePlayer
+            every { mockGamePlayer.player } returns testPlayer
+            every { mockPitchingRecord.gamePlayer } returns mockPitcherGamePlayer
+            every { mockPitcherGamePlayer.player } returns testPitcher
+        }
+
+        @Test
+        fun `경기 종료 시 SeasonPitchingStats가 신규 생성되고 기록이 누적됨`() {
+            // given
+            val careerPitching = CareerPitchingStats.create(testPitcher)
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns listOf(mockPitchingRecord)
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns null
+            every { seasonPitchingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerPitchingStatsRepository.findByPlayerId(testPitcher.id) } returns careerPitching
+            every { careerPitchingStatsRepository.save(any()) } answers { firstArg() }
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: 새 SeasonPitchingStats 생성 및 저장 확인
+            verify(exactly = 1) { seasonPitchingStatsRepository.save(any()) }
+            // CareerPitchingStats도 저장됨
+            verify(exactly = 1) { careerPitchingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `경기 종료 시 기존 SeasonPitchingStats에 기록이 누적됨`() {
+            // given
+            val seasonPitching = SeasonPitchingStats.create(testPitcher, 2024)
+            val careerPitching = CareerPitchingStats.create(testPitcher)
+            careerPitching.addSeason()
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns listOf(mockPitchingRecord)
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns seasonPitching
+            every { seasonPitchingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerPitchingStatsRepository.findByPlayerId(testPitcher.id) } returns careerPitching
+            every { careerPitchingStatsRepository.save(any()) } answers { firstArg() }
+
+            val initialGames = seasonPitching.gamesPlayed
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: gamesPlayed 가 1 증가함
+            assertThat(seasonPitching.gamesPlayed).isEqualTo(initialGames + 1)
+            verify(exactly = 1) { seasonPitchingStatsRepository.save(seasonPitching) }
+        }
+
+        @Test
+        fun `첫 시즌 투수 기록 시 CareerPitchingStats에 addSeason 호출됨`() {
+            // given: 시즌 통계 없음(첫 시즌)
+            val careerPitching = CareerPitchingStats.create(testPitcher)
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns listOf(mockPitchingRecord)
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns null
+            every { seasonPitchingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerPitchingStatsRepository.findByPlayerId(testPitcher.id) } returns careerPitching
+            every { careerPitchingStatsRepository.save(any()) } answers { firstArg() }
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: 첫 시즌이므로 seasonsPlayed = 1
+            assertThat(careerPitching.seasonsPlayed).isEqualTo(1)
+        }
+
+        @Test
+        fun `기존 시즌 투수 기록 시 CareerPitchingStats에 addSeason 호출되지 않음`() {
+            // given: 시즌 통계 이미 존재
+            val existingSeason = SeasonPitchingStats.create(testPitcher, 2024)
+            val careerPitching = CareerPitchingStats.create(testPitcher)
+            careerPitching.addSeason() // 이미 시즌 카운트 1
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns listOf(mockPitchingRecord)
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns existingSeason
+            every { seasonPitchingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerPitchingStatsRepository.findByPlayerId(testPitcher.id) } returns careerPitching
+            every { careerPitchingStatsRepository.save(any()) } answers { firstArg() }
+
+            val initialSeasons = careerPitching.seasonsPlayed
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: addSeason 호출 안 됨 - seasonsPlayed 변화 없음
+            assertThat(careerPitching.seasonsPlayed).isEqualTo(initialSeasons)
+        }
+
+        @Test
+        fun `경기 종료 시 CareerBattingStats가 신규 생성되고 기록이 누적됨`() {
+            // given
+            every { battingRecordRepository.findAllByGameId(gameId) } returns listOf(mockBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns null
+            every { careerBattingStatsRepository.findByPlayerId(testPlayer.id) } returns null
+            every { careerBattingStatsRepository.save(any()) } answers { firstArg() }
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: 새 CareerBattingStats 생성 및 저장 확인
+            verify(exactly = 1) { careerBattingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `경기 종료 시 기존 CareerBattingStats에 기록이 누적됨`() {
+            // given: 이미 존재하는 커리어 통계
+            val careerBatting = CareerBattingStats.create(testPlayer)
+            careerBatting.addSeason()
+            val existingSeason = SeasonBattingStats.create(testPlayer, 2024)
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns listOf(mockBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns existingSeason
+            every { careerBattingStatsRepository.findByPlayerId(testPlayer.id) } returns careerBatting
+            every { careerBattingStatsRepository.save(any()) } answers { firstArg() }
+
+            val initialGames = careerBatting.gamesPlayed
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: gamesPlayed 가 1 증가함
+            assertThat(careerBatting.gamesPlayed).isEqualTo(initialGames + 1)
+            verify(exactly = 1) { careerBattingStatsRepository.save(careerBatting) }
+        }
+
+        @Test
+        fun `첫 시즌 타격 기록 시 CareerBattingStats에 addSeason 호출됨`() {
+            // given: 시즌 타격 통계 없음 (첫 시즌)
+            val careerBatting = CareerBattingStats.create(testPlayer)
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns listOf(mockBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns null
+            every { careerBattingStatsRepository.findByPlayerId(testPlayer.id) } returns careerBatting
+            every { careerBattingStatsRepository.save(any()) } answers { firstArg() }
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: 첫 시즌이므로 seasonsPlayed = 1
+            assertThat(careerBatting.seasonsPlayed).isEqualTo(1)
+        }
+
+        @Test
+        fun `기존 시즌 타격 기록 시 CareerBattingStats에 addSeason 호출되지 않음`() {
+            // given: 이미 시즌 타격 통계 존재
+            val existingSeason = SeasonBattingStats.create(testPlayer, 2024)
+            val careerBatting = CareerBattingStats.create(testPlayer)
+            careerBatting.addSeason()
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns listOf(mockBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns existingSeason
+            every { careerBattingStatsRepository.findByPlayerId(testPlayer.id) } returns careerBatting
+            every { careerBattingStatsRepository.save(any()) } answers { firstArg() }
+
+            val initialSeasons = careerBatting.seasonsPlayed
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: addSeason 호출 안 됨
+            assertThat(careerBatting.seasonsPlayed).isEqualTo(initialSeasons)
+        }
+
+        @Test
+        fun `타격 기록과 투수 기록이 모두 없는 경우 아무것도 저장하지 않음`() {
+            // given
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then
+            verify(exactly = 0) { seasonPitchingStatsRepository.save(any()) }
+            verify(exactly = 0) { careerBattingStatsRepository.save(any()) }
+            verify(exactly = 0) { careerPitchingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `경기를 찾을 수 없는 경우 GameNotFoundException 발생`() {
+            // given
+            every { gameRepository.findByIdOrNull(any()) } returns null
+
+            val badEvent =
+                GameResultConfirmedEvent(
+                    gameId = 999L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    homeScore = 0,
+                    awayScore = 0,
+                )
+
+            // when & then
+            assertThrows<GameNotFoundException> {
+                listener.onGameResultConfirmed(badEvent)
             }
         }
     }


### PR DESCRIPTION
## Summary

> - Closes #214

경기 종료 시 `GameResultConfirmedEvent`를 수신하여 시즌 투수 스탯 및 커리어 타격/투수 스탯을 자동으로 집계하는 파이프라인을 구축합니다.

기존에는 `PlateAppearanceRecordedEvent`를 통해 `SeasonBattingStats`만 실시간으로 갱신되고, `SeasonPitchingStats`·`CareerBattingStats`·`CareerPitchingStats`는 경기 종료 시 집계하는 로직이 없었습니다.

## Tasks

- `StatsEventListener`에 `onGameResultConfirmed` 핸들러 추가 (`@TransactionalEventListener(phase = AFTER_COMMIT)`)
- `SeasonPitchingStats` 갱신: 경기의 모든 `PitchingRecord`를 누적 집계 (없으면 신규 생성)
- `CareerPitchingStats` 갱신: 첫 시즌 여부 판단 후 `addSeason()` 및 `addGameRecord()` 호출
- `CareerBattingStats` 갱신: 첫 시즌 여부 판단 후 `addSeason()` 및 `addGameRecord()` 호출
- 중복 방지: `SeasonBattingStats`는 `PlateAppearanceRecordedEvent`로 이미 실시간 반영되므로 제외
- 순서 보장: `isFirstSeasonRecord` 판단을 `SeasonPitchingStats` 저장 **전**에 수행하여 정확성 보장
- `StatsEventListenerTest`에 `onGameResultConfirmed` 핸들러 테스트 9개 추가

## To Reviewer

- `onGameResultConfirmed` 핸들러 내에서 투수 스탯을 먼저 처리하고, 그 뒤 커리어 타자 스탯을 처리합니다. 이 순서는 `isFirstSeasonRecord` 플래그를 올바르게 계산하기 위한 것입니다.
- `SeasonBattingStats`를 경기 종료 시점에 재집계하지 않는 이유: `PlateAppearanceRecordedEvent`로 이미 실시간 갱신되어 있어 중복 집계가 발생할 수 있습니다.
- 새로운 생성자 파라미터(`seasonPitchingStatsRepository`, `careerBattingStatsRepository`, `careerPitchingStatsRepository`, `battingRecordRepository`, `pitchingRecordRepository`)가 `StatsEventListener`에 추가되었습니다. Spring DI로 자동 주입됩니다.