### PR TITLE
feat(#216): 수비 기록(Fielding Record) 시스템 구축

### DIFF
--- a/.claude/agent-memory/implementer/MEMORY.md
+++ b/.claude/agent-memory/implementer/MEMORY.md
@@ -1,0 +1,49 @@
+# Implementer Agent Memory - NEXT-UP Project
+
+## Key Navigation Paths (JPQL)
+- GamePlayer -> game: use `gp.gameTeam.game` (NOT `gp.game` - GamePlayer has no direct game field)
+- BattingRecord -> game: `br.gamePlayer.gameTeam.game`
+- FieldingRecord -> game: `fr.gamePlayer.gameTeam.game`
+- Game scheduled field: `game.scheduledAt` (LocalDateTime, NOT scheduledDate)
+
+## Existing Code Patterns
+- Record entities: `@ManyToOne` to GamePlayer, no `unique=true` (one per game player)
+- Stats entities: player + year unique constraint for season, OneToOne for career
+- Repository: Direct JPA + Port pattern (`interface Repo: JpaRepository<E,Long>, PortInterface`)
+- Service: in `nextup-core/service/{domain}/` with `@Service @Transactional(readOnly=true)`
+- `gamePlayerRepository.findByIdOrNull(id)` - uses `findByIdOrNull` not `findById`
+
+## Exception Patterns
+- All domain exceptions in `nextup-common/exception/`
+- `RecordAlreadyExistsException(gamePlayerId, "RecordType")` for duplicates
+- `StatsValidationException(message)` for stats validation
+- `FieldingRecordNotFoundException(gamePlayerId)` - added in FieldingExceptions.kt
+
+## Build Commands
+- Full build: `./gradlew clean build --no-daemon --max-workers=2`
+- Kill daemons: `pkill -9 -f GradleDaemon`
+- Gradle always runs in background - use `sleep N && cat output_file` to check
+
+## Module File Locations
+- Core entities: `nextup-core/domain/game/` or `nextup-core/domain/stats/`
+- Core ports: `nextup-core/port/repository/`
+- Core services: `nextup-core/service/{game,stats}/`
+- Infra repos: `nextup-infrastructure/repository/{game,stats}/`
+- Migrations: `nextup-infrastructure/resources/db/migration/`
+- API DTOs: `nextup-api/dto/stats/` or `nextup-api/dto/game/`
+- API mappers: `nextup-api/mapper/stats/` or `nextup-api/mapper/game/`
+- Scorer DTOs: `nextup-scorer/dto/{domain}/`
+- Scorer controllers: `nextup-scorer/controller/{domain}/`
+- Common exceptions: `nextup-common/exception/`
+
+## Scorer URL Pattern
+- Scorer uses `/api/scorer/` prefix (NOT `/api/v1/scorer/`)
+- See scorer.md rules
+
+## API URL Pattern
+- API uses `/api/v1/` prefix
+
+## ktlint Notes
+- Multiline expressions must start on new line
+- No trailing whitespace
+- BigDecimal?.toPlainString() for nullable, .toPlainString() for non-null

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/PlayerFieldingStatsController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/PlayerFieldingStatsController.kt
@@ -1,0 +1,74 @@
+package com.nextup.api.controller.stats
+
+import com.nextup.api.dto.stats.CareerFieldingStatsResponse
+import com.nextup.api.dto.stats.SeasonFieldingStatsResponse
+import com.nextup.api.mapper.stats.toResponse
+import com.nextup.api.mapper.stats.toSeasonFieldingResponse
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.stats.PlayerFieldingStatsService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 선수 수비 통계 조회 API
+ *
+ * 선수별 시즌/통산 수비 통계를 조회합니다.
+ * 모든 응답은 ApiResponse로 래핑됩니다.
+ */
+@RestController
+@RequestMapping("/api/v1/players/{playerId}/stats")
+class PlayerFieldingStatsController(
+    private val playerFieldingStatsService: PlayerFieldingStatsService,
+) {
+    /**
+     * 시즌 수비 통계 조회
+     *
+     * GET /api/v1/players/{playerId}/stats/fielding/season/{year}
+     *
+     * @param playerId 선수 ID
+     * @param year 시즌 연도
+     * @return 시즌 수비 통계 응답
+     */
+    @GetMapping("/fielding/season/{year}")
+    fun getSeasonFieldingStats(
+        @PathVariable playerId: Long,
+        @PathVariable year: Int,
+    ): ApiResponse<SeasonFieldingStatsResponse> {
+        val stats = playerFieldingStatsService.getSeasonFieldingStats(playerId, year)
+        return ApiResponse.success(stats.toResponse())
+    }
+
+    /**
+     * 통산 수비 통계 조회
+     *
+     * GET /api/v1/players/{playerId}/stats/fielding/career
+     *
+     * @param playerId 선수 ID
+     * @return 통산 수비 통계 응답
+     */
+    @GetMapping("/fielding/career")
+    fun getCareerFieldingStats(
+        @PathVariable playerId: Long,
+    ): ApiResponse<CareerFieldingStatsResponse> {
+        val stats = playerFieldingStatsService.getCareerFieldingStats(playerId)
+        return ApiResponse.success(stats.toResponse())
+    }
+
+    /**
+     * 모든 시즌 수비 통계 조회
+     *
+     * GET /api/v1/players/{playerId}/stats/fielding/seasons
+     *
+     * @param playerId 선수 ID
+     * @return 모든 시즌 수비 통계 리스트
+     */
+    @GetMapping("/fielding/seasons")
+    fun getAllSeasonFieldingStats(
+        @PathVariable playerId: Long,
+    ): ApiResponse<List<SeasonFieldingStatsResponse>> {
+        val statsList = playerFieldingStatsService.getAllSeasonFieldingStats(playerId)
+        return ApiResponse.success(statsList.toSeasonFieldingResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/CareerFieldingStatsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/CareerFieldingStatsResponse.kt
@@ -1,0 +1,25 @@
+package com.nextup.api.dto.stats
+
+import java.time.Instant
+
+/**
+ * 통산 수비 통계 응답 DTO
+ */
+data class CareerFieldingStatsResponse(
+    val id: Long,
+    val playerId: Long,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    // 시즌 및 출전 정보
+    val seasonsPlayed: Int,
+    val gamesPlayed: Int,
+    // 기본 수비 기록
+    val putOuts: Int,
+    val assists: Int,
+    val errors: Int,
+    val doublePlays: Int,
+    val passedBalls: Int,
+    // 계산 속성
+    val totalChances: Int,
+    val fieldingPercentage: String?,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/SeasonFieldingStatsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/SeasonFieldingStatsResponse.kt
@@ -1,0 +1,25 @@
+package com.nextup.api.dto.stats
+
+import java.time.Instant
+
+/**
+ * 시즌 수비 통계 응답 DTO
+ */
+data class SeasonFieldingStatsResponse(
+    val id: Long,
+    val playerId: Long,
+    val year: Int,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    // 출전 정보
+    val gamesPlayed: Int,
+    // 기본 수비 기록
+    val putOuts: Int,
+    val assists: Int,
+    val errors: Int,
+    val doublePlays: Int,
+    val passedBalls: Int,
+    // 계산 속성
+    val totalChances: Int,
+    val fieldingPercentage: String?,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/FieldingStatsMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/stats/FieldingStatsMapper.kt
@@ -1,0 +1,60 @@
+package com.nextup.api.mapper.stats
+
+import com.nextup.api.dto.stats.CareerFieldingStatsResponse
+import com.nextup.api.dto.stats.SeasonFieldingStatsResponse
+import com.nextup.core.domain.stats.CareerFieldingStats
+import com.nextup.core.domain.stats.SeasonFieldingStats
+
+/**
+ * SeasonFieldingStats Entity를 SeasonFieldingStatsResponse DTO로 변환하는 Extension Function
+ */
+fun SeasonFieldingStats.toResponse(): SeasonFieldingStatsResponse =
+    SeasonFieldingStatsResponse(
+        // 메타 정보
+        id = this.id,
+        playerId = this.player.id,
+        year = this.year,
+        createdAt = this.createdAt,
+        updatedAt = this.updatedAt,
+        // 출전 정보
+        gamesPlayed = this.gamesPlayed,
+        // 기본 수비 기록
+        putOuts = this.putOuts,
+        assists = this.assists,
+        errors = this.errors,
+        doublePlays = this.doublePlays,
+        passedBalls = this.passedBalls,
+        // 계산 속성
+        totalChances = this.totalChances,
+        fieldingPercentage = this.fieldingPercentage?.toPlainString(),
+    )
+
+/**
+ * CareerFieldingStats Entity를 CareerFieldingStatsResponse DTO로 변환하는 Extension Function
+ */
+fun CareerFieldingStats.toResponse(): CareerFieldingStatsResponse =
+    CareerFieldingStatsResponse(
+        // 메타 정보
+        id = this.id,
+        playerId = this.player.id,
+        createdAt = this.createdAt,
+        updatedAt = this.updatedAt,
+        // 시즌 및 출전 정보
+        seasonsPlayed = this.seasonsPlayed,
+        gamesPlayed = this.gamesPlayed,
+        // 기본 수비 기록
+        putOuts = this.putOuts,
+        assists = this.assists,
+        errors = this.errors,
+        doublePlays = this.doublePlays,
+        passedBalls = this.passedBalls,
+        // 계산 속성
+        totalChances = this.totalChances,
+        fieldingPercentage = this.fieldingPercentage?.toPlainString(),
+    )
+
+/**
+ * List<SeasonFieldingStats>를 List<SeasonFieldingStatsResponse>로 변환
+ */
+fun List<SeasonFieldingStats>.toSeasonFieldingResponse(): List<SeasonFieldingStatsResponse> =
+    this.map { it.toResponse() }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/PlayerFieldingStatsControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/PlayerFieldingStatsControllerTest.kt
@@ -1,0 +1,249 @@
+package com.nextup.api.controller.stats
+
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.CareerFieldingStatsNotFoundException
+import com.nextup.common.exception.SeasonFieldingStatsNotFoundException
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.domain.stats.CareerFieldingStats
+import com.nextup.core.domain.stats.SeasonFieldingStats
+import com.nextup.core.service.stats.PlayerFieldingStatsService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("PlayerFieldingStatsController 테스트")
+class PlayerFieldingStatsControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var playerFieldingStatsService: PlayerFieldingStatsService
+
+    private val playerId = 1L
+    private val year = 2026
+
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.SHORTSTOP,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = playerId,
+        )
+
+    @BeforeEach
+    fun setUp() {
+        playerFieldingStatsService = mockk()
+
+        val controller = PlayerFieldingStatsController(playerFieldingStatsService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/players/{playerId}/stats/fielding/season/{year}")
+    inner class GetSeasonFieldingStats {
+        @Test
+        fun `시즌 수비 통계를 성공적으로 조회한다`() {
+            // given
+            val stats =
+                SeasonFieldingStats.create(testPlayer, year).apply {
+                    setStatsDirectly(
+                        gamesPlayed = 15,
+                        putOuts = 30,
+                        assists = 20,
+                        errors = 3,
+                        doublePlays = 5,
+                        passedBalls = 0,
+                    )
+                }
+
+            every { playerFieldingStatsService.getSeasonFieldingStats(playerId, year) } returns stats
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/fielding/season/$year"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.playerId").value(playerId))
+                .andExpect(jsonPath("$.data.year").value(year))
+                .andExpect(jsonPath("$.data.gamesPlayed").value(15))
+                .andExpect(jsonPath("$.data.putOuts").value(30))
+                .andExpect(jsonPath("$.data.assists").value(20))
+                .andExpect(jsonPath("$.data.errors").value(3))
+                .andExpect(jsonPath("$.data.doublePlays").value(5))
+                .andExpect(jsonPath("$.data.passedBalls").value(0))
+                .andExpect(jsonPath("$.data.totalChances").value(53))
+        }
+
+        @Test
+        fun `시즌 수비 통계가 없으면 404를 반환한다`() {
+            // given
+            every { playerFieldingStatsService.getSeasonFieldingStats(playerId, year) } throws
+                SeasonFieldingStatsNotFoundException(playerId, year)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/fielding/season/$year"))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/players/{playerId}/stats/fielding/career")
+    inner class GetCareerFieldingStats {
+        @Test
+        fun `통산 수비 통계를 성공적으로 조회한다`() {
+            // given
+            val stats =
+                CareerFieldingStats.create(testPlayer).apply {
+                    setCareerStatsDirectly(
+                        seasonsPlayed = 3,
+                        gamesPlayed = 45,
+                        putOuts = 90,
+                        assists = 60,
+                        errors = 8,
+                        doublePlays = 12,
+                        passedBalls = 2,
+                    )
+                }
+
+            every { playerFieldingStatsService.getCareerFieldingStats(playerId) } returns stats
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/fielding/career"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.playerId").value(playerId))
+                .andExpect(jsonPath("$.data.seasonsPlayed").value(3))
+                .andExpect(jsonPath("$.data.gamesPlayed").value(45))
+                .andExpect(jsonPath("$.data.putOuts").value(90))
+                .andExpect(jsonPath("$.data.assists").value(60))
+                .andExpect(jsonPath("$.data.errors").value(8))
+                .andExpect(jsonPath("$.data.doublePlays").value(12))
+                .andExpect(jsonPath("$.data.passedBalls").value(2))
+                .andExpect(jsonPath("$.data.totalChances").value(158))
+        }
+
+        @Test
+        fun `통산 수비 통계가 없으면 404를 반환한다`() {
+            // given
+            every { playerFieldingStatsService.getCareerFieldingStats(playerId) } throws
+                CareerFieldingStatsNotFoundException(playerId)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/fielding/career"))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/players/{playerId}/stats/fielding/seasons")
+    inner class GetAllSeasonFieldingStats {
+        @Test
+        fun `모든 시즌 수비 통계를 성공적으로 조회한다`() {
+            // given
+            val stats2025 =
+                SeasonFieldingStats.create(testPlayer, 2025).apply {
+                    setStatsDirectly(gamesPlayed = 10, putOuts = 20, assists = 10, errors = 2)
+                }
+            val stats2026 =
+                SeasonFieldingStats.create(testPlayer, 2026).apply {
+                    setStatsDirectly(gamesPlayed = 15, putOuts = 30, assists = 20, errors = 3)
+                }
+
+            every { playerFieldingStatsService.getAllSeasonFieldingStats(playerId) } returns
+                listOf(stats2025, stats2026)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/fielding/seasons"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].year").value(2025))
+                .andExpect(jsonPath("$.data[0].gamesPlayed").value(10))
+                .andExpect(jsonPath("$.data[1].year").value(2026))
+                .andExpect(jsonPath("$.data[1].gamesPlayed").value(15))
+        }
+
+        @Test
+        fun `시즌 수비 통계가 없으면 빈 리스트를 반환한다`() {
+            // given
+            every { playerFieldingStatsService.getAllSeasonFieldingStats(playerId) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/stats/fielding/seasons"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+    }
+
+    // Helper methods
+
+    private fun SeasonFieldingStats.setStatsDirectly(
+        gamesPlayed: Int = 0,
+        putOuts: Int = 0,
+        assists: Int = 0,
+        errors: Int = 0,
+        doublePlays: Int = 0,
+        passedBalls: Int = 0,
+    ) {
+        val clazz = SeasonFieldingStats::class.java
+        setField(clazz, this, "gamesPlayed", gamesPlayed)
+        setField(clazz, this, "putOuts", putOuts)
+        setField(clazz, this, "assists", assists)
+        setField(clazz, this, "errors", errors)
+        setField(clazz, this, "doublePlays", doublePlays)
+        setField(clazz, this, "passedBalls", passedBalls)
+    }
+
+    private fun CareerFieldingStats.setCareerStatsDirectly(
+        seasonsPlayed: Int = 0,
+        gamesPlayed: Int = 0,
+        putOuts: Int = 0,
+        assists: Int = 0,
+        errors: Int = 0,
+        doublePlays: Int = 0,
+        passedBalls: Int = 0,
+    ) {
+        val clazz = CareerFieldingStats::class.java
+        setField(clazz, this, "seasonsPlayed", seasonsPlayed)
+        setField(clazz, this, "gamesPlayed", gamesPlayed)
+        setField(clazz, this, "putOuts", putOuts)
+        setField(clazz, this, "assists", assists)
+        setField(clazz, this, "errors", errors)
+        setField(clazz, this, "doublePlays", doublePlays)
+        setField(clazz, this, "passedBalls", passedBalls)
+    }
+
+    private fun setField(
+        clazz: Class<*>,
+        obj: Any,
+        fieldName: String,
+        value: Any?,
+    ) {
+        val field = clazz.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(obj, value)
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/FieldingExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/FieldingExceptions.kt
@@ -1,0 +1,29 @@
+package com.nextup.common.exception
+
+/**
+ * 수비 기록을 찾을 수 없을 때 발생하는 예외
+ */
+class FieldingRecordNotFoundException(
+    gamePlayerId: Long,
+) : NotFoundException("FIELDING_RECORD_NOT_FOUND", "Fielding record not found for GamePlayer: $gamePlayerId")
+
+/**
+ * 시즌 수비 통계를 찾을 수 없을 때 발생하는 예외
+ */
+class SeasonFieldingStatsNotFoundException(
+    playerId: Long,
+    year: Int,
+) : NotFoundException(
+        "SEASON_FIELDING_STATS_NOT_FOUND",
+        "Season fielding stats not found for Player: $playerId, Year: $year",
+    )
+
+/**
+ * 통산 수비 통계를 찾을 수 없을 때 발생하는 예외
+ */
+class CareerFieldingStatsNotFoundException(
+    playerId: Long,
+) : NotFoundException(
+        "CAREER_FIELDING_STATS_NOT_FOUND",
+        "Career fielding stats not found for Player: $playerId",
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/FieldingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/FieldingRecord.kt
@@ -1,0 +1,187 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * 수비 기록 엔티티
+ *
+ * 경기 출전 선수(GamePlayer)의 수비 기록을 저장합니다.
+ * 한 경기에서 선수당 하나의 수비 기록만 존재합니다.
+ */
+@Entity
+@Table(
+    name = "fielding_records",
+    indexes = [
+        Index(name = "idx_fielding_records_game_player", columnList = "game_player_id"),
+    ],
+)
+class FieldingRecord(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_player_id", nullable = false)
+    val gamePlayer: GamePlayer,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 자살(PO, Put Out) - 아웃을 직접 성립시킨 횟수
+     */
+    @Column(name = "put_outs", nullable = false)
+    var putOuts: Int = 0
+        protected set
+
+    /**
+     * 보살(A, Assist) - 아웃에 도움을 준 횟수
+     */
+    @Column(nullable = false)
+    var assists: Int = 0
+        protected set
+
+    /**
+     * 실책(E, Error) - 수비 실수로 인한 오류 횟수
+     */
+    @Column(nullable = false)
+    var errors: Int = 0
+        protected set
+
+    /**
+     * 병살 관여(DP, Double Play) - 병살에 관여한 횟수
+     */
+    @Column(name = "double_plays", nullable = false)
+    var doublePlays: Int = 0
+        protected set
+
+    /**
+     * 포일(PB, Passed Ball) - 포수의 공 처리 실패 횟수 (포수 전용)
+     */
+    @Column(name = "passed_balls", nullable = false)
+    var passedBalls: Int = 0
+        protected set
+
+    // Calculated properties
+
+    /**
+     * 수비 기회(TC, Total Chances) = 자살 + 보살 + 실책
+     */
+    val totalChances: Int
+        get() = putOuts + assists + errors
+
+    /**
+     * 수비율(FPCT, Fielding Percentage) = (자살 + 보살) / 수비 기회
+     * 수비 기회가 0이면 null (계산 불가)
+     */
+    val fieldingPercentage: BigDecimal?
+        get() =
+            if (totalChances == 0) {
+                null
+            } else {
+                BigDecimal(putOuts + assists).divide(BigDecimal(totalChances), 3, RoundingMode.HALF_UP)
+            }
+
+    // Business logic
+
+    /**
+     * 자살(PO)을 기록합니다.
+     */
+    fun recordPutOut() {
+        putOuts++
+    }
+
+    /**
+     * 보살(A)을 기록합니다.
+     */
+    fun recordAssist() {
+        assists++
+    }
+
+    /**
+     * 실책(E)을 기록합니다.
+     */
+    fun recordError() {
+        errors++
+    }
+
+    /**
+     * 병살 관여(DP)를 기록합니다.
+     */
+    fun recordDoublePlay() {
+        doublePlays++
+    }
+
+    /**
+     * 포일(PB)을 기록합니다.
+     */
+    fun recordPassedBall() {
+        passedBalls++
+    }
+
+    /**
+     * 자살(PO)을 취소합니다 (Undo용).
+     */
+    fun revertPutOut() {
+        require(putOuts > 0) { "취소할 자살 기록이 없습니다." }
+        putOuts--
+    }
+
+    /**
+     * 보살(A)을 취소합니다 (Undo용).
+     */
+    fun revertAssist() {
+        require(assists > 0) { "취소할 보살 기록이 없습니다." }
+        assists--
+    }
+
+    /**
+     * 실책(E)을 취소합니다 (Undo용).
+     */
+    fun revertError() {
+        require(errors > 0) { "취소할 실책 기록이 없습니다." }
+        errors--
+    }
+
+    /**
+     * 병살 관여(DP)를 취소합니다 (Undo용).
+     */
+    fun revertDoublePlay() {
+        require(doublePlays > 0) { "취소할 병살 관여 기록이 없습니다." }
+        doublePlays--
+    }
+
+    /**
+     * 포일(PB)을 취소합니다 (Undo용).
+     */
+    fun revertPassedBall() {
+        require(passedBalls > 0) { "취소할 포일 기록이 없습니다." }
+        passedBalls--
+    }
+
+    /**
+     * 기록 유효성을 검증합니다.
+     */
+    fun validate() {
+        require(putOuts >= 0) { "자살($putOuts)은 음수일 수 없습니다." }
+        require(assists >= 0) { "보살($assists)은 음수일 수 없습니다." }
+        require(errors >= 0) { "실책($errors)은 음수일 수 없습니다." }
+        require(doublePlays >= 0) { "병살 관여($doublePlays)는 음수일 수 없습니다." }
+        require(passedBalls >= 0) { "포일($passedBalls)은 음수일 수 없습니다." }
+    }
+
+    companion object {
+        /**
+         * 경기 출전 선수의 수비 기록을 생성합니다.
+         */
+        fun create(gamePlayer: GamePlayer): FieldingRecord = FieldingRecord(gamePlayer = gamePlayer)
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerFieldingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerFieldingStats.kt
@@ -1,0 +1,146 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.common.exception.StatsValidationException
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.player.Player
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * 통산 수비 통계 엔티티
+ *
+ * 선수의 통산 수비 통계를 저장합니다.
+ * FieldingRecord를 누적하여 커리어 전체 기록을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "career_fielding_stats",
+    indexes = [
+        Index(name = "idx_career_fielding_stats_player", columnList = "player_id"),
+    ],
+)
+class CareerFieldingStats(
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "player_id", nullable = false, unique = true)
+    val player: Player,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    // 시즌 수
+    @Column(name = "seasons_played", nullable = false)
+    var seasonsPlayed: Int = 0
+        protected set
+
+    // 출전 경기 수
+    @Column(name = "games_played", nullable = false)
+    var gamesPlayed: Int = 0
+        protected set
+
+    // 기본 수비 기록
+    @Column(name = "put_outs", nullable = false)
+    var putOuts: Int = 0
+        protected set
+
+    @Column(nullable = false)
+    var assists: Int = 0
+        protected set
+
+    @Column(nullable = false)
+    var errors: Int = 0
+        protected set
+
+    @Column(name = "double_plays", nullable = false)
+    var doublePlays: Int = 0
+        protected set
+
+    @Column(name = "passed_balls", nullable = false)
+    var passedBalls: Int = 0
+        protected set
+
+    // Calculated properties
+
+    /**
+     * 수비 기회(TC) = 자살 + 보살 + 실책
+     */
+    val totalChances: Int
+        get() = putOuts + assists + errors
+
+    /**
+     * 수비율(FPCT) = (자살 + 보살) / 수비 기회
+     * 수비 기회가 0이면 null
+     */
+    val fieldingPercentage: BigDecimal?
+        get() =
+            if (totalChances == 0) {
+                null
+            } else {
+                BigDecimal(putOuts + assists).divide(BigDecimal(totalChances), 3, RoundingMode.HALF_UP)
+            }
+
+    // Business logic
+
+    /**
+     * 경기 수비 기록을 누적합니다.
+     */
+    fun addGameRecord(record: FieldingRecord) {
+        gamesPlayed++
+        putOuts += record.putOuts
+        assists += record.assists
+        errors += record.errors
+        doublePlays += record.doublePlays
+        passedBalls += record.passedBalls
+    }
+
+    /**
+     * 시즌을 추가합니다.
+     */
+    fun addSeason() {
+        seasonsPlayed++
+    }
+
+    /**
+     * 기록 유효성을 검증합니다.
+     */
+    fun validate() {
+        if (seasonsPlayed < 0) {
+            throw StatsValidationException("시즌 수는 0 이상이어야 합니다.")
+        }
+        if (gamesPlayed < 0) {
+            throw StatsValidationException("출전 경기 수는 0 이상이어야 합니다.")
+        }
+        if (putOuts < 0) {
+            throw StatsValidationException("자살($putOuts)은 음수일 수 없습니다.")
+        }
+        if (assists < 0) {
+            throw StatsValidationException("보살($assists)은 음수일 수 없습니다.")
+        }
+        if (errors < 0) {
+            throw StatsValidationException("실책($errors)은 음수일 수 없습니다.")
+        }
+        if (doublePlays < 0) {
+            throw StatsValidationException("병살 관여($doublePlays)는 음수일 수 없습니다.")
+        }
+        if (passedBalls < 0) {
+            throw StatsValidationException("포일($passedBalls)은 음수일 수 없습니다.")
+        }
+    }
+
+    companion object {
+        /**
+         * 선수의 통산 수비 통계를 생성합니다.
+         */
+        fun create(player: Player): CareerFieldingStats = CareerFieldingStats(player = player)
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonFieldingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonFieldingStats.kt
@@ -1,0 +1,149 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.common.exception.StatsValidationException
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.player.Player
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * 시즌 수비 통계 엔티티
+ *
+ * 선수의 시즌별 수비 통계를 저장합니다.
+ * FieldingRecord를 누적하여 시즌 통산 기록을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "season_fielding_stats",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_season_fielding_stats_player_year",
+            columnNames = ["player_id", "year"],
+        ),
+    ],
+    indexes = [
+        Index(name = "idx_season_fielding_stats_player", columnList = "player_id"),
+        Index(name = "idx_season_fielding_stats_year", columnList = "year"),
+    ],
+)
+class SeasonFieldingStats(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "player_id", nullable = false)
+    val player: Player,
+    @Column(nullable = false)
+    val year: Int,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    // 출전 경기 수
+    @Column(name = "games_played", nullable = false)
+    var gamesPlayed: Int = 0
+        protected set
+
+    // 기본 수비 기록
+    @Column(name = "put_outs", nullable = false)
+    var putOuts: Int = 0
+        protected set
+
+    @Column(nullable = false)
+    var assists: Int = 0
+        protected set
+
+    @Column(nullable = false)
+    var errors: Int = 0
+        protected set
+
+    @Column(name = "double_plays", nullable = false)
+    var doublePlays: Int = 0
+        protected set
+
+    @Column(name = "passed_balls", nullable = false)
+    var passedBalls: Int = 0
+        protected set
+
+    // Calculated properties
+
+    /**
+     * 수비 기회(TC) = 자살 + 보살 + 실책
+     */
+    val totalChances: Int
+        get() = putOuts + assists + errors
+
+    /**
+     * 수비율(FPCT) = (자살 + 보살) / 수비 기회
+     * 수비 기회가 0이면 null
+     */
+    val fieldingPercentage: BigDecimal?
+        get() =
+            if (totalChances == 0) {
+                null
+            } else {
+                BigDecimal(putOuts + assists).divide(BigDecimal(totalChances), 3, RoundingMode.HALF_UP)
+            }
+
+    // Business logic
+
+    /**
+     * 경기 수비 기록을 누적합니다.
+     */
+    fun addGameRecord(record: FieldingRecord) {
+        gamesPlayed++
+        putOuts += record.putOuts
+        assists += record.assists
+        errors += record.errors
+        doublePlays += record.doublePlays
+        passedBalls += record.passedBalls
+    }
+
+    /**
+     * 기록 유효성을 검증합니다.
+     */
+    fun validate() {
+        if (gamesPlayed < 0) {
+            throw StatsValidationException("출전 경기 수는 0 이상이어야 합니다.")
+        }
+        if (putOuts < 0) {
+            throw StatsValidationException("자살($putOuts)은 음수일 수 없습니다.")
+        }
+        if (assists < 0) {
+            throw StatsValidationException("보살($assists)은 음수일 수 없습니다.")
+        }
+        if (errors < 0) {
+            throw StatsValidationException("실책($errors)은 음수일 수 없습니다.")
+        }
+        if (doublePlays < 0) {
+            throw StatsValidationException("병살 관여($doublePlays)는 음수일 수 없습니다.")
+        }
+        if (passedBalls < 0) {
+            throw StatsValidationException("포일($passedBalls)은 음수일 수 없습니다.")
+        }
+    }
+
+    companion object {
+        /**
+         * 선수의 시즌 수비 통계를 생성합니다.
+         */
+        fun create(
+            player: Player,
+            year: Int,
+        ): SeasonFieldingStats {
+            if (year <= 0) {
+                throw StatsValidationException("연도는 양수여야 합니다.")
+            }
+            return SeasonFieldingStats(player = player, year = year)
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CareerFieldingStatsRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CareerFieldingStatsRepositoryPort.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.stats.CareerFieldingStats
+
+/**
+ * CareerFieldingStats Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface CareerFieldingStatsRepositoryPort {
+    fun save(stats: CareerFieldingStats): CareerFieldingStats
+
+    /**
+     * 선수 ID로 통산 수비 통계를 조회합니다.
+     */
+    fun findByPlayerId(playerId: Long): CareerFieldingStats?
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/FieldingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/FieldingRecordRepositoryPort.kt
@@ -1,0 +1,38 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.GamePlayer
+
+/**
+ * FieldingRecord Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface FieldingRecordRepositoryPort {
+    fun save(fieldingRecord: FieldingRecord): FieldingRecord
+
+    fun findAll(): List<FieldingRecord>
+
+    fun delete(fieldingRecord: FieldingRecord)
+
+    fun deleteById(id: Long)
+
+    /**
+     * GamePlayer로 수비 기록을 조회합니다.
+     */
+    fun findByGamePlayer(gamePlayer: GamePlayer): FieldingRecord?
+
+    /**
+     * GamePlayer ID로 수비 기록을 조회합니다.
+     */
+    fun findByGamePlayerId(gamePlayerId: Long): FieldingRecord?
+
+    /**
+     * 경기 ID로 모든 수비 기록을 조회합니다.
+     */
+    fun findAllByGameId(gameId: Long): List<FieldingRecord>
+
+    /**
+     * 선수 ID로 모든 수비 기록을 조회합니다.
+     */
+    fun findAllByPlayerId(playerId: Long): List<FieldingRecord>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonFieldingStatsRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonFieldingStatsRepositoryPort.kt
@@ -1,0 +1,29 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.stats.SeasonFieldingStats
+
+/**
+ * SeasonFieldingStats Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface SeasonFieldingStatsRepositoryPort {
+    fun save(stats: SeasonFieldingStats): SeasonFieldingStats
+
+    /**
+     * 선수 ID와 연도로 시즌 수비 통계를 조회합니다.
+     */
+    fun findByPlayerIdAndYear(
+        playerId: Long,
+        year: Int,
+    ): SeasonFieldingStats?
+
+    /**
+     * 선수 ID로 모든 시즌 수비 통계를 조회합니다.
+     */
+    fun findAllByPlayerId(playerId: Long): List<SeasonFieldingStats>
+
+    /**
+     * 특정 연도의 모든 시즌 수비 통계를 조회합니다.
+     */
+    fun findAllByYear(year: Int): List<SeasonFieldingStats>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/FieldingRecordService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/FieldingRecordService.kt
@@ -1,0 +1,102 @@
+package com.nextup.core.service.game
+
+import com.nextup.common.exception.FieldingRecordNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.RecordAlreadyExistsException
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 수비 기록 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class FieldingRecordService(
+    private val fieldingRecordRepository: FieldingRecordRepositoryPort,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
+) {
+    /**
+     * 수비 기록을 생성합니다.
+     */
+    @Transactional
+    fun createRecord(gamePlayerId: Long): FieldingRecord {
+        val gamePlayer =
+            gamePlayerRepository.findByIdOrNull(gamePlayerId)
+                ?: throw GamePlayerNotFoundException(gamePlayerId)
+
+        // 중복 체크
+        fieldingRecordRepository.findByGamePlayer(gamePlayer)?.let {
+            throw RecordAlreadyExistsException(gamePlayerId, "Fielding")
+        }
+
+        val fieldingRecord = FieldingRecord.create(gamePlayer)
+        return fieldingRecordRepository.save(fieldingRecord)
+    }
+
+    /**
+     * GamePlayer ID로 수비 기록을 조회합니다.
+     */
+    fun getByGamePlayerId(gamePlayerId: Long): FieldingRecord =
+        fieldingRecordRepository.findByGamePlayerId(gamePlayerId)
+            ?: throw FieldingRecordNotFoundException(gamePlayerId)
+
+    /**
+     * 자살(PO)을 기록합니다.
+     */
+    @Transactional
+    fun recordPutOut(gamePlayerId: Long) {
+        val record = getByGamePlayerId(gamePlayerId)
+        record.recordPutOut()
+    }
+
+    /**
+     * 보살(A)을 기록합니다.
+     */
+    @Transactional
+    fun recordAssist(gamePlayerId: Long) {
+        val record = getByGamePlayerId(gamePlayerId)
+        record.recordAssist()
+    }
+
+    /**
+     * 실책(E)을 기록합니다.
+     */
+    @Transactional
+    fun recordError(gamePlayerId: Long) {
+        val record = getByGamePlayerId(gamePlayerId)
+        record.recordError()
+    }
+
+    /**
+     * 병살 관여(DP)를 기록합니다.
+     */
+    @Transactional
+    fun recordDoublePlay(gamePlayerId: Long) {
+        val record = getByGamePlayerId(gamePlayerId)
+        record.recordDoublePlay()
+    }
+
+    /**
+     * 포일(PB)을 기록합니다.
+     */
+    @Transactional
+    fun recordPassedBall(gamePlayerId: Long) {
+        val record = getByGamePlayerId(gamePlayerId)
+        record.recordPassedBall()
+    }
+
+    /**
+     * 경기 ID로 모든 수비 기록을 조회합니다.
+     */
+    fun getAllByGameId(gameId: Long): List<FieldingRecord> = fieldingRecordRepository.findAllByGameId(gameId)
+
+    /**
+     * 선수 ID로 모든 수비 기록을 조회합니다.
+     */
+    fun getAllByPlayerId(playerId: Long): List<FieldingRecord> = fieldingRecordRepository.findAllByPlayerId(playerId)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/PlayerFieldingStatsService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/PlayerFieldingStatsService.kt
@@ -1,0 +1,45 @@
+package com.nextup.core.service.stats
+
+import com.nextup.common.exception.CareerFieldingStatsNotFoundException
+import com.nextup.common.exception.SeasonFieldingStatsNotFoundException
+import com.nextup.core.domain.stats.CareerFieldingStats
+import com.nextup.core.domain.stats.SeasonFieldingStats
+import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 선수 수비 통계 서비스
+ *
+ * 선수의 시즌/통산 수비 통계를 조회합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class PlayerFieldingStatsService(
+    private val seasonFieldingStatsRepository: SeasonFieldingStatsRepositoryPort,
+    private val careerFieldingStatsRepository: CareerFieldingStatsRepositoryPort,
+) {
+    /**
+     * 시즌 수비 통계를 조회합니다.
+     */
+    fun getSeasonFieldingStats(
+        playerId: Long,
+        year: Int,
+    ): SeasonFieldingStats =
+        seasonFieldingStatsRepository.findByPlayerIdAndYear(playerId, year)
+            ?: throw SeasonFieldingStatsNotFoundException(playerId, year)
+
+    /**
+     * 통산 수비 통계를 조회합니다.
+     */
+    fun getCareerFieldingStats(playerId: Long): CareerFieldingStats =
+        careerFieldingStatsRepository.findByPlayerId(playerId)
+            ?: throw CareerFieldingStatsNotFoundException(playerId)
+
+    /**
+     * 선수의 모든 시즌 수비 통계를 조회합니다.
+     */
+    fun getAllSeasonFieldingStats(playerId: Long): List<SeasonFieldingStats> =
+        seasonFieldingStatsRepository.findAllByPlayerId(playerId)
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/FieldingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/FieldingRecordTest.kt
@@ -1,0 +1,249 @@
+package com.nextup.core.domain.game
+
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("FieldingRecord")
+class FieldingRecordTest {
+    private lateinit var gamePlayer: GamePlayer
+    private lateinit var fieldingRecord: FieldingRecord
+
+    @BeforeEach
+    fun setup() {
+        gamePlayer = mockk<GamePlayer>(relaxed = true)
+        fieldingRecord = FieldingRecord.create(gamePlayer)
+    }
+
+    @Nested
+    @DisplayName("수비 기록 초기화")
+    inner class InitialStateTest {
+        @Test
+        fun `생성 직후 모든 수비 기록은 0이다`() {
+            assertThat(fieldingRecord.putOuts).isEqualTo(0)
+            assertThat(fieldingRecord.assists).isEqualTo(0)
+            assertThat(fieldingRecord.errors).isEqualTo(0)
+            assertThat(fieldingRecord.doublePlays).isEqualTo(0)
+            assertThat(fieldingRecord.passedBalls).isEqualTo(0)
+        }
+
+        @Test
+        fun `수비 기회가 0이면 수비율은 null이다`() {
+            assertThat(fieldingRecord.totalChances).isEqualTo(0)
+            assertThat(fieldingRecord.fieldingPercentage).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("자살(PO) 기록")
+    inner class RecordPutOutTest {
+        @Test
+        fun `자살을 기록하면 putOuts가 1 증가한다`() {
+            // when
+            fieldingRecord.recordPutOut()
+
+            // then
+            assertThat(fieldingRecord.putOuts).isEqualTo(1)
+        }
+
+        @Test
+        fun `자살을 여러 번 기록하면 누적된다`() {
+            // when
+            repeat(3) { fieldingRecord.recordPutOut() }
+
+            // then
+            assertThat(fieldingRecord.putOuts).isEqualTo(3)
+        }
+    }
+
+    @Nested
+    @DisplayName("보살(A) 기록")
+    inner class RecordAssistTest {
+        @Test
+        fun `보살을 기록하면 assists가 1 증가한다`() {
+            // when
+            fieldingRecord.recordAssist()
+
+            // then
+            assertThat(fieldingRecord.assists).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("실책(E) 기록")
+    inner class RecordErrorTest {
+        @Test
+        fun `실책을 기록하면 errors가 1 증가한다`() {
+            // when
+            fieldingRecord.recordError()
+
+            // then
+            assertThat(fieldingRecord.errors).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("병살 관여(DP) 기록")
+    inner class RecordDoublePlayTest {
+        @Test
+        fun `병살 관여를 기록하면 doublePlays가 1 증가한다`() {
+            // when
+            fieldingRecord.recordDoublePlay()
+
+            // then
+            assertThat(fieldingRecord.doublePlays).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("포일(PB) 기록")
+    inner class RecordPassedBallTest {
+        @Test
+        fun `포일을 기록하면 passedBalls가 1 증가한다`() {
+            // when
+            fieldingRecord.recordPassedBall()
+
+            // then
+            assertThat(fieldingRecord.passedBalls).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("수비 기회(TC) 계산")
+    inner class TotalChancesTest {
+        @Test
+        fun `수비 기회는 자살 + 보살 + 실책이다`() {
+            // given
+            fieldingRecord.recordPutOut()
+            fieldingRecord.recordPutOut()
+            fieldingRecord.recordAssist()
+            fieldingRecord.recordError()
+
+            // then
+            assertThat(fieldingRecord.totalChances).isEqualTo(4)
+        }
+    }
+
+    @Nested
+    @DisplayName("수비율(FPCT) 계산")
+    inner class FieldingPercentageTest {
+        @Test
+        fun `수비 기회가 있을 때 수비율 = (자살 + 보살) 나누기 수비 기회`() {
+            // given: PO=2, A=1, E=1 -> TC=4, FPCT=3/4=0.750
+            fieldingRecord.recordPutOut()
+            fieldingRecord.recordPutOut()
+            fieldingRecord.recordAssist()
+            fieldingRecord.recordError()
+
+            // then
+            assertThat(fieldingRecord.fieldingPercentage)
+                .isEqualByComparingTo(BigDecimal("0.750"))
+        }
+
+        @Test
+        fun `실책이 없으면 수비율은 1이다`() {
+            // given
+            fieldingRecord.recordPutOut()
+            fieldingRecord.recordAssist()
+
+            // then
+            assertThat(fieldingRecord.fieldingPercentage)
+                .isEqualByComparingTo(BigDecimal("1.000"))
+        }
+
+        @Test
+        fun `수비 기회가 0이면 수비율은 null이다`() {
+            assertThat(fieldingRecord.fieldingPercentage).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("Undo 기능")
+    inner class RevertTest {
+        @Test
+        fun `자살을 취소하면 putOuts가 1 감소한다`() {
+            // given
+            fieldingRecord.recordPutOut()
+
+            // when
+            fieldingRecord.revertPutOut()
+
+            // then
+            assertThat(fieldingRecord.putOuts).isEqualTo(0)
+        }
+
+        @Test
+        fun `자살 기록이 없는 상태에서 취소하면 예외가 발생한다`() {
+            assertThatThrownBy { fieldingRecord.revertPutOut() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `보살을 취소하면 assists가 1 감소한다`() {
+            // given
+            fieldingRecord.recordAssist()
+
+            // when
+            fieldingRecord.revertAssist()
+
+            // then
+            assertThat(fieldingRecord.assists).isEqualTo(0)
+        }
+
+        @Test
+        fun `실책을 취소하면 errors가 1 감소한다`() {
+            // given
+            fieldingRecord.recordError()
+
+            // when
+            fieldingRecord.revertError()
+
+            // then
+            assertThat(fieldingRecord.errors).isEqualTo(0)
+        }
+
+        @Test
+        fun `병살 관여를 취소하면 doublePlays가 1 감소한다`() {
+            // given
+            fieldingRecord.recordDoublePlay()
+
+            // when
+            fieldingRecord.revertDoublePlay()
+
+            // then
+            assertThat(fieldingRecord.doublePlays).isEqualTo(0)
+        }
+
+        @Test
+        fun `포일을 취소하면 passedBalls가 1 감소한다`() {
+            // given
+            fieldingRecord.recordPassedBall()
+
+            // when
+            fieldingRecord.revertPassedBall()
+
+            // then
+            assertThat(fieldingRecord.passedBalls).isEqualTo(0)
+        }
+    }
+
+    @Nested
+    @DisplayName("유효성 검증")
+    inner class ValidateTest {
+        @Test
+        fun `정상 상태에서 validate는 예외를 발생시키지 않는다`() {
+            // given
+            fieldingRecord.recordPutOut()
+            fieldingRecord.recordAssist()
+            fieldingRecord.recordError()
+
+            // when & then (no exception)
+            fieldingRecord.validate()
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/FieldingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/FieldingRecordTest.kt
@@ -233,6 +233,34 @@ class FieldingRecordTest {
     }
 
     @Nested
+    @DisplayName("Undo 실패 케이스")
+    inner class RevertFailureTest {
+        @Test
+        fun `보살 기록이 없는 상태에서 취소하면 예외가 발생한다`() {
+            assertThatThrownBy { fieldingRecord.revertAssist() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `실책 기록이 없는 상태에서 취소하면 예외가 발생한다`() {
+            assertThatThrownBy { fieldingRecord.revertError() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `병살 관여 기록이 없는 상태에서 취소하면 예외가 발생한다`() {
+            assertThatThrownBy { fieldingRecord.revertDoublePlay() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `포일 기록이 없는 상태에서 취소하면 예외가 발생한다`() {
+            assertThatThrownBy { fieldingRecord.revertPassedBall() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
     @DisplayName("유효성 검증")
     inner class ValidateTest {
         @Test
@@ -244,6 +272,21 @@ class FieldingRecordTest {
 
             // when & then (no exception)
             fieldingRecord.validate()
+        }
+
+        @Test
+        fun `초기 상태에서 validate는 예외를 발생시키지 않는다`() {
+            fieldingRecord.validate()
+        }
+    }
+
+    @Nested
+    @DisplayName("팩토리 메서드")
+    inner class FactoryTest {
+        @Test
+        fun `create로 생성된 FieldingRecord는 gamePlayer를 올바르게 설정한다`() {
+            val record = FieldingRecord.create(gamePlayer)
+            assertThat(record.gamePlayer).isEqualTo(gamePlayer)
         }
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerFieldingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerFieldingStatsTest.kt
@@ -1,0 +1,286 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.common.exception.StatsValidationException
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.player.Player
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("CareerFieldingStats")
+class CareerFieldingStatsTest {
+    private lateinit var player: Player
+    private lateinit var careerFieldingStats: CareerFieldingStats
+
+    @BeforeEach
+    fun setup() {
+        player = mockk(relaxed = true)
+        careerFieldingStats = CareerFieldingStats.create(player)
+    }
+
+    @Nested
+    @DisplayName("생성")
+    inner class CreateTest {
+        @Test
+        fun `create로 생성하면 초기값이 모두 0이다`() {
+            assertThat(careerFieldingStats.seasonsPlayed).isEqualTo(0)
+            assertThat(careerFieldingStats.gamesPlayed).isEqualTo(0)
+            assertThat(careerFieldingStats.putOuts).isEqualTo(0)
+            assertThat(careerFieldingStats.assists).isEqualTo(0)
+            assertThat(careerFieldingStats.errors).isEqualTo(0)
+            assertThat(careerFieldingStats.doublePlays).isEqualTo(0)
+            assertThat(careerFieldingStats.passedBalls).isEqualTo(0)
+        }
+
+        @Test
+        fun `생성 시 player가 올바르게 설정된다`() {
+            assertThat(careerFieldingStats.player).isEqualTo(player)
+        }
+    }
+
+    @Nested
+    @DisplayName("시즌 추가")
+    inner class AddSeasonTest {
+        @Test
+        fun `addSeason을 호출하면 seasonsPlayed가 1 증가한다`() {
+            careerFieldingStats.addSeason()
+            assertThat(careerFieldingStats.seasonsPlayed).isEqualTo(1)
+        }
+
+        @Test
+        fun `addSeason을 여러 번 호출하면 누적된다`() {
+            repeat(3) { careerFieldingStats.addSeason() }
+            assertThat(careerFieldingStats.seasonsPlayed).isEqualTo(3)
+        }
+    }
+
+    @Nested
+    @DisplayName("경기 기록 누적")
+    inner class AddGameRecordTest {
+        @Test
+        fun `addGameRecord 호출 시 gamesPlayed가 1 증가하고 수비 기록이 누적된다`() {
+            // given
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 5
+            every { record.assists } returns 3
+            every { record.errors } returns 1
+            every { record.doublePlays } returns 2
+            every { record.passedBalls } returns 1
+
+            // when
+            careerFieldingStats.addGameRecord(record)
+
+            // then
+            assertThat(careerFieldingStats.gamesPlayed).isEqualTo(1)
+            assertThat(careerFieldingStats.putOuts).isEqualTo(5)
+            assertThat(careerFieldingStats.assists).isEqualTo(3)
+            assertThat(careerFieldingStats.errors).isEqualTo(1)
+            assertThat(careerFieldingStats.doublePlays).isEqualTo(2)
+            assertThat(careerFieldingStats.passedBalls).isEqualTo(1)
+        }
+
+        @Test
+        fun `여러 경기 기록을 누적하면 합산된다`() {
+            // given
+            val record1 = mockk<FieldingRecord>()
+            every { record1.putOuts } returns 3
+            every { record1.assists } returns 1
+            every { record1.errors } returns 0
+            every { record1.doublePlays } returns 0
+            every { record1.passedBalls } returns 0
+
+            val record2 = mockk<FieldingRecord>()
+            every { record2.putOuts } returns 4
+            every { record2.assists } returns 2
+            every { record2.errors } returns 1
+            every { record2.doublePlays } returns 1
+            every { record2.passedBalls } returns 0
+
+            // when
+            careerFieldingStats.addGameRecord(record1)
+            careerFieldingStats.addGameRecord(record2)
+
+            // then
+            assertThat(careerFieldingStats.gamesPlayed).isEqualTo(2)
+            assertThat(careerFieldingStats.putOuts).isEqualTo(7)
+            assertThat(careerFieldingStats.assists).isEqualTo(3)
+            assertThat(careerFieldingStats.errors).isEqualTo(1)
+            assertThat(careerFieldingStats.doublePlays).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("수비 기회(TC) 계산")
+    inner class TotalChancesTest {
+        @Test
+        fun `초기 상태에서 수비 기회는 0이다`() {
+            assertThat(careerFieldingStats.totalChances).isEqualTo(0)
+        }
+
+        @Test
+        fun `수비 기회는 자살 + 보살 + 실책이다`() {
+            // given
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 5
+            every { record.assists } returns 3
+            every { record.errors } returns 2
+            every { record.doublePlays } returns 0
+            every { record.passedBalls } returns 0
+
+            careerFieldingStats.addGameRecord(record)
+
+            // then: TC = 5 + 3 + 2 = 10
+            assertThat(careerFieldingStats.totalChances).isEqualTo(10)
+        }
+    }
+
+    @Nested
+    @DisplayName("수비율(FPCT) 계산")
+    inner class FieldingPercentageTest {
+        @Test
+        fun `수비 기회가 0이면 수비율은 null이다`() {
+            assertThat(careerFieldingStats.fieldingPercentage).isNull()
+        }
+
+        @Test
+        fun `수비 기회가 있으면 수비율을 반환한다`() {
+            // given: PO=9, A=3, E=1 -> TC=13, FPCT=12/13
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 9
+            every { record.assists } returns 3
+            every { record.errors } returns 1
+            every { record.doublePlays } returns 0
+            every { record.passedBalls } returns 0
+
+            careerFieldingStats.addGameRecord(record)
+
+            // then
+            assertThat(careerFieldingStats.fieldingPercentage).isNotNull
+        }
+
+        @Test
+        fun `실책이 없으면 수비율은 1이다`() {
+            // given: PO=5, A=3, E=0 -> TC=8, FPCT=8/8=1.000
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 5
+            every { record.assists } returns 3
+            every { record.errors } returns 0
+            every { record.doublePlays } returns 0
+            every { record.passedBalls } returns 0
+
+            careerFieldingStats.addGameRecord(record)
+
+            // then
+            assertThat(careerFieldingStats.fieldingPercentage)
+                .isEqualByComparingTo(BigDecimal("1.000"))
+        }
+
+        @Test
+        fun `수비율은 소수점 3자리로 계산된다`() {
+            // given: PO=2, A=1, E=1 -> TC=4, FPCT=3/4=0.750
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 2
+            every { record.assists } returns 1
+            every { record.errors } returns 1
+            every { record.doublePlays } returns 0
+            every { record.passedBalls } returns 0
+
+            careerFieldingStats.addGameRecord(record)
+
+            // then
+            assertThat(careerFieldingStats.fieldingPercentage)
+                .isEqualByComparingTo(BigDecimal("0.750"))
+        }
+    }
+
+    @Nested
+    @DisplayName("유효성 검증")
+    inner class ValidateTest {
+        @Test
+        fun `정상 상태에서 validate는 예외를 발생시키지 않는다`() {
+            // given: 정상 상태
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 3
+            every { record.assists } returns 1
+            every { record.errors } returns 0
+            every { record.doublePlays } returns 0
+            every { record.passedBalls } returns 0
+            careerFieldingStats.addGameRecord(record)
+            careerFieldingStats.addSeason()
+
+            // when & then (no exception)
+            careerFieldingStats.validate()
+        }
+
+        @Test
+        fun `초기 상태에서 validate는 예외를 발생시키지 않는다`() {
+            careerFieldingStats.validate()
+        }
+
+        @Test
+        fun `seasonsPlayed가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(careerFieldingStats, "seasonsPlayed", -1)
+            assertThatThrownBy { careerFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `gamesPlayed가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(careerFieldingStats, "gamesPlayed", -1)
+            assertThatThrownBy { careerFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `putOuts가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(careerFieldingStats, "putOuts", -1)
+            assertThatThrownBy { careerFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `assists가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(careerFieldingStats, "assists", -1)
+            assertThatThrownBy { careerFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `errors가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(careerFieldingStats, "errors", -1)
+            assertThatThrownBy { careerFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `doublePlays가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(careerFieldingStats, "doublePlays", -1)
+            assertThatThrownBy { careerFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `passedBalls가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(careerFieldingStats, "passedBalls", -1)
+            assertThatThrownBy { careerFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+    }
+
+    private fun setFieldDirectly(
+        obj: Any,
+        fieldName: String,
+        value: Int,
+    ) {
+        val clazz = obj.javaClass
+        val field = clazz.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(obj, value)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonFieldingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonFieldingStatsTest.kt
@@ -128,5 +128,114 @@ class SeasonFieldingStatsTest {
             assertThat(seasonFieldingStats.totalChances).isEqualTo(13)
             assertThat(seasonFieldingStats.fieldingPercentage).isNotNull
         }
+
+        @Test
+        fun `실책이 없으면 수비율은 1이다`() {
+            // given: PO=5, A=3, E=0 -> TC=8, FPCT=8/8=1.000
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 5
+            every { record.assists } returns 3
+            every { record.errors } returns 0
+            every { record.doublePlays } returns 0
+            every { record.passedBalls } returns 0
+
+            seasonFieldingStats.addGameRecord(record)
+
+            // then
+            assertThat(seasonFieldingStats.fieldingPercentage)
+                .isEqualByComparingTo(java.math.BigDecimal("1.000"))
+        }
+
+        @Test
+        fun `수비율은 소수점 3자리로 계산된다`() {
+            // given: PO=2, A=1, E=1 -> TC=4, FPCT=3/4=0.750
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 2
+            every { record.assists } returns 1
+            every { record.errors } returns 1
+            every { record.doublePlays } returns 0
+            every { record.passedBalls } returns 0
+
+            seasonFieldingStats.addGameRecord(record)
+
+            // then
+            assertThat(seasonFieldingStats.fieldingPercentage)
+                .isEqualByComparingTo(java.math.BigDecimal("0.750"))
+        }
+    }
+
+    @Nested
+    @DisplayName("유효성 검증")
+    inner class ValidateTest {
+        @Test
+        fun `정상 상태에서 validate는 예외를 발생시키지 않는다`() {
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 3
+            every { record.assists } returns 1
+            every { record.errors } returns 0
+            every { record.doublePlays } returns 0
+            every { record.passedBalls } returns 0
+            seasonFieldingStats.addGameRecord(record)
+
+            seasonFieldingStats.validate()
+        }
+
+        @Test
+        fun `초기 상태에서 validate는 예외를 발생시키지 않는다`() {
+            seasonFieldingStats.validate()
+        }
+
+        @Test
+        fun `gamesPlayed가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(seasonFieldingStats, "gamesPlayed", -1)
+            assertThatThrownBy { seasonFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `putOuts가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(seasonFieldingStats, "putOuts", -1)
+            assertThatThrownBy { seasonFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `assists가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(seasonFieldingStats, "assists", -1)
+            assertThatThrownBy { seasonFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `errors가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(seasonFieldingStats, "errors", -1)
+            assertThatThrownBy { seasonFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `doublePlays가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(seasonFieldingStats, "doublePlays", -1)
+            assertThatThrownBy { seasonFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `passedBalls가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(seasonFieldingStats, "passedBalls", -1)
+            assertThatThrownBy { seasonFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+    }
+
+    private fun setFieldDirectly(
+        obj: Any,
+        fieldName: String,
+        value: Int,
+    ) {
+        val clazz = obj.javaClass
+        val field = clazz.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(obj, value)
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonFieldingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonFieldingStatsTest.kt
@@ -1,0 +1,132 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.common.exception.StatsValidationException
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.player.Player
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("SeasonFieldingStats")
+class SeasonFieldingStatsTest {
+    private lateinit var player: Player
+    private lateinit var seasonFieldingStats: SeasonFieldingStats
+
+    @BeforeEach
+    fun setup() {
+        player = mockk(relaxed = true)
+        seasonFieldingStats = SeasonFieldingStats.create(player, 2026)
+    }
+
+    @Nested
+    @DisplayName("생성")
+    inner class CreateTest {
+        @Test
+        fun `정상적인 연도로 생성하면 초기값이 0이다`() {
+            assertThat(seasonFieldingStats.year).isEqualTo(2026)
+            assertThat(seasonFieldingStats.gamesPlayed).isEqualTo(0)
+            assertThat(seasonFieldingStats.putOuts).isEqualTo(0)
+            assertThat(seasonFieldingStats.assists).isEqualTo(0)
+            assertThat(seasonFieldingStats.errors).isEqualTo(0)
+            assertThat(seasonFieldingStats.doublePlays).isEqualTo(0)
+            assertThat(seasonFieldingStats.passedBalls).isEqualTo(0)
+        }
+
+        @Test
+        fun `연도가 0 이하이면 StatsValidationException이 발생한다`() {
+            assertThatThrownBy { SeasonFieldingStats.create(player, 0) }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `연도가 음수이면 StatsValidationException이 발생한다`() {
+            assertThatThrownBy { SeasonFieldingStats.create(player, -1) }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("경기 기록 누적")
+    inner class AddGameRecordTest {
+        @Test
+        fun `경기 기록을 누적하면 gamesPlayed와 수비 기록이 증가한다`() {
+            // given
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 3
+            every { record.assists } returns 2
+            every { record.errors } returns 1
+            every { record.doublePlays } returns 1
+            every { record.passedBalls } returns 0
+
+            // when
+            seasonFieldingStats.addGameRecord(record)
+
+            // then
+            assertThat(seasonFieldingStats.gamesPlayed).isEqualTo(1)
+            assertThat(seasonFieldingStats.putOuts).isEqualTo(3)
+            assertThat(seasonFieldingStats.assists).isEqualTo(2)
+            assertThat(seasonFieldingStats.errors).isEqualTo(1)
+            assertThat(seasonFieldingStats.doublePlays).isEqualTo(1)
+            assertThat(seasonFieldingStats.passedBalls).isEqualTo(0)
+        }
+
+        @Test
+        fun `여러 경기 기록을 누적하면 합산된다`() {
+            // given
+            val record1 = mockk<FieldingRecord>()
+            every { record1.putOuts } returns 2
+            every { record1.assists } returns 1
+            every { record1.errors } returns 0
+            every { record1.doublePlays } returns 0
+            every { record1.passedBalls } returns 0
+
+            val record2 = mockk<FieldingRecord>()
+            every { record2.putOuts } returns 3
+            every { record2.assists } returns 2
+            every { record2.errors } returns 1
+            every { record2.doublePlays } returns 1
+            every { record2.passedBalls } returns 1
+
+            // when
+            seasonFieldingStats.addGameRecord(record1)
+            seasonFieldingStats.addGameRecord(record2)
+
+            // then
+            assertThat(seasonFieldingStats.gamesPlayed).isEqualTo(2)
+            assertThat(seasonFieldingStats.putOuts).isEqualTo(5)
+            assertThat(seasonFieldingStats.assists).isEqualTo(3)
+            assertThat(seasonFieldingStats.errors).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("수비율 계산")
+    inner class FieldingPercentageTest {
+        @Test
+        fun `수비 기회가 0이면 수비율은 null이다`() {
+            assertThat(seasonFieldingStats.fieldingPercentage).isNull()
+        }
+
+        @Test
+        fun `수비 기회가 있으면 수비율을 반환한다`() {
+            // given: PO=9, A=3, E=1 -> TC=13, FPCT=12/13
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 9
+            every { record.assists } returns 3
+            every { record.errors } returns 1
+            every { record.doublePlays } returns 0
+            every { record.passedBalls } returns 0
+
+            seasonFieldingStats.addGameRecord(record)
+
+            // then
+            assertThat(seasonFieldingStats.totalChances).isEqualTo(13)
+            assertThat(seasonFieldingStats.fieldingPercentage).isNotNull
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/FieldingRecordServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/FieldingRecordServiceTest.kt
@@ -135,6 +135,34 @@ class FieldingRecordServiceTest {
     }
 
     @Test
+    fun `should record double play`() {
+        // given
+        val gamePlayerId = 1L
+        every { fieldingRecordRepository.findByGamePlayerId(gamePlayerId) } returns mockFieldingRecord
+        every { mockFieldingRecord.recordDoublePlay() } returns Unit
+
+        // when
+        fieldingRecordService.recordDoublePlay(gamePlayerId)
+
+        // then
+        verify(exactly = 1) { mockFieldingRecord.recordDoublePlay() }
+    }
+
+    @Test
+    fun `should record passed ball`() {
+        // given
+        val gamePlayerId = 1L
+        every { fieldingRecordRepository.findByGamePlayerId(gamePlayerId) } returns mockFieldingRecord
+        every { mockFieldingRecord.recordPassedBall() } returns Unit
+
+        // when
+        fieldingRecordService.recordPassedBall(gamePlayerId)
+
+        // then
+        verify(exactly = 1) { mockFieldingRecord.recordPassedBall() }
+    }
+
+    @Test
     fun `should return all fielding records by game id`() {
         // given
         val gameId = 10L
@@ -145,5 +173,47 @@ class FieldingRecordServiceTest {
 
         // then
         assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun `should return all fielding records by player id`() {
+        // given
+        val playerId = 5L
+        every { fieldingRecordRepository.findAllByPlayerId(playerId) } returns
+            listOf(mockFieldingRecord, mockFieldingRecord)
+
+        // when
+        val result = fieldingRecordService.getAllByPlayerId(playerId)
+
+        // then
+        assertThat(result).hasSize(2)
+    }
+
+    @Test
+    fun `should get fielding record by gamePlayerId successfully`() {
+        // given
+        val gamePlayerId = 1L
+        every { fieldingRecordRepository.findByGamePlayerId(gamePlayerId) } returns mockFieldingRecord
+        every { mockFieldingRecord.id } returns 100L
+
+        // when
+        val result = fieldingRecordService.getByGamePlayerId(gamePlayerId)
+
+        // then
+        assertThat(result).isNotNull
+        assertThat(result.id).isEqualTo(100L)
+    }
+
+    @Test
+    fun `should return empty list when no fielding records exist for game`() {
+        // given
+        val gameId = 99L
+        every { fieldingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+
+        // when
+        val result = fieldingRecordService.getAllByGameId(gameId)
+
+        // then
+        assertThat(result).isEmpty()
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/FieldingRecordServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/FieldingRecordServiceTest.kt
@@ -1,0 +1,149 @@
+package com.nextup.core.service.game
+
+import com.nextup.common.exception.FieldingRecordNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.RecordAlreadyExistsException
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class FieldingRecordServiceTest {
+    private lateinit var fieldingRecordRepository: FieldingRecordRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var fieldingRecordService: FieldingRecordService
+
+    private lateinit var mockGamePlayer: GamePlayer
+    private lateinit var mockFieldingRecord: FieldingRecord
+
+    @BeforeEach
+    fun setUp() {
+        fieldingRecordRepository = mockk()
+        gamePlayerRepository = mockk()
+        fieldingRecordService =
+            FieldingRecordService(
+                fieldingRecordRepository = fieldingRecordRepository,
+                gamePlayerRepository = gamePlayerRepository,
+            )
+
+        mockGamePlayer = mockk(relaxed = true)
+        mockFieldingRecord = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `should create fielding record successfully`() {
+        // given
+        val gamePlayerId = 1L
+        every { gamePlayerRepository.findByIdOrNull(gamePlayerId) } returns mockGamePlayer
+        every { fieldingRecordRepository.findByGamePlayer(mockGamePlayer) } returns null
+        every { fieldingRecordRepository.save(any()) } returns mockFieldingRecord
+        every { mockFieldingRecord.id } returns 100L
+
+        // when
+        val result = fieldingRecordService.createRecord(gamePlayerId)
+
+        // then
+        assertThat(result).isNotNull
+        assertThat(result.id).isEqualTo(100L)
+        verify(exactly = 1) { fieldingRecordRepository.save(any()) }
+    }
+
+    @Test
+    fun `should throw GamePlayerNotFoundException when GamePlayer not found on create`() {
+        // given
+        val gamePlayerId = 1L
+        every { gamePlayerRepository.findByIdOrNull(gamePlayerId) } returns null
+
+        // when & then
+        assertThrows<GamePlayerNotFoundException> {
+            fieldingRecordService.createRecord(gamePlayerId)
+        }
+    }
+
+    @Test
+    fun `should throw RecordAlreadyExistsException when fielding record already exists`() {
+        // given
+        val gamePlayerId = 1L
+        every { gamePlayerRepository.findByIdOrNull(gamePlayerId) } returns mockGamePlayer
+        every { fieldingRecordRepository.findByGamePlayer(mockGamePlayer) } returns mockFieldingRecord
+
+        // when & then
+        assertThrows<RecordAlreadyExistsException> {
+            fieldingRecordService.createRecord(gamePlayerId)
+        }
+    }
+
+    @Test
+    fun `should throw FieldingRecordNotFoundException when record not found on get`() {
+        // given
+        val gamePlayerId = 99L
+        every { fieldingRecordRepository.findByGamePlayerId(gamePlayerId) } returns null
+
+        // when & then
+        assertThrows<FieldingRecordNotFoundException> {
+            fieldingRecordService.getByGamePlayerId(gamePlayerId)
+        }
+    }
+
+    @Test
+    fun `should record put out`() {
+        // given
+        val gamePlayerId = 1L
+        every { fieldingRecordRepository.findByGamePlayerId(gamePlayerId) } returns mockFieldingRecord
+        every { mockFieldingRecord.recordPutOut() } returns Unit
+
+        // when
+        fieldingRecordService.recordPutOut(gamePlayerId)
+
+        // then
+        verify(exactly = 1) { mockFieldingRecord.recordPutOut() }
+    }
+
+    @Test
+    fun `should record assist`() {
+        // given
+        val gamePlayerId = 1L
+        every { fieldingRecordRepository.findByGamePlayerId(gamePlayerId) } returns mockFieldingRecord
+        every { mockFieldingRecord.recordAssist() } returns Unit
+
+        // when
+        fieldingRecordService.recordAssist(gamePlayerId)
+
+        // then
+        verify(exactly = 1) { mockFieldingRecord.recordAssist() }
+    }
+
+    @Test
+    fun `should record error`() {
+        // given
+        val gamePlayerId = 1L
+        every { fieldingRecordRepository.findByGamePlayerId(gamePlayerId) } returns mockFieldingRecord
+        every { mockFieldingRecord.recordError() } returns Unit
+
+        // when
+        fieldingRecordService.recordError(gamePlayerId)
+
+        // then
+        verify(exactly = 1) { mockFieldingRecord.recordError() }
+    }
+
+    @Test
+    fun `should return all fielding records by game id`() {
+        // given
+        val gameId = 10L
+        every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
+
+        // when
+        val result = fieldingRecordService.getAllByGameId(gameId)
+
+        // then
+        assertThat(result).hasSize(1)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stats/PlayerFieldingStatsServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stats/PlayerFieldingStatsServiceTest.kt
@@ -1,0 +1,129 @@
+package com.nextup.core.service.stats
+
+import com.nextup.common.exception.CareerFieldingStatsNotFoundException
+import com.nextup.common.exception.SeasonFieldingStatsNotFoundException
+import com.nextup.core.domain.stats.CareerFieldingStats
+import com.nextup.core.domain.stats.SeasonFieldingStats
+import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("PlayerFieldingStatsService 테스트")
+class PlayerFieldingStatsServiceTest {
+    private lateinit var seasonFieldingStatsRepository: SeasonFieldingStatsRepositoryPort
+    private lateinit var careerFieldingStatsRepository: CareerFieldingStatsRepositoryPort
+    private lateinit var playerFieldingStatsService: PlayerFieldingStatsService
+
+    @BeforeEach
+    fun setUp() {
+        seasonFieldingStatsRepository = mockk()
+        careerFieldingStatsRepository = mockk()
+        playerFieldingStatsService =
+            PlayerFieldingStatsService(
+                seasonFieldingStatsRepository = seasonFieldingStatsRepository,
+                careerFieldingStatsRepository = careerFieldingStatsRepository,
+            )
+    }
+
+    @Nested
+    @DisplayName("시즌 수비 통계 조회")
+    inner class GetSeasonFieldingStatsTest {
+        @Test
+        fun `시즌 수비 통계를 정상적으로 조회한다`() {
+            // given
+            val playerId = 1L
+            val year = 2026
+            val mockStats = mockk<SeasonFieldingStats>(relaxed = true)
+            every { seasonFieldingStatsRepository.findByPlayerIdAndYear(playerId, year) } returns mockStats
+
+            // when
+            val result = playerFieldingStatsService.getSeasonFieldingStats(playerId, year)
+
+            // then
+            assertThat(result).isEqualTo(mockStats)
+        }
+
+        @Test
+        fun `시즌 수비 통계가 없으면 SeasonFieldingStatsNotFoundException이 발생한다`() {
+            // given
+            val playerId = 1L
+            val year = 2026
+            every { seasonFieldingStatsRepository.findByPlayerIdAndYear(playerId, year) } returns null
+
+            // when & then
+            assertThrows<SeasonFieldingStatsNotFoundException> {
+                playerFieldingStatsService.getSeasonFieldingStats(playerId, year)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("통산 수비 통계 조회")
+    inner class GetCareerFieldingStatsTest {
+        @Test
+        fun `통산 수비 통계를 정상적으로 조회한다`() {
+            // given
+            val playerId = 1L
+            val mockStats = mockk<CareerFieldingStats>(relaxed = true)
+            every { careerFieldingStatsRepository.findByPlayerId(playerId) } returns mockStats
+
+            // when
+            val result = playerFieldingStatsService.getCareerFieldingStats(playerId)
+
+            // then
+            assertThat(result).isEqualTo(mockStats)
+        }
+
+        @Test
+        fun `통산 수비 통계가 없으면 CareerFieldingStatsNotFoundException이 발생한다`() {
+            // given
+            val playerId = 1L
+            every { careerFieldingStatsRepository.findByPlayerId(playerId) } returns null
+
+            // when & then
+            assertThrows<CareerFieldingStatsNotFoundException> {
+                playerFieldingStatsService.getCareerFieldingStats(playerId)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("모든 시즌 수비 통계 조회")
+    inner class GetAllSeasonFieldingStatsTest {
+        @Test
+        fun `모든 시즌 수비 통계를 정상적으로 조회한다`() {
+            // given
+            val playerId = 1L
+            val mockStats1 = mockk<SeasonFieldingStats>(relaxed = true)
+            val mockStats2 = mockk<SeasonFieldingStats>(relaxed = true)
+            every { seasonFieldingStatsRepository.findAllByPlayerId(playerId) } returns
+                listOf(mockStats1, mockStats2)
+
+            // when
+            val result = playerFieldingStatsService.getAllSeasonFieldingStats(playerId)
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+
+        @Test
+        fun `시즌 수비 통계가 없으면 빈 리스트를 반환한다`() {
+            // given
+            val playerId = 99L
+            every { seasonFieldingStatsRepository.findAllByPlayerId(playerId) } returns emptyList()
+
+            // when
+            val result = playerFieldingStatsService.getAllSeasonFieldingStats(playerId)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/FieldingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/FieldingRecordRepository.kt
@@ -1,0 +1,54 @@
+package com.nextup.infrastructure.repository.game
+
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface FieldingRecordRepository :
+    JpaRepository<FieldingRecord, Long>,
+    FieldingRecordRepositoryPort {
+    /**
+     * GamePlayer로 수비 기록을 조회합니다.
+     */
+    override fun findByGamePlayer(gamePlayer: GamePlayer): FieldingRecord?
+
+    /**
+     * GamePlayer ID로 수비 기록을 조회합니다.
+     */
+    @Query("SELECT fr FROM FieldingRecord fr WHERE fr.gamePlayer.id = :gamePlayerId")
+    override fun findByGamePlayerId(
+        @Param("gamePlayerId") gamePlayerId: Long,
+    ): FieldingRecord?
+
+    /**
+     * 경기 ID로 모든 수비 기록을 조회합니다.
+     */
+    @Query(
+        """
+        SELECT fr FROM FieldingRecord fr
+        JOIN fr.gamePlayer gp
+        WHERE gp.gameTeam.game.id = :gameId
+    """,
+    )
+    override fun findAllByGameId(
+        @Param("gameId") gameId: Long,
+    ): List<FieldingRecord>
+
+    /**
+     * 선수 ID로 모든 수비 기록을 조회합니다.
+     */
+    @Query(
+        """
+        SELECT fr FROM FieldingRecord fr
+        JOIN fr.gamePlayer gp
+        WHERE gp.player.id = :playerId
+        ORDER BY gp.gameTeam.game.scheduledAt DESC
+    """,
+    )
+    override fun findAllByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): List<FieldingRecord>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/CareerFieldingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/CareerFieldingStatsRepository.kt
@@ -1,0 +1,19 @@
+package com.nextup.infrastructure.repository.stats
+
+import com.nextup.core.domain.stats.CareerFieldingStats
+import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface CareerFieldingStatsRepository :
+    JpaRepository<CareerFieldingStats, Long>,
+    CareerFieldingStatsRepositoryPort {
+    /**
+     * 선수 ID로 통산 수비 통계를 조회합니다.
+     */
+    @Query("SELECT c FROM CareerFieldingStats c WHERE c.player.id = :playerId")
+    override fun findByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): CareerFieldingStats?
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonFieldingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonFieldingStatsRepository.kt
@@ -1,0 +1,36 @@
+package com.nextup.infrastructure.repository.stats
+
+import com.nextup.core.domain.stats.SeasonFieldingStats
+import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface SeasonFieldingStatsRepository :
+    JpaRepository<SeasonFieldingStats, Long>,
+    SeasonFieldingStatsRepositoryPort {
+    /**
+     * 선수 ID와 연도로 시즌 수비 통계를 조회합니다.
+     */
+    @Query("SELECT s FROM SeasonFieldingStats s WHERE s.player.id = :playerId AND s.year = :year")
+    override fun findByPlayerIdAndYear(
+        @Param("playerId") playerId: Long,
+        @Param("year") year: Int,
+    ): SeasonFieldingStats?
+
+    /**
+     * 선수 ID로 모든 시즌 수비 통계를 조회합니다.
+     */
+    @Query("SELECT s FROM SeasonFieldingStats s WHERE s.player.id = :playerId ORDER BY s.year DESC")
+    override fun findAllByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): List<SeasonFieldingStats>
+
+    /**
+     * 특정 연도의 모든 시즌 수비 통계를 조회합니다.
+     */
+    @Query("SELECT s FROM SeasonFieldingStats s WHERE s.year = :year")
+    override fun findAllByYear(
+        @Param("year") year: Int,
+    ): List<SeasonFieldingStats>
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V024__create_fielding_records_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V024__create_fielding_records_table.sql
@@ -1,0 +1,16 @@
+-- V024: 수비 기록 테이블 생성
+CREATE TABLE fielding_records (
+    id                BIGSERIAL PRIMARY KEY,
+    game_player_id    BIGINT       NOT NULL,
+    put_outs          INTEGER      NOT NULL DEFAULT 0,
+    assists           INTEGER      NOT NULL DEFAULT 0,
+    errors            INTEGER      NOT NULL DEFAULT 0,
+    double_plays      INTEGER      NOT NULL DEFAULT 0,
+    passed_balls      INTEGER      NOT NULL DEFAULT 0,
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_fielding_records_game_player
+        FOREIGN KEY (game_player_id) REFERENCES game_players(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_fielding_records_game_player ON fielding_records(game_player_id);

--- a/nextup-infrastructure/src/main/resources/db/migration/V025__create_fielding_stats_tables.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V025__create_fielding_stats_tables.sql
@@ -1,0 +1,42 @@
+-- V025: 시즌/통산 수비 통계 테이블 생성
+
+-- 시즌 수비 통계
+CREATE TABLE season_fielding_stats (
+    id           BIGSERIAL PRIMARY KEY,
+    player_id    BIGINT  NOT NULL,
+    year         INTEGER NOT NULL,
+    games_played INTEGER NOT NULL DEFAULT 0,
+    put_outs     INTEGER NOT NULL DEFAULT 0,
+    assists      INTEGER NOT NULL DEFAULT 0,
+    errors       INTEGER NOT NULL DEFAULT 0,
+    double_plays INTEGER NOT NULL DEFAULT 0,
+    passed_balls INTEGER NOT NULL DEFAULT 0,
+    created_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_season_fielding_stats_player
+        FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE,
+    CONSTRAINT uk_season_fielding_stats_player_year
+        UNIQUE (player_id, year)
+);
+
+CREATE INDEX idx_season_fielding_stats_player ON season_fielding_stats(player_id);
+CREATE INDEX idx_season_fielding_stats_year   ON season_fielding_stats(year);
+
+-- 통산 수비 통계
+CREATE TABLE career_fielding_stats (
+    id              BIGSERIAL PRIMARY KEY,
+    player_id       BIGINT  NOT NULL UNIQUE,
+    seasons_played  INTEGER NOT NULL DEFAULT 0,
+    games_played    INTEGER NOT NULL DEFAULT 0,
+    put_outs        INTEGER NOT NULL DEFAULT 0,
+    assists         INTEGER NOT NULL DEFAULT 0,
+    errors          INTEGER NOT NULL DEFAULT 0,
+    double_plays    INTEGER NOT NULL DEFAULT 0,
+    passed_balls    INTEGER NOT NULL DEFAULT 0,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_career_fielding_stats_player
+        FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_career_fielding_stats_player ON career_fielding_stats(player_id);

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerController.kt
@@ -1,0 +1,85 @@
+package com.nextup.scorer.controller.fielding
+
+import com.nextup.common.dto.ApiResponse
+import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
+import com.nextup.core.service.game.FieldingRecordService
+import com.nextup.infrastructure.repository.game.GamePlayerRepository
+import com.nextup.scorer.dto.fielding.FieldingEventRequest
+import com.nextup.scorer.dto.fielding.FieldingEventType
+import com.nextup.scorer.dto.fielding.FieldingRecordResponse
+import com.nextup.scorer.dto.fielding.toScorerResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 기록원 전용 수비 기록 컨트롤러
+ *
+ * 실시간 경기에서 수비 이벤트(자살/보살/실책/병살/포일)를 기록합니다.
+ */
+@RestController
+@RequestMapping("/api/scorer/games/{gameId}/fielding")
+class FieldingRecordScorerController(
+    private val fieldingRecordService: FieldingRecordService,
+    private val gamePlayerRepository: GamePlayerRepository,
+) {
+    /**
+     * 수비 기록을 생성합니다 (경기 시작 시 선수별 초기화).
+     *
+     * POST /api/scorer/games/{gameId}/fielding/players/{playerId}
+     */
+    @PostMapping("/players/{playerId}")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createFieldingRecord(
+        @PathVariable gameId: Long,
+        @PathVariable playerId: Long,
+    ): ApiResponse<FieldingRecordResponse> {
+        val gamePlayer =
+            gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId)
+                ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, playerId)
+        val record = fieldingRecordService.createRecord(gamePlayer.id)
+        return ApiResponse.success(record.toScorerResponse())
+    }
+
+    /**
+     * 수비 이벤트를 기록합니다.
+     *
+     * POST /api/scorer/games/{gameId}/fielding/events
+     */
+    @PostMapping("/events")
+    @ResponseStatus(HttpStatus.OK)
+    fun recordFieldingEvent(
+        @PathVariable gameId: Long,
+        @Valid @RequestBody request: FieldingEventRequest,
+    ): ApiResponse<FieldingRecordResponse> {
+        val gamePlayerId = request.gamePlayerId!!
+        when (request.eventType!!) {
+            FieldingEventType.PUT_OUT -> fieldingRecordService.recordPutOut(gamePlayerId)
+            FieldingEventType.ASSIST -> fieldingRecordService.recordAssist(gamePlayerId)
+            FieldingEventType.ERROR -> fieldingRecordService.recordError(gamePlayerId)
+            FieldingEventType.DOUBLE_PLAY -> fieldingRecordService.recordDoublePlay(gamePlayerId)
+            FieldingEventType.PASSED_BALL -> fieldingRecordService.recordPassedBall(gamePlayerId)
+        }
+        val record = fieldingRecordService.getByGamePlayerId(gamePlayerId)
+        return ApiResponse.success(record.toScorerResponse())
+    }
+
+    /**
+     * 경기의 모든 수비 기록을 조회합니다.
+     *
+     * GET /api/scorer/games/{gameId}/fielding
+     */
+    @GetMapping
+    fun getFieldingRecordsByGame(
+        @PathVariable gameId: Long,
+    ): ApiResponse<List<FieldingRecordResponse>> {
+        val records = fieldingRecordService.getAllByGameId(gameId)
+        return ApiResponse.success(records.toScorerResponse())
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/fielding/FieldingEventRequest.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/fielding/FieldingEventRequest.kt
@@ -1,0 +1,28 @@
+package com.nextup.scorer.dto.fielding
+
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 수비 이벤트 요청 DTO
+ *
+ * 실시간 경기 기록 시 수비 이벤트를 입력하기 위한 요청입니다.
+ */
+data class FieldingEventRequest(
+    @field:NotNull(message = "gamePlayerId는 필수입니다.")
+    val gamePlayerId: Long?,
+    @field:NotNull(message = "eventType은 필수입니다.")
+    val eventType: FieldingEventType?,
+)
+
+/**
+ * 수비 이벤트 유형
+ */
+enum class FieldingEventType(
+    val displayName: String,
+) {
+    PUT_OUT("자살"),
+    ASSIST("보살"),
+    ERROR("실책"),
+    DOUBLE_PLAY("병살 관여"),
+    PASSED_BALL("포일"),
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/fielding/FieldingRecordResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/fielding/FieldingRecordResponse.kt
@@ -1,0 +1,33 @@
+package com.nextup.scorer.dto.fielding
+
+import com.nextup.core.domain.game.FieldingRecord
+
+/**
+ * 수비 기록 응답 DTO (Scorer 모듈)
+ */
+data class FieldingRecordResponse(
+    val id: Long,
+    val gamePlayerId: Long,
+    val putOuts: Int,
+    val assists: Int,
+    val errors: Int,
+    val doublePlays: Int,
+    val passedBalls: Int,
+    val totalChances: Int,
+    val fieldingPercentage: String?,
+)
+
+fun FieldingRecord.toScorerResponse(): FieldingRecordResponse =
+    FieldingRecordResponse(
+        id = this.id,
+        gamePlayerId = this.gamePlayer.id,
+        putOuts = this.putOuts,
+        assists = this.assists,
+        errors = this.errors,
+        doublePlays = this.doublePlays,
+        passedBalls = this.passedBalls,
+        totalChances = this.totalChances,
+        fieldingPercentage = this.fieldingPercentage?.toPlainString(),
+    )
+
+fun List<FieldingRecord>.toScorerResponse(): List<FieldingRecordResponse> = this.map { it.toScorerResponse() }

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerControllerTest.kt
@@ -1,0 +1,337 @@
+package com.nextup.scorer.controller.fielding
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.service.game.FieldingRecordService
+import com.nextup.infrastructure.repository.game.GamePlayerRepository
+import com.nextup.scorer.dto.fielding.FieldingEventRequest
+import com.nextup.scorer.dto.fielding.FieldingEventType
+import com.nextup.scorer.exception.GlobalExceptionHandler
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@DisplayName("FieldingRecordScorerController 테스트")
+class FieldingRecordScorerControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var fieldingRecordService: FieldingRecordService
+    private lateinit var gamePlayerRepository: GamePlayerRepository
+    private lateinit var objectMapper: ObjectMapper
+
+    private val gameId = 1L
+    private val playerId = 10L
+    private val gamePlayerId = 100L
+
+    @BeforeEach
+    fun setUp() {
+        fieldingRecordService = mockk()
+        gamePlayerRepository = mockk()
+        objectMapper = jacksonObjectMapper()
+
+        val controller =
+            FieldingRecordScorerController(
+                fieldingRecordService = fieldingRecordService,
+                gamePlayerRepository = gamePlayerRepository,
+            )
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/fielding/players/{playerId}")
+    inner class CreateFieldingRecord {
+        @Test
+        fun `수비 기록을 성공적으로 생성한다`() {
+            // given
+            val mockGamePlayer = mockk<GamePlayer>(relaxed = true)
+            every { mockGamePlayer.id } returns gamePlayerId
+
+            val mockRecord = mockk<FieldingRecord>(relaxed = true)
+            every { mockRecord.id } returns 1L
+            every { mockRecord.gamePlayer } returns mockGamePlayer
+            every { mockRecord.putOuts } returns 0
+            every { mockRecord.assists } returns 0
+            every { mockRecord.errors } returns 0
+            every { mockRecord.doublePlays } returns 0
+            every { mockRecord.passedBalls } returns 0
+            every { mockRecord.totalChances } returns 0
+            every { mockRecord.fieldingPercentage } returns null
+
+            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns mockGamePlayer
+            every { fieldingRecordService.createRecord(gamePlayerId) } returns mockRecord
+
+            // when & then
+            mockMvc
+                .perform(post("/api/scorer/games/$gameId/fielding/players/$playerId"))
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.gamePlayerId").value(gamePlayerId))
+                .andExpect(jsonPath("$.data.putOuts").value(0))
+                .andExpect(jsonPath("$.data.assists").value(0))
+                .andExpect(jsonPath("$.data.errors").value(0))
+
+            verify(exactly = 1) { fieldingRecordService.createRecord(gamePlayerId) }
+        }
+
+        @Test
+        fun `GamePlayer를 찾을 수 없으면 404를 반환한다`() {
+            // given
+            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns null
+
+            // when & then
+            mockMvc
+                .perform(post("/api/scorer/games/$gameId/fielding/players/$playerId"))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/fielding/events")
+    inner class RecordFieldingEvent {
+        @Test
+        fun `자살(PUT_OUT) 이벤트를 성공적으로 기록한다`() {
+            // given
+            val request = FieldingEventRequest(gamePlayerId = gamePlayerId, eventType = FieldingEventType.PUT_OUT)
+            val mockGamePlayer = mockk<GamePlayer>(relaxed = true)
+            every { mockGamePlayer.id } returns gamePlayerId
+
+            val mockRecord = mockk<FieldingRecord>(relaxed = true)
+            every { mockRecord.id } returns 1L
+            every { mockRecord.gamePlayer } returns mockGamePlayer
+            every { mockRecord.putOuts } returns 1
+            every { mockRecord.assists } returns 0
+            every { mockRecord.errors } returns 0
+            every { mockRecord.doublePlays } returns 0
+            every { mockRecord.passedBalls } returns 0
+            every { mockRecord.totalChances } returns 1
+            every { mockRecord.fieldingPercentage } returns java.math.BigDecimal("1.000")
+
+            every { fieldingRecordService.recordPutOut(gamePlayerId) } returns Unit
+            every { fieldingRecordService.getByGamePlayerId(gamePlayerId) } returns mockRecord
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/scorer/games/$gameId/fielding/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.putOuts").value(1))
+                .andExpect(jsonPath("$.data.fieldingPercentage").value("1.000"))
+
+            verify(exactly = 1) { fieldingRecordService.recordPutOut(gamePlayerId) }
+        }
+
+        @Test
+        fun `보살(ASSIST) 이벤트를 성공적으로 기록한다`() {
+            // given
+            val request = FieldingEventRequest(gamePlayerId = gamePlayerId, eventType = FieldingEventType.ASSIST)
+            val mockGamePlayer = mockk<GamePlayer>(relaxed = true)
+            every { mockGamePlayer.id } returns gamePlayerId
+
+            val mockRecord = mockk<FieldingRecord>(relaxed = true)
+            every { mockRecord.id } returns 1L
+            every { mockRecord.gamePlayer } returns mockGamePlayer
+            every { mockRecord.putOuts } returns 0
+            every { mockRecord.assists } returns 1
+            every { mockRecord.errors } returns 0
+            every { mockRecord.doublePlays } returns 0
+            every { mockRecord.passedBalls } returns 0
+            every { mockRecord.totalChances } returns 1
+            every { mockRecord.fieldingPercentage } returns java.math.BigDecimal("1.000")
+
+            every { fieldingRecordService.recordAssist(gamePlayerId) } returns Unit
+            every { fieldingRecordService.getByGamePlayerId(gamePlayerId) } returns mockRecord
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/scorer/games/$gameId/fielding/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.assists").value(1))
+
+            verify(exactly = 1) { fieldingRecordService.recordAssist(gamePlayerId) }
+        }
+
+        @Test
+        fun `실책(ERROR) 이벤트를 성공적으로 기록한다`() {
+            // given
+            val request = FieldingEventRequest(gamePlayerId = gamePlayerId, eventType = FieldingEventType.ERROR)
+            val mockGamePlayer = mockk<GamePlayer>(relaxed = true)
+            every { mockGamePlayer.id } returns gamePlayerId
+
+            val mockRecord = mockk<FieldingRecord>(relaxed = true)
+            every { mockRecord.id } returns 1L
+            every { mockRecord.gamePlayer } returns mockGamePlayer
+            every { mockRecord.putOuts } returns 0
+            every { mockRecord.assists } returns 0
+            every { mockRecord.errors } returns 1
+            every { mockRecord.doublePlays } returns 0
+            every { mockRecord.passedBalls } returns 0
+            every { mockRecord.totalChances } returns 1
+            every { mockRecord.fieldingPercentage } returns java.math.BigDecimal("0.000")
+
+            every { fieldingRecordService.recordError(gamePlayerId) } returns Unit
+            every { fieldingRecordService.getByGamePlayerId(gamePlayerId) } returns mockRecord
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/scorer/games/$gameId/fielding/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.errors").value(1))
+
+            verify(exactly = 1) { fieldingRecordService.recordError(gamePlayerId) }
+        }
+
+        @Test
+        fun `병살(DOUBLE_PLAY) 이벤트를 성공적으로 기록한다`() {
+            // given
+            val request =
+                FieldingEventRequest(gamePlayerId = gamePlayerId, eventType = FieldingEventType.DOUBLE_PLAY)
+            val mockGamePlayer = mockk<GamePlayer>(relaxed = true)
+            every { mockGamePlayer.id } returns gamePlayerId
+
+            val mockRecord = mockk<FieldingRecord>(relaxed = true)
+            every { mockRecord.id } returns 1L
+            every { mockRecord.gamePlayer } returns mockGamePlayer
+            every { mockRecord.putOuts } returns 0
+            every { mockRecord.assists } returns 0
+            every { mockRecord.errors } returns 0
+            every { mockRecord.doublePlays } returns 1
+            every { mockRecord.passedBalls } returns 0
+            every { mockRecord.totalChances } returns 0
+            every { mockRecord.fieldingPercentage } returns null
+
+            every { fieldingRecordService.recordDoublePlay(gamePlayerId) } returns Unit
+            every { fieldingRecordService.getByGamePlayerId(gamePlayerId) } returns mockRecord
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/scorer/games/$gameId/fielding/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.doublePlays").value(1))
+
+            verify(exactly = 1) { fieldingRecordService.recordDoublePlay(gamePlayerId) }
+        }
+
+        @Test
+        fun `포일(PASSED_BALL) 이벤트를 성공적으로 기록한다`() {
+            // given
+            val request =
+                FieldingEventRequest(gamePlayerId = gamePlayerId, eventType = FieldingEventType.PASSED_BALL)
+            val mockGamePlayer = mockk<GamePlayer>(relaxed = true)
+            every { mockGamePlayer.id } returns gamePlayerId
+
+            val mockRecord = mockk<FieldingRecord>(relaxed = true)
+            every { mockRecord.id } returns 1L
+            every { mockRecord.gamePlayer } returns mockGamePlayer
+            every { mockRecord.putOuts } returns 0
+            every { mockRecord.assists } returns 0
+            every { mockRecord.errors } returns 0
+            every { mockRecord.doublePlays } returns 0
+            every { mockRecord.passedBalls } returns 1
+            every { mockRecord.totalChances } returns 0
+            every { mockRecord.fieldingPercentage } returns null
+
+            every { fieldingRecordService.recordPassedBall(gamePlayerId) } returns Unit
+            every { fieldingRecordService.getByGamePlayerId(gamePlayerId) } returns mockRecord
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/scorer/games/$gameId/fielding/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.passedBalls").value(1))
+
+            verify(exactly = 1) { fieldingRecordService.recordPassedBall(gamePlayerId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/scorer/games/{gameId}/fielding")
+    inner class GetFieldingRecordsByGame {
+        @Test
+        fun `경기의 수비 기록을 성공적으로 조회한다`() {
+            // given
+            val mockGamePlayer = mockk<GamePlayer>(relaxed = true)
+            every { mockGamePlayer.id } returns gamePlayerId
+
+            val mockRecord = mockk<FieldingRecord>(relaxed = true)
+            every { mockRecord.id } returns 1L
+            every { mockRecord.gamePlayer } returns mockGamePlayer
+            every { mockRecord.putOuts } returns 5
+            every { mockRecord.assists } returns 3
+            every { mockRecord.errors } returns 1
+            every { mockRecord.doublePlays } returns 1
+            every { mockRecord.passedBalls } returns 0
+            every { mockRecord.totalChances } returns 9
+            every { mockRecord.fieldingPercentage } returns java.math.BigDecimal("0.889")
+
+            every { fieldingRecordService.getAllByGameId(gameId) } returns listOf(mockRecord)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/scorer/games/$gameId/fielding"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].putOuts").value(5))
+                .andExpect(jsonPath("$.data[0].assists").value(3))
+                .andExpect(jsonPath("$.data[0].errors").value(1))
+                .andExpect(jsonPath("$.data[0].totalChances").value(9))
+        }
+
+        @Test
+        fun `경기의 수비 기록이 없으면 빈 리스트를 반환한다`() {
+            // given
+            every { fieldingRecordService.getAllByGameId(gameId) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/scorer/games/$gameId/fielding"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #216

야구 기록의 3대 축(타격/투구/수비) 중 부재했던 수비 기록 시스템 구축.

## Tasks

- FieldingRecord 엔티티: putOuts, assists, errors, totalChances, fieldingPercentage
- SeasonFieldingStats, CareerFieldingStats 시즌/커리어 통계
- 수비 기록 API (실책 선수 지정, 수비 관여 선수 기록)
- 포지션별 수비율 리더보드
- 단위 테스트 작성

## To Reviewer

- Rich Domain Model: 수비율 계산은 Entity 내부
- 사회인 야구 특성상 필수 필드(PO/A/E)와 선택 필드 구분

🤖 Generated with [Claude Code](https://claude.com/claude-code)