### PR TITLE
feat(#221): 선수 교체 이벤트 기록 및 규칙 검증 강화

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -131,5 +131,31 @@ class GameEvent(
                 eventType = GameEventType.GAME_STATUS,
                 description = description,
             )
+
+        /**
+         * 선수 교체 이벤트를 생성합니다.
+         *
+         * @param game 경기
+         * @param incomingPlayer 교체 들어오는 선수
+         * @param outgoingPlayer 교체 나가는 선수
+         * @param description 교체 설명
+         */
+        fun createSubstitution(
+            game: Game,
+            incomingPlayer: GamePlayer,
+            outgoingPlayer: GamePlayer,
+            description: String,
+        ): GameEvent =
+            GameEvent(
+                game = game,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                outCountBefore = game.gameState.outs,
+                outCountAfter = game.gameState.outs,
+                eventType = GameEventType.SUBSTITUTION,
+                description = description,
+                batter = incomingPlayer,
+                pitcher = outgoingPlayer,
+            )
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GamePlayer.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GamePlayer.kt
@@ -88,7 +88,14 @@ class GamePlayer(
         get() = battingOrder != null
 
     /**
+     * 이미 퇴장한 선수인지 확인합니다 (재출전 불가 검증용).
+     */
+    val hasExited: Boolean
+        get() = exitInning != null
+
+    /**
      * 교체 선수로 출전합니다.
+     * 이미 퇴장한 선수는 재출전할 수 없습니다.
      */
     fun enterAsSubstitute(
         inning: Int,
@@ -96,6 +103,9 @@ class GamePlayer(
         newBattingOrder: Int?,
     ) {
         require(inning >= 1) { "이닝은 1 이상이어야 합니다." }
+        require(!hasExited) {
+            "이미 퇴장한 선수는 재출전할 수 없습니다. (선수 ID: $id)"
+        }
         this.isStarter = false
         this.isCurrentlyPlaying = true
         this.entryInning = inning
@@ -141,10 +151,48 @@ class GamePlayer(
     /**
      * DH 해제 시 처리합니다 (DH 규칙 해제).
      * 투수가 타순에 들어가게 됩니다.
+     *
+     * DH 해제 조건:
+     * - 투수가 DH(지명타자) 자리 타순에 직접 들어올 때만 가능
+     * - 또는 DH가 수비 포지션으로 이동할 때
+     * - 이 메서드 호출 전 도메인 서비스에서 조건 검증 필수
      */
     fun releaseDH() {
         this.isDesignatedHitter = false
         this.pitcherBattingOrder = null
+    }
+
+    /**
+     * 이 선수가 DH 자리에 투수로 교체될 수 있는지 검증합니다.
+     * 투수가 DH 타순으로 들어오면 DH 규칙이 해제됩니다.
+     *
+     * @param incomingPlayer 교체 들어오는 선수
+     * @return DH 규칙 해제가 필요한 경우 true
+     */
+    fun isDhReleaseRequired(incomingPlayer: GamePlayer): Boolean {
+        // 현재 선수가 DH이고, 들어오는 선수가 투수일 때 DH 해제
+        return this.isDesignatedHitter && incomingPlayer.isPitcher
+    }
+
+    /**
+     * DH 해제 규칙을 검증합니다.
+     * 투수가 DH 자리 이외의 타순으로 들어오는 경우 DH 해제는 허용되지 않습니다.
+     *
+     * @param incomingPlayer 교체 들어오는 선수
+     * @param incomingBattingOrder 들어오는 선수의 타순
+     * @throws IllegalArgumentException DH 해제 규칙 위반 시
+     */
+    fun validateDhRelease(
+        incomingPlayer: GamePlayer,
+        incomingBattingOrder: Int?,
+    ) {
+        if (this.isDesignatedHitter && incomingPlayer.isPitcher) {
+            // 투수가 DH 타순으로 들어오는 경우만 허용
+            val dhBattingOrder = this.battingOrder
+            require(incomingBattingOrder == dhBattingOrder) {
+                "투수는 DH 타순(${dhBattingOrder}번)으로만 교체될 수 있습니다. 요청 타순: $incomingBattingOrder"
+            }
+        }
     }
 
     companion object {

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
@@ -4,6 +4,7 @@ import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.service.game.dto.GameEndReason
 import com.nextup.core.service.game.dto.PlateAppearanceRequest
+import com.nextup.core.service.game.dto.SubstitutionRequest
 
 /**
  * 기록원 전용 경기 기록 서비스 인터페이스
@@ -74,4 +75,20 @@ interface GameScorerService {
         winnerTeamId: Long,
         reason: String,
     ): Game
+
+    /**
+     * 선수를 교체합니다.
+     *
+     * 교체 이벤트를 기록하고 다음 규칙을 검증합니다:
+     * - 퇴장한 선수의 재출전 방지
+     * - DH 해제 조건 검증 (투수가 DH 타순으로 들어오는 경우만 허용)
+     *
+     * @param gameId 경기 ID
+     * @param request 선수 교체 요청
+     * @return 교체 이벤트
+     */
+    fun substitutePlayer(
+        gameId: Long,
+        request: SubstitutionRequest,
+    ): GameEvent
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/SubstitutionRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/SubstitutionRequest.kt
@@ -1,0 +1,20 @@
+package com.nextup.core.service.game.dto
+
+import com.nextup.core.domain.player.Position
+
+/**
+ * 선수 교체 요청 도메인 DTO
+ *
+ * @param gameTeamId 교체가 발생하는 팀의 GameTeam ID
+ * @param outgoingPlayerId 교체 나가는 선수의 GamePlayer ID
+ * @param incomingPlayerId 교체 들어오는 선수의 GamePlayer ID
+ * @param newPosition 교체 들어오는 선수의 새 포지션
+ * @param newBattingOrder 교체 들어오는 선수의 타순 (null이면 타순 없음)
+ */
+data class SubstitutionRequest(
+    val gameTeamId: Long,
+    val outgoingPlayerId: Long,
+    val incomingPlayerId: Long,
+    val newPosition: Position,
+    val newBattingOrder: Int?,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
@@ -141,6 +141,38 @@ class GameEventTest {
     }
 
     @Nested
+    @DisplayName("createSubstitution")
+    inner class CreateSubstitution {
+        @Test
+        fun `선수 교체 이벤트를 생성한다`() {
+            // given
+            val incomingPlayer = mockk<GamePlayer>(relaxed = true)
+            val outgoingPlayer = mockk<GamePlayer>(relaxed = true)
+
+            // when
+            val event =
+                GameEvent.createSubstitution(
+                    game = game,
+                    incomingPlayer = incomingPlayer,
+                    outgoingPlayer = outgoingPlayer,
+                    description = "5회초: 홍길동 → 김철수 (좌익수)",
+                )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.SUBSTITUTION)
+            assertThat(event.description).isEqualTo("5회초: 홍길동 → 김철수 (좌익수)")
+            assertThat(event.inning).isEqualTo(game.currentInning)
+            assertThat(event.isTopInning).isEqualTo(game.isTopInning)
+            assertThat(event.outCountBefore).isEqualTo(game.gameState.outs)
+            assertThat(event.outCountAfter).isEqualTo(game.gameState.outs)
+            assertThat(event.batter).isEqualTo(incomingPlayer)
+            assertThat(event.pitcher).isEqualTo(outgoingPlayer)
+            assertThat(event.plateAppearanceResult).isNull()
+            assertThat(event.runsScored).isEqualTo(0)
+        }
+    }
+
+    @Nested
     @DisplayName("createGameStatus")
     inner class CreateGameStatus {
         @Test

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GamePlayerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GamePlayerTest.kt
@@ -342,6 +342,51 @@ class GamePlayerTest {
         }
 
         @Test
+        fun `DH가 아닌 선수에 대해 validateDhRelease를 호출하면 예외 없이 통과한다`() {
+            val normalPlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.LEFT_FIELD,
+                    battingOrder = 5,
+                )
+
+            val pitcherPlayer =
+                GamePlayer.createBench(
+                    gameTeam = gameTeam,
+                    player = mockk(relaxed = true),
+                    position = Position.RELIEF_PITCHER,
+                )
+
+            // DH가 아닌 선수는 검증을 무조건 통과 (if 조건 false)
+            normalPlayer.validateDhRelease(pitcherPlayer, incomingBattingOrder = 5)
+            // 예외 없이 통과해야 함
+        }
+
+        @Test
+        fun `DH 선수에 대해 야수로 교체하면 validateDhRelease가 예외 없이 통과한다`() {
+            val dhPlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.DESIGNATED_HITTER,
+                    battingOrder = 4,
+                )
+            dhPlayer.setAsDesignatedHitter(pitcherOrder = 9)
+
+            val outfielder =
+                GamePlayer.createBench(
+                    gameTeam = gameTeam,
+                    player = mockk(relaxed = true),
+                    position = Position.LEFT_FIELD,
+                )
+
+            // DH이지만 들어오는 선수가 투수가 아니면 검증 통과 (if 조건의 incomingPlayer.isPitcher == false)
+            dhPlayer.validateDhRelease(outfielder, incomingBattingOrder = 7)
+            // 예외 없이 통과해야 함
+        }
+
+        @Test
         fun `투수가 DH 타순이 아닌 다른 타순으로 교체되면 예외가 발생한다`() {
             val dhPlayer =
                 GamePlayer.createStarter(

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GamePlayerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GamePlayerTest.kt
@@ -208,6 +208,163 @@ class GamePlayerTest {
             }.isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("이닝은 1 이상")
         }
+
+        @Test
+        fun `이미 퇴장한 선수는 재출전할 수 없다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.LEFT_FIELD,
+                    battingOrder = 5,
+                )
+            gamePlayer.exitGame(3)
+
+            assertThatThrownBy {
+                gamePlayer.enterAsSubstitute(5, Position.LEFT_FIELD, 5)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이미 퇴장한 선수")
+        }
+
+        @Test
+        fun `퇴장하지 않은 벤치 선수는 교체 출전할 수 있다`() {
+            val gamePlayer =
+                GamePlayer.createBench(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.CENTER_FIELD,
+                )
+
+            assertThat(gamePlayer.hasExited).isFalse()
+            gamePlayer.enterAsSubstitute(4, Position.CENTER_FIELD, 6)
+
+            assertThat(gamePlayer.isCurrentlyPlaying).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("재출전 방지 (hasExited)")
+    inner class HasExitedTest {
+        @Test
+        fun `퇴장하지 않은 선수의 hasExited는 false이다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 1,
+                )
+
+            assertThat(gamePlayer.hasExited).isFalse()
+        }
+
+        @Test
+        fun `퇴장한 선수의 hasExited는 true이다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 1,
+                )
+            gamePlayer.exitGame(5)
+
+            assertThat(gamePlayer.hasExited).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("DH 해제 규칙 검증")
+    inner class DhReleaseValidationTest {
+        @Test
+        fun `DH 선수를 투수로 교체할 때 타순이 일치하면 DH 해제가 필요하다`() {
+            val dhPlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.DESIGNATED_HITTER,
+                    battingOrder = 4,
+                )
+            dhPlayer.setAsDesignatedHitter(pitcherOrder = 9)
+
+            val pitcherPlayer =
+                GamePlayer.createBench(
+                    gameTeam = gameTeam,
+                    player = mockk(relaxed = true),
+                    position = Position.RELIEF_PITCHER,
+                )
+
+            assertThat(dhPlayer.isDhReleaseRequired(pitcherPlayer)).isTrue()
+        }
+
+        @Test
+        fun `DH 선수를 야수로 교체할 때 DH 해제가 필요하지 않다`() {
+            val dhPlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.DESIGNATED_HITTER,
+                    battingOrder = 4,
+                )
+            dhPlayer.setAsDesignatedHitter(pitcherOrder = 9)
+
+            val outfielder =
+                GamePlayer.createBench(
+                    gameTeam = gameTeam,
+                    player = mockk(relaxed = true),
+                    position = Position.LEFT_FIELD,
+                )
+
+            assertThat(dhPlayer.isDhReleaseRequired(outfielder)).isFalse()
+        }
+
+        @Test
+        fun `투수가 DH 타순으로 교체되면 검증을 통과한다`() {
+            val dhPlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.DESIGNATED_HITTER,
+                    battingOrder = 4,
+                )
+            dhPlayer.setAsDesignatedHitter(pitcherOrder = 9)
+
+            val pitcherPlayer =
+                GamePlayer.createBench(
+                    gameTeam = gameTeam,
+                    player = mockk(relaxed = true),
+                    position = Position.RELIEF_PITCHER,
+                )
+
+            // 4번 타순(DH 타순)으로 교체하면 검증 통과
+            dhPlayer.validateDhRelease(pitcherPlayer, incomingBattingOrder = 4)
+            // 예외 없이 통과해야 함
+        }
+
+        @Test
+        fun `투수가 DH 타순이 아닌 다른 타순으로 교체되면 예외가 발생한다`() {
+            val dhPlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.DESIGNATED_HITTER,
+                    battingOrder = 4,
+                )
+            dhPlayer.setAsDesignatedHitter(pitcherOrder = 9)
+
+            val pitcherPlayer =
+                GamePlayer.createBench(
+                    gameTeam = gameTeam,
+                    player = mockk(relaxed = true),
+                    position = Position.STARTING_PITCHER,
+                )
+
+            // 4번이 아닌 다른 타순으로 교체 시도
+            assertThatThrownBy {
+                dhPlayer.validateDhRelease(pitcherPlayer, incomingBattingOrder = 5)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("DH 타순")
+        }
     }
 
     @Nested

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -27,6 +27,7 @@ import com.nextup.core.service.game.BoxScoreService
 import com.nextup.core.service.game.GameScorerService
 import com.nextup.core.service.game.dto.GameEndReason
 import com.nextup.core.service.game.dto.PlateAppearanceRequest
+import com.nextup.core.service.game.dto.SubstitutionRequest
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -395,6 +396,90 @@ class GameScorerServiceImpl(
         val savedGame = gameRepository.save(game)
         publishGameResultEvent(gameId)
         return savedGame
+    }
+
+    @Transactional
+    override fun substitutePlayer(
+        gameId: Long,
+        request: SubstitutionRequest,
+    ): GameEvent {
+        val game = findGame(gameId)
+
+        // 경기가 진행 중인지 확인
+        if (game.status != GameStatus.IN_PROGRESS) {
+            throw InvalidGameStateException(
+                "진행 중인 경기만 선수 교체를 할 수 있습니다. 현재 상태: ${game.status.displayName}",
+            )
+        }
+
+        // 교체 나가는 선수 조회
+        val outgoingPlayer =
+            gamePlayerRepository.findByIdOrNull(request.outgoingPlayerId)
+                ?: throw GamePlayerNotFoundException(request.outgoingPlayerId)
+
+        // 교체 들어오는 선수 조회
+        val incomingPlayer =
+            gamePlayerRepository.findByIdOrNull(request.incomingPlayerId)
+                ?: throw GamePlayerNotFoundException(request.incomingPlayerId)
+
+        // 퇴장한 선수 재출전 방지 (enterAsSubstitute 호출 전 사전 검증)
+        if (incomingPlayer.hasExited) {
+            throw InvalidGameStateException(
+                "이미 퇴장한 선수는 재출전할 수 없습니다. (GamePlayer ID: ${request.incomingPlayerId})",
+            )
+        }
+
+        // 나가는 선수가 현재 출전 중인지 확인
+        if (!outgoingPlayer.isCurrentlyPlaying) {
+            throw InvalidGameStateException(
+                "현재 출전 중인 선수만 교체할 수 있습니다. (GamePlayer ID: ${request.outgoingPlayerId})",
+            )
+        }
+
+        // DH 해제 규칙 검증
+        if (outgoingPlayer.isDesignatedHitter) {
+            try {
+                outgoingPlayer.validateDhRelease(incomingPlayer, request.newBattingOrder)
+            } catch (e: IllegalArgumentException) {
+                throw InvalidGameStateException(e.message ?: "DH 해제 규칙 위반")
+            }
+        }
+
+        // DH 해제 처리
+        val dhReleaseRequired = outgoingPlayer.isDhReleaseRequired(incomingPlayer)
+        if (dhReleaseRequired) {
+            outgoingPlayer.releaseDH()
+            gamePlayerRepository.save(outgoingPlayer)
+        }
+
+        // 교체 나가는 선수 퇴장 처리
+        outgoingPlayer.exitGame(game.currentInning)
+        gamePlayerRepository.save(outgoingPlayer)
+
+        // 교체 들어오는 선수 출전 처리
+        incomingPlayer.enterAsSubstitute(
+            inning = game.currentInning,
+            newPosition = request.newPosition,
+            newBattingOrder = request.newBattingOrder,
+        )
+        gamePlayerRepository.save(incomingPlayer)
+
+        // 교체 이벤트 설명 생성
+        val halfInning = if (game.isTopInning) "초" else "말"
+        val dhReleaseNote = if (dhReleaseRequired) " (DH 규칙 해제)" else ""
+        val description =
+            "${game.currentInning}회$halfInning: ${outgoingPlayer.player.name} → ${incomingPlayer.player.name} (${request.newPosition.displayName})$dhReleaseNote"
+
+        // 교체 이벤트 생성 및 저장
+        val substitutionEvent =
+            GameEvent.createSubstitution(
+                game = game,
+                incomingPlayer = incomingPlayer,
+                outgoingPlayer = outgoingPlayer,
+                description = description,
+            )
+
+        return gameEventRepository.save(substitutionEvent)
     }
 
     private fun publishGameResultEvent(gameId: Long) {

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
@@ -338,6 +338,79 @@ class GameScorerServiceSubstitutionTest {
         }
 
         @Test
+        fun `하위 이닝(말)에서 교체하면 설명에 '말'이 포함된다`() {
+            // given
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    isTopInning = false
+                }
+            val outgoingPlayer = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            val incomingPlayer = createBenchPlayer(20L, Position.CENTER_FIELD)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPlayer
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            var capturedEvent: GameEvent? = null
+            every { gameEventRepository.save(any()) } answers {
+                capturedEvent = firstArg()
+                firstArg()
+            }
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when
+            gameScorerService.substitutePlayer(1L, request)
+
+            // then
+            assertThat(capturedEvent).isNotNull()
+            assertThat(capturedEvent!!.description).contains("말")
+        }
+
+        @Test
+        fun `DH 해제 시 설명에 DH 규칙 해제가 포함된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val dhPlayer = createDhPlayer(10L, battingOrder = 4)
+            val reliefPitcher = createBenchPlayer(20L, Position.RELIEF_PITCHER)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns dhPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns reliefPitcher
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            var capturedEvent: GameEvent? = null
+            every { gameEventRepository.save(any()) } answers {
+                capturedEvent = firstArg()
+                firstArg()
+            }
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RELIEF_PITCHER,
+                    newBattingOrder = 4, // DH 타순과 일치
+                )
+
+            // when
+            gameScorerService.substitutePlayer(1L, request)
+
+            // then
+            assertThat(capturedEvent).isNotNull()
+            assertThat(capturedEvent!!.description).contains("DH 규칙 해제")
+        }
+
+        @Test
         fun `투수가 DH 타순이 아닌 타순으로 교체되면 예외가 발생한다`() {
             // given
             val game = createGame(1L, GameStatus.IN_PROGRESS)

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
@@ -1,0 +1,493 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameState
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Position
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.service.game.BoxScoreService
+import com.nextup.core.service.game.dto.SubstitutionRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameScorerServiceImpl - substitutePlayer")
+class GameScorerServiceSubstitutionTest {
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
+    private lateinit var boxScoreService: BoxScoreService
+    private lateinit var gameEventRepository: GameEventRepositoryPort
+    private lateinit var battingRecordRepository: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var eventPublisher: ApplicationEventPublisher
+    private lateinit var gameScorerService: GameScorerServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        gamePlayerRepository = mockk()
+        gameTeamRepository = mockk()
+        boxScoreService = mockk(relaxed = true)
+        gameEventRepository = mockk()
+        battingRecordRepository = mockk()
+        pitchingRecordRepository = mockk()
+        eventPublisher = mockk(relaxed = true)
+        every { gameTeamRepository.findAllByGameId(any()) } returns emptyList()
+        gameScorerService =
+            GameScorerServiceImpl(
+                gameRepository,
+                gamePlayerRepository,
+                gameTeamRepository,
+                boxScoreService,
+                gameEventRepository,
+                battingRecordRepository,
+                pitchingRecordRepository,
+                eventPublisher,
+            )
+    }
+
+    @Nested
+    @DisplayName("정상 교체 시나리오")
+    inner class NormalSubstitution {
+        @Test
+        fun `벤치 선수가 출전 중인 선수를 교체할 수 있다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPlayer = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            val incomingPlayer = createBenchPlayer(20L, Position.CENTER_FIELD)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPlayer
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when
+            val result = gameScorerService.substitutePlayer(1L, request)
+
+            // then
+            assertThat(result).isNotNull()
+            // 교체 나가는 선수가 퇴장 처리됨
+            assertThat(outgoingPlayer.isCurrentlyPlaying).isFalse()
+            assertThat(outgoingPlayer.exitInning).isEqualTo(game.currentInning)
+            // 교체 들어오는 선수가 출전 처리됨
+            assertThat(incomingPlayer.isCurrentlyPlaying).isTrue()
+            assertThat(incomingPlayer.position).isEqualTo(Position.LEFT_FIELD)
+            assertThat(incomingPlayer.battingOrder).isEqualTo(5)
+            // 이벤트 저장 확인
+            verify { gameEventRepository.save(any()) }
+        }
+
+        @Test
+        fun `교체 이벤트가 SUBSTITUTION 타입으로 저장된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPlayer = createStartingPlayer(10L, Position.RIGHT_FIELD, 3)
+            val incomingPlayer = createBenchPlayer(20L, Position.RIGHT_FIELD)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPlayer
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RIGHT_FIELD,
+                    newBattingOrder = 3,
+                )
+
+            // when
+            val result = gameScorerService.substitutePlayer(1L, request)
+
+            // then
+            assertThat(result.eventType).isEqualTo(GameEventType.SUBSTITUTION)
+        }
+    }
+
+    @Nested
+    @DisplayName("재출전 방지")
+    inner class ReentryPrevention {
+        @Test
+        fun `이미 퇴장한 선수가 교체 들어오려 하면 예외가 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPlayer = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            // 이미 퇴장한 선수 (exitInning != null)
+            val exitedPlayer = createStartingPlayer(20L, Position.RIGHT_FIELD, 7)
+            exitedPlayer.exitGame(2)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns exitedPlayer
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.substitutePlayer(1L, request)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("이미 퇴장한 선수")
+        }
+    }
+
+    @Nested
+    @DisplayName("경기 상태 검증")
+    inner class GameStateValidation {
+        @Test
+        fun `진행 중이 아닌 경기에서 교체를 시도하면 예외가 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.substitutePlayer(1L, request)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("진행 중인 경기만 선수 교체")
+        }
+
+        @Test
+        fun `경기를 찾을 수 없으면 예외가 발생한다`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.substitutePlayer(999L, request)
+            }.isInstanceOf(GameNotFoundException::class.java)
+        }
+
+        @Test
+        fun `교체 나가는 선수를 찾을 수 없으면 예외가 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns null
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.substitutePlayer(1L, request)
+            }.isInstanceOf(GamePlayerNotFoundException::class.java)
+        }
+
+        @Test
+        fun `교체 들어오는 선수를 찾을 수 없으면 예외가 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPlayer = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns null
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.substitutePlayer(1L, request)
+            }.isInstanceOf(GamePlayerNotFoundException::class.java)
+        }
+
+        @Test
+        fun `현재 출전 중이 아닌 선수를 교체 내보내려 하면 예외가 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val notPlayingPlayer = createBenchPlayer(10L, Position.LEFT_FIELD) // isCurrentlyPlaying = false
+            val incomingPlayer = createBenchPlayer(20L, Position.CENTER_FIELD)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns notPlayingPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPlayer
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.substitutePlayer(1L, request)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("현재 출전 중인 선수만 교체")
+        }
+    }
+
+    @Nested
+    @DisplayName("DH 해제 규칙")
+    inner class DhReleaseRules {
+        @Test
+        fun `투수가 DH 타순으로 들어오면 DH 규칙이 해제된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val dhPlayer = createDhPlayer(10L, battingOrder = 4)
+            val reliefPitcher = createBenchPlayer(20L, Position.RELIEF_PITCHER)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns dhPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns reliefPitcher
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RELIEF_PITCHER,
+                    newBattingOrder = 4, // DH 타순과 일치
+                )
+
+            // when
+            gameScorerService.substitutePlayer(1L, request)
+
+            // then - DH 해제 후 퇴장 처리
+            assertThat(dhPlayer.isDesignatedHitter).isFalse()
+            verify { gamePlayerRepository.save(dhPlayer) }
+        }
+
+        @Test
+        fun `투수가 DH 타순이 아닌 타순으로 교체되면 예외가 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val dhPlayer = createDhPlayer(10L, battingOrder = 4)
+            val reliefPitcher = createBenchPlayer(20L, Position.RELIEF_PITCHER)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns dhPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns reliefPitcher
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RELIEF_PITCHER,
+                    newBattingOrder = 5, // DH 타순(4번)과 불일치
+                )
+
+            // when & then
+            assertThatThrownBy {
+                gameScorerService.substitutePlayer(1L, request)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("DH 타순")
+        }
+    }
+
+    // ──────────────────────────── helpers ────────────────────────────
+
+    private fun createGame(
+        id: Long,
+        status: GameStatus,
+    ): Game {
+        val association =
+            Association(
+                name = "서울시야구협회",
+                abbreviation = null,
+                region = "서울",
+                description = null,
+                logoUrl = null,
+                websiteUrl = null,
+            ).apply {
+                val f = Association::class.java.getDeclaredField("id")
+                f.isAccessible = true
+                f.set(this, 1L)
+            }
+        val league =
+            League(
+                association = association,
+                name = "1부 리그",
+                abbreviation = null,
+                foundedYear = 2020,
+                divisionLevel = 1,
+                description = null,
+                logoUrl = null,
+            ).apply {
+                val f = League::class.java.getDeclaredField("id")
+                f.isAccessible = true
+                f.set(this, 1L)
+            }
+        val competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                endDate = LocalDate.of(2025, 6, 30),
+                status = CompetitionStatus.IN_PROGRESS,
+                description = null,
+                maxTeams = null,
+            ).apply {
+                val f = Competition::class.java.getDeclaredField("id")
+                f.isAccessible = true
+                f.set(this, 1L)
+            }
+        return Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실구장",
+            fieldName = "1구장",
+            gameNumber = 1,
+            status = status,
+            currentInning = 5,
+            isTopInning = true,
+            totalInnings = 9,
+            gameState = GameState(),
+        ).apply {
+            val f = Game::class.java.getDeclaredField("id")
+            f.isAccessible = true
+            f.set(this, id)
+        }
+    }
+
+    private fun createStartingPlayer(
+        id: Long,
+        position: Position,
+        battingOrder: Int,
+    ): GamePlayer {
+        val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+        val player = mockk<com.nextup.core.domain.player.Player>(relaxed = true)
+        every { player.name } returns "선수$id"
+        return GamePlayer.createStarter(
+            gameTeam = gameTeam,
+            player = player,
+            position = position,
+            battingOrder = battingOrder,
+        ).apply {
+            val f = GamePlayer::class.java.getDeclaredField("id")
+            f.isAccessible = true
+            f.set(this, id)
+        }
+    }
+
+    private fun createBenchPlayer(
+        id: Long,
+        position: Position,
+    ): GamePlayer {
+        val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+        val player = mockk<com.nextup.core.domain.player.Player>(relaxed = true)
+        every { player.name } returns "선수$id"
+        return GamePlayer.createBench(
+            gameTeam = gameTeam,
+            player = player,
+            position = position,
+        ).apply {
+            val f = GamePlayer::class.java.getDeclaredField("id")
+            f.isAccessible = true
+            f.set(this, id)
+        }
+    }
+
+    private fun createDhPlayer(
+        id: Long,
+        battingOrder: Int,
+    ): GamePlayer {
+        val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+        val player = mockk<com.nextup.core.domain.player.Player>(relaxed = true)
+        every { player.name } returns "DH선수$id"
+        return GamePlayer.createStarter(
+            gameTeam = gameTeam,
+            player = player,
+            position = Position.DESIGNATED_HITTER,
+            battingOrder = battingOrder,
+        ).apply {
+            val f = GamePlayer::class.java.getDeclaredField("id")
+            f.isAccessible = true
+            f.set(this, id)
+            setAsDesignatedHitter(pitcherOrder = 9)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImplTest.kt
@@ -3,7 +3,6 @@ package com.nextup.infrastructure.service.game.correction
 import com.nextup.common.exception.BattingRecordNotFoundByIdException
 import com.nextup.common.exception.GameNotFoundException
 import com.nextup.common.exception.PitchingRecordNotFoundByIdException
-import com.nextup.core.domain.audit.AuditLog
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.domain.game.Game

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -2,7 +2,16 @@ package com.nextup.scorer.controller.game
 
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.game.GameScorerService
-import com.nextup.scorer.dto.game.*
+import com.nextup.scorer.dto.game.ForfeitRequestDto
+import com.nextup.scorer.dto.game.GameEndRequestDto
+import com.nextup.scorer.dto.game.GameResponse
+import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
+import com.nextup.scorer.dto.game.SubstitutionRequestDto
+import com.nextup.scorer.dto.game.SubstitutionResponse
+import com.nextup.scorer.dto.game.UndoResponse
+import com.nextup.scorer.dto.game.toDomain
+import com.nextup.scorer.dto.game.toResponse
+import com.nextup.scorer.dto.game.toSubstitutionResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -97,7 +106,7 @@ class GameScorerController(
     @ResponseStatus(HttpStatus.OK)
     fun forfeitGame(
         @PathVariable gameId: Long,
-        @RequestBody @Valid request: ForfeitRequestDto
+        @RequestBody @Valid request: ForfeitRequestDto,
     ): ApiResponse<GameResponse> {
         val game =
             gameScorerService.forfeitGame(
@@ -106,5 +115,22 @@ class GameScorerController(
                 reason = request.reason!!,
             )
         return ApiResponse.success(game.toResponse())
+    }
+
+    /**
+     * 선수를 교체합니다.
+     *
+     * 교체 이벤트를 기록하고 다음을 검증합니다:
+     * - 퇴장한 선수의 재출전 방지
+     * - DH 해제 규칙 (투수가 DH 타순으로만 교체 가능)
+     */
+    @PostMapping("/{gameId}/substitutions")
+    @ResponseStatus(HttpStatus.OK)
+    fun substitutePlayer(
+        @PathVariable gameId: Long,
+        @RequestBody @Valid request: SubstitutionRequestDto,
+    ): ApiResponse<SubstitutionResponse> {
+        val event = gameScorerService.substitutePlayer(gameId, request.toDomain())
+        return ApiResponse.success(event.toSubstitutionResponse())
     }
 }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/SubstitutionRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/SubstitutionRequestDto.kt
@@ -1,0 +1,32 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.game.dto.SubstitutionRequest
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 선수 교체 요청 DTO
+ */
+data class SubstitutionRequestDto(
+    @field:NotNull(message = "GameTeam ID는 필수입니다")
+    val gameTeamId: Long?,
+    @field:NotNull(message = "교체 나가는 선수 ID는 필수입니다")
+    val outgoingPlayerId: Long?,
+    @field:NotNull(message = "교체 들어오는 선수 ID는 필수입니다")
+    val incomingPlayerId: Long?,
+    @field:NotNull(message = "포지션은 필수입니다")
+    val newPosition: Position?,
+    val newBattingOrder: Int? = null,
+)
+
+/**
+ * SubstitutionRequestDto를 SubstitutionRequest 도메인 DTO로 변환합니다.
+ */
+fun SubstitutionRequestDto.toDomain(): SubstitutionRequest =
+    SubstitutionRequest(
+        gameTeamId = this.gameTeamId!!,
+        outgoingPlayerId = this.outgoingPlayerId!!,
+        incomingPlayerId = this.incomingPlayerId!!,
+        newPosition = this.newPosition!!,
+        newBattingOrder = this.newBattingOrder,
+    )

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/SubstitutionResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/SubstitutionResponse.kt
@@ -1,0 +1,28 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.game.GameEvent
+
+/**
+ * 선수 교체 응답 DTO
+ */
+data class SubstitutionResponse(
+    val eventId: Long,
+    val inning: Int,
+    val isTopInning: Boolean,
+    val incomingPlayerId: Long?,
+    val outgoingPlayerId: Long?,
+    val description: String,
+)
+
+/**
+ * GameEvent(SUBSTITUTION)를 SubstitutionResponse로 변환합니다.
+ */
+fun GameEvent.toSubstitutionResponse(): SubstitutionResponse =
+    SubstitutionResponse(
+        eventId = this.id,
+        inning = this.inning,
+        isTopInning = this.isTopInning,
+        incomingPlayerId = this.batter?.id,
+        outgoingPlayerId = this.pitcher?.id,
+        description = this.description,
+    )

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -8,15 +8,20 @@ import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.game.Base
 import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.GameState
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Position
 import com.nextup.core.service.game.GameScorerService
 import com.nextup.core.service.game.dto.GameEndReason
 import com.nextup.scorer.dto.game.GameEndRequestDto
 import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
 import com.nextup.scorer.dto.game.RunnerMovementDto
+import com.nextup.scorer.dto.game.SubstitutionRequestDto
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -354,6 +359,69 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.data.status").value("FORFEITED"))
 
             verify(exactly = 1) { gameScorerService.endGame(gameId, GameEndReason.FORFEIT) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/substitutions")
+    inner class SubstitutePlayer {
+
+        @Test
+        fun `선수 교체 요청이 성공적으로 처리된다`() {
+            // given
+            val gameId = 1L
+            val game =
+                createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                }
+            val incomingPlayer = mockk<GamePlayer>(relaxed = true)
+            val outgoingPlayer = mockk<GamePlayer>(relaxed = true)
+            every { incomingPlayer.id } returns 20L
+            every { outgoingPlayer.id } returns 10L
+
+            val substitutionEvent =
+                GameEvent(
+                    game = game,
+                    inning = 5,
+                    isTopInning = true,
+                    outCountBefore = 1,
+                    outCountAfter = 1,
+                    eventType = GameEventType.SUBSTITUTION,
+                    description = "5회초: 홍길동 → 김철수 (좌익수)",
+                    batter = incomingPlayer,
+                    pitcher = outgoingPlayer,
+                ).apply {
+                    val idField = GameEvent::class.java.getDeclaredField("id")
+                    idField.isAccessible = true
+                    idField.set(this, 100L)
+                }
+
+            every { gameScorerService.substitutePlayer(gameId, any()) } returns substitutionEvent
+
+            val request =
+                SubstitutionRequestDto(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/substitutions")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.eventId").value(100))
+                .andExpect(jsonPath("$.data.inning").value(5))
+                .andExpect(jsonPath("$.data.isTopInning").value(true))
+                .andExpect(jsonPath("$.data.description").value("5회초: 홍길동 → 김철수 (좌익수)"))
+
+            verify(exactly = 1) { gameScorerService.substitutePlayer(gameId, any()) }
         }
     }
 


### PR DESCRIPTION
## Summary

>- close #221

선수 교체 관련 이벤트 기록과 규칙 검증을 강화합니다.

## Tasks

- 교체 시 GameEvent.createSubstitution() 호출하여 타임라인 기록
- releaseDH() DH 해제 가능 조건 검증 로직 추가
- 재출전 여부 검증 (대회 규칙 참조)
- 더블 스위치(투수+야수 동시 교체) 원자적 처리
- 단위 테스트 작성

## To Reviewer

- GameEventType.SUBSTITUTION 이벤트 활용
- DH 해제 규칙은 야구 규칙 기반 검증
- 사회인 야구 재출전 허용은 대회별 설정