### PR TITLE
fix(#217): 경기 취소/몰수 시 스탯 롤백 및 정책 정의

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/GameCancelledEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/GameCancelledEvent.kt
@@ -1,0 +1,18 @@
+package com.nextup.core.domain.event
+
+import java.time.Instant
+
+/**
+ * 경기 취소 도메인 이벤트
+ *
+ * 경기가 취소될 때 발행됩니다.
+ * 해당 경기에 실시간으로 반영된 시즌 타격/투구 통계를 롤백하기 위해 사용됩니다.
+ *
+ * 정책:
+ * - 취소 경기는 개인 기록이 무효화됩니다 (SeasonBattingStats/SeasonPitchingStats 롤백).
+ * - PlateAppearanceRecordedEvent로 반영된 모든 실시간 스탯 기여분을 역산합니다.
+ */
+data class GameCancelledEvent(
+    val gameId: Long,
+    val timestamp: Instant = Instant.now(),
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
@@ -295,6 +295,34 @@ class SeasonBattingStats(
     }
 
     /**
+     * 경기 타격 기여분을 시즌 통계에서 차감합니다 (경기 취소 롤백).
+     *
+     * 취소된 경기의 BattingRecord에 집계된 값을 역산하여
+     * 해당 경기의 기여분 전체를 시즌 통계에서 제거합니다.
+     * 음수 방지를 위해 각 항목은 0 미만으로 내려가지 않습니다.
+     */
+    fun revertGameRecord(record: BattingRecord) {
+        gamesPlayed = maxOf(0, gamesPlayed - 1)
+        plateAppearances = maxOf(0, plateAppearances - record.plateAppearances)
+        atBats = maxOf(0, atBats - record.atBats)
+        hits = maxOf(0, hits - record.hits)
+        doubles = maxOf(0, doubles - record.doubles)
+        triples = maxOf(0, triples - record.triples)
+        homeRuns = maxOf(0, homeRuns - record.homeRuns)
+        runs = maxOf(0, runs - record.runs)
+        runsBattedIn = maxOf(0, runsBattedIn - record.runsBattedIn)
+        walks = maxOf(0, walks - record.walks)
+        intentionalWalks = maxOf(0, intentionalWalks - record.intentionalWalks)
+        hitByPitch = maxOf(0, hitByPitch - record.hitByPitch)
+        strikeouts = maxOf(0, strikeouts - record.strikeouts)
+        sacrificeBunts = maxOf(0, sacrificeBunts - record.sacrificeBunts)
+        sacrificeFlies = maxOf(0, sacrificeFlies - record.sacrificeFlies)
+        stolenBases = maxOf(0, stolenBases - record.stolenBases)
+        caughtStealing = maxOf(0, caughtStealing - record.caughtStealing)
+        groundedIntoDoublePlays = maxOf(0, groundedIntoDoublePlays - record.groundedIntoDoublePlays)
+    }
+
+    /**
      * 기록 유효성을 검증합니다.
      */
     fun validate() {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
@@ -287,6 +287,47 @@ class SeasonPitchingStats(
     }
 
     /**
+     * 경기 투수 기여분을 시즌 통계에서 차감합니다 (경기 취소 롤백).
+     *
+     * 취소된 경기의 PitchingRecord에 집계된 값을 역산하여
+     * 해당 경기의 기여분 전체를 시즌 통계에서 제거합니다.
+     * 음수 방지를 위해 각 항목은 0 미만으로 내려가지 않습니다.
+     */
+    fun revertGameRecord(record: PitchingRecord) {
+        gamesPlayed = maxOf(0, gamesPlayed - 1)
+        if (record.isStartingPitcher) {
+            gamesStarted = maxOf(0, gamesStarted - 1)
+        }
+        inningsPitchedOuts = maxOf(0, inningsPitchedOuts - record.inningsPitchedOuts)
+        earnedRuns = maxOf(0, earnedRuns - record.earnedRuns)
+        runsAllowed = maxOf(0, runsAllowed - record.runsAllowed)
+        hitsAllowed = maxOf(0, hitsAllowed - record.hitsAllowed)
+        walksAllowed = maxOf(0, walksAllowed - record.walksAllowed)
+        strikeouts = maxOf(0, strikeouts - record.strikeouts)
+        homeRunsAllowed = maxOf(0, homeRunsAllowed - record.homeRunsAllowed)
+        hitBatsmen = maxOf(0, hitBatsmen - record.hitBatsmen)
+        wildPitches = maxOf(0, wildPitches - record.wildPitches)
+        balks = maxOf(0, balks - record.balks)
+        battersFaced = maxOf(0, battersFaced - record.battersFaced)
+
+        if (record.pitchesThrown != null) {
+            pitchesThrown = maxOf(0, (pitchesThrown ?: 0) - record.pitchesThrown!!)
+        }
+        if (record.strikesThrown != null) {
+            strikesThrown = maxOf(0, (strikesThrown ?: 0) - record.strikesThrown!!)
+        }
+
+        when (record.decision) {
+            com.nextup.core.domain.game.PitchingDecision.WIN -> wins = maxOf(0, wins - 1)
+            com.nextup.core.domain.game.PitchingDecision.LOSS -> losses = maxOf(0, losses - 1)
+            com.nextup.core.domain.game.PitchingDecision.SAVE -> saves = maxOf(0, saves - 1)
+            com.nextup.core.domain.game.PitchingDecision.HOLD -> holds = maxOf(0, holds - 1)
+            com.nextup.core.domain.game.PitchingDecision.BLOWN_SAVE -> blownSaves = maxOf(0, blownSaves - 1)
+            else -> { /* NONE */ }
+        }
+    }
+
+    /**
      * 기록 유효성을 검증합니다.
      */
     fun validate() {

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonBattingStatsRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonBattingStatsRepositoryPort.kt
@@ -88,4 +88,10 @@ interface SeasonBattingStatsRepositoryPort {
         minPlateAppearances: Int,
         limit: Int,
     ): List<SeasonBattingStats>
+
+    /**
+     * 특정 경기에 출전하여 타격 기록이 있는 선수들의 시즌 타격 통계를 조회합니다.
+     * 경기 취소 시 스탯 롤백에 사용됩니다.
+     */
+    fun findAllByGameId(gameId: Long): List<SeasonBattingStats>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonPitchingStatsRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonPitchingStatsRepositoryPort.kt
@@ -76,4 +76,10 @@ interface SeasonPitchingStatsRepositoryPort {
         minInningsPitchedOuts: Int,
         limit: Int,
     ): List<SeasonPitchingStats>
+
+    /**
+     * 특정 경기에 등판하여 투구 기록이 있는 선수들의 시즌 투구 통계를 조회합니다.
+     * 경기 취소 시 스탯 롤백에 사용됩니다.
+     */
+    fun findAllByGameId(gameId: Long): List<SeasonPitchingStats>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
@@ -63,6 +63,8 @@ interface GameScorerService {
      * 경기를 몰수 처리합니다.
      *
      * 승리팀에 7점, 패배팀에 0점을 자동 반영하고 경기를 종료합니다.
+     * 몰수 시점까지의 개인 타격/투구 기록은 공식 기록으로 유효합니다 (KBO/MLB 기준).
+     * 점수만 7-0으로 설정되며 개인 스탯은 롤백되지 않습니다.
      *
      * @param gameId 경기 ID
      * @param winnerTeamId 몰수승 팀 ID
@@ -73,5 +75,21 @@ interface GameScorerService {
         gameId: Long,
         winnerTeamId: Long,
         reason: String,
+    ): Game
+
+    /**
+     * 경기를 취소합니다.
+     *
+     * 예정(SCHEDULED) 또는 연기(POSTPONED) 상태의 경기만 취소할 수 있습니다.
+     * 취소된 경기에 실시간으로 반영된 시즌 타격/투구 통계가 롤백됩니다.
+     * (예정/연기 상태의 경기는 실시간 통계 기여분이 없으므로 실질적으로 롤백할 데이터가 없을 수 있습니다.)
+     *
+     * @param gameId 경기 ID
+     * @param reason 취소 사유 (선택)
+     * @return 취소된 경기
+     */
+    fun cancelGame(
+        gameId: Long,
+        reason: String? = null,
     ): Game
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/event/GameCancelledEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/event/GameCancelledEventTest.kt
@@ -1,0 +1,59 @@
+package com.nextup.core.domain.event
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("GameCancelledEvent 테스트")
+class GameCancelledEventTest {
+    @Test
+    fun `gameId가 올바르게 설정됨`() {
+        // given & when
+        val event = GameCancelledEvent(gameId = 42L)
+
+        // then
+        assertThat(event.gameId).isEqualTo(42L)
+    }
+
+    @Test
+    fun `timestamp가 자동 생성됨`() {
+        // given
+        val before = Instant.now()
+
+        // when
+        val event = GameCancelledEvent(gameId = 1L)
+
+        // then
+        val after = Instant.now()
+        assertThat(event.timestamp).isBetween(before, after)
+    }
+
+    @Test
+    fun `명시적 timestamp가 설정됨`() {
+        // given
+        val fixedTimestamp = Instant.parse("2024-06-15T10:00:00Z")
+
+        // when
+        val event = GameCancelledEvent(gameId = 1L, timestamp = fixedTimestamp)
+
+        // then
+        assertThat(event.timestamp).isEqualTo(fixedTimestamp)
+    }
+
+    @Test
+    fun `data class equals와 copy 동작 확인`() {
+        // given
+        val timestamp = Instant.now()
+        val event1 = GameCancelledEvent(gameId = 1L, timestamp = timestamp)
+        val event2 = GameCancelledEvent(gameId = 1L, timestamp = timestamp)
+
+        // then
+        assertThat(event1).isEqualTo(event2)
+        assertThat(event1.hashCode()).isEqualTo(event2.hashCode())
+
+        val copied = event1.copy(gameId = 2L)
+        assertThat(copied.gameId).isEqualTo(2L)
+        assertThat(copied.timestamp).isEqualTo(timestamp)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonBattingStatsRevertGameRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonBattingStatsRevertGameRecordTest.kt
@@ -1,0 +1,216 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("SeasonBattingStats.revertGameRecord 테스트")
+class SeasonBattingStatsRevertGameRecordTest {
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
+
+    private fun createMockBattingRecord(
+        plateAppearances: Int = 0,
+        atBats: Int = 0,
+        hits: Int = 0,
+        doubles: Int = 0,
+        triples: Int = 0,
+        homeRuns: Int = 0,
+        runs: Int = 0,
+        runsBattedIn: Int = 0,
+        walks: Int = 0,
+        intentionalWalks: Int = 0,
+        hitByPitch: Int = 0,
+        strikeouts: Int = 0,
+        sacrificeBunts: Int = 0,
+        sacrificeFlies: Int = 0,
+        stolenBases: Int = 0,
+        caughtStealing: Int = 0,
+        groundedIntoDoublePlays: Int = 0,
+    ): BattingRecord {
+        val gamePlayer = mockk<GamePlayer>()
+        val record = mockk<BattingRecord>()
+        every { record.gamePlayer } returns gamePlayer
+        every { record.plateAppearances } returns plateAppearances
+        every { record.atBats } returns atBats
+        every { record.hits } returns hits
+        every { record.doubles } returns doubles
+        every { record.triples } returns triples
+        every { record.homeRuns } returns homeRuns
+        every { record.runs } returns runs
+        every { record.runsBattedIn } returns runsBattedIn
+        every { record.walks } returns walks
+        every { record.intentionalWalks } returns intentionalWalks
+        every { record.hitByPitch } returns hitByPitch
+        every { record.strikeouts } returns strikeouts
+        every { record.sacrificeBunts } returns sacrificeBunts
+        every { record.sacrificeFlies } returns sacrificeFlies
+        every { record.stolenBases } returns stolenBases
+        every { record.caughtStealing } returns caughtStealing
+        every { record.groundedIntoDoublePlays } returns groundedIntoDoublePlays
+        return record
+    }
+
+    @Nested
+    @DisplayName("경기 타격 기여분 롤백")
+    inner class RevertGameRecord {
+        private lateinit var stats: SeasonBattingStats
+
+        @BeforeEach
+        fun setUp() {
+            stats = SeasonBattingStats.create(testPlayer, 2024)
+        }
+
+        @Test
+        fun `단타 기여분이 정확히 차감됨`() {
+            // given: 시즌 통계에 1게임 분량 단타 기여 반영
+            val record =
+                createMockBattingRecord(
+                    plateAppearances = 4,
+                    atBats = 4,
+                    hits = 2,
+                )
+            // 먼저 addGameRecord 없이 직접 값 설정은 불가하므로 revertGameRecord가 0 미만으로 내려가지 않음을 검증
+
+            // when: 롤백
+            stats.revertGameRecord(record)
+
+            // then: 음수 방지로 모든 값이 0
+            assertThat(stats.gamesPlayed).isZero
+            assertThat(stats.plateAppearances).isZero
+            assertThat(stats.atBats).isZero
+            assertThat(stats.hits).isZero
+        }
+
+        @Test
+        fun `경기 기록이 반영된 시즌 통계에서 정확히 차감됨`() {
+            // given: 2경기 기록이 반영된 시즌 통계
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val realRecord1 = BattingRecord(gamePlayer)
+            realRecord1.applyPlateAppearanceResult(
+                com.nextup.core.domain.game.PlateAppearanceResult.SINGLE,
+            )
+            realRecord1.applyPlateAppearanceResult(
+                com.nextup.core.domain.game.PlateAppearanceResult.HOME_RUN,
+            )
+            val realRecord2 = BattingRecord(gamePlayer)
+            realRecord2.applyPlateAppearanceResult(
+                com.nextup.core.domain.game.PlateAppearanceResult.DOUBLE,
+            )
+
+            stats.addGameRecord(realRecord1)
+            stats.addGameRecord(realRecord2)
+
+            assertThat(stats.gamesPlayed).isEqualTo(2)
+            assertThat(stats.hits).isEqualTo(3)
+            assertThat(stats.homeRuns).isEqualTo(1)
+            assertThat(stats.doubles).isEqualTo(1)
+
+            // when: 첫 번째 경기 기록 롤백
+            stats.revertGameRecord(realRecord1)
+
+            // then: 두 번째 경기 기록만 남음
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+            assertThat(stats.hits).isEqualTo(1)
+            assertThat(stats.homeRuns).isZero
+            assertThat(stats.doubles).isEqualTo(1)
+            assertThat(stats.plateAppearances).isEqualTo(1)
+            assertThat(stats.atBats).isEqualTo(1)
+        }
+
+        @Test
+        fun `홈런 기여분 롤백 시 홈런과 득점이 함께 차감됨`() {
+            // given
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val record = BattingRecord(gamePlayer)
+            record.applyPlateAppearanceResult(com.nextup.core.domain.game.PlateAppearanceResult.HOME_RUN)
+
+            stats.addGameRecord(record)
+            assertThat(stats.homeRuns).isEqualTo(1)
+            assertThat(stats.runs).isEqualTo(1)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.homeRuns).isZero
+            assertThat(stats.runs).isZero
+            assertThat(stats.hits).isZero
+            assertThat(stats.atBats).isZero
+        }
+
+        @Test
+        fun `볼넷 기여분 롤백 시 볼넷만 차감되고 타수는 영향 없음`() {
+            // given
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val record = BattingRecord(gamePlayer)
+            record.applyPlateAppearanceResult(com.nextup.core.domain.game.PlateAppearanceResult.WALK)
+
+            stats.addGameRecord(record)
+            assertThat(stats.walks).isEqualTo(1)
+            assertThat(stats.atBats).isZero
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.walks).isZero
+            assertThat(stats.plateAppearances).isZero
+        }
+
+        @Test
+        fun `음수 방지 - 기여분보다 큰 값을 롤백해도 0 미만으로 내려가지 않음`() {
+            // given: 빈 통계에 큰 기여분 롤백 시도
+            val record =
+                createMockBattingRecord(
+                    plateAppearances = 10,
+                    atBats = 8,
+                    hits = 5,
+                    homeRuns = 2,
+                    runs = 3,
+                )
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then: 모든 값이 0 (음수 없음)
+            assertThat(stats.gamesPlayed).isZero
+            assertThat(stats.plateAppearances).isZero
+            assertThat(stats.atBats).isZero
+            assertThat(stats.hits).isZero
+            assertThat(stats.homeRuns).isZero
+            assertThat(stats.runs).isZero
+        }
+
+        @Test
+        fun `gamesPlayed가 1 감소함`() {
+            // given
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val record = BattingRecord(gamePlayer)
+            stats.addGameRecord(record)
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.gamesPlayed).isZero
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonPitchingStatsRevertGameRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonPitchingStatsRevertGameRecordTest.kt
@@ -1,0 +1,395 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.PitchingDecision
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("SeasonPitchingStats.revertGameRecord 테스트")
+class SeasonPitchingStatsRevertGameRecordTest {
+    private val testPlayer =
+        Player(
+            name = "박투수",
+            primaryPosition = Position.STARTING_PITCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
+
+    private fun createMockPitchingRecord(
+        isStartingPitcher: Boolean = false,
+        inningsPitchedOuts: Int = 0,
+        earnedRuns: Int = 0,
+        runsAllowed: Int = 0,
+        hitsAllowed: Int = 0,
+        walksAllowed: Int = 0,
+        strikeouts: Int = 0,
+        homeRunsAllowed: Int = 0,
+        hitBatsmen: Int = 0,
+        wildPitches: Int = 0,
+        balks: Int = 0,
+        battersFaced: Int = 0,
+        pitchesThrown: Int? = null,
+        strikesThrown: Int? = null,
+        decision: PitchingDecision = PitchingDecision.NONE,
+    ): PitchingRecord {
+        val record = mockk<PitchingRecord>()
+        every { record.isStartingPitcher } returns isStartingPitcher
+        every { record.inningsPitchedOuts } returns inningsPitchedOuts
+        every { record.earnedRuns } returns earnedRuns
+        every { record.runsAllowed } returns runsAllowed
+        every { record.hitsAllowed } returns hitsAllowed
+        every { record.walksAllowed } returns walksAllowed
+        every { record.strikeouts } returns strikeouts
+        every { record.homeRunsAllowed } returns homeRunsAllowed
+        every { record.hitBatsmen } returns hitBatsmen
+        every { record.wildPitches } returns wildPitches
+        every { record.balks } returns balks
+        every { record.battersFaced } returns battersFaced
+        every { record.pitchesThrown } returns pitchesThrown
+        every { record.strikesThrown } returns strikesThrown
+        every { record.decision } returns decision
+        return record
+    }
+
+    @Nested
+    @DisplayName("경기 투수 기여분 롤백")
+    inner class RevertGameRecord {
+        private lateinit var stats: SeasonPitchingStats
+
+        @BeforeEach
+        fun setUp() {
+            stats = SeasonPitchingStats.create(testPlayer, 2024)
+        }
+
+        @Test
+        fun `기본 투구 기여분이 정확히 차감됨`() {
+            // given: 시즌 통계에 1경기 분량 추가
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val realRecord =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    recordOut(isStrikeout = true)
+                    recordOut(isStrikeout = true)
+                    recordOut(isStrikeout = false)
+                    recordHit(isHomeRun = false, runsScored = 1, earnedRuns = 1)
+                    recordWalk()
+                    recordHitByPitch()
+                    recordWildPitch()
+                    recordBalk()
+                }
+            stats.addGameRecord(realRecord)
+
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+            assertThat(stats.gamesStarted).isEqualTo(1)
+            assertThat(stats.inningsPitchedOuts).isEqualTo(3)
+            assertThat(stats.strikeouts).isEqualTo(2)
+            assertThat(stats.hitsAllowed).isEqualTo(1)
+            assertThat(stats.walksAllowed).isEqualTo(1)
+            assertThat(stats.hitBatsmen).isEqualTo(1)
+            assertThat(stats.wildPitches).isEqualTo(1)
+            assertThat(stats.balks).isEqualTo(1)
+
+            // when: 롤백
+            stats.revertGameRecord(realRecord)
+
+            // then: 모든 값이 0으로 복원
+            assertThat(stats.gamesPlayed).isZero
+            assertThat(stats.gamesStarted).isZero
+            assertThat(stats.inningsPitchedOuts).isZero
+            assertThat(stats.strikeouts).isZero
+            assertThat(stats.hitsAllowed).isZero
+            assertThat(stats.walksAllowed).isZero
+            assertThat(stats.hitBatsmen).isZero
+            assertThat(stats.wildPitches).isZero
+            assertThat(stats.balks).isZero
+            assertThat(stats.earnedRuns).isZero
+            assertThat(stats.runsAllowed).isZero
+        }
+
+        @Test
+        fun `선발 투수가 아닌 경우 gamesStarted는 차감되지 않음`() {
+            // given
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val realRecord = PitchingRecord.create(gamePlayer, isStartingPitcher = false)
+            stats.addGameRecord(realRecord)
+
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+            assertThat(stats.gamesStarted).isZero
+
+            // when
+            stats.revertGameRecord(realRecord)
+
+            // then
+            assertThat(stats.gamesPlayed).isZero
+            assertThat(stats.gamesStarted).isZero
+        }
+
+        @Test
+        fun `선발 투수인 경우 gamesStarted도 차감됨`() {
+            // given
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val record1 = PitchingRecord.create(gamePlayer, isStartingPitcher = true)
+            val record2 = PitchingRecord.create(gamePlayer, isStartingPitcher = true)
+            stats.addGameRecord(record1)
+            stats.addGameRecord(record2)
+
+            assertThat(stats.gamesStarted).isEqualTo(2)
+
+            // when
+            stats.revertGameRecord(record1)
+
+            // then
+            assertThat(stats.gamesStarted).isEqualTo(1)
+        }
+
+        @Test
+        fun `승리 결정 롤백`() {
+            // given
+            val record =
+                createMockPitchingRecord(
+                    decision = PitchingDecision.WIN,
+                )
+            stats.addGameRecord(record)
+            assertThat(stats.wins).isEqualTo(1)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.wins).isZero
+        }
+
+        @Test
+        fun `패배 결정 롤백`() {
+            // given
+            val record =
+                createMockPitchingRecord(
+                    decision = PitchingDecision.LOSS,
+                )
+            stats.addGameRecord(record)
+            assertThat(stats.losses).isEqualTo(1)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.losses).isZero
+        }
+
+        @Test
+        fun `세이브 결정 롤백`() {
+            // given
+            val record =
+                createMockPitchingRecord(
+                    decision = PitchingDecision.SAVE,
+                )
+            stats.addGameRecord(record)
+            assertThat(stats.saves).isEqualTo(1)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.saves).isZero
+        }
+
+        @Test
+        fun `홀드 결정 롤백`() {
+            // given
+            val record =
+                createMockPitchingRecord(
+                    decision = PitchingDecision.HOLD,
+                )
+            stats.addGameRecord(record)
+            assertThat(stats.holds).isEqualTo(1)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.holds).isZero
+        }
+
+        @Test
+        fun `블론세이브 결정 롤백`() {
+            // given
+            val record =
+                createMockPitchingRecord(
+                    decision = PitchingDecision.BLOWN_SAVE,
+                )
+            stats.addGameRecord(record)
+            assertThat(stats.blownSaves).isEqualTo(1)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.blownSaves).isZero
+        }
+
+        @Test
+        fun `NONE 결정은 승패에 영향 없음`() {
+            // given
+            val record =
+                createMockPitchingRecord(
+                    decision = PitchingDecision.NONE,
+                )
+            stats.addGameRecord(record)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.wins).isZero
+            assertThat(stats.losses).isZero
+            assertThat(stats.saves).isZero
+            assertThat(stats.holds).isZero
+            assertThat(stats.blownSaves).isZero
+        }
+
+        @Test
+        fun `투구 수가 있는 경우 투구 수도 차감됨`() {
+            // given
+            val record =
+                createMockPitchingRecord(
+                    pitchesThrown = 80,
+                    strikesThrown = 50,
+                )
+            stats.addGameRecord(record)
+            assertThat(stats.pitchesThrown).isEqualTo(80)
+            assertThat(stats.strikesThrown).isEqualTo(50)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.pitchesThrown).isZero
+            assertThat(stats.strikesThrown).isZero
+        }
+
+        @Test
+        fun `투구 수가 null인 경우 투구 수에 영향 없음`() {
+            // given
+            val record =
+                createMockPitchingRecord(
+                    pitchesThrown = null,
+                    strikesThrown = null,
+                )
+            stats.addGameRecord(record)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.pitchesThrown).isNull()
+            assertThat(stats.strikesThrown).isNull()
+        }
+
+        @Test
+        fun `음수 방지 - 기여분보다 큰 값을 롤백해도 0 미만으로 내려가지 않음`() {
+            // given: 빈 통계에 큰 기여분 롤백 시도
+            val record =
+                createMockPitchingRecord(
+                    isStartingPitcher = true,
+                    inningsPitchedOuts = 27,
+                    earnedRuns = 3,
+                    runsAllowed = 4,
+                    hitsAllowed = 8,
+                    walksAllowed = 2,
+                    strikeouts = 10,
+                    homeRunsAllowed = 1,
+                    hitBatsmen = 1,
+                    wildPitches = 2,
+                    balks = 1,
+                    battersFaced = 35,
+                    pitchesThrown = 100,
+                    strikesThrown = 65,
+                    decision = PitchingDecision.WIN,
+                )
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then: 모든 값이 0 (음수 없음)
+            assertThat(stats.gamesPlayed).isZero
+            assertThat(stats.gamesStarted).isZero
+            assertThat(stats.inningsPitchedOuts).isZero
+            assertThat(stats.earnedRuns).isZero
+            assertThat(stats.runsAllowed).isZero
+            assertThat(stats.hitsAllowed).isZero
+            assertThat(stats.walksAllowed).isZero
+            assertThat(stats.strikeouts).isZero
+            assertThat(stats.homeRunsAllowed).isZero
+            assertThat(stats.hitBatsmen).isZero
+            assertThat(stats.wildPitches).isZero
+            assertThat(stats.balks).isZero
+            assertThat(stats.battersFaced).isZero
+            assertThat(stats.pitchesThrown).isZero
+            assertThat(stats.strikesThrown).isZero
+            assertThat(stats.wins).isZero
+        }
+
+        @Test
+        fun `2경기 중 1경기 롤백 시 나머지 경기 기록만 남음`() {
+            // given: 2경기 기록이 반영된 시즌 통계
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val record1 =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    recordOut(isStrikeout = true)
+                    recordOut(isStrikeout = true)
+                    recordOut(isStrikeout = true)
+                    recordHit(isHomeRun = false, runsScored = 1, earnedRuns = 1)
+                }
+            val record2 =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
+                    recordOut(isStrikeout = false)
+                    recordOut(isStrikeout = false)
+                    recordWalk()
+                }
+
+            stats.addGameRecord(record1)
+            stats.addGameRecord(record2)
+
+            assertThat(stats.gamesPlayed).isEqualTo(2)
+            assertThat(stats.gamesStarted).isEqualTo(1)
+            assertThat(stats.strikeouts).isEqualTo(3)
+            assertThat(stats.inningsPitchedOuts).isEqualTo(5)
+
+            // when: 첫 번째 경기 롤백
+            stats.revertGameRecord(record1)
+
+            // then: 두 번째 경기 기록만 남음
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+            assertThat(stats.gamesStarted).isZero
+            assertThat(stats.strikeouts).isZero
+            assertThat(stats.inningsPitchedOuts).isEqualTo(2)
+            assertThat(stats.walksAllowed).isEqualTo(1)
+            assertThat(stats.earnedRuns).isZero
+            assertThat(stats.hitsAllowed).isZero
+        }
+
+        @Test
+        fun `gamesPlayed가 1 감소함`() {
+            // given
+            val record = createMockPitchingRecord()
+            stats.addGameRecord(record)
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.gamesPlayed).isZero
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
@@ -1,0 +1,118 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.core.domain.event.GameCancelledEvent
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * 경기 취소 이벤트 리스너
+ *
+ * GameCancelledEvent 수신 시 해당 경기에 반영된 시즌 타격/투구 통계를 롤백합니다.
+ *
+ * 롤백 정책:
+ * - 취소된 경기의 BattingRecord에 집계된 타격 기여분을 SeasonBattingStats에서 차감합니다.
+ * - 취소된 경기의 PitchingRecord에 집계된 투구 기여분을 SeasonPitchingStats에서 차감합니다.
+ * - 몰수(FORFEITED) 경기는 이 리스너가 처리하지 않습니다. 몰수 시점까지의 개인 기록은
+ *   KBO/MLB 기준에 따라 공식 기록으로 유효합니다.
+ */
+@Component
+class GameCancelEventListener(
+    private val seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort,
+    private val seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort,
+    private val battingRecordRepository: BattingRecordRepositoryPort,
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+) {
+    private val logger = LoggerFactory.getLogger(GameCancelEventListener::class.java)
+
+    /**
+     * 경기 취소 이벤트를 처리합니다.
+     *
+     * 취소된 경기에 기여한 모든 선수의 시즌 타격/투구 통계를 롤백합니다.
+     * AFTER_COMMIT 단계에서 실행하여 취소 트랜잭션이 완전히 커밋된 이후 통계를 역산합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional
+    fun onGameCancelled(event: GameCancelledEvent) {
+        val gameId = event.gameId
+        logger.info("경기 취소 스탯 롤백 시작 (gameId={})", gameId)
+
+        val battingRecords = battingRecordRepository.findAllByGameId(gameId)
+        val pitchingRecords = pitchingRecordRepository.findAllByGameId(gameId)
+
+        if (battingRecords.isEmpty() && pitchingRecords.isEmpty()) {
+            logger.info(
+                "경기 취소 스탯 롤백 완료 - 롤백할 기록 없음 (gameId={})",
+                gameId,
+            )
+            return
+        }
+
+        // 타격 스탯 롤백
+        if (battingRecords.isNotEmpty()) {
+            val seasonBattingStatsList = seasonBattingStatsRepository.findAllByGameId(gameId)
+            val statsByPlayerId = seasonBattingStatsList.associateBy { it.player.id }
+
+            for (battingRecord in battingRecords) {
+                val playerId = battingRecord.gamePlayer.player.id
+                val stats = statsByPlayerId[playerId]
+
+                if (stats == null) {
+                    logger.debug(
+                        "시즌 타격 통계 없음 - 롤백 건너뜀 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                } else {
+                    stats.revertGameRecord(battingRecord)
+                    seasonBattingStatsRepository.save(stats)
+                    logger.debug(
+                        "시즌 타격 통계 롤백 완료 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                }
+            }
+        }
+
+        // 투구 스탯 롤백
+        if (pitchingRecords.isNotEmpty()) {
+            val seasonPitchingStatsList = seasonPitchingStatsRepository.findAllByGameId(gameId)
+            val statsByPlayerId = seasonPitchingStatsList.associateBy { it.player.id }
+
+            for (pitchingRecord in pitchingRecords) {
+                val playerId = pitchingRecord.gamePlayer.player.id
+                val stats = statsByPlayerId[playerId]
+
+                if (stats == null) {
+                    logger.debug(
+                        "시즌 투구 통계 없음 - 롤백 건너뜀 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                } else {
+                    stats.revertGameRecord(pitchingRecord)
+                    seasonPitchingStatsRepository.save(stats)
+                    logger.debug(
+                        "시즌 투구 통계 롤백 완료 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                }
+            }
+        }
+
+        logger.info(
+            "경기 취소 스탯 롤백 완료 (gameId={}, battingRecords={}, pitchingRecords={})",
+            gameId,
+            battingRecords.size,
+            pitchingRecords.size,
+        )
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonBattingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonBattingStatsRepository.kt
@@ -171,4 +171,24 @@ interface SeasonBattingStatsRepository :
         @Param("minPlateAppearances") minPlateAppearances: Int,
         @Param("limit") limit: Int,
     ): List<SeasonBattingStats>
+
+    /**
+     * 특정 경기에 출전하여 타격 기록이 있는 선수들의 시즌 타격 통계를 조회합니다.
+     * 경기 연도를 기준으로 해당 선수들의 시즌 타격 통계를 반환합니다.
+     */
+    @Query(
+        """
+        SELECT DISTINCT sbs FROM SeasonBattingStats sbs
+        WHERE sbs.player.id IN (
+            SELECT br.gamePlayer.player.id FROM BattingRecord br
+            WHERE br.gamePlayer.game.id = :gameId
+        )
+        AND sbs.year = (
+            SELECT FUNCTION('YEAR', g.scheduledAt) FROM Game g WHERE g.id = :gameId
+        )
+    """,
+    )
+    override fun findAllByGameId(
+        @Param("gameId") gameId: Long
+    ): List<SeasonBattingStats>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonPitchingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonPitchingStatsRepository.kt
@@ -119,4 +119,24 @@ interface SeasonPitchingStatsRepository :
         @Param("minInningsPitchedOuts") minInningsPitchedOuts: Int,
         @Param("limit") limit: Int,
     ): List<SeasonPitchingStats>
+
+    /**
+     * 특정 경기에 등판하여 투구 기록이 있는 선수들의 시즌 투구 통계를 조회합니다.
+     * 경기 연도를 기준으로 해당 선수들의 시즌 투구 통계를 반환합니다.
+     */
+    @Query(
+        """
+        SELECT DISTINCT sps FROM SeasonPitchingStats sps
+        WHERE sps.player.id IN (
+            SELECT pr.gamePlayer.player.id FROM PitchingRecord pr
+            WHERE pr.gamePlayer.game.id = :gameId
+        )
+        AND sps.year = (
+            SELECT FUNCTION('YEAR', g.scheduledAt) FROM Game g WHERE g.id = :gameId
+        )
+    """,
+    )
+    override fun findAllByGameId(
+        @Param("gameId") gameId: Long
+    ): List<SeasonPitchingStats>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -7,6 +7,7 @@ import com.nextup.common.exception.InvalidGameStateException
 import com.nextup.common.exception.NoEventToUndoException
 import com.nextup.common.exception.PitchingRecordNotFoundException
 import com.nextup.common.exception.UndoNotAvailableException
+import com.nextup.core.domain.event.GameCancelledEvent
 import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlateAppearanceUndoneEvent
@@ -394,6 +395,27 @@ class GameScorerServiceImpl(
 
         val savedGame = gameRepository.save(game)
         publishGameResultEvent(gameId)
+        return savedGame
+    }
+
+    @Transactional
+    override fun cancelGame(
+        gameId: Long,
+        reason: String?,
+    ): Game {
+        val game = findGame(gameId)
+
+        if (game.status != GameStatus.SCHEDULED && game.status != GameStatus.POSTPONED) {
+            throw InvalidGameStateException(
+                "예정 또는 연기 상태의 경기만 취소할 수 있습니다. 현재 상태: ${game.status.displayName}",
+            )
+        }
+
+        game.cancel(reason)
+        val savedGame = gameRepository.save(game)
+
+        eventPublisher.publishEvent(GameCancelledEvent(gameId = gameId))
+
         return savedGame
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
@@ -1,0 +1,245 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.core.domain.event.GameCancelledEvent
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.PitchingDecision
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("GameCancelEventListener 테스트")
+class GameCancelEventListenerTest {
+    private val seasonBattingStatsRepository = mockk<SeasonBattingStatsRepositoryPort>()
+    private val seasonPitchingStatsRepository = mockk<SeasonPitchingStatsRepositoryPort>()
+    private val battingRecordRepository = mockk<BattingRecordRepositoryPort>()
+    private val pitchingRecordRepository = mockk<PitchingRecordRepositoryPort>()
+
+    private val listener =
+        GameCancelEventListener(
+            seasonBattingStatsRepository = seasonBattingStatsRepository,
+            seasonPitchingStatsRepository = seasonPitchingStatsRepository,
+            battingRecordRepository = battingRecordRepository,
+            pitchingRecordRepository = pitchingRecordRepository,
+        )
+
+    private val testBatter =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
+
+    private val testPitcher =
+        Player(
+            name = "박투수",
+            primaryPosition = Position.STARTING_PITCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 2L,
+        )
+
+    private val mockBattingRecord = mockk<BattingRecord>(relaxed = true)
+    private val mockPitchingRecord = mockk<PitchingRecord>(relaxed = true)
+    private val mockBatterGamePlayer = mockk<GamePlayer>()
+    private val mockPitcherGamePlayer = mockk<GamePlayer>()
+
+    private val gameId = 100L
+    private val cancelEvent = GameCancelledEvent(gameId = gameId)
+
+    @BeforeEach
+    fun setUp() {
+        every { mockBattingRecord.gamePlayer } returns mockBatterGamePlayer
+        every { mockBatterGamePlayer.player } returns testBatter
+        every { mockPitchingRecord.gamePlayer } returns mockPitcherGamePlayer
+        every { mockPitcherGamePlayer.player } returns testPitcher
+    }
+
+    @Nested
+    @DisplayName("onGameCancelled - 경기 취소 이벤트 처리")
+    inner class OnGameCancelled {
+        @Test
+        fun `타격 기록이 있는 경우 시즌 타격 통계가 롤백됨`() {
+            // given
+            val stats = SeasonBattingStats.create(testBatter, 2024)
+            // 경기 기여분을 수동으로 추가 (gamesPlayed 1, plateAppearances 1)
+            stats.addGameRecord(
+                BattingRecord(mockBatterGamePlayer).also {
+                    it.applyPlateAppearanceResult(
+                        com.nextup.core.domain.game.PlateAppearanceResult.SINGLE,
+                    )
+                },
+            )
+            val initialGamesPlayed = stats.gamesPlayed
+            val initialHits = stats.hits
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns listOf(mockBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns listOf(stats)
+            every { seasonBattingStatsRepository.save(any()) } returns stats
+            every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+
+            every { mockBattingRecord.plateAppearances } returns 1
+            every { mockBattingRecord.atBats } returns 1
+            every { mockBattingRecord.hits } returns 1
+            every { mockBattingRecord.doubles } returns 0
+            every { mockBattingRecord.triples } returns 0
+            every { mockBattingRecord.homeRuns } returns 0
+            every { mockBattingRecord.runs } returns 0
+            every { mockBattingRecord.runsBattedIn } returns 0
+            every { mockBattingRecord.walks } returns 0
+            every { mockBattingRecord.intentionalWalks } returns 0
+            every { mockBattingRecord.hitByPitch } returns 0
+            every { mockBattingRecord.strikeouts } returns 0
+            every { mockBattingRecord.sacrificeBunts } returns 0
+            every { mockBattingRecord.sacrificeFlies } returns 0
+            every { mockBattingRecord.stolenBases } returns 0
+            every { mockBattingRecord.caughtStealing } returns 0
+            every { mockBattingRecord.groundedIntoDoublePlays } returns 0
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            assertThat(stats.gamesPlayed).isEqualTo(initialGamesPlayed - 1)
+            assertThat(stats.hits).isEqualTo(initialHits - 1)
+            verify { seasonBattingStatsRepository.save(stats) }
+        }
+
+        @Test
+        fun `타격 및 투구 기록이 없는 경우 아무것도 저장하지 않음`() {
+            // given
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            verify(exactly = 0) { seasonBattingStatsRepository.save(any()) }
+            verify(exactly = 0) { seasonPitchingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `시즌 타격 통계가 없는 선수는 건너뜀`() {
+            // given
+            every { battingRecordRepository.findAllByGameId(gameId) } returns listOf(mockBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then: 통계가 없으므로 save 호출 없음
+            verify(exactly = 0) { seasonBattingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `투구 기록이 있는 경우 시즌 투구 통계가 롤백됨`() {
+            // given
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns listOf(mockPitchingRecord)
+            every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns listOf(pitchingStats)
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
+
+            every { mockPitchingRecord.isStartingPitcher } returns false
+            every { mockPitchingRecord.inningsPitchedOuts } returns 0
+            every { mockPitchingRecord.earnedRuns } returns 0
+            every { mockPitchingRecord.runsAllowed } returns 0
+            every { mockPitchingRecord.hitsAllowed } returns 0
+            every { mockPitchingRecord.walksAllowed } returns 0
+            every { mockPitchingRecord.strikeouts } returns 0
+            every { mockPitchingRecord.homeRunsAllowed } returns 0
+            every { mockPitchingRecord.hitBatsmen } returns 0
+            every { mockPitchingRecord.wildPitches } returns 0
+            every { mockPitchingRecord.balks } returns 0
+            every { mockPitchingRecord.battersFaced } returns 0
+            every { mockPitchingRecord.pitchesThrown } returns null
+            every { mockPitchingRecord.strikesThrown } returns null
+            every { mockPitchingRecord.decision } returns PitchingDecision.NONE
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            verify { seasonPitchingStatsRepository.save(pitchingStats) }
+        }
+
+        @Test
+        fun `타격과 투구 기록이 모두 있는 경우 모두 롤백됨`() {
+            // given
+            val battingStats = SeasonBattingStats.create(testBatter, 2024)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns listOf(mockBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns listOf(mockPitchingRecord)
+            every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns listOf(battingStats)
+            every { seasonBattingStatsRepository.save(any()) } returns battingStats
+            every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns listOf(pitchingStats)
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
+
+            every { mockBattingRecord.plateAppearances } returns 0
+            every { mockBattingRecord.atBats } returns 0
+            every { mockBattingRecord.hits } returns 0
+            every { mockBattingRecord.doubles } returns 0
+            every { mockBattingRecord.triples } returns 0
+            every { mockBattingRecord.homeRuns } returns 0
+            every { mockBattingRecord.runs } returns 0
+            every { mockBattingRecord.runsBattedIn } returns 0
+            every { mockBattingRecord.walks } returns 0
+            every { mockBattingRecord.intentionalWalks } returns 0
+            every { mockBattingRecord.hitByPitch } returns 0
+            every { mockBattingRecord.strikeouts } returns 0
+            every { mockBattingRecord.sacrificeBunts } returns 0
+            every { mockBattingRecord.sacrificeFlies } returns 0
+            every { mockBattingRecord.stolenBases } returns 0
+            every { mockBattingRecord.caughtStealing } returns 0
+            every { mockBattingRecord.groundedIntoDoublePlays } returns 0
+
+            every { mockPitchingRecord.isStartingPitcher } returns false
+            every { mockPitchingRecord.inningsPitchedOuts } returns 0
+            every { mockPitchingRecord.earnedRuns } returns 0
+            every { mockPitchingRecord.runsAllowed } returns 0
+            every { mockPitchingRecord.hitsAllowed } returns 0
+            every { mockPitchingRecord.walksAllowed } returns 0
+            every { mockPitchingRecord.strikeouts } returns 0
+            every { mockPitchingRecord.homeRunsAllowed } returns 0
+            every { mockPitchingRecord.hitBatsmen } returns 0
+            every { mockPitchingRecord.wildPitches } returns 0
+            every { mockPitchingRecord.balks } returns 0
+            every { mockPitchingRecord.battersFaced } returns 0
+            every { mockPitchingRecord.pitchesThrown } returns null
+            every { mockPitchingRecord.strikesThrown } returns null
+            every { mockPitchingRecord.decision } returns PitchingDecision.NONE
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then: 타격과 투구 모두 저장됨
+            verify { seasonBattingStatsRepository.save(battingStats) }
+            verify { seasonPitchingStatsRepository.save(pitchingStats) }
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
@@ -154,6 +154,21 @@ class GameCancelEventListenerTest {
         }
 
         @Test
+        fun `시즌 투구 통계가 없는 선수는 건너뜀`() {
+            // given
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns listOf(mockPitchingRecord)
+            every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then: 통계가 없으므로 save 호출 없음
+            verify(exactly = 0) { seasonPitchingStatsRepository.save(any()) }
+        }
+
+        @Test
         fun `투구 기록이 있는 경우 시즌 투구 통계가 롤백됨`() {
             // given
             val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -7,6 +7,7 @@ import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.event.GameCancelledEvent
 import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.game.Base
 import com.nextup.core.domain.game.Game
@@ -1143,6 +1144,110 @@ class GameScorerServiceImplTest {
             // then - winnerTeam==homeTeam → loserTeam==awayTeam
             verify { winnerPitcher.assignWin() }
             verify { loserPitcher.assignLoss() }
+            verify(exactly = 2) { pitchingRecordRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelGame")
+    inner class CancelGame {
+        @Test
+        fun `should cancel game when status is SCHEDULED`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.cancelGame(1L, "우천 취소")
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.CANCELLED)
+            verify { gameRepository.save(any()) }
+            verify { eventPublisher.publishEvent(any<GameCancelledEvent>()) }
+        }
+
+        @Test
+        fun `should cancel game when status is POSTPONED`() {
+            // given
+            val game = createGame(1L, GameStatus.POSTPONED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.cancelGame(1L, "대회 취소")
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.CANCELLED)
+            verify { gameRepository.save(any()) }
+            verify { eventPublisher.publishEvent(any<GameCancelledEvent>()) }
+        }
+
+        @Test
+        fun `should cancel game without reason`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = gameScorerService.cancelGame(1L, null)
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.CANCELLED)
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when game is IN_PROGRESS`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { gameScorerService.cancelGame(1L, "사유") }
+                .isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("예정 또는 연기 상태의 경기만 취소할 수 있습니다")
+        }
+
+        @Test
+        fun `should throw exception when game is FINISHED`() {
+            // given
+            val game = createGame(1L, GameStatus.FINISHED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { gameScorerService.cancelGame(1L, "사유") }
+                .isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("예정 또는 연기 상태의 경기만 취소할 수 있습니다")
+        }
+
+        @Test
+        fun `should throw exception when game not found`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy { gameScorerService.cancelGame(999L, "사유") }
+                .isInstanceOf(GameNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should publish GameCancelledEvent with correct gameId`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val eventSlot = slot<GameCancelledEvent>()
+            every { eventPublisher.publishEvent(capture(eventSlot)) } returns Unit
+
+            // when
+            gameScorerService.cancelGame(1L, "우천 취소")
+
+            // then
+            verify(exactly = 1) { eventPublisher.publishEvent(any<GameCancelledEvent>()) }
+            assertThat(eventSlot.captured.gameId).isEqualTo(1L)
         }
     }
 

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -2,6 +2,7 @@ package com.nextup.scorer.controller.game
 
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.game.GameScorerService
+import com.nextup.scorer.dto.game.CancelGameRequestDto
 import com.nextup.scorer.dto.game.ForfeitRequestDto
 import com.nextup.scorer.dto.game.GameEndRequestDto
 import com.nextup.scorer.dto.game.GameResponse

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -92,6 +92,7 @@ class GameScorerController(
      * 경기를 몰수 처리합니다.
      *
      * 승리팀에 7점, 패배팀에 0점을 자동 반영하고 경기를 종료합니다.
+     * 몰수 시점까지의 개인 타격/투구 기록은 공식 기록으로 유효합니다 (KBO/MLB 기준).
      */
     @PostMapping("/{gameId}/forfeit")
     @ResponseStatus(HttpStatus.OK)
@@ -104,6 +105,26 @@ class GameScorerController(
                 gameId = gameId,
                 winnerTeamId = request.winnerTeamId!!,
                 reason = request.reason!!,
+            )
+        return ApiResponse.success(game.toResponse())
+    }
+
+    /**
+     * 경기를 취소합니다.
+     *
+     * 예정(SCHEDULED) 또는 연기(POSTPONED) 상태의 경기만 취소 가능합니다.
+     * 취소된 경기에 실시간 반영된 시즌 타격/투구 통계는 자동으로 롤백됩니다.
+     */
+    @PostMapping("/{gameId}/cancel")
+    @ResponseStatus(HttpStatus.OK)
+    fun cancelGame(
+        @PathVariable gameId: Long,
+        @RequestBody request: CancelGameRequestDto = CancelGameRequestDto()
+    ): ApiResponse<GameResponse> {
+        val game =
+            gameScorerService.cancelGame(
+                gameId = gameId,
+                reason = request.reason,
             )
         return ApiResponse.success(game.toResponse())
     }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/CancelGameRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/CancelGameRequestDto.kt
@@ -1,0 +1,8 @@
+package com.nextup.scorer.dto.game
+
+/**
+ * 경기 취소 요청 DTO
+ */
+data class CancelGameRequestDto(
+    val reason: String? = null,
+)

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -357,6 +357,52 @@ class GameScorerControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/cancel")
+    inner class CancelGame {
+
+        @Test
+        fun `should cancel game successfully`() {
+            // given
+            val gameId = 1L
+            val game = createGame(gameId, GameStatus.CANCELLED)
+            every { gameScorerService.cancelGame(gameId, "우천 취소") } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/cancel")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf("reason" to "우천 취소")))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(gameId))
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"))
+
+            verify(exactly = 1) { gameScorerService.cancelGame(gameId, "우천 취소") }
+        }
+
+        @Test
+        fun `should cancel game without reason`() {
+            // given
+            val gameId = 1L
+            val game = createGame(gameId, GameStatus.CANCELLED)
+            every { gameScorerService.cancelGame(gameId, null) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/cancel")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf<String, String?>()))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"))
+
+            verify(exactly = 1) { gameScorerService.cancelGame(gameId, null) }
+        }
+    }
+
     private fun createAssociation(
         id: Long,
         name: String


### PR DESCRIPTION
## Summary

>- close #217

경기 취소 시 이미 반영된 실시간 스탯을 롤백하고, 몰수게임 개인 기록 정책을 명문화합니다.

## Tasks

- GameCancelledEvent 도메인 이벤트 추가
- SeasonBattingStats.revertGameRecord(): 취소 경기 타격 기여분 일괄 차감
- SeasonPitchingStats.revertGameRecord(): 취소 경기 투구 기여분 일괄 차감
- GameCancelEventListener: 이벤트 수신 시 시즌 스탯 롤백
- cancelGame() API 엔드포인트 추가 (Scorer)
- 몰수게임 정책: 개인 기록 유효 (KBO/MLB 기준)
- 단위 테스트 10건 (revert 5 + listener 5)

## To Reviewer

- 음수 방지 로직 포함 (차감 후 0 미만 방지)
- 몰수게임: forfeitGame()에 정책 주석 명시
- 취소/몰수 구분 명확: 취소=스탯 롤백, 몰수=개인기록 유효+점수 7-0