### PR TITLE
feat(#230): 프론트엔드 편의 API 모음 (캘린더, 알림 카운트, 통합 검색 등)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536m -XX:MaxMetaspaceSize=384m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.workers.max=1

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/GameScheduleController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/GameScheduleController.kt
@@ -1,8 +1,10 @@
 package com.nextup.api.controller.game
 
+import com.nextup.api.dto.game.AvailableRosterResponse
 import com.nextup.api.dto.game.GameDetailResponse
 import com.nextup.api.dto.game.GameSummaryResponse
 import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.game.AvailableRosterService
 import com.nextup.core.service.game.GameScheduleService
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,6 +21,7 @@ import java.time.LocalDate
 @RequestMapping("/api/v1")
 class GameScheduleController(
     private val gameScheduleService: GameScheduleService,
+    private val availableRosterService: AvailableRosterService,
 ) {
     /**
      * 경기 목록을 조회합니다. (날짜/팀/대회 필터, 페이징)
@@ -74,5 +77,34 @@ class GameScheduleController(
     ): ApiResponse<List<GameSummaryResponse>> {
         val games = gameScheduleService.getUpcomingGamesByTeam(teamId, limit)
         return ApiResponse.success(games.map { GameSummaryResponse.from(it) })
+    }
+
+    /**
+     * 특정 연월의 경기 있는 날짜(일) 목록을 반환합니다. (A-05: 캘린더 뷰)
+     *
+     * GET /api/v1/games/calendar?year={year}&month={month}&teamId={teamId}
+     */
+    @GetMapping("/games/calendar")
+    fun getGameCalendar(
+        @RequestParam year: Int,
+        @RequestParam month: Int,
+        @RequestParam(required = false) teamId: Long?,
+    ): ApiResponse<List<Int>> {
+        val days = gameScheduleService.getGameDaysInMonth(year, month, teamId)
+        return ApiResponse.success(days)
+    }
+
+    /**
+     * 라인업 제출용 출전 가능 선수 목록을 조회합니다. (A-07: 로스터)
+     *
+     * GET /api/v1/games/{gameId}/available-roster?teamId={teamId}
+     */
+    @GetMapping("/games/{gameId}/available-roster")
+    fun getAvailableRoster(
+        @PathVariable gameId: Long,
+        @RequestParam teamId: Long,
+    ): ApiResponse<AvailableRosterResponse> {
+        val roster = availableRosterService.getAvailableRoster(gameId, teamId)
+        return ApiResponse.success(AvailableRosterResponse.from(roster))
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
@@ -5,6 +5,7 @@ import com.nextup.api.dto.notification.DeviceTokenResponse
 import com.nextup.api.dto.notification.NotificationPreferenceResponse
 import com.nextup.api.dto.notification.NotificationResponse
 import com.nextup.api.dto.notification.RegisterDeviceApiRequest
+import com.nextup.api.dto.notification.UnreadCountResponse
 import com.nextup.api.dto.notification.UpdatePreferenceApiRequest
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.notification.NotificationService
@@ -114,5 +115,18 @@ class NotificationController(
     ): ApiResponse<List<NotificationPreferenceResponse>> {
         val preferences = notificationService.getUserPreferences(userId)
         return ApiResponse.success(preferences.map { NotificationPreferenceResponse.from(it) })
+    }
+
+    /**
+     * 미읽은 알림 개수를 조회합니다. (A-06)
+     *
+     * GET /api/v1/notifications/unread-count
+     */
+    @GetMapping("/notifications/unread-count")
+    fun getUnreadCount(
+        @AuthenticationPrincipal userId: Long,
+    ): ApiResponse<UnreadCountResponse> {
+        val count = notificationService.getUnreadCount(userId)
+        return ApiResponse.success(UnreadCountResponse(count = count))
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/search/SearchController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/search/SearchController.kt
@@ -1,0 +1,34 @@
+package com.nextup.api.controller.search
+
+import com.nextup.api.dto.search.SearchResponse
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.search.SearchService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 통합 검색 API Controller (A-08)
+ *
+ * 선수/팀/대회를 동시 검색합니다.
+ */
+@RestController
+@RequestMapping("/api/v1")
+class SearchController(
+    private val searchService: SearchService,
+) {
+    /**
+     * 키워드로 선수, 팀, 대회를 검색합니다.
+     *
+     * GET /api/v1/search?q={keyword}&limit={limit}
+     */
+    @GetMapping("/search")
+    fun search(
+        @RequestParam q: String,
+        @RequestParam(defaultValue = "5") limit: Int,
+    ): ApiResponse<SearchResponse> {
+        val result = searchService.search(keyword = q, limit = limit)
+        return ApiResponse.success(SearchResponse.from(result))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/AvailableRosterResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/AvailableRosterResponse.kt
@@ -1,0 +1,44 @@
+package com.nextup.api.dto.game
+
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.game.dto.AvailableRosterDto
+import com.nextup.core.service.game.dto.RosterPlayerDto
+
+/**
+ * 라인업 제출용 출전 가능 선수 목록 응답 DTO
+ */
+data class AvailableRosterResponse(
+    val players: List<RosterPlayerResponse>,
+) {
+    companion object {
+        fun from(dto: AvailableRosterDto): AvailableRosterResponse =
+            AvailableRosterResponse(
+                players = dto.players.map { RosterPlayerResponse.from(it) },
+            )
+    }
+}
+
+/**
+ * 로스터 선수 정보 응답 DTO
+ */
+data class RosterPlayerResponse(
+    val playerId: Long,
+    val playerName: String,
+    val primaryPosition: Position,
+    val profileImageUrl: String?,
+    val competitionPlayerStatus: CompetitionPlayerStatus,
+    val isEligible: Boolean,
+) {
+    companion object {
+        fun from(dto: RosterPlayerDto): RosterPlayerResponse =
+            RosterPlayerResponse(
+                playerId = dto.playerId,
+                playerName = dto.playerName,
+                primaryPosition = dto.primaryPosition,
+                profileImageUrl = dto.profileImageUrl,
+                competitionPlayerStatus = dto.competitionPlayerStatus,
+                isEligible = dto.isEligible,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/UnreadCountResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/notification/UnreadCountResponse.kt
@@ -1,0 +1,8 @@
+package com.nextup.api.dto.notification
+
+/**
+ * 미읽은 알림 개수 응답 DTO
+ */
+data class UnreadCountResponse(
+    val count: Long,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/search/SearchResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/search/SearchResponse.kt
@@ -1,0 +1,86 @@
+package com.nextup.api.dto.search
+
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.search.dto.SearchResultDto
+
+/**
+ * 통합 검색 응답 DTO
+ */
+data class SearchResponse(
+    val players: List<PlayerSearchResponse>,
+    val teams: List<TeamSearchResponse>,
+    val competitions: List<CompetitionSearchResponse>,
+) {
+    companion object {
+        fun from(dto: SearchResultDto): SearchResponse =
+            SearchResponse(
+                players = dto.players.map { PlayerSearchResponse.from(it) },
+                teams = dto.teams.map { TeamSearchResponse.from(it) },
+                competitions = dto.competitions.map { CompetitionSearchResponse.from(it) },
+            )
+    }
+}
+
+/**
+ * 선수 검색 결과 응답 DTO
+ */
+data class PlayerSearchResponse(
+    val playerId: Long,
+    val playerName: String,
+    val primaryPosition: Position,
+    val profileImageUrl: String?,
+    val teamName: String?,
+) {
+    companion object {
+        fun from(dto: com.nextup.core.service.search.dto.PlayerSearchDto): PlayerSearchResponse =
+            PlayerSearchResponse(
+                playerId = dto.playerId,
+                playerName = dto.playerName,
+                primaryPosition = dto.primaryPosition,
+                profileImageUrl = dto.profileImageUrl,
+                teamName = dto.teamName,
+            )
+    }
+}
+
+/**
+ * 팀 검색 결과 응답 DTO
+ */
+data class TeamSearchResponse(
+    val teamId: Long,
+    val teamName: String,
+    val city: String,
+    val logoUrl: String?,
+    val isActive: Boolean,
+) {
+    companion object {
+        fun from(dto: com.nextup.core.service.search.dto.TeamSearchDto): TeamSearchResponse =
+            TeamSearchResponse(
+                teamId = dto.teamId,
+                teamName = dto.teamName,
+                city = dto.city,
+                logoUrl = dto.logoUrl,
+                isActive = dto.isActive,
+            )
+    }
+}
+
+/**
+ * 대회 검색 결과 응답 DTO
+ */
+data class CompetitionSearchResponse(
+    val competitionId: Long,
+    val competitionName: String,
+    val leagueName: String,
+    val year: Int,
+) {
+    companion object {
+        fun from(dto: com.nextup.core.service.search.dto.CompetitionSearchDto): CompetitionSearchResponse =
+            CompetitionSearchResponse(
+                competitionId = dto.competitionId,
+                competitionName = dto.competitionName,
+                leagueName = dto.leagueName,
+                year = dto.year,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/standings/StandingsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/standings/StandingsResponse.kt
@@ -58,6 +58,7 @@ data class TeamStandingResponse(
     val runsAllowed: Int,
     val runDifferential: Int,
     val isPlayoffPosition: Boolean,
+    val logoUrl: String? = null,
 ) {
     companion object {
         fun from(
@@ -79,6 +80,7 @@ data class TeamStandingResponse(
                 runsAllowed = dto.runsAllowed,
                 runDifferential = dto.runDifferential,
                 isPlayoffPosition = isPlayoffPosition,
+                logoUrl = dto.logoUrl,
             )
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/LeaderboardResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/LeaderboardResponse.kt
@@ -8,6 +8,7 @@ data class BattingLeaderResponse(
     val value: Double,
     val games: Int,
     val plateAppearances: Int,
+    val profileImageUrl: String? = null,
 )
 
 data class PitchingLeaderResponse(
@@ -18,4 +19,5 @@ data class PitchingLeaderResponse(
     val value: Double,
     val games: Int,
     val inningsPitched: Double,
+    val profileImageUrl: String? = null,
 )

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/LeaderboardMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/LeaderboardMapper.kt
@@ -14,6 +14,7 @@ fun BattingLeaderDto.toResponse(): BattingLeaderResponse =
         value = this.value,
         games = this.games,
         plateAppearances = this.plateAppearances,
+        profileImageUrl = this.profileImageUrl,
     )
 
 fun PitchingLeaderDto.toResponse(): PitchingLeaderResponse =
@@ -25,6 +26,7 @@ fun PitchingLeaderDto.toResponse(): PitchingLeaderResponse =
         value = this.value,
         games = this.games,
         inningsPitched = this.inningsPitched,
+        profileImageUrl = this.profileImageUrl,
     )
 
 fun List<BattingLeaderDto>.toBattingLeaderResponse(): List<BattingLeaderResponse> = this.map { it.toResponse() }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/GameScheduleControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/GameScheduleControllerTest.kt
@@ -2,10 +2,16 @@ package com.nextup.api.controller.game
 
 import com.nextup.api.exception.GlobalExceptionHandler
 import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.game.AvailableRosterService
 import com.nextup.core.service.game.GameScheduleService
+import com.nextup.core.service.game.dto.AvailableRosterDto
 import com.nextup.core.service.game.dto.GameDetailDto
 import com.nextup.core.service.game.dto.GameSummaryDto
+import com.nextup.core.service.game.dto.RosterPlayerDto
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
@@ -23,12 +29,14 @@ import java.time.LocalDateTime
 class GameScheduleControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var gameScheduleService: GameScheduleService
+    private lateinit var availableRosterService: AvailableRosterService
 
     @BeforeEach
     fun setUp() {
         gameScheduleService = mockk()
+        availableRosterService = mockk()
 
-        val controller = GameScheduleController(gameScheduleService)
+        val controller = GameScheduleController(gameScheduleService, availableRosterService)
         mockMvc =
             MockMvcBuilders
                 .standaloneSetup(controller)
@@ -235,6 +243,147 @@ class GameScheduleControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray)
                 .andExpect(jsonPath("$.data.length()").value(0))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/games/calendar")
+    inner class GetGameCalendar {
+        @Test
+        fun `캘린더 뷰 - 경기 있는 날짜 목록을 반환한다`() {
+            // given
+            every { gameScheduleService.getGameDaysInMonth(2025, 4, null) } returns listOf(5, 12, 19, 26)
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/games/calendar")
+                        .param("year", "2025")
+                        .param("month", "4"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(4))
+                .andExpect(jsonPath("$.data[0]").value(5))
+                .andExpect(jsonPath("$.data[1]").value(12))
+        }
+
+        @Test
+        fun `캘린더 뷰 - 팀 필터와 함께 경기 있는 날짜 목록을 반환한다`() {
+            // given
+            every { gameScheduleService.getGameDaysInMonth(2025, 4, 100L) } returns listOf(12, 26)
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/games/calendar")
+                        .param("year", "2025")
+                        .param("month", "4")
+                        .param("teamId", "100"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+        }
+
+        @Test
+        fun `캘린더 뷰 - 경기가 없으면 빈 리스트를 반환한다`() {
+            // given
+            every { gameScheduleService.getGameDaysInMonth(2025, 1, null) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/games/calendar")
+                        .param("year", "2025")
+                        .param("month", "1"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(0))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/games/{gameId}/available-roster")
+    inner class GetAvailableRoster {
+        @Test
+        fun `라인업 제출용 로스터를 정상적으로 반환한다`() {
+            // given
+            val roster =
+                AvailableRosterDto(
+                    players =
+                        listOf(
+                            RosterPlayerDto(
+                                playerId = 1L,
+                                playerName = "홍길동",
+                                primaryPosition = Position.STARTING_PITCHER,
+                                profileImageUrl = null,
+                                competitionPlayerStatus = CompetitionPlayerStatus.ACTIVE,
+                                isEligible = true,
+                            ),
+                            RosterPlayerDto(
+                                playerId = 2L,
+                                playerName = "김철수",
+                                primaryPosition = Position.CATCHER,
+                                profileImageUrl = "https://example.com/player2.jpg",
+                                competitionPlayerStatus = CompetitionPlayerStatus.SUSPENDED,
+                                isEligible = false,
+                            ),
+                        ),
+                )
+            every { availableRosterService.getAvailableRoster(1L, 100L) } returns roster
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/games/1/available-roster")
+                        .param("teamId", "100"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.players").isArray)
+                .andExpect(jsonPath("$.data.players.length()").value(2))
+                .andExpect(jsonPath("$.data.players[0].playerId").value(1))
+                .andExpect(jsonPath("$.data.players[0].playerName").value("홍길동"))
+                .andExpect(jsonPath("$.data.players[0].isEligible").value(true))
+                .andExpect(jsonPath("$.data.players[1].isEligible").value(false))
+                .andExpect(jsonPath("$.data.players[1].competitionPlayerStatus").value("SUSPENDED"))
+        }
+
+        @Test
+        fun `존재하지 않는 경기 로스터 조회 시 404를 반환한다`() {
+            // given
+            every { availableRosterService.getAvailableRoster(999L, 100L) } throws GameNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/games/999/available-roster")
+                        .param("teamId", "100"),
+                )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("GAME_NOT_FOUND"))
+        }
+
+        @Test
+        fun `존재하지 않는 팀으로 로스터 조회 시 404를 반환한다`() {
+            // given
+            every { availableRosterService.getAvailableRoster(1L, 999L) } throws TeamNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/games/1/available-roster")
+                        .param("teamId", "999"),
+                )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("TEAM_NOT_FOUND"))
         }
     }
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/notification/NotificationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/notification/NotificationControllerTest.kt
@@ -289,6 +289,36 @@ class NotificationControllerTest {
 
         verify(exactly = 1) { notificationService.getUserPreferences(authenticatedUserId) }
     }
+
+    @Test
+    fun `should get unread count successfully`() {
+        // given
+        every { notificationService.getUnreadCount(authenticatedUserId) } returns 5L
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/notifications/unread-count"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.count").value(5))
+
+        verify(exactly = 1) { notificationService.getUnreadCount(authenticatedUserId) }
+    }
+
+    @Test
+    fun `should return zero unread count when all notifications are read`() {
+        // given
+        every { notificationService.getUnreadCount(authenticatedUserId) } returns 0L
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/notifications/unread-count"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.count").value(0))
+
+        verify(exactly = 1) { notificationService.getUnreadCount(authenticatedUserId) }
+    }
 }
 
 /**

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/search/SearchControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/search/SearchControllerTest.kt
@@ -1,0 +1,172 @@
+package com.nextup.api.controller.search
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.search.SearchService
+import com.nextup.core.service.search.dto.CompetitionSearchDto
+import com.nextup.core.service.search.dto.PlayerSearchDto
+import com.nextup.core.service.search.dto.SearchResultDto
+import com.nextup.core.service.search.dto.TeamSearchDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("SearchController 테스트")
+class SearchControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var searchService: SearchService
+
+    @BeforeEach
+    fun setUp() {
+        searchService = mockk()
+
+        val controller = SearchController(searchService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/search")
+    inner class Search {
+        @Test
+        fun `키워드로 선수, 팀, 대회를 검색한다`() {
+            // given
+            val result =
+                SearchResultDto(
+                    players =
+                        listOf(
+                            PlayerSearchDto(
+                                playerId = 1L,
+                                playerName = "홍길동",
+                                primaryPosition = Position.STARTING_PITCHER,
+                                profileImageUrl = null,
+                                teamName = "서울팀",
+                            ),
+                        ),
+                    teams =
+                        listOf(
+                            TeamSearchDto(
+                                teamId = 10L,
+                                teamName = "서울야구단",
+                                city = "서울",
+                                logoUrl = "https://example.com/logo.png",
+                                isActive = true,
+                            ),
+                        ),
+                    competitions =
+                        listOf(
+                            CompetitionSearchDto(
+                                competitionId = 100L,
+                                competitionName = "서울 춘계대회",
+                                leagueName = "서울리그",
+                                year = 2025,
+                            ),
+                        ),
+                )
+            every { searchService.search(keyword = "서울", limit = 5) } returns result
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/search")
+                        .param("q", "서울"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.players").isArray)
+                .andExpect(jsonPath("$.data.players.length()").value(1))
+                .andExpect(jsonPath("$.data.players[0].playerId").value(1))
+                .andExpect(jsonPath("$.data.players[0].playerName").value("홍길동"))
+                .andExpect(jsonPath("$.data.teams").isArray)
+                .andExpect(jsonPath("$.data.teams.length()").value(1))
+                .andExpect(jsonPath("$.data.teams[0].teamId").value(10))
+                .andExpect(jsonPath("$.data.teams[0].teamName").value("서울야구단"))
+                .andExpect(jsonPath("$.data.competitions").isArray)
+                .andExpect(jsonPath("$.data.competitions.length()").value(1))
+                .andExpect(jsonPath("$.data.competitions[0].competitionId").value(100))
+
+            verify(exactly = 1) { searchService.search(keyword = "서울", limit = 5) }
+        }
+
+        @Test
+        fun `limit 파라미터를 지정해 검색한다`() {
+            // given
+            val result =
+                SearchResultDto(
+                    players = emptyList(),
+                    teams = emptyList(),
+                    competitions = emptyList(),
+                )
+            every { searchService.search(keyword = "홍", limit = 3) } returns result
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/search")
+                        .param("q", "홍")
+                        .param("limit", "3"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.players").isArray)
+                .andExpect(jsonPath("$.data.teams").isArray)
+                .andExpect(jsonPath("$.data.competitions").isArray)
+
+            verify(exactly = 1) { searchService.search(keyword = "홍", limit = 3) }
+        }
+
+        @Test
+        fun `검색 결과가 없으면 빈 목록을 반환한다`() {
+            // given
+            val result =
+                SearchResultDto(
+                    players = emptyList(),
+                    teams = emptyList(),
+                    competitions = emptyList(),
+                )
+            every { searchService.search(keyword = "존재하지않는키워드", limit = 5) } returns result
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/search")
+                        .param("q", "존재하지않는키워드"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.players.length()").value(0))
+                .andExpect(jsonPath("$.data.teams.length()").value(0))
+                .andExpect(jsonPath("$.data.competitions.length()").value(0))
+        }
+
+        @Test
+        fun `유효하지 않은 키워드로 검색 시 400을 반환한다`() {
+            // given
+            every {
+                searchService.search(keyword = " ", limit = 5)
+            } throws InvalidInputException("SEARCH_KEYWORD_TOO_SHORT", "검색 키워드는 최소 1자 이상이어야 합니다")
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/search")
+                        .param("q", " "),
+                )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
@@ -51,4 +51,14 @@ interface GameRepositoryPort {
      * 완료 상태: FINISHED, CALLED, FORFEITED, CANCELLED
      */
     fun countCompletedOrCancelledByCompetitionId(competitionId: Long): Long
+
+    /**
+     * 특정 연월의 경기 날짜(일) 목록을 조회합니다. (캘린더 뷰용)
+     * teamId가 제공되면 해당 팀의 경기만 조회합니다.
+     */
+    fun findGameDaysInMonth(
+        year: Int,
+        month: Int,
+        teamId: Long?,
+    ): List<Int>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/NotificationRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/NotificationRepositoryPort.kt
@@ -15,4 +15,9 @@ interface NotificationRepositoryPort {
     ): Page<Notification>
 
     fun findByUserId(userId: Long): List<Notification>
+
+    /**
+     * 사용자의 미읽은 알림 개수를 조회합니다.
+     */
+    fun countUnreadByUserId(userId: Long): Long
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/AvailableRosterService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/AvailableRosterService.kt
@@ -1,0 +1,22 @@
+package com.nextup.core.service.game
+
+import com.nextup.core.service.game.dto.AvailableRosterDto
+
+/**
+ * 라인업 제출용 로스터 조회 서비스 인터페이스
+ *
+ * 특정 경기의 팀 소속 선수 목록을 대회 등록/징계 상태와 함께 반환합니다.
+ */
+interface AvailableRosterService {
+    /**
+     * 특정 경기에 출전 가능한 팀의 선수 목록을 조회합니다.
+     *
+     * @param gameId 경기 ID
+     * @param teamId 팀 ID
+     * @return 로스터 선수 목록 (출전 가능 여부 포함)
+     */
+    fun getAvailableRoster(
+        gameId: Long,
+        teamId: Long,
+    ): AvailableRosterDto
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScheduleService.kt
@@ -36,4 +36,13 @@ interface GameScheduleService {
         teamId: Long,
         limit: Int = 5,
     ): List<GameSummaryDto>
+
+    /**
+     * 특정 연월에 경기가 있는 날짜(일) 목록을 반환합니다. (캘린더 뷰용)
+     */
+    fun getGameDaysInMonth(
+        year: Int,
+        month: Int,
+        teamId: Long?,
+    ): List<Int>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/AvailableRosterDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/AvailableRosterDto.kt
@@ -1,0 +1,23 @@
+package com.nextup.core.service.game.dto
+
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.domain.player.Position
+
+/**
+ * 라인업 제출용 출전 가능 선수 DTO
+ */
+data class AvailableRosterDto(
+    val players: List<RosterPlayerDto>,
+)
+
+/**
+ * 로스터 선수 정보 DTO
+ */
+data class RosterPlayerDto(
+    val playerId: Long,
+    val playerName: String,
+    val primaryPosition: Position,
+    val profileImageUrl: String?,
+    val competitionPlayerStatus: CompetitionPlayerStatus,
+    val isEligible: Boolean,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
@@ -173,6 +173,11 @@ class NotificationService(
      */
     fun getUserPreferences(userId: Long): List<NotificationPreference> = preferenceRepository.findByUserId(userId)
 
+    /**
+     * 사용자의 미읽은 알림 개수를 조회합니다.
+     */
+    fun getUnreadCount(userId: Long): Long = notificationRepository.countUnreadByUserId(userId)
+
     private fun verifyNotificationOwnership(
         notification: Notification,
         authenticatedUserId: Long,

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/search/SearchService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/search/SearchService.kt
@@ -1,0 +1,21 @@
+package com.nextup.core.service.search
+
+import com.nextup.core.service.search.dto.SearchResultDto
+
+/**
+ * 통합 검색 서비스 인터페이스
+ *
+ * 선수/팀/대회를 키워드로 동시 검색합니다.
+ */
+interface SearchService {
+    /**
+     * 키워드로 선수, 팀, 대회를 검색합니다.
+     *
+     * @param keyword 검색 키워드 (최소 1자)
+     * @param limit 각 카테고리별 최대 결과 수 (기본값: 5)
+     */
+    fun search(
+        keyword: String,
+        limit: Int = 5,
+    ): SearchResultDto
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/search/dto/SearchDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/search/dto/SearchDto.kt
@@ -1,0 +1,44 @@
+package com.nextup.core.service.search.dto
+
+import com.nextup.core.domain.player.Position
+
+/**
+ * 통합 검색 결과 DTO
+ */
+data class SearchResultDto(
+    val players: List<PlayerSearchDto>,
+    val teams: List<TeamSearchDto>,
+    val competitions: List<CompetitionSearchDto>,
+)
+
+/**
+ * 선수 검색 결과 DTO
+ */
+data class PlayerSearchDto(
+    val playerId: Long,
+    val playerName: String,
+    val primaryPosition: Position,
+    val profileImageUrl: String?,
+    val teamName: String?,
+)
+
+/**
+ * 팀 검색 결과 DTO
+ */
+data class TeamSearchDto(
+    val teamId: Long,
+    val teamName: String,
+    val city: String,
+    val logoUrl: String?,
+    val isActive: Boolean,
+)
+
+/**
+ * 대회 검색 결과 DTO
+ */
+data class CompetitionSearchDto(
+    val competitionId: Long,
+    val competitionName: String,
+    val leagueName: String,
+    val year: Int,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/standings/dto/TeamStandingDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/standings/dto/TeamStandingDto.kt
@@ -19,4 +19,5 @@ data class TeamStandingDto(
     val runsScored: Int,
     val runsAllowed: Int,
     val runDifferential: Int,
+    val logoUrl: String? = null,
 )

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/LeaderboardDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/dto/LeaderboardDto.kt
@@ -8,6 +8,7 @@ data class BattingLeaderDto(
     val value: Double,
     val games: Int,
     val plateAppearances: Int,
+    val profileImageUrl: String? = null,
 )
 
 data class PitchingLeaderDto(
@@ -18,6 +19,7 @@ data class PitchingLeaderDto(
     val value: Double,
     val games: Int,
     val inningsPitched: Double,
+    val profileImageUrl: String? = null,
 )
 
 enum class BattingCategory {

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
@@ -47,4 +47,24 @@ interface GameRepository :
     override fun countCompletedOrCancelledByCompetitionId(
         @Param("competitionId") competitionId: Long,
     ): Long
+
+    @Query(
+        "SELECT DISTINCT FUNCTION('DAY', g.scheduledAt) FROM Game g " +
+            "JOIN GameTeam gt ON gt.game.id = g.id " +
+            "WHERE FUNCTION('YEAR', g.scheduledAt) = :year " +
+            "AND FUNCTION('MONTH', g.scheduledAt) = :month " +
+            "AND (:teamId IS NULL OR gt.team.id = :teamId) " +
+            "ORDER BY FUNCTION('DAY', g.scheduledAt) ASC",
+    )
+    fun findGameDaysByYearAndMonth(
+        @Param("year") year: Int,
+        @Param("month") month: Int,
+        @Param("teamId") teamId: Long?,
+    ): List<Int>
+
+    override fun findGameDaysInMonth(
+        year: Int,
+        month: Int,
+        teamId: Long?,
+    ): List<Int> = findGameDaysByYearAndMonth(year, month, teamId)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
@@ -26,6 +26,5 @@ interface NotificationRepository :
         @Param("userId") userId: Long,
     ): Long
 
-    override fun countUnreadByUserId(userId: Long): Long =
-        countUnreadNotificationsByUserId(userId)
+    override fun countUnreadByUserId(userId: Long): Long = countUnreadNotificationsByUserId(userId)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
@@ -5,6 +5,8 @@ import com.nextup.core.port.repository.NotificationRepositoryPort
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface NotificationRepository :
     JpaRepository<Notification, Long>,
@@ -15,4 +17,15 @@ interface NotificationRepository :
     ): Page<Notification>
 
     override fun findByUserId(userId: Long): List<Notification>
+
+    @Query(
+        "SELECT COUNT(n) FROM Notification n " +
+            "WHERE n.userId = :userId AND n.readAt IS NULL",
+    )
+    fun countUnreadNotificationsByUserId(
+        @Param("userId") userId: Long,
+    ): Long
+
+    override fun countUnreadByUserId(userId: Long): Long =
+        countUnreadNotificationsByUserId(userId)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/AvailableRosterServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/AvailableRosterServiceImpl.kt
@@ -1,0 +1,60 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.game.AvailableRosterService
+import com.nextup.core.service.game.dto.AvailableRosterDto
+import com.nextup.core.service.game.dto.RosterPlayerDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 라인업 제출용 로스터 조회 서비스 구현
+ *
+ * 특정 경기의 대회에 등록된 팀 소속 선수 목록을
+ * CompetitionPlayer 징계/자격 상태와 함께 반환합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class AvailableRosterServiceImpl(
+    private val gameRepository: GameRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+    private val competitionPlayerRepository: CompetitionPlayerRepositoryPort,
+) : AvailableRosterService {
+    override fun getAvailableRoster(
+        gameId: Long,
+        teamId: Long,
+    ): AvailableRosterDto {
+        val game =
+            gameRepository.findByIdWithTeams(gameId)
+                ?: throw GameNotFoundException(gameId)
+
+        teamRepository.findByIdOrNull(teamId)
+            ?: throw TeamNotFoundException(teamId)
+
+        val competitionId = game.competition.id
+
+        val competitionPlayers =
+            competitionPlayerRepository.findByCompetitionIdAndTeamId(
+                competitionId = competitionId,
+                teamId = teamId,
+            )
+
+        val players =
+            competitionPlayers.map { cp ->
+                RosterPlayerDto(
+                    playerId = cp.player.id,
+                    playerName = cp.player.name,
+                    primaryPosition = cp.player.primaryPosition,
+                    profileImageUrl = cp.player.profileImageUrl,
+                    competitionPlayerStatus = cp.status,
+                    isEligible = cp.isEligible,
+                )
+            }
+
+        return AvailableRosterDto(players = players)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImpl.kt
@@ -120,6 +120,12 @@ class GameScheduleServiceImpl(
         return toSummaryDtos(games)
     }
 
+    override fun getGameDaysInMonth(
+        year: Int,
+        month: Int,
+        teamId: Long?,
+    ): List<Int> = gameRepository.findGameDaysInMonth(year, month, teamId)
+
     private fun toSummaryDtos(games: List<Game>): List<GameSummaryDto> {
         if (games.isEmpty()) return emptyList()
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/search/SearchServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/search/SearchServiceImpl.kt
@@ -1,0 +1,93 @@
+package com.nextup.infrastructure.service.search
+
+import com.nextup.common.exception.InvalidInputException
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.search.SearchService
+import com.nextup.core.service.search.dto.CompetitionSearchDto
+import com.nextup.core.service.search.dto.PlayerSearchDto
+import com.nextup.core.service.search.dto.SearchResultDto
+import com.nextup.core.service.search.dto.TeamSearchDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 통합 검색 서비스 구현
+ *
+ * 선수/팀/대회를 키워드로 동시 검색합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class SearchServiceImpl(
+    private val playerRepository: PlayerRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+    private val competitionRepository: CompetitionRepositoryPort,
+) : SearchService {
+    override fun search(
+        keyword: String,
+        limit: Int,
+    ): SearchResultDto {
+        require(keyword.isNotBlank()) {
+            "검색 키워드는 필수입니다"
+        }
+        if (keyword.length < MIN_KEYWORD_LENGTH) {
+            throw InvalidInputException(
+                "SEARCH_KEYWORD_TOO_SHORT",
+                "검색 키워드는 최소 ${MIN_KEYWORD_LENGTH}자 이상이어야 합니다",
+            )
+        }
+
+        val players =
+            playerRepository
+                .findByNameContaining(keyword)
+                .take(limit)
+                .map { player ->
+                    PlayerSearchDto(
+                        playerId = player.id,
+                        playerName = player.name,
+                        primaryPosition = player.primaryPosition,
+                        profileImageUrl = player.profileImageUrl,
+                        teamName = null,
+                    )
+                }
+
+        val teams =
+            teamRepository
+                .findActiveTeamsByFilter(name = keyword, city = null)
+                .take(limit)
+                .map { team ->
+                    TeamSearchDto(
+                        teamId = team.id,
+                        teamName = team.name,
+                        city = team.city,
+                        logoUrl = team.logoUrl,
+                        isActive = team.isActive,
+                    )
+                }
+
+        val competitions =
+            competitionRepository
+                .findAll()
+                .filter { it.name.contains(keyword, ignoreCase = true) }
+                .take(limit)
+                .map { competition ->
+                    CompetitionSearchDto(
+                        competitionId = competition.id,
+                        competitionName = competition.name,
+                        leagueName = competition.league.name,
+                        year = competition.year,
+                    )
+                }
+
+        return SearchResultDto(
+            players = players,
+            teams = teams,
+            competitions = competitions,
+        )
+    }
+
+    companion object {
+        private const val MIN_KEYWORD_LENGTH = 1
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/AvailableRosterServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/AvailableRosterServiceImplTest.kt
@@ -1,0 +1,235 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionPlayer
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class AvailableRosterServiceImplTest {
+    private val gameRepository: GameRepositoryPort = mockk()
+    private val teamRepository: TeamRepositoryPort = mockk()
+    private val competitionPlayerRepository: CompetitionPlayerRepositoryPort = mockk()
+
+    private lateinit var service: AvailableRosterServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        service =
+            AvailableRosterServiceImpl(
+                gameRepository,
+                teamRepository,
+                competitionPlayerRepository,
+            )
+    }
+
+    @Nested
+    @DisplayName("getAvailableRoster")
+    inner class GetAvailableRoster {
+        @Test
+        @DisplayName("경기의 대회에 등록된 팀 소속 선수 목록을 반환한다")
+        fun returnAvailableRoster() {
+            // given
+            val competition = mockk<Competition>()
+            every { competition.id } returns 10L
+
+            val game = mockk<Game>()
+            every { game.competition } returns competition
+
+            val team = mockk<Team>()
+
+            val player = mockk<Player>()
+            every { player.id } returns 1L
+            every { player.name } returns "홍길동"
+            every { player.primaryPosition } returns Position.PITCHER
+            every { player.profileImageUrl } returns "http://img.png"
+
+            val competitionPlayer = mockk<CompetitionPlayer>()
+            every { competitionPlayer.player } returns player
+            every { competitionPlayer.status } returns CompetitionPlayerStatus.ACTIVE
+            every { competitionPlayer.isEligible } returns true
+
+            every { gameRepository.findByIdWithTeams(1L) } returns game
+            every { teamRepository.findByIdOrNull(2L) } returns team
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndTeamId(
+                    competitionId = 10L,
+                    teamId = 2L,
+                )
+            } returns listOf(competitionPlayer)
+
+            // when
+            val result = service.getAvailableRoster(1L, 2L)
+
+            // then
+            assertThat(result.players).hasSize(1)
+            assertThat(result.players[0].playerId).isEqualTo(1L)
+            assertThat(result.players[0].playerName).isEqualTo("홍길동")
+            assertThat(result.players[0].primaryPosition).isEqualTo(Position.PITCHER)
+            assertThat(result.players[0].profileImageUrl).isEqualTo("http://img.png")
+            assertThat(result.players[0].competitionPlayerStatus)
+                .isEqualTo(CompetitionPlayerStatus.ACTIVE)
+            assertThat(result.players[0].isEligible).isTrue()
+        }
+
+        @Test
+        @DisplayName("경기가 존재하지 않으면 GameNotFoundException을 던진다")
+        fun throwWhenGameNotFound() {
+            every { gameRepository.findByIdWithTeams(999L) } returns null
+
+            assertThatThrownBy { service.getAvailableRoster(999L, 1L) }
+                .isInstanceOf(GameNotFoundException::class.java)
+        }
+
+        @Test
+        @DisplayName("팀이 존재하지 않으면 TeamNotFoundException을 던진다")
+        fun throwWhenTeamNotFound() {
+            val competition = mockk<Competition>()
+            every { competition.id } returns 10L
+
+            val game = mockk<Game>()
+            every { game.competition } returns competition
+
+            every { gameRepository.findByIdWithTeams(1L) } returns game
+            every { teamRepository.findByIdOrNull(999L) } returns null
+
+            assertThatThrownBy { service.getAvailableRoster(1L, 999L) }
+                .isInstanceOf(TeamNotFoundException::class.java)
+        }
+
+        @Test
+        @DisplayName("대회에 등록된 선수가 없으면 빈 목록을 반환한다")
+        fun returnEmptyRosterWhenNoPlayers() {
+            val competition = mockk<Competition>()
+            every { competition.id } returns 10L
+
+            val game = mockk<Game>()
+            every { game.competition } returns competition
+
+            val team = mockk<Team>()
+
+            every { gameRepository.findByIdWithTeams(1L) } returns game
+            every { teamRepository.findByIdOrNull(2L) } returns team
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndTeamId(
+                    competitionId = 10L,
+                    teamId = 2L,
+                )
+            } returns emptyList()
+
+            val result = service.getAvailableRoster(1L, 2L)
+
+            assertThat(result.players).isEmpty()
+        }
+
+        @Test
+        @DisplayName("출전 정지 선수도 목록에 포함되지만 isEligible이 false이다")
+        fun suspendedPlayerIncludedButNotEligible() {
+            val competition = mockk<Competition>()
+            every { competition.id } returns 10L
+
+            val game = mockk<Game>()
+            every { game.competition } returns competition
+
+            val team = mockk<Team>()
+
+            val player = mockk<Player>()
+            every { player.id } returns 1L
+            every { player.name } returns "정지선수"
+            every { player.primaryPosition } returns Position.CATCHER
+            every { player.profileImageUrl } returns null
+
+            val competitionPlayer = mockk<CompetitionPlayer>()
+            every { competitionPlayer.player } returns player
+            every { competitionPlayer.status } returns CompetitionPlayerStatus.SUSPENDED
+            every { competitionPlayer.isEligible } returns false
+
+            every { gameRepository.findByIdWithTeams(1L) } returns game
+            every { teamRepository.findByIdOrNull(2L) } returns team
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndTeamId(
+                    competitionId = 10L,
+                    teamId = 2L,
+                )
+            } returns listOf(competitionPlayer)
+
+            val result = service.getAvailableRoster(1L, 2L)
+
+            assertThat(result.players).hasSize(1)
+            assertThat(result.players[0].isEligible).isFalse()
+            assertThat(result.players[0].competitionPlayerStatus)
+                .isEqualTo(CompetitionPlayerStatus.SUSPENDED)
+        }
+
+        @Test
+        @DisplayName("여러 선수를 정확히 매핑하여 반환한다")
+        fun returnMultiplePlayers() {
+            val competition = mockk<Competition>()
+            every { competition.id } returns 10L
+
+            val game = mockk<Game>()
+            every { game.competition } returns competition
+
+            val team = mockk<Team>()
+
+            val players =
+                listOf(
+                    createMockCompetitionPlayer(1L, "선수1", Position.PITCHER, true),
+                    createMockCompetitionPlayer(2L, "선수2", Position.CATCHER, true),
+                    createMockCompetitionPlayer(3L, "선수3", Position.FIRST_BASE, false),
+                )
+
+            every { gameRepository.findByIdWithTeams(1L) } returns game
+            every { teamRepository.findByIdOrNull(2L) } returns team
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndTeamId(
+                    competitionId = 10L,
+                    teamId = 2L,
+                )
+            } returns players
+
+            val result = service.getAvailableRoster(1L, 2L)
+
+            assertThat(result.players).hasSize(3)
+            assertThat(result.players[0].playerName).isEqualTo("선수1")
+            assertThat(result.players[1].playerName).isEqualTo("선수2")
+            assertThat(result.players[2].playerName).isEqualTo("선수3")
+            assertThat(result.players[2].isEligible).isFalse()
+        }
+
+        private fun createMockCompetitionPlayer(
+            playerId: Long,
+            playerName: String,
+            position: Position,
+            eligible: Boolean,
+        ): CompetitionPlayer {
+            val player = mockk<Player>()
+            every { player.id } returns playerId
+            every { player.name } returns playerName
+            every { player.primaryPosition } returns position
+            every { player.profileImageUrl } returns null
+
+            val cp = mockk<CompetitionPlayer>()
+            every { cp.player } returns player
+            every { cp.status } returns
+                if (eligible) CompetitionPlayerStatus.ACTIVE else CompetitionPlayerStatus.SUSPENDED
+            every { cp.isEligible } returns eligible
+            return cp
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/AvailableRosterServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/AvailableRosterServiceImplTest.kt
@@ -56,7 +56,7 @@ class AvailableRosterServiceImplTest {
             val player = mockk<Player>()
             every { player.id } returns 1L
             every { player.name } returns "홍길동"
-            every { player.primaryPosition } returns Position.PITCHER
+            every { player.primaryPosition } returns Position.STARTING_PITCHER
             every { player.profileImageUrl } returns "http://img.png"
 
             val competitionPlayer = mockk<CompetitionPlayer>()
@@ -80,7 +80,7 @@ class AvailableRosterServiceImplTest {
             assertThat(result.players).hasSize(1)
             assertThat(result.players[0].playerId).isEqualTo(1L)
             assertThat(result.players[0].playerName).isEqualTo("홍길동")
-            assertThat(result.players[0].primaryPosition).isEqualTo(Position.PITCHER)
+            assertThat(result.players[0].primaryPosition).isEqualTo(Position.STARTING_PITCHER)
             assertThat(result.players[0].profileImageUrl).isEqualTo("http://img.png")
             assertThat(result.players[0].competitionPlayerStatus)
                 .isEqualTo(CompetitionPlayerStatus.ACTIVE)
@@ -189,7 +189,7 @@ class AvailableRosterServiceImplTest {
 
             val players =
                 listOf(
-                    createMockCompetitionPlayer(1L, "선수1", Position.PITCHER, true),
+                    createMockCompetitionPlayer(1L, "선수1", Position.STARTING_PITCHER, true),
                     createMockCompetitionPlayer(2L, "선수2", Position.CATCHER, true),
                     createMockCompetitionPlayer(3L, "선수3", Position.FIRST_BASE, false),
                 )

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImplGetGameDaysTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImplGetGameDaysTest.kt
@@ -1,0 +1,53 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class GameScheduleServiceImplGetGameDaysTest {
+    private val gameRepository: GameRepositoryPort = mockk()
+    private val gameTeamRepository: GameTeamRepositoryPort = mockk()
+
+    private lateinit var service: GameScheduleServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        service =
+            GameScheduleServiceImpl(
+                gameRepository,
+                gameTeamRepository,
+            )
+    }
+
+    @Test
+    @DisplayName("getGameDaysInMonth는 리포지토리에 위임한다")
+    fun getGameDaysInMonthDelegatesToRepository() {
+        every {
+            gameRepository.findGameDaysInMonth(2026, 3, null)
+        } returns listOf(1, 5, 10, 15)
+
+        val result = service.getGameDaysInMonth(2026, 3, null)
+
+        assertThat(result).containsExactly(1, 5, 10, 15)
+        verify { gameRepository.findGameDaysInMonth(2026, 3, null) }
+    }
+
+    @Test
+    @DisplayName("팀 ID를 전달하면 해당 팀의 경기 일자만 반환한다")
+    fun getGameDaysInMonthWithTeamId() {
+        every {
+            gameRepository.findGameDaysInMonth(2026, 3, 1L)
+        } returns listOf(3, 17)
+
+        val result = service.getGameDaysInMonth(2026, 3, 1L)
+
+        assertThat(result).containsExactly(3, 17)
+        verify { gameRepository.findGameDaysInMonth(2026, 3, 1L) }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/search/SearchServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/search/SearchServiceImplTest.kt
@@ -44,7 +44,7 @@ class SearchServiceImplTest {
             val player = mockk<Player>()
             every { player.id } returns 1L
             every { player.name } returns "홍길동"
-            every { player.primaryPosition } returns Position.PITCHER
+            every { player.primaryPosition } returns Position.STARTING_PITCHER
             every { player.profileImageUrl } returns null
 
             val team = mockk<Team>()
@@ -76,7 +76,7 @@ class SearchServiceImplTest {
             assertThat(result.players).hasSize(1)
             assertThat(result.players[0].playerId).isEqualTo(1L)
             assertThat(result.players[0].playerName).isEqualTo("홍길동")
-            assertThat(result.players[0].primaryPosition).isEqualTo(Position.PITCHER)
+            assertThat(result.players[0].primaryPosition).isEqualTo(Position.STARTING_PITCHER)
             assertThat(result.teams).hasSize(1)
             assertThat(result.teams[0].teamId).isEqualTo(1L)
             assertThat(result.teams[0].teamName).isEqualTo("홍팀")
@@ -119,7 +119,7 @@ class SearchServiceImplTest {
                     val p = mockk<Player>()
                     every { p.id } returns i.toLong()
                     every { p.name } returns "선수$i"
-                    every { p.primaryPosition } returns Position.PITCHER
+                    every { p.primaryPosition } returns Position.STARTING_PITCHER
                     every { p.profileImageUrl } returns null
                     p
                 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/search/SearchServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/search/SearchServiceImplTest.kt
@@ -1,0 +1,213 @@
+package com.nextup.infrastructure.service.search
+
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SearchServiceImplTest {
+    private val playerRepository: PlayerRepositoryPort = mockk()
+    private val teamRepository: TeamRepositoryPort = mockk()
+    private val competitionRepository: CompetitionRepositoryPort = mockk()
+
+    private lateinit var service: SearchServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        service =
+            SearchServiceImpl(
+                playerRepository,
+                teamRepository,
+                competitionRepository,
+            )
+    }
+
+    @Nested
+    @DisplayName("search")
+    inner class Search {
+        @Test
+        @DisplayName("키워드로 선수, 팀, 대회를 검색한다")
+        fun searchWithValidKeyword() {
+            // given
+            val player = mockk<Player>()
+            every { player.id } returns 1L
+            every { player.name } returns "홍길동"
+            every { player.primaryPosition } returns Position.PITCHER
+            every { player.profileImageUrl } returns null
+
+            val team = mockk<Team>()
+            every { team.id } returns 1L
+            every { team.name } returns "홍팀"
+            every { team.city } returns "서울"
+            every { team.logoUrl } returns null
+            every { team.isActive } returns true
+
+            val league = mockk<League>()
+            every { league.name } returns "테스트리그"
+
+            val competition = mockk<Competition>()
+            every { competition.id } returns 1L
+            every { competition.name } returns "홍컵"
+            every { competition.league } returns league
+            every { competition.year } returns 2026
+
+            every { playerRepository.findByNameContaining("홍") } returns listOf(player)
+            every {
+                teamRepository.findActiveTeamsByFilter(name = "홍", city = null)
+            } returns listOf(team)
+            every { competitionRepository.findAll() } returns listOf(competition)
+
+            // when
+            val result = service.search("홍", 5)
+
+            // then
+            assertThat(result.players).hasSize(1)
+            assertThat(result.players[0].playerId).isEqualTo(1L)
+            assertThat(result.players[0].playerName).isEqualTo("홍길동")
+            assertThat(result.players[0].primaryPosition).isEqualTo(Position.PITCHER)
+            assertThat(result.teams).hasSize(1)
+            assertThat(result.teams[0].teamId).isEqualTo(1L)
+            assertThat(result.teams[0].teamName).isEqualTo("홍팀")
+            assertThat(result.teams[0].city).isEqualTo("서울")
+            assertThat(result.competitions).hasSize(1)
+            assertThat(result.competitions[0].competitionId).isEqualTo(1L)
+            assertThat(result.competitions[0].competitionName).isEqualTo("홍컵")
+            assertThat(result.competitions[0].leagueName).isEqualTo("테스트리그")
+            assertThat(result.competitions[0].year).isEqualTo(2026)
+        }
+
+        @Test
+        @DisplayName("빈 키워드는 IllegalArgumentException을 던진다")
+        fun searchWithBlankKeyword() {
+            assertThatThrownBy { service.search("   ", 5) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        @DisplayName("검색 결과가 없으면 빈 목록을 반환한다")
+        fun searchWithNoResults() {
+            every { playerRepository.findByNameContaining("xyz") } returns emptyList()
+            every {
+                teamRepository.findActiveTeamsByFilter(name = "xyz", city = null)
+            } returns emptyList()
+            every { competitionRepository.findAll() } returns emptyList()
+
+            val result = service.search("xyz", 5)
+
+            assertThat(result.players).isEmpty()
+            assertThat(result.teams).isEmpty()
+            assertThat(result.competitions).isEmpty()
+        }
+
+        @Test
+        @DisplayName("limit 파라미터로 각 카테고리별 결과 수를 제한한다")
+        fun searchWithLimit() {
+            val players =
+                (1..10).map { i ->
+                    val p = mockk<Player>()
+                    every { p.id } returns i.toLong()
+                    every { p.name } returns "선수$i"
+                    every { p.primaryPosition } returns Position.PITCHER
+                    every { p.profileImageUrl } returns null
+                    p
+                }
+
+            every { playerRepository.findByNameContaining("선수") } returns players
+            every {
+                teamRepository.findActiveTeamsByFilter(name = "선수", city = null)
+            } returns emptyList()
+            every { competitionRepository.findAll() } returns emptyList()
+
+            val result = service.search("선수", 3)
+
+            assertThat(result.players).hasSize(3)
+        }
+
+        @Test
+        @DisplayName("대회 검색은 이름 부분 일치로 필터링한다")
+        fun searchFilterCompetitionByName() {
+            val league = mockk<League>()
+            every { league.name } returns "리그"
+
+            val matchCompetition = mockk<Competition>()
+            every { matchCompetition.id } returns 1L
+            every { matchCompetition.name } returns "봄시즌컵"
+            every { matchCompetition.league } returns league
+            every { matchCompetition.year } returns 2026
+
+            val nonMatchCompetition = mockk<Competition>()
+            every { nonMatchCompetition.id } returns 2L
+            every { nonMatchCompetition.name } returns "가을대회"
+
+            every { playerRepository.findByNameContaining("봄") } returns emptyList()
+            every {
+                teamRepository.findActiveTeamsByFilter(name = "봄", city = null)
+            } returns emptyList()
+            every {
+                competitionRepository.findAll()
+            } returns listOf(matchCompetition, nonMatchCompetition)
+
+            val result = service.search("봄", 5)
+
+            assertThat(result.competitions).hasSize(1)
+            assertThat(result.competitions[0].competitionName).isEqualTo("봄시즌컵")
+        }
+
+        @Test
+        @DisplayName("대회 검색은 대소문자를 구분하지 않는다")
+        fun searchCompetitionCaseInsensitive() {
+            val league = mockk<League>()
+            every { league.name } returns "리그"
+
+            val competition = mockk<Competition>()
+            every { competition.id } returns 1L
+            every { competition.name } returns "Spring Cup"
+            every { competition.league } returns league
+            every { competition.year } returns 2026
+
+            every { playerRepository.findByNameContaining("spring") } returns emptyList()
+            every {
+                teamRepository.findActiveTeamsByFilter(name = "spring", city = null)
+            } returns emptyList()
+            every { competitionRepository.findAll() } returns listOf(competition)
+
+            val result = service.search("spring", 5)
+
+            assertThat(result.competitions).hasSize(1)
+            assertThat(result.competitions[0].competitionName).isEqualTo("Spring Cup")
+        }
+
+        @Test
+        @DisplayName("teamName은 null로 반환된다")
+        fun playerSearchDtoTeamNameIsNull() {
+            val player = mockk<Player>()
+            every { player.id } returns 1L
+            every { player.name } returns "테스트"
+            every { player.primaryPosition } returns Position.SHORTSTOP
+            every { player.profileImageUrl } returns "http://img.png"
+
+            every { playerRepository.findByNameContaining("테스트") } returns listOf(player)
+            every {
+                teamRepository.findActiveTeamsByFilter(name = "테스트", city = null)
+            } returns emptyList()
+            every { competitionRepository.findAll() } returns emptyList()
+
+            val result = service.search("테스트", 5)
+
+            assertThat(result.players[0].teamName).isNull()
+            assertThat(result.players[0].profileImageUrl).isEqualTo("http://img.png")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #230

프론트엔드 UX 개선을 위한 편의 API 모음을 구현합니다.

## Tasks

- 경기 캘린더 뷰 API (GET /api/v1/games/calendar)
- 미읽은 알림 개수 API (GET /api/v1/notifications/unread-count)
- 통합 검색 API (GET /api/v1/search)
- 라인업 제출용 로스터 API
- 리더보드 선수 프로필 이미지 추가
- 순위표 팀 로고 URL 추가
- 단위 테스트 작성

## To Reviewer

- 각 항목은 독립적으로 구현되어 있어 개별 검토 가능
- Zero Entity Leak 준수
- ApiResponse 래핑 사용