### PR TITLE
feat(#224): 주루 기록 상세화 (도루 루별 기록, 주루 이벤트 상세)

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BaseRunningResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BaseRunningResult.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.domain.game
+
+/**
+ * 주루 플레이 결과 유형
+ */
+enum class BaseRunningResult(
+    val displayName: String,
+) {
+    STOLEN_BASE("도루 성공"),
+    CAUGHT_STEALING("도루 실패"),
+    PICKED_OFF("견제사"),
+    ADVANCED_ON_ERROR("실책으로 진루"),
+    ADVANCED_ON_WILD_PITCH("폭투 진루"),
+    ADVANCED_ON_PASSED_BALL("포일 진루"),
+    ADVANCED_ON_BALK("보크 진루"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -48,6 +48,18 @@ class GameEvent(
     @Enumerated(EnumType.STRING)
     @Column(name = "plate_appearance_result", length = 30)
     val plateAppearanceResult: PlateAppearanceResult? = null,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "runner_player_id")
+    val runnerPlayer: GamePlayer? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "from_base", length = 10)
+    val fromBase: Base? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "to_base", length = 10)
+    val toBase: Base? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "base_running_result", length = 30)
+    val baseRunningResult: BaseRunningResult? = null,
     @Column(name = "runs_scored", nullable = false)
     val runsScored: Int = 0,
     @Column(nullable = false)
@@ -113,6 +125,37 @@ class GameEvent(
                 outCountAfter = 0,
                 eventType = GameEventType.INNING_CHANGE,
                 description = description,
+            )
+
+        /**
+         * 주루 플레이 이벤트를 생성합니다.
+         */
+        fun createBaseRunning(
+            game: Game,
+            runner: GamePlayer,
+            fromBase: Base,
+            toBase: Base,
+            result: BaseRunningResult,
+            description: String,
+            outCountBefore: Int,
+            outCountAfter: Int,
+            runnersBeforeJson: String?,
+            runnersAfterJson: String?,
+        ): GameEvent =
+            GameEvent(
+                game = game,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                outCountBefore = outCountBefore,
+                outCountAfter = outCountAfter,
+                eventType = GameEventType.BASE_RUNNING,
+                description = description,
+                runnerPlayer = runner,
+                fromBase = fromBase,
+                toBase = toBase,
+                baseRunningResult = result,
+                runnersBeforeJson = runnersBeforeJson,
+                runnersAfterJson = runnersAfterJson,
             )
 
         /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -64,199 +64,6 @@ class GameEvent(
     val runsScored: Int = 0,
     @Column(nullable = false)
     val rbis: Int = 0,
-    @Column(name = "event_timestamp", nullable = false)
-    val eventTimestamp: Instant = Instant.now(),
-    @Column(nullable = false)
-    var undone: Boolean = false,
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L,
-) : BaseTimeEntity() {
-    fun markUndone() {
-        undone = true
-    }
-
-    companion object {
-        /**
-         * 타석 결과 이벤트를 생성합니다.
-         */
-        fun createPlateAppearance(
-            game: Game,
-            batter: GamePlayer,
-            pitcher: GamePlayer,
-            result: PlateAppearanceResult,
-            description: String,
-            outCountBefore: Int,
-            outCountAfter: Int,
-            runnersBeforeJson: String?,
-            runnersAfterJson: String?,
-            runsScored: Int = 0,
-            rbis: Int = 0,
-        ): GameEvent =
-            GameEvent(
-                game = game,
-                inning = game.currentInning,
-                isTopInning = game.isTopInning,
-                outCountBefore = outCountBefore,
-                outCountAfter = outCountAfter,
-                eventType = GameEventType.PLATE_APPEARANCE,
-                description = description,
-                batter = batter,
-                pitcher = pitcher,
-                runnersBeforeJson = runnersBeforeJson,
-                runnersAfterJson = runnersAfterJson,
-                plateAppearanceResult = result,
-                runsScored = runsScored,
-                rbis = rbis,
-            )
-
-        /**
-         * 이닝 전환 이벤트를 생성합니다.
-         */
-        fun createInningChange(
-            game: Game,
-            description: String,
-        ): GameEvent =
-            GameEvent(
-                game = game,
-                inning = game.currentInning,
-                isTopInning = game.isTopInning,
-                outCountBefore = 3,
-                outCountAfter = 0,
-                eventType = GameEventType.INNING_CHANGE,
-                description = description,
-            )
-
-        /**
-         * 주루 플레이 이벤트를 생성합니다.
-         */
-        fun createBaseRunning(
-            game: Game,
-            runner: GamePlayer,
-            fromBase: Base,
-            toBase: Base,
-            result: BaseRunningResult,
-            description: String,
-            outCountBefore: Int,
-            outCountAfter: Int,
-            runnersBeforeJson: String?,
-            runnersAfterJson: String?,
-        ): GameEvent =
-            GameEvent(
-                game = game,
-                inning = game.currentInning,
-                isTopInning = game.isTopInning,
-                outCountBefore = outCountBefore,
-                outCountAfter = outCountAfter,
-                eventType = GameEventType.BASE_RUNNING,
-                description = description,
-                runnerPlayer = runner,
-                fromBase = fromBase,
-                toBase = toBase,
-                baseRunningResult = result,
-                runnersBeforeJson = runnersBeforeJson,
-                runnersAfterJson = runnersAfterJson,
-            )
-
-        /**
-         * 경기 상태 변경 이벤트를 생성합니다.
-         */
-        fun createGameStatus(
-            game: Game,
-            description: String,
-        ): GameEvent =
-            GameEvent(
-                game = game,
-                inning = game.currentInning,
-                isTopInning = game.isTopInning,
-                outCountBefore = game.gameState.outs,
-                outCountAfter = game.gameState.outs,
-                eventType = GameEventType.GAME_STATUS,
-                description = description,
-            )
-
-        /**
-         * 선수 교체 이벤트를 생성합니다.
-         *
-         * @param game 경기
-         * @param incomingPlayer 교체 들어오는 선수
-         * @param outgoingPlayer 교체 나가는 선수
-         * @param description 교체 설명
-         */
-        fun createSubstitution(
-            game: Game,
-            incomingPlayer: GamePlayer,
-            outgoingPlayer: GamePlayer,
-            description: String,
-        ): GameEvent =
-            GameEvent(
-                game = game,
-                inning = game.currentInning,
-                isTopInning = game.isTopInning,
-                outCountBefore = game.gameState.outs,
-                outCountAfter = game.gameState.outs,
-                eventType = GameEventType.SUBSTITUTION,
-                description = description,
-                batter = incomingPlayer,
-                pitcher = outgoingPlayer,
-            )
-    }
-}
-=======
-package com.nextup.core.domain.game
-
-import com.nextup.core.common.BaseTimeEntity
-import jakarta.persistence.*
-import java.time.Instant
-
-/**
- * 경기 이벤트 엔티티
- *
- * 경기 중 발생하는 모든 이벤트를 기록합니다.
- */
-@Entity
-@Table(
-    name = "game_events",
-    indexes = [
-        Index(name = "idx_game_events_game", columnList = "game_id"),
-        Index(name = "idx_game_events_game_inning", columnList = "game_id, inning, is_top_inning"),
-        Index(name = "idx_game_events_timestamp", columnList = "event_timestamp"),
-    ],
-)
-class GameEvent(
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "game_id", nullable = false)
-    val game: Game,
-    @Column(nullable = false)
-    val inning: Int,
-    @Column(name = "is_top_inning", nullable = false)
-    val isTopInning: Boolean,
-    @Column(name = "out_count_before", nullable = false)
-    val outCountBefore: Int,
-    @Column(name = "out_count_after", nullable = false)
-    val outCountAfter: Int,
-    @Enumerated(EnumType.STRING)
-    @Column(name = "event_type", nullable = false, length = 30)
-    val eventType: GameEventType,
-    @Column(nullable = false, length = 500)
-    val description: String,
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "batter_id")
-    val batter: GamePlayer? = null,
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "pitcher_id")
-    val pitcher: GamePlayer? = null,
-    @Column(name = "runners_before_json", columnDefinition = "TEXT")
-    val runnersBeforeJson: String? = null,
-    @Column(name = "runners_after_json", columnDefinition = "TEXT")
-    val runnersAfterJson: String? = null,
-    @Enumerated(EnumType.STRING)
-    @Column(name = "plate_appearance_result", length = 30)
-    val plateAppearanceResult: PlateAppearanceResult? = null,
-    @Column(name = "runs_scored", nullable = false)
-    val runsScored: Int = 0,
-    @Column(nullable = false)
-    val rbis: Int = 0,
     /**
      * 득점 주자 ID 목록 (D-15: 타점 경로 상세 기록)
      * 형식: "playerId1,playerId2,..." (CSV)
@@ -340,6 +147,37 @@ class GameEvent(
                 outCountAfter = 0,
                 eventType = GameEventType.INNING_CHANGE,
                 description = description,
+            )
+
+        /**
+         * 주루 플레이 이벤트를 생성합니다.
+         */
+        fun createBaseRunning(
+            game: Game,
+            runner: GamePlayer,
+            fromBase: Base,
+            toBase: Base,
+            result: BaseRunningResult,
+            description: String,
+            outCountBefore: Int,
+            outCountAfter: Int,
+            runnersBeforeJson: String?,
+            runnersAfterJson: String?,
+        ): GameEvent =
+            GameEvent(
+                game = game,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                outCountBefore = outCountBefore,
+                outCountAfter = outCountAfter,
+                eventType = GameEventType.BASE_RUNNING,
+                description = description,
+                runnerPlayer = runner,
+                fromBase = fromBase,
+                toBase = toBase,
+                baseRunningResult = result,
+                runnersBeforeJson = runnersBeforeJson,
+                runnersAfterJson = runnersAfterJson,
             )
 
         /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
@@ -2,6 +2,7 @@ package com.nextup.core.service.game
 
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.service.game.dto.BaseRunningRequest
 import com.nextup.core.service.game.dto.GameEndReason
 import com.nextup.core.service.game.dto.PlateAppearanceRequest
 
@@ -50,6 +51,20 @@ interface GameScorerService {
         gameId: Long,
         reason: GameEndReason,
     ): Game
+
+    /**
+     * 주루 플레이를 기록합니다.
+     *
+     * 도루, 도루 실패, 견제사, 폭투 진루 등 타석 외 주루 이벤트를 기록합니다.
+     *
+     * @param gameId 경기 ID
+     * @param request 주루 플레이 요청
+     * @return 생성된 GameEvent
+     */
+    fun recordBaseRunning(
+        gameId: Long,
+        request: BaseRunningRequest,
+    ): GameEvent
 
     /**
      * 마지막 이벤트를 되돌립니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/BaseRunningRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/BaseRunningRequest.kt
@@ -1,0 +1,19 @@
+package com.nextup.core.service.game.dto
+
+import com.nextup.core.domain.game.Base
+import com.nextup.core.domain.game.BaseRunningResult
+
+/**
+ * 주루 플레이 기록 요청 DTO (core 서비스 계층)
+ *
+ * @property runnerId 주자 ID (GamePlayer ID)
+ * @property fromBase 출발 베이스
+ * @property toBase 도착 베이스
+ * @property result 주루 플레이 결과
+ */
+data class BaseRunningRequest(
+    val runnerId: Long,
+    val fromBase: Base,
+    val toBase: Base,
+    val result: BaseRunningResult,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BaseRunningResultTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BaseRunningResultTest.kt
@@ -1,0 +1,153 @@
+package com.nextup.core.domain.game
+
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("BaseRunningResult")
+class BaseRunningResultTest {
+
+    @Nested
+    @DisplayName("열거형 값 검증")
+    inner class EnumValueTest {
+
+        @Test
+        fun `STOLEN_BASE의 displayName은 도루 성공이다`() {
+            assertThat(BaseRunningResult.STOLEN_BASE.displayName).isEqualTo("도루 성공")
+        }
+
+        @Test
+        fun `CAUGHT_STEALING의 displayName은 도루 실패이다`() {
+            assertThat(BaseRunningResult.CAUGHT_STEALING.displayName).isEqualTo("도루 실패")
+        }
+
+        @Test
+        fun `PICKED_OFF의 displayName은 견제사이다`() {
+            assertThat(BaseRunningResult.PICKED_OFF.displayName).isEqualTo("견제사")
+        }
+
+        @Test
+        fun `ADVANCED_ON_ERROR의 displayName은 실책으로 진루이다`() {
+            assertThat(BaseRunningResult.ADVANCED_ON_ERROR.displayName).isEqualTo("실책으로 진루")
+        }
+
+        @Test
+        fun `ADVANCED_ON_WILD_PITCH의 displayName은 폭투 진루이다`() {
+            assertThat(BaseRunningResult.ADVANCED_ON_WILD_PITCH.displayName).isEqualTo("폭투 진루")
+        }
+
+        @Test
+        fun `ADVANCED_ON_PASSED_BALL의 displayName은 포일 진루이다`() {
+            assertThat(BaseRunningResult.ADVANCED_ON_PASSED_BALL.displayName).isEqualTo("포일 진루")
+        }
+
+        @Test
+        fun `ADVANCED_ON_BALK의 displayName은 보크 진루이다`() {
+            assertThat(BaseRunningResult.ADVANCED_ON_BALK.displayName).isEqualTo("보크 진루")
+        }
+
+        @Test
+        fun `모든 BaseRunningResult 값이 7개이다`() {
+            assertThat(BaseRunningResult.entries).hasSize(7)
+        }
+    }
+}
+
+@DisplayName("BattingRecord - 주루 기록")
+class BattingRecordBaseRunningTest {
+
+    private lateinit var gamePlayer: GamePlayer
+    private lateinit var battingRecord: BattingRecord
+
+    @BeforeEach
+    fun setup() {
+        gamePlayer = mockk<GamePlayer>(relaxed = true)
+        battingRecord = BattingRecord.create(gamePlayer)
+    }
+
+    @Nested
+    @DisplayName("도루 기록")
+    inner class StolenBaseTest {
+
+        @Test
+        fun `도루를 기록하면 stolenBases가 1 증가한다`() {
+            // when
+            battingRecord.recordStolenBase()
+
+            // then
+            assertThat(battingRecord.stolenBases).isEqualTo(1)
+        }
+
+        @Test
+        fun `도루를 여러 번 기록하면 stolenBases가 누적된다`() {
+            // when
+            battingRecord.recordStolenBase()
+            battingRecord.recordStolenBase()
+            battingRecord.recordStolenBase()
+
+            // then
+            assertThat(battingRecord.stolenBases).isEqualTo(3)
+        }
+    }
+
+    @Nested
+    @DisplayName("도루 실패 기록")
+    inner class CaughtStealingTest {
+
+        @Test
+        fun `도루 실패를 기록하면 caughtStealing이 1 증가한다`() {
+            // when
+            battingRecord.recordCaughtStealing()
+
+            // then
+            assertThat(battingRecord.caughtStealing).isEqualTo(1)
+        }
+
+        @Test
+        fun `도루 실패를 여러 번 기록하면 caughtStealing이 누적된다`() {
+            // when
+            battingRecord.recordCaughtStealing()
+            battingRecord.recordCaughtStealing()
+
+            // then
+            assertThat(battingRecord.caughtStealing).isEqualTo(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("도루 성공률 계산")
+    inner class StolenBasePercentageTest {
+
+        @Test
+        fun `도루 시도가 없으면 성공률은 0이다`() {
+            assertThat(battingRecord.stolenBasePercentage).isEqualByComparingTo("0.000")
+        }
+
+        @Test
+        fun `도루 1회 성공 시 성공률은 1_000이다`() {
+            battingRecord.recordStolenBase()
+
+            assertThat(battingRecord.stolenBasePercentage).isEqualByComparingTo("1.000")
+        }
+
+        @Test
+        fun `도루 2회 시도 중 1회 성공 시 성공률은 0_500이다`() {
+            battingRecord.recordStolenBase()
+            battingRecord.recordCaughtStealing()
+
+            assertThat(battingRecord.stolenBasePercentage).isEqualByComparingTo("0.500")
+        }
+
+        @Test
+        fun `도루 3회 시도 중 2회 성공 시 성공률은 0_667이다`() {
+            battingRecord.recordStolenBase()
+            battingRecord.recordStolenBase()
+            battingRecord.recordCaughtStealing()
+
+            assertThat(battingRecord.stolenBasePercentage).isEqualByComparingTo("0.667")
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -10,6 +10,8 @@ import com.nextup.common.exception.UndoNotAvailableException
 import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlateAppearanceUndoneEvent
+import com.nextup.core.domain.game.Base
+import com.nextup.core.domain.game.BaseRunningResult
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.domain.game.GameEventType
@@ -25,6 +27,7 @@ import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.BoxScoreService
 import com.nextup.core.service.game.GameScorerService
+import com.nextup.core.service.game.dto.BaseRunningRequest
 import com.nextup.core.service.game.dto.GameEndReason
 import com.nextup.core.service.game.dto.PlateAppearanceRequest
 import org.springframework.context.ApplicationEventPublisher
@@ -360,6 +363,113 @@ class GameScorerServiceImpl(
         )
         game.gameState.restoreRunners(event.runnersBeforeJson)
     }
+
+    @Transactional
+    override fun recordBaseRunning(
+        gameId: Long,
+        request: BaseRunningRequest,
+    ): GameEvent {
+        val game = findGame(gameId)
+
+        if (game.status != GameStatus.IN_PROGRESS) {
+            throw InvalidGameStateException(
+                "진행 중인 경기만 주루 기록을 입력할 수 있습니다. 현재 상태: ${game.status.displayName}",
+            )
+        }
+
+        val runner =
+            gamePlayerRepository.findByIdOrNull(request.runnerId)
+                ?: throw GamePlayerNotFoundException(request.runnerId)
+
+        val outCountBefore = game.gameState.outs
+
+        // 주루 플레이 전 주자 상태 스냅샷
+        val runnersBeforeJson = serializeRunners(game.gameState)
+
+        // 주루 플레이 결과에 따른 처리
+        val outCountAfter: Int
+        when (request.result) {
+            BaseRunningResult.STOLEN_BASE,
+            BaseRunningResult.ADVANCED_ON_ERROR,
+            BaseRunningResult.ADVANCED_ON_WILD_PITCH,
+            BaseRunningResult.ADVANCED_ON_PASSED_BALL,
+            BaseRunningResult.ADVANCED_ON_BALK,
+            -> {
+                // 진루: 출발 베이스 비우고 도착 베이스에 주자 배치
+                game.gameState.setRunner(request.fromBase, null)
+                if (request.toBase != Base.HOME) {
+                    game.gameState.setRunner(request.toBase, runner.id)
+                }
+                if (request.result == BaseRunningResult.STOLEN_BASE) {
+                    val battingRecord =
+                        battingRecordRepository.findByGamePlayer(runner)
+                            ?: throw BattingRecordNotFoundException(runner.id)
+                    battingRecord.recordStolenBase()
+                }
+                outCountAfter = game.gameState.outs
+            }
+            BaseRunningResult.CAUGHT_STEALING,
+            BaseRunningResult.PICKED_OFF,
+            -> {
+                // 아웃: 출발 베이스 비우고 아웃 카운트 증가
+                game.gameState.setRunner(request.fromBase, null)
+                game.recordOut()
+                if (request.result == BaseRunningResult.CAUGHT_STEALING) {
+                    val battingRecord =
+                        battingRecordRepository.findByGamePlayer(runner)
+                            ?: throw BattingRecordNotFoundException(runner.id)
+                    battingRecord.recordCaughtStealing()
+                }
+                outCountAfter = game.gameState.outs
+            }
+        }
+
+        val runnersAfterJson = serializeRunners(game.gameState)
+
+        val description = buildBaseRunningDescription(request)
+
+        val event =
+            GameEvent.createBaseRunning(
+                game = game,
+                runner = runner,
+                fromBase = request.fromBase,
+                toBase = request.toBase,
+                result = request.result,
+                description = description,
+                outCountBefore = outCountBefore,
+                outCountAfter = outCountAfter,
+                runnersBeforeJson = runnersBeforeJson,
+                runnersAfterJson = runnersAfterJson,
+            )
+
+        val savedEvent = gameEventRepository.save(event)
+        gameRepository.save(game)
+        return savedEvent
+    }
+
+    private fun serializeRunners(gameState: com.nextup.core.domain.game.GameState): String? {
+        val entries =
+            buildList {
+                gameState.runnerOnFirstId?.let { add("1루:$it") }
+                gameState.runnerOnSecondId?.let { add("2루:$it") }
+                gameState.runnerOnThirdId?.let { add("3루:$it") }
+            }
+        return if (entries.isEmpty()) null else entries.joinToString(",")
+    }
+
+    private fun buildBaseRunningDescription(request: BaseRunningRequest): String {
+        val fromDisplay = baseDisplay(request.fromBase)
+        val toDisplay = baseDisplay(request.toBase)
+        return "${request.result.displayName}: $fromDisplay → $toDisplay"
+    }
+
+    private fun baseDisplay(base: Base): String =
+        when (base) {
+            Base.FIRST -> "1루"
+            Base.SECOND -> "2루"
+            Base.THIRD -> "3루"
+            Base.HOME -> "홈"
+        }
 
     @Transactional
     override fun forfeitGame(

--- a/nextup-infrastructure/src/main/resources/db/migration/V024__add_base_running_fields_to_game_events.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V024__add_base_running_fields_to_game_events.sql
@@ -1,0 +1,11 @@
+-- 주루 플레이 상세 기록 컬럼 추가 (game_events 테이블)
+ALTER TABLE game_events
+    ADD COLUMN runner_player_id BIGINT REFERENCES game_players(id),
+    ADD COLUMN from_base        VARCHAR(10),
+    ADD COLUMN to_base          VARCHAR(10),
+    ADD COLUMN base_running_result VARCHAR(30);
+
+COMMENT ON COLUMN game_events.runner_player_id  IS '주루 플레이 주자 GamePlayer ID';
+COMMENT ON COLUMN game_events.from_base          IS '출발 베이스 (FIRST/SECOND/THIRD/HOME)';
+COMMENT ON COLUMN game_events.to_base            IS '도착 베이스 (FIRST/SECOND/THIRD/HOME)';
+COMMENT ON COLUMN game_events.base_running_result IS '주루 플레이 결과 (STOLEN_BASE/CAUGHT_STEALING/PICKED_OFF 등)';

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceBaseRunningTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceBaseRunningTest.kt
@@ -1,0 +1,474 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Base
+import com.nextup.core.domain.game.BaseRunningResult
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameState
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.league.League
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.service.game.BoxScoreService
+import com.nextup.core.service.game.dto.BaseRunningRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameScorerServiceImpl - recordBaseRunning")
+class GameScorerServiceBaseRunningTest {
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
+    private lateinit var boxScoreService: BoxScoreService
+    private lateinit var gameEventRepository: GameEventRepositoryPort
+    private lateinit var battingRecordRepository: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var eventPublisher: ApplicationEventPublisher
+    private lateinit var gameScorerService: GameScorerServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        gamePlayerRepository = mockk()
+        gameTeamRepository = mockk()
+        boxScoreService = mockk(relaxed = true)
+        gameEventRepository = mockk()
+        battingRecordRepository = mockk()
+        pitchingRecordRepository = mockk()
+        eventPublisher = mockk(relaxed = true)
+        every { gameTeamRepository.findAllByGameId(any()) } returns emptyList()
+        every { pitchingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { pitchingRecordRepository.findByGamePlayer(any()) } returns null
+        every { gameEventRepository.save(any()) } answers { firstArg() }
+        every { gameRepository.save(any()) } answers { firstArg() }
+        gameScorerService =
+            GameScorerServiceImpl(
+                gameRepository,
+                gamePlayerRepository,
+                gameTeamRepository,
+                boxScoreService,
+                gameEventRepository,
+                battingRecordRepository,
+                pitchingRecordRepository,
+                eventPublisher,
+            )
+    }
+
+    @Nested
+    @DisplayName("도루 성공")
+    inner class StolenBase {
+        @Test
+        fun `should record stolen base from first to second`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val runner = createGamePlayer(10L)
+            val battingRecord: BattingRecord = mockk(relaxed = true)
+            game.gameState.setRunner(Base.FIRST, 10L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns runner
+            every { battingRecordRepository.findByGamePlayer(runner) } returns battingRecord
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 10L,
+                    fromBase = Base.FIRST,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.STOLEN_BASE,
+                )
+
+            // when
+            val result = gameScorerService.recordBaseRunning(1L, request)
+
+            // then
+            assertThat(result.eventType).isEqualTo(GameEventType.BASE_RUNNING)
+            assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.STOLEN_BASE)
+            assertThat(result.fromBase).isEqualTo(Base.FIRST)
+            assertThat(result.toBase).isEqualTo(Base.SECOND)
+            verify { battingRecord.recordStolenBase() }
+            verify { gameRepository.save(game) }
+        }
+
+        @Test
+        fun `should record stolen base to home (scoring)`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val runner = createGamePlayer(10L)
+            val battingRecord: BattingRecord = mockk(relaxed = true)
+            game.gameState.setRunner(Base.THIRD, 10L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns runner
+            every { battingRecordRepository.findByGamePlayer(runner) } returns battingRecord
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 10L,
+                    fromBase = Base.THIRD,
+                    toBase = Base.HOME,
+                    result = BaseRunningResult.STOLEN_BASE,
+                )
+
+            // when
+            val result = gameScorerService.recordBaseRunning(1L, request)
+
+            // then
+            assertThat(result.eventType).isEqualTo(GameEventType.BASE_RUNNING)
+            assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.STOLEN_BASE)
+            verify { battingRecord.recordStolenBase() }
+            // 홈으로 도루 시 toBase가 HOME이므로 setRunner(HOME, runner)는 호출하지 않음
+            assertThat(game.gameState.runnerOnThirdId).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("도루 실패 (아웃)")
+    inner class CaughtStealing {
+        @Test
+        fun `should record caught stealing and increase out count`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val runner = createGamePlayer(10L)
+            val battingRecord: BattingRecord = mockk(relaxed = true)
+            game.gameState.setRunner(Base.FIRST, 10L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns runner
+            every { battingRecordRepository.findByGamePlayer(runner) } returns battingRecord
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 10L,
+                    fromBase = Base.FIRST,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.CAUGHT_STEALING,
+                )
+
+            // when
+            val result = gameScorerService.recordBaseRunning(1L, request)
+
+            // then
+            assertThat(result.eventType).isEqualTo(GameEventType.BASE_RUNNING)
+            assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.CAUGHT_STEALING)
+            assertThat(result.outCountAfter).isEqualTo(1)
+            verify { battingRecord.recordCaughtStealing() }
+            assertThat(game.gameState.runnerOnFirstId).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("견제사")
+    inner class PickedOff {
+        @Test
+        fun `should record picked off and increase out count`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val runner = createGamePlayer(10L)
+            game.gameState.setRunner(Base.SECOND, 10L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns runner
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 10L,
+                    fromBase = Base.SECOND,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.PICKED_OFF,
+                )
+
+            // when
+            val result = gameScorerService.recordBaseRunning(1L, request)
+
+            // then
+            assertThat(result.eventType).isEqualTo(GameEventType.BASE_RUNNING)
+            assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.PICKED_OFF)
+            assertThat(result.outCountAfter).isEqualTo(1)
+            assertThat(game.gameState.runnerOnSecondId).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("기타 진루")
+    inner class AdvancedRunning {
+        @Test
+        fun `should record advanced on wild pitch`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val runner = createGamePlayer(10L)
+            game.gameState.setRunner(Base.SECOND, 10L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns runner
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 10L,
+                    fromBase = Base.SECOND,
+                    toBase = Base.THIRD,
+                    result = BaseRunningResult.ADVANCED_ON_WILD_PITCH,
+                )
+
+            // when
+            val result = gameScorerService.recordBaseRunning(1L, request)
+
+            // then
+            assertThat(result.eventType).isEqualTo(GameEventType.BASE_RUNNING)
+            assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.ADVANCED_ON_WILD_PITCH)
+            assertThat(game.gameState.runnerOnSecondId).isNull()
+            assertThat(game.gameState.runnerOnThirdId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should record advanced on error`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val runner = createGamePlayer(10L)
+            game.gameState.setRunner(Base.FIRST, 10L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns runner
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 10L,
+                    fromBase = Base.FIRST,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.ADVANCED_ON_ERROR,
+                )
+
+            // when
+            val result = gameScorerService.recordBaseRunning(1L, request)
+
+            // then
+            assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.ADVANCED_ON_ERROR)
+            assertThat(game.gameState.runnerOnFirstId).isNull()
+            assertThat(game.gameState.runnerOnSecondId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should record advanced on passed ball`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val runner = createGamePlayer(10L)
+            game.gameState.setRunner(Base.FIRST, 10L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns runner
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 10L,
+                    fromBase = Base.FIRST,
+                    toBase = Base.THIRD,
+                    result = BaseRunningResult.ADVANCED_ON_PASSED_BALL,
+                )
+
+            // when
+            val result = gameScorerService.recordBaseRunning(1L, request)
+
+            // then
+            assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.ADVANCED_ON_PASSED_BALL)
+            assertThat(game.gameState.runnerOnFirstId).isNull()
+            assertThat(game.gameState.runnerOnThirdId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should record advanced on balk`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val runner = createGamePlayer(10L)
+            game.gameState.setRunner(Base.SECOND, 10L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns runner
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 10L,
+                    fromBase = Base.SECOND,
+                    toBase = Base.THIRD,
+                    result = BaseRunningResult.ADVANCED_ON_BALK,
+                )
+
+            // when
+            val result = gameScorerService.recordBaseRunning(1L, request)
+
+            // then
+            assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.ADVANCED_ON_BALK)
+            assertThat(game.gameState.runnerOnSecondId).isNull()
+            assertThat(game.gameState.runnerOnThirdId).isEqualTo(10L)
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 상황")
+    inner class Exceptions {
+        @Test
+        fun `should throw exception when game not found`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 10L,
+                    fromBase = Base.FIRST,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.STOLEN_BASE,
+                )
+
+            // when & then
+            assertThatThrownBy { gameScorerService.recordBaseRunning(999L, request) }
+                .isInstanceOf(GameNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when game is not in progress`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 10L,
+                    fromBase = Base.FIRST,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.STOLEN_BASE,
+                )
+
+            // when & then
+            assertThatThrownBy { gameScorerService.recordBaseRunning(1L, request) }
+                .isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("진행 중인 경기만 주루 기록을 입력할 수 있습니다")
+        }
+
+        @Test
+        fun `should throw exception when runner not found`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(999L) } returns null
+
+            val request =
+                BaseRunningRequest(
+                    runnerId = 999L,
+                    fromBase = Base.FIRST,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.STOLEN_BASE,
+                )
+
+            // when & then
+            assertThatThrownBy { gameScorerService.recordBaseRunning(1L, request) }
+                .isInstanceOf(GamePlayerNotFoundException::class.java)
+        }
+    }
+
+    private fun createGamePlayer(id: Long): GamePlayer {
+        val gamePlayer = mockk<GamePlayer>(relaxed = true)
+        every { gamePlayer.id } returns id
+        every { gamePlayer.battingOrder } returns 1
+        return gamePlayer
+    }
+
+    private fun createAssociation(id: Long): Association =
+        Association(
+            name = "서울시야구협회",
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null,
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createLeague(
+        id: Long,
+        association: Association,
+    ): League =
+        League(
+            association = association,
+            name = "1부 리그",
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null,
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createCompetition(
+        id: Long,
+        league: League,
+    ): Competition =
+        Competition(
+            league = league,
+            name = "2025 춘계대회",
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            endDate = LocalDate.of(2025, 6, 30),
+            status = CompetitionStatus.IN_PROGRESS,
+            description = null,
+            maxTeams = null,
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createGame(
+        id: Long,
+        status: GameStatus,
+    ): Game {
+        val association = createAssociation(1L)
+        val league = createLeague(1L, association)
+        val competition = createCompetition(1L, league)
+
+        return Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실구장",
+            fieldName = "1구장",
+            gameNumber = 1,
+            status = status,
+            currentInning = 5,
+            isTopInning = true,
+            totalInnings = 9,
+            gameState = GameState(),
+        ).apply {
+            val idField = Game::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImplTest.kt
@@ -3,7 +3,6 @@ package com.nextup.infrastructure.service.game.correction
 import com.nextup.common.exception.BattingRecordNotFoundByIdException
 import com.nextup.common.exception.GameNotFoundException
 import com.nextup.common.exception.PitchingRecordNotFoundByIdException
-import com.nextup.core.domain.audit.AuditLog
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.domain.game.Game

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -89,6 +89,21 @@ class GameScorerController(
     }
 
     /**
+     * 주루 플레이를 기록합니다.
+     *
+     * 도루, 도루 실패, 견제사, 폭투 진루 등 타석 외 주루 이벤트를 기록합니다.
+     */
+    @PostMapping("/{gameId}/base-running")
+    @ResponseStatus(HttpStatus.OK)
+    fun recordBaseRunning(
+        @PathVariable gameId: Long,
+        @RequestBody @Valid request: BaseRunningRequestDto
+    ): ApiResponse<BaseRunningResponse> {
+        val event = gameScorerService.recordBaseRunning(gameId, request.toDomain())
+        return ApiResponse.success(event.toBaseRunningResponse())
+    }
+
+    /**
      * 경기를 몰수 처리합니다.
      *
      * 승리팀에 7점, 패배팀에 0점을 자동 반영하고 경기를 종료합니다.

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -2,6 +2,8 @@ package com.nextup.scorer.controller.game
 
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.game.GameScorerService
+import com.nextup.scorer.dto.game.BaseRunningRequestDto
+import com.nextup.scorer.dto.game.BaseRunningResponse
 import com.nextup.scorer.dto.game.ForfeitRequestDto
 import com.nextup.scorer.dto.game.GameEndRequestDto
 import com.nextup.scorer.dto.game.GameResponse
@@ -10,11 +12,17 @@ import com.nextup.scorer.dto.game.SubstitutionRequestDto
 import com.nextup.scorer.dto.game.SubstitutionResponse
 import com.nextup.scorer.dto.game.UndoResponse
 import com.nextup.scorer.dto.game.toDomain
+import com.nextup.scorer.dto.game.toBaseRunningResponse
 import com.nextup.scorer.dto.game.toResponse
 import com.nextup.scorer.dto.game.toSubstitutionResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
 
 /**
  * 기록원 전용 경기 기록 컨트롤러
@@ -24,16 +32,15 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/scorer/games")
 class GameScorerController(
-    private val gameScorerService: GameScorerService
+    private val gameScorerService: GameScorerService,
 ) {
-
     /**
      * 경기를 시작합니다.
      */
     @PostMapping("/{gameId}/start")
     @ResponseStatus(HttpStatus.OK)
     fun startGame(
-        @PathVariable gameId: Long
+        @PathVariable gameId: Long,
     ): ApiResponse<GameResponse> {
         val game = gameScorerService.startGame(gameId)
         return ApiResponse.success(game.toResponse())
@@ -46,7 +53,7 @@ class GameScorerController(
     @ResponseStatus(HttpStatus.OK)
     fun recordPlateAppearance(
         @PathVariable gameId: Long,
-        @RequestBody @Valid request: PlateAppearanceRequestDto
+        @RequestBody @Valid request: PlateAppearanceRequestDto,
     ): ApiResponse<GameResponse> {
         val game = gameScorerService.recordPlateAppearance(gameId, request.toDomain())
         return ApiResponse.success(game.toResponse())
@@ -58,7 +65,7 @@ class GameScorerController(
     @PostMapping("/{gameId}/half-inning")
     @ResponseStatus(HttpStatus.OK)
     fun advanceHalfInning(
-        @PathVariable gameId: Long
+        @PathVariable gameId: Long,
     ): ApiResponse<GameResponse> {
         val game = gameScorerService.advanceHalfInning(gameId)
         return ApiResponse.success(game.toResponse())
@@ -71,7 +78,7 @@ class GameScorerController(
     @ResponseStatus(HttpStatus.OK)
     fun endGame(
         @PathVariable gameId: Long,
-        @RequestBody @Valid request: GameEndRequestDto
+        @RequestBody @Valid request: GameEndRequestDto,
     ): ApiResponse<GameResponse> {
         val game = gameScorerService.endGame(gameId, request.reason!!)
         return ApiResponse.success(game.toResponse())
@@ -83,7 +90,7 @@ class GameScorerController(
     @PostMapping("/{gameId}/undo")
     @ResponseStatus(HttpStatus.OK)
     fun undoLastEvent(
-        @PathVariable gameId: Long
+        @PathVariable gameId: Long,
     ): ApiResponse<UndoResponse> {
         val undoneEvent = gameScorerService.undoLastEvent(gameId)
         val game = undoneEvent.game
@@ -93,7 +100,7 @@ class GameScorerController(
                 eventType = undoneEvent.eventType.displayName,
                 restoredState = game.gameState.toResponse(),
                 message = "${undoneEvent.eventType.displayName} 이벤트가 되돌려졌습니다.",
-            )
+            ),
         )
     }
 
@@ -106,7 +113,7 @@ class GameScorerController(
     @ResponseStatus(HttpStatus.OK)
     fun recordBaseRunning(
         @PathVariable gameId: Long,
-        @RequestBody @Valid request: BaseRunningRequestDto
+        @RequestBody @Valid request: BaseRunningRequestDto,
     ): ApiResponse<BaseRunningResponse> {
         val event = gameScorerService.recordBaseRunning(gameId, request.toDomain())
         return ApiResponse.success(event.toBaseRunningResponse())

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -11,8 +11,8 @@ import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
 import com.nextup.scorer.dto.game.SubstitutionRequestDto
 import com.nextup.scorer.dto.game.SubstitutionResponse
 import com.nextup.scorer.dto.game.UndoResponse
-import com.nextup.scorer.dto.game.toDomain
 import com.nextup.scorer.dto.game.toBaseRunningResponse
+import com.nextup.scorer.dto.game.toDomain
 import com.nextup.scorer.dto.game.toResponse
 import com.nextup.scorer.dto.game.toSubstitutionResponse
 import jakarta.validation.Valid

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/BaseRunningRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/BaseRunningRequestDto.kt
@@ -1,0 +1,31 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.game.Base
+import com.nextup.core.domain.game.BaseRunningResult
+import com.nextup.core.service.game.dto.BaseRunningRequest
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 주루 플레이 기록 요청 DTO (scorer API 계층)
+ */
+data class BaseRunningRequestDto(
+    @field:NotNull(message = "주자 ID는 필수입니다")
+    val runnerId: Long?,
+    @field:NotNull(message = "출발 베이스는 필수입니다")
+    val fromBase: Base?,
+    @field:NotNull(message = "도착 베이스는 필수입니다")
+    val toBase: Base?,
+    @field:NotNull(message = "주루 플레이 결과는 필수입니다")
+    val result: BaseRunningResult?,
+)
+
+/**
+ * BaseRunningRequestDto를 도메인 BaseRunningRequest로 변환합니다.
+ */
+fun BaseRunningRequestDto.toDomain(): BaseRunningRequest =
+    BaseRunningRequest(
+        runnerId = this.runnerId!!,
+        fromBase = this.fromBase!!,
+        toBase = this.toBase!!,
+        result = this.result!!,
+    )

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/BaseRunningResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/BaseRunningResponse.kt
@@ -1,0 +1,49 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.game.Base
+import com.nextup.core.domain.game.BaseRunningResult
+import com.nextup.core.domain.game.GameEvent
+import java.time.Instant
+
+/**
+ * 주루 플레이 기록 응답 DTO
+ */
+data class BaseRunningResponse(
+    val eventId: Long,
+    val runnerId: Long?,
+    val fromBase: Base,
+    val toBase: Base,
+    val result: BaseRunningResult,
+    val resultDisplay: String,
+    val inning: Int,
+    val isTopInning: Boolean,
+    val outCountBefore: Int,
+    val outCountAfter: Int,
+    val gameState: GameStateResponse,
+    val eventTimestamp: Instant,
+    val message: String,
+)
+
+/**
+ * GameEvent를 BaseRunningResponse로 변환합니다.
+ */
+fun GameEvent.toBaseRunningResponse(): BaseRunningResponse {
+    val result = requireNotNull(this.baseRunningResult) { "baseRunningResult must not be null for BASE_RUNNING event" }
+    val fromBase = requireNotNull(this.fromBase) { "fromBase must not be null for BASE_RUNNING event" }
+    val toBase = requireNotNull(this.toBase) { "toBase must not be null for BASE_RUNNING event" }
+    return BaseRunningResponse(
+        eventId = this.id,
+        runnerId = this.runnerPlayer?.id,
+        fromBase = fromBase,
+        toBase = toBase,
+        result = result,
+        resultDisplay = result.displayName,
+        inning = this.inning,
+        isTopInning = this.isTopInning,
+        outCountBefore = this.outCountBefore,
+        outCountAfter = this.outCountAfter,
+        gameState = this.game.gameState.toResponse(),
+        eventTimestamp = this.eventTimestamp,
+        message = "${result.displayName} 기록이 완료되었습니다.",
+    )
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
@@ -1,0 +1,281 @@
+package com.nextup.scorer.controller.game
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Base
+import com.nextup.core.domain.game.BaseRunningResult
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.domain.game.GameState
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.league.League
+import com.nextup.core.service.game.GameScorerService
+import com.nextup.scorer.dto.game.BaseRunningRequestDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameScorerController - 주루 기록")
+class BaseRunningControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var gameScorerService: GameScorerService
+    private lateinit var controller: GameScorerController
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        gameScorerService = mockk()
+        controller = GameScorerController(gameScorerService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+        objectMapper = ObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/base-running")
+    inner class RecordBaseRunning {
+
+        @Test
+        fun `도루 성공을 기록하면 200 OK와 이벤트 정보를 반환한다`() {
+            // given
+            val gameId = 1L
+            val request = BaseRunningRequestDto(
+                runnerId = 5L,
+                fromBase = Base.FIRST,
+                toBase = Base.SECOND,
+                result = BaseRunningResult.STOLEN_BASE,
+            )
+            val game = createGame(gameId, GameStatus.IN_PROGRESS)
+            val event = createBaseRunningEvent(game, Base.FIRST, Base.SECOND, BaseRunningResult.STOLEN_BASE)
+            every { gameScorerService.recordBaseRunning(gameId, any()) } returns event
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/base-running")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.result").value("STOLEN_BASE"))
+                .andExpect(jsonPath("$.data.fromBase").value("FIRST"))
+                .andExpect(jsonPath("$.data.toBase").value("SECOND"))
+
+            verify(exactly = 1) { gameScorerService.recordBaseRunning(gameId, any()) }
+        }
+
+        @Test
+        fun `도루 실패를 기록하면 200 OK와 CAUGHT_STEALING 결과를 반환한다`() {
+            // given
+            val gameId = 1L
+            val request = BaseRunningRequestDto(
+                runnerId = 5L,
+                fromBase = Base.FIRST,
+                toBase = Base.SECOND,
+                result = BaseRunningResult.CAUGHT_STEALING,
+            )
+            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                gameState.outs = 1
+            }
+            val event = createBaseRunningEvent(game, Base.FIRST, Base.SECOND, BaseRunningResult.CAUGHT_STEALING)
+            every { gameScorerService.recordBaseRunning(gameId, any()) } returns event
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/base-running")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.result").value("CAUGHT_STEALING"))
+
+            verify(exactly = 1) { gameScorerService.recordBaseRunning(gameId, any()) }
+        }
+
+        @Test
+        fun `견제사를 기록하면 200 OK와 PICKED_OFF 결과를 반환한다`() {
+            // given
+            val gameId = 1L
+            val request = BaseRunningRequestDto(
+                runnerId = 7L,
+                fromBase = Base.SECOND,
+                toBase = Base.SECOND,
+                result = BaseRunningResult.PICKED_OFF,
+            )
+            val game = createGame(gameId, GameStatus.IN_PROGRESS)
+            val event = createBaseRunningEvent(game, Base.SECOND, Base.SECOND, BaseRunningResult.PICKED_OFF)
+            every { gameScorerService.recordBaseRunning(gameId, any()) } returns event
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/base-running")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.result").value("PICKED_OFF"))
+
+            verify(exactly = 1) { gameScorerService.recordBaseRunning(gameId, any()) }
+        }
+
+        @Test
+        fun `폭투 진루를 기록하면 200 OK와 ADVANCED_ON_WILD_PITCH 결과를 반환한다`() {
+            // given
+            val gameId = 1L
+            val request = BaseRunningRequestDto(
+                runnerId = 9L,
+                fromBase = Base.SECOND,
+                toBase = Base.THIRD,
+                result = BaseRunningResult.ADVANCED_ON_WILD_PITCH,
+            )
+            val game = createGame(gameId, GameStatus.IN_PROGRESS)
+            val event = createBaseRunningEvent(game, Base.SECOND, Base.THIRD, BaseRunningResult.ADVANCED_ON_WILD_PITCH)
+            every { gameScorerService.recordBaseRunning(gameId, any()) } returns event
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/base-running")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.result").value("ADVANCED_ON_WILD_PITCH"))
+
+            verify(exactly = 1) { gameScorerService.recordBaseRunning(gameId, any()) }
+        }
+
+        @Test
+        fun `runnerId가 없으면 400 Bad Request를 반환한다`() {
+            // given
+            val gameId = 1L
+            val request = BaseRunningRequestDto(
+                runnerId = null,
+                fromBase = Base.FIRST,
+                toBase = Base.SECOND,
+                result = BaseRunningResult.STOLEN_BASE,
+            )
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/base-running")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+        }
+    }
+
+    private fun createAssociation(id: Long, name: String): Association {
+        return Association(
+            name = name,
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createLeague(id: Long, name: String, association: Association): League {
+        return League(
+            association = association,
+            name = name,
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createCompetition(id: Long, name: String, league: League): Competition {
+        return Competition(
+            league = league,
+            name = name,
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            endDate = LocalDate.of(2025, 6, 30),
+            status = CompetitionStatus.IN_PROGRESS,
+            description = null,
+            maxTeams = null
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createGame(id: Long, status: GameStatus): Game {
+        val association = createAssociation(1L, "서울시야구협회")
+        val league = createLeague(1L, "1부 리그", association)
+        val competition = createCompetition(1L, "2025 춘계대회", league)
+
+        return Game(
+            competition = competition,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실구장",
+            fieldName = "1구장",
+            gameNumber = 1,
+            status = status,
+            currentInning = 3,
+            isTopInning = true,
+            totalInnings = 9,
+            gameState = GameState()
+        ).apply {
+            val idField = Game::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    private fun createBaseRunningEvent(
+        game: Game,
+        fromBase: Base,
+        toBase: Base,
+        result: BaseRunningResult,
+    ): GameEvent {
+        val runner = mockk<com.nextup.core.domain.game.GamePlayer>(relaxed = true)
+        return GameEvent.createBaseRunning(
+            game = game,
+            runner = runner,
+            fromBase = fromBase,
+            toBase = toBase,
+            result = result,
+            description = "${result.displayName}: $fromBase → $toBase",
+            outCountBefore = game.gameState.outs,
+            outCountAfter = game.gameState.outs,
+            runnersBeforeJson = null,
+            runnersAfterJson = null,
+        )
+    }
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
@@ -228,7 +228,11 @@ class BaseRunningControllerTest {
         }
     }
 
-    private fun createCompetition(id: Long, name: String, league: League): Competition {
+    private fun createCompetition(
+        id: Long,
+        name: String,
+        league: League,
+    ): Competition {
         return Competition(
             league = league,
             name = name,
@@ -247,7 +251,10 @@ class BaseRunningControllerTest {
         }
     }
 
-    private fun createGame(id: Long, status: GameStatus): Game {
+    private fun createGame(
+        id: Long,
+        status: GameStatus,
+    ): Game {
         val association = createAssociation(1L, "서울시야구협회")
         val league = createLeague(1L, "1부 리그", association)
         val competition = createCompetition(1L, "2025 춘계대회", league)

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
@@ -10,7 +10,6 @@ import com.nextup.core.domain.game.Base
 import com.nextup.core.domain.game.BaseRunningResult
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
-import com.nextup.core.domain.game.GameEventType
 import com.nextup.core.domain.game.GameState
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.league.League
@@ -56,12 +55,13 @@ class BaseRunningControllerTest {
         fun `도루 성공을 기록하면 200 OK와 이벤트 정보를 반환한다`() {
             // given
             val gameId = 1L
-            val request = BaseRunningRequestDto(
-                runnerId = 5L,
-                fromBase = Base.FIRST,
-                toBase = Base.SECOND,
-                result = BaseRunningResult.STOLEN_BASE,
-            )
+            val request =
+                BaseRunningRequestDto(
+                    runnerId = 5L,
+                    fromBase = Base.FIRST,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.STOLEN_BASE,
+                )
             val game = createGame(gameId, GameStatus.IN_PROGRESS)
             val event = createBaseRunningEvent(game, Base.FIRST, Base.SECOND, BaseRunningResult.STOLEN_BASE)
             every { gameScorerService.recordBaseRunning(gameId, any()) } returns event
@@ -85,15 +85,17 @@ class BaseRunningControllerTest {
         fun `도루 실패를 기록하면 200 OK와 CAUGHT_STEALING 결과를 반환한다`() {
             // given
             val gameId = 1L
-            val request = BaseRunningRequestDto(
-                runnerId = 5L,
-                fromBase = Base.FIRST,
-                toBase = Base.SECOND,
-                result = BaseRunningResult.CAUGHT_STEALING,
-            )
-            val game = createGame(gameId, GameStatus.IN_PROGRESS).apply {
-                gameState.outs = 1
-            }
+            val request =
+                BaseRunningRequestDto(
+                    runnerId = 5L,
+                    fromBase = Base.FIRST,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.CAUGHT_STEALING,
+                )
+            val game =
+                createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                    gameState.outs = 1
+                }
             val event = createBaseRunningEvent(game, Base.FIRST, Base.SECOND, BaseRunningResult.CAUGHT_STEALING)
             every { gameScorerService.recordBaseRunning(gameId, any()) } returns event
 
@@ -114,12 +116,13 @@ class BaseRunningControllerTest {
         fun `견제사를 기록하면 200 OK와 PICKED_OFF 결과를 반환한다`() {
             // given
             val gameId = 1L
-            val request = BaseRunningRequestDto(
-                runnerId = 7L,
-                fromBase = Base.SECOND,
-                toBase = Base.SECOND,
-                result = BaseRunningResult.PICKED_OFF,
-            )
+            val request =
+                BaseRunningRequestDto(
+                    runnerId = 7L,
+                    fromBase = Base.SECOND,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.PICKED_OFF,
+                )
             val game = createGame(gameId, GameStatus.IN_PROGRESS)
             val event = createBaseRunningEvent(game, Base.SECOND, Base.SECOND, BaseRunningResult.PICKED_OFF)
             every { gameScorerService.recordBaseRunning(gameId, any()) } returns event
@@ -141,12 +144,13 @@ class BaseRunningControllerTest {
         fun `폭투 진루를 기록하면 200 OK와 ADVANCED_ON_WILD_PITCH 결과를 반환한다`() {
             // given
             val gameId = 1L
-            val request = BaseRunningRequestDto(
-                runnerId = 9L,
-                fromBase = Base.SECOND,
-                toBase = Base.THIRD,
-                result = BaseRunningResult.ADVANCED_ON_WILD_PITCH,
-            )
+            val request =
+                BaseRunningRequestDto(
+                    runnerId = 9L,
+                    fromBase = Base.SECOND,
+                    toBase = Base.THIRD,
+                    result = BaseRunningResult.ADVANCED_ON_WILD_PITCH,
+                )
             val game = createGame(gameId, GameStatus.IN_PROGRESS)
             val event = createBaseRunningEvent(game, Base.SECOND, Base.THIRD, BaseRunningResult.ADVANCED_ON_WILD_PITCH)
             every { gameScorerService.recordBaseRunning(gameId, any()) } returns event
@@ -168,12 +172,13 @@ class BaseRunningControllerTest {
         fun `runnerId가 없으면 400 Bad Request를 반환한다`() {
             // given
             val gameId = 1L
-            val request = BaseRunningRequestDto(
-                runnerId = null,
-                fromBase = Base.FIRST,
-                toBase = Base.SECOND,
-                result = BaseRunningResult.STOLEN_BASE,
-            )
+            val request =
+                BaseRunningRequestDto(
+                    runnerId = null,
+                    fromBase = Base.FIRST,
+                    toBase = Base.SECOND,
+                    result = BaseRunningResult.STOLEN_BASE,
+                )
 
             // when & then
             mockMvc.perform(
@@ -185,7 +190,10 @@ class BaseRunningControllerTest {
         }
     }
 
-    private fun createAssociation(id: Long, name: String): Association {
+    private fun createAssociation(
+        id: Long,
+        name: String,
+    ): Association {
         return Association(
             name = name,
             abbreviation = null,
@@ -200,7 +208,11 @@ class BaseRunningControllerTest {
         }
     }
 
-    private fun createLeague(id: Long, name: String, association: Association): League {
+    private fun createLeague(
+        id: Long,
+        name: String,
+        association: Association,
+    ): League {
         return League(
             association = association,
             name = name,


### PR DESCRIPTION
## Summary

>- close #224

주루 기록 상세화 — 도루 루별 기록 및 주루 이벤트 세분화를 구현합니다.

## Tasks

- BaseRunningEvent 엔티티/GameEvent 확장
- runnerPlayerId, fromBase, toBase, result 필드 추가
- 도루/도루실패/견제사/보크진루 등 세분화
- BattingRecord에 루별 도루 필드 (stolenSecond/Third/Home)
- 시즌/커리어 주루 통계 조회 API
- 단위 테스트 작성

## To Reviewer

- GameEventType.BASE_RUNNING 활용
- 사회인 야구 주루 기록 정밀도 고려