### PR TITLE
feat(#229): 기록 상세화 (투구 수 경고, 타순 위반 감지, 수비 이력, 타점 경로)

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/GameRules.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/GameRules.kt
@@ -50,6 +50,12 @@ data class GameRules(
     /** 시간 제한 (분, null이면 무제한) */
     @Column(name = "time_limit_minutes")
     val timeLimitMinutes: Int? = null,
+    /** 투구 수 제한 (null이면 무제한, 사회인 야구 투구 수 보호 규칙) */
+    @Column(name = "pitch_count_limit")
+    val pitchCountLimit: Int? = null,
+    /** 투구 수 경고 임박 기준 (제한 대비 몇 구 전에 경고할지, 기본 10구) */
+    @Column(name = "pitch_count_warning_threshold")
+    val pitchCountWarningThreshold: Int = 10,
 ) {
     init {
         require(defaultInnings in 3..12) { "기본 이닝은 3~12 사이여야 합니다." }
@@ -76,5 +82,11 @@ data class GameRules(
         timeLimitMinutes?.let {
             require(it > 0) { "시간 제한은 양수여야 합니다." }
         }
+
+        pitchCountLimit?.let {
+            require(it > 0) { "투구 수 제한은 양수여야 합니다." }
+        }
+
+        require(pitchCountWarningThreshold > 0) { "투구 수 경고 임박 기준은 양수여야 합니다." }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/BattingOrderViolationEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/BattingOrderViolationEvent.kt
@@ -1,0 +1,26 @@
+package com.nextup.core.domain.event
+
+/**
+ * 타순 위반 감지 이벤트
+ *
+ * 타석 기록 시 현재 타자가 올바른 타순이 아닐 때 발행됩니다.
+ * 사회인 야구의 유연성을 고려하여 예외(Exception)가 아닌 경고(Warning) 이벤트로 처리합니다.
+ * 기록원이 실수를 인지하고 수동 수정할 수 있도록 알림을 제공합니다.
+ *
+ * @property gameId 경기 ID
+ * @property gamePlayerId 타자 GamePlayer ID
+ * @property playerId 타자 Player ID
+ * @property expectedBattingOrder 예상 타순
+ * @property actualBattingOrder 실제 입력된 타자의 타순
+ * @property inning 발생 이닝
+ * @property isTopInning 초(true)/말(false) 여부
+ */
+data class BattingOrderViolationEvent(
+    val gameId: Long,
+    val gamePlayerId: Long,
+    val playerId: Long,
+    val expectedBattingOrder: Int,
+    val actualBattingOrder: Int,
+    val inning: Int,
+    val isTopInning: Boolean,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/PitchCountWarningEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/PitchCountWarningEvent.kt
@@ -1,0 +1,40 @@
+package com.nextup.core.domain.event
+
+/**
+ * 투구 수 제한 경고 이벤트
+ *
+ * 투수의 투구 수가 제한에 임박하거나 초과했을 때 발행됩니다.
+ * 사회인 야구 투수 보호 규칙 지원을 위한 알림 이벤트입니다.
+ *
+ * @property gameId 경기 ID
+ * @property gamePlayerId 투수 GamePlayer ID
+ * @property playerId 투수 Player ID
+ * @property pitchesThrown 현재까지 던진 투구 수
+ * @property pitchCountLimit 투구 수 제한
+ * @property warningType 경고 유형
+ */
+data class PitchCountWarningEvent(
+    val gameId: Long,
+    val gamePlayerId: Long,
+    val playerId: Long,
+    val pitchesThrown: Int,
+    val pitchCountLimit: Int,
+    val warningType: PitchCountWarningType,
+) {
+    /** 남은 투구 수 (제한 초과 시 음수) */
+    val remainingPitches: Int
+        get() = pitchCountLimit - pitchesThrown
+}
+
+/**
+ * 투구 수 경고 유형
+ */
+enum class PitchCountWarningType(
+    val displayName: String,
+) {
+    /** 투구 수 제한 임박 (threshold 이하 남음) */
+    APPROACHING_LIMIT("투구 수 제한 임박"),
+
+    /** 투구 수 제한 도달 */
+    LIMIT_REACHED("투구 수 제한 도달"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -52,6 +52,13 @@ class GameEvent(
     val runsScored: Int = 0,
     @Column(nullable = false)
     val rbis: Int = 0,
+    /**
+     * 득점 주자 ID 목록 (D-15: 타점 경로 상세 기록)
+     * 형식: "playerId1,playerId2,..." (CSV)
+     * 홈런 타자 자신은 타자 ID로 포함됨
+     */
+    @Column(name = "scoring_runner_ids", columnDefinition = "TEXT")
+    val scoringRunnerIds: String? = null,
     @Column(name = "event_timestamp", nullable = false)
     val eventTimestamp: Instant = Instant.now(),
     @Column(nullable = false)
@@ -63,6 +70,11 @@ class GameEvent(
     fun markUndone() {
         undone = true
     }
+
+    /**
+     * 득점 주자 ID 목록을 반환합니다 (D-15: 타점 경로).
+     */
+    fun getScoringRunnerIdList(): List<Long> = parseScoringRunnerIds(scoringRunnerIds)
 
     companion object {
         /**
@@ -80,6 +92,7 @@ class GameEvent(
             runnersAfterJson: String?,
             runsScored: Int = 0,
             rbis: Int = 0,
+            scoringRunnerIds: List<Long> = emptyList(),
         ): GameEvent =
             GameEvent(
                 game = game,
@@ -96,7 +109,16 @@ class GameEvent(
                 plateAppearanceResult = result,
                 runsScored = runsScored,
                 rbis = rbis,
+                scoringRunnerIds = scoringRunnerIds.joinToString(",").ifEmpty { null },
             )
+
+        /**
+         * 득점 주자 ID 목록을 파싱합니다.
+         */
+        fun parseScoringRunnerIds(scoringRunnerIds: String?): List<Long> {
+            if (scoringRunnerIds.isNullOrBlank()) return emptyList()
+            return scoringRunnerIds.split(",").mapNotNull { it.trim().toLongOrNull() }
+        }
 
         /**
          * 이닝 전환 이벤트를 생성합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
@@ -12,4 +12,5 @@ enum class GameEventType(
     PITCHING_CHANGE("투수 교체"),
     INNING_CHANGE("이닝 전환"),
     GAME_STATUS("경기 상태 변경"),
+    POSITION_CHANGE("포지션 변경"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GamePlayer.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GamePlayer.kt
@@ -70,6 +70,14 @@ class GamePlayer(
         protected set
 
     /**
+     * 포지션 변경 이력 (JSON 형식: "이닝:포지션,이닝:포지션,...")
+     * 예: "1:PITCHER,3:FIRST_BASE"
+     */
+    @Column(name = "position_history", columnDefinition = "TEXT")
+    var positionHistory: String? = null
+        protected set
+
+    /**
      * 선발 출전 선수인지 확인합니다.
      */
     val isStartingLineup: Boolean
@@ -115,10 +123,59 @@ class GamePlayer(
 
     /**
      * 포지션을 변경합니다.
+     * 변경 전 포지션과 이닝을 이력에 기록합니다.
+     *
+     * @param newPosition 새 포지션
+     * @param currentInning 현재 이닝 (이력 기록용, null이면 이력 미기록)
      */
-    fun changePosition(newPosition: Position) {
+    fun changePosition(
+        newPosition: Position,
+        currentInning: Int? = null,
+    ) {
         require(isCurrentlyPlaying) { "현재 출전 중인 선수만 포지션을 변경할 수 있습니다." }
+        if (currentInning != null) {
+            recordPositionHistory(currentInning, this.position)
+        }
         this.position = newPosition
+    }
+
+    /**
+     * 포지션 이력을 추가합니다.
+     * 형식: "이닝:포지션명" (예: "1:PITCHER,3:FIRST_BASE")
+     */
+    private fun recordPositionHistory(
+        inning: Int,
+        previousPosition: Position,
+    ) {
+        val entry = "$inning:${previousPosition.name}"
+        positionHistory =
+            if (positionHistory.isNullOrBlank()) {
+                entry
+            } else {
+                "$positionHistory,$entry"
+            }
+    }
+
+    /**
+     * 포지션 이력을 파싱하여 반환합니다.
+     * @return 이닝-포지션 쌍의 목록 (이닝 오름차순)
+     */
+    fun getPositionHistoryList(): List<Pair<Int, Position>> {
+        if (positionHistory.isNullOrBlank()) return emptyList()
+        return positionHistory!!
+            .split(",")
+            .mapNotNull { entry ->
+                val parts = entry.split(":")
+                if (parts.size == 2) {
+                    val inning = parts[0].trim().toIntOrNull() ?: return@mapNotNull null
+                    val position =
+                        runCatching { Position.valueOf(parts[1].trim()) }.getOrNull() ?: return@mapNotNull null
+                    Pair(inning, position)
+                } else {
+                    null
+                }
+            }
+            .sortedBy { it.first }
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
@@ -283,4 +283,41 @@ class GameState(
      */
     val countDisplay: String
         get() = "${balls}B-${strikes}S"
+
+    /**
+     * 타자의 타순이 올바른지 검증합니다 (D-17: 타순 위반 감지).
+     *
+     * 사회인 야구의 유연성을 고려하여 예외가 아닌 검증 결과를 반환합니다.
+     * 위반 시 호출자(Service)가 경고 이벤트를 발행합니다.
+     *
+     * @param batterBattingOrder 타석에 들어선 타자의 타순
+     * @param isHomeTeam 홈팀 여부
+     * @return 타순 위반 결과 (null이면 정상)
+     */
+    fun validateBattingOrder(
+        batterBattingOrder: Int?,
+        isHomeTeam: Boolean,
+    ): BattingOrderViolation? {
+        if (batterBattingOrder == null) return null
+        val expectedOrder = if (isHomeTeam) homeBattingOrder else awayBattingOrder
+        return if (batterBattingOrder != expectedOrder) {
+            BattingOrderViolation(
+                expectedBattingOrder = expectedOrder,
+                actualBattingOrder = batterBattingOrder,
+            )
+        } else {
+            null
+        }
+    }
 }
+
+/**
+ * 타순 위반 정보
+ *
+ * @property expectedBattingOrder 예상 타순
+ * @property actualBattingOrder 실제 입력된 타순
+ */
+data class BattingOrderViolation(
+    val expectedBattingOrder: Int,
+    val actualBattingOrder: Int,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchCountStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchCountStatus.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.domain.game
+
+/**
+ * 투구 수 제한 상태
+ *
+ * 투수의 현재 투구 수가 규칙상 제한과 비교하여 어떤 상태인지를 나타냅니다.
+ */
+enum class PitchCountStatus(
+    val displayName: String,
+) {
+    /** 투구 수 제한 임박 (threshold 이하 남음) */
+    APPROACHING_LIMIT("투구 수 제한 임박"),
+
+    /** 투구 수 제한 도달 */
+    LIMIT_REACHED("투구 수 제한 도달"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
@@ -297,6 +297,25 @@ class PitchingRecord(
     }
 
     /**
+     * 투구 수 한계 상태를 확인합니다 (D-20: 투구 수 경고).
+     *
+     * @param limit 투구 수 제한
+     * @param warningThreshold 경고 임박 기준 (제한 대비 몇 구 전에 경고할지)
+     * @return 투구 수 경고 상태 (null이면 정상 또는 투구 수 미기록)
+     */
+    fun checkPitchCountStatus(
+        limit: Int,
+        warningThreshold: Int = 10,
+    ): PitchCountStatus? {
+        val thrown = pitchesThrown ?: return null
+        return when {
+            thrown >= limit -> PitchCountStatus.LIMIT_REACHED
+            thrown >= limit - warningThreshold -> PitchCountStatus.APPROACHING_LIMIT
+            else -> null
+        }
+    }
+
+    /**
      * 선발 투수로 설정합니다.
      */
     fun setAsStartingPitcher() {

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScorerService.kt
@@ -3,6 +3,7 @@ package com.nextup.core.service.game
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.service.game.dto.GameEndReason
+import com.nextup.core.service.game.dto.PlateAppearanceRecordResult
 import com.nextup.core.service.game.dto.PlateAppearanceRequest
 
 /**
@@ -22,14 +23,16 @@ interface GameScorerService {
     /**
      * 타석 결과를 기록합니다.
      *
+     * 타석 기록 후 투구 수 경고, 타순 위반 경고 등을 함께 반환합니다.
+     *
      * @param gameId 경기 ID
      * @param request 타석 결과 요청
-     * @return 업데이트된 경기
+     * @return 업데이트된 경기와 경고 목록
      */
     fun recordPlateAppearance(
         gameId: Long,
         request: PlateAppearanceRequest,
-    ): Game
+    ): PlateAppearanceRecordResult
 
     /**
      * 반 이닝을 진행합니다 (공수 교대).

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/PlateAppearanceRecordResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/PlateAppearanceRecordResult.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.service.game.dto
+
+import com.nextup.core.domain.game.Game
+
+/**
+ * 타석 결과 기록 후 반환 DTO
+ *
+ * 경기 상태와 함께 경고 메시지를 포함합니다.
+ *
+ * @property game 업데이트된 경기 엔티티
+ * @property warnings 경고 메시지 목록 (투구 수 경고, 타순 위반 경고 등)
+ */
+data class PlateAppearanceRecordResult(
+    val game: Game,
+    val warnings: List<String> = emptyList(),
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
@@ -141,6 +141,113 @@ class GameEventTest {
     }
 
     @Nested
+    @DisplayName("createPlateAppearance - scoringRunnerIds (D-15)")
+    inner class CreatePlateAppearanceWithScoringRunnerIds {
+        @Test
+        fun `should record scoring runner ids for home run`() {
+            // given
+            val scoringRunnerIds = listOf(100L, 101L)
+
+            // when
+            val event =
+                GameEvent.createPlateAppearance(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.HOME_RUN,
+                    description = "2점 홈런",
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runnersAfterJson = null,
+                    runsScored = 2,
+                    rbis = 2,
+                    scoringRunnerIds = scoringRunnerIds,
+                )
+
+            // then
+            assertThat(event.getScoringRunnerIdList()).containsExactly(100L, 101L)
+            assertThat(event.scoringRunnerIds).isEqualTo("100,101")
+        }
+
+        @Test
+        fun `should return empty list when no scoring runners`() {
+            // when
+            val event =
+                GameEvent.createPlateAppearance(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.SINGLE,
+                    description = "우전 안타",
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runnersAfterJson = null,
+                    runsScored = 0,
+                    rbis = 0,
+                )
+
+            // then
+            assertThat(event.getScoringRunnerIdList()).isEmpty()
+            assertThat(event.scoringRunnerIds).isNull()
+        }
+
+        @Test
+        fun `should record single scoring runner for RBI single`() {
+            // given
+            val scoringRunnerIds = listOf(200L)
+
+            // when
+            val event =
+                GameEvent.createPlateAppearance(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.SINGLE,
+                    description = "중전 적시타",
+                    outCountBefore = 1,
+                    outCountAfter = 1,
+                    runnersBeforeJson = null,
+                    runnersAfterJson = null,
+                    runsScored = 1,
+                    rbis = 1,
+                    scoringRunnerIds = scoringRunnerIds,
+                )
+
+            // then
+            assertThat(event.getScoringRunnerIdList()).containsExactly(200L)
+        }
+
+        @Test
+        fun `parseScoringRunnerIds should handle null input`() {
+            // when
+            val result = GameEvent.parseScoringRunnerIds(null)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `parseScoringRunnerIds should handle blank input`() {
+            // when
+            val result = GameEvent.parseScoringRunnerIds("  ")
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `parseScoringRunnerIds should parse comma-separated ids`() {
+            // when
+            val result = GameEvent.parseScoringRunnerIds("10,20,30")
+
+            // then
+            assertThat(result).containsExactly(10L, 20L, 30L)
+        }
+    }
+
+    @Nested
     @DisplayName("createGameStatus")
     inner class CreateGameStatus {
         @Test

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GamePlayerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GamePlayerTest.kt
@@ -293,6 +293,111 @@ class GamePlayerTest {
             }.isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("현재 출전 중인 선수만")
         }
+
+        @Test
+        fun `이닝 정보를 포함하여 포지션을 변경하면 이전 포지션이 이력에 기록된다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 2,
+                )
+
+            gamePlayer.changePosition(Position.SECOND_BASE, currentInning = 3)
+
+            assertThat(gamePlayer.position).isEqualTo(Position.SECOND_BASE)
+            assertThat(gamePlayer.positionHistory).isEqualTo("3:SHORTSTOP")
+        }
+
+        @Test
+        fun `포지션을 여러 번 변경하면 모든 이력이 누적된다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 2,
+                )
+
+            gamePlayer.changePosition(Position.SECOND_BASE, currentInning = 3)
+            gamePlayer.changePosition(Position.THIRD_BASE, currentInning = 6)
+
+            assertThat(gamePlayer.position).isEqualTo(Position.THIRD_BASE)
+            assertThat(gamePlayer.positionHistory).isEqualTo("3:SHORTSTOP,6:SECOND_BASE")
+        }
+
+        @Test
+        fun `이닝 정보 없이 포지션을 변경하면 이력에 기록되지 않는다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 2,
+                )
+
+            gamePlayer.changePosition(Position.SECOND_BASE)
+
+            assertThat(gamePlayer.position).isEqualTo(Position.SECOND_BASE)
+            assertThat(gamePlayer.positionHistory).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("포지션 이력 조회")
+    inner class GetPositionHistoryTest {
+        @Test
+        fun `이력이 없으면 빈 목록을 반환한다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 2,
+                )
+
+            assertThat(gamePlayer.getPositionHistoryList()).isEmpty()
+        }
+
+        @Test
+        fun `포지션 이력을 이닝-포지션 쌍으로 반환한다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 2,
+                )
+
+            gamePlayer.changePosition(Position.SECOND_BASE, currentInning = 3)
+            gamePlayer.changePosition(Position.THIRD_BASE, currentInning = 6)
+
+            val history = gamePlayer.getPositionHistoryList()
+
+            assertThat(history).hasSize(2)
+            assertThat(history[0]).isEqualTo(Pair(3, Position.SHORTSTOP))
+            assertThat(history[1]).isEqualTo(Pair(6, Position.SECOND_BASE))
+        }
+
+        @Test
+        fun `이력이 이닝 오름차순으로 정렬되어 반환된다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 2,
+                )
+
+            gamePlayer.changePosition(Position.SECOND_BASE, currentInning = 6)
+            gamePlayer.changePosition(Position.THIRD_BASE, currentInning = 3)
+
+            val history = gamePlayer.getPositionHistoryList()
+
+            assertThat(history[0].first).isEqualTo(3)
+            assertThat(history[1].first).isEqualTo(6)
+        }
     }
 
     @Nested

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameStateTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameStateTest.kt
@@ -950,4 +950,84 @@ class GameStateTest {
         assertThat(gameState.runnerOnSecondPitcherId).isNull()
         assertThat(gameState.runnerOnThirdPitcherId).isNull()
     }
+
+    @Test
+    fun `should return null when batting order is correct for home team`() {
+        // given
+        val gameState = GameState(homeBattingOrder = 3)
+
+        // when
+        val violation = gameState.validateBattingOrder(batterBattingOrder = 3, isHomeTeam = true)
+
+        // then
+        assertThat(violation).isNull()
+    }
+
+    @Test
+    fun `should return null when batting order is correct for away team`() {
+        // given
+        val gameState = GameState(awayBattingOrder = 5)
+
+        // when
+        val violation = gameState.validateBattingOrder(batterBattingOrder = 5, isHomeTeam = false)
+
+        // then
+        assertThat(violation).isNull()
+    }
+
+    @Test
+    fun `should return violation when home team batting order is wrong`() {
+        // given
+        val gameState = GameState(homeBattingOrder = 3)
+
+        // when
+        val violation = gameState.validateBattingOrder(batterBattingOrder = 5, isHomeTeam = true)
+
+        // then
+        assertThat(violation).isNotNull()
+        assertThat(violation!!.expectedBattingOrder).isEqualTo(3)
+        assertThat(violation.actualBattingOrder).isEqualTo(5)
+    }
+
+    @Test
+    fun `should return violation when away team batting order is wrong`() {
+        // given
+        val gameState = GameState(awayBattingOrder = 2)
+
+        // when
+        val violation = gameState.validateBattingOrder(batterBattingOrder = 4, isHomeTeam = false)
+
+        // then
+        assertThat(violation).isNotNull()
+        assertThat(violation!!.expectedBattingOrder).isEqualTo(2)
+        assertThat(violation.actualBattingOrder).isEqualTo(4)
+    }
+
+    @Test
+    fun `should return null when batterBattingOrder is null`() {
+        // given
+        val gameState = GameState(homeBattingOrder = 3)
+
+        // when
+        val violation = gameState.validateBattingOrder(batterBattingOrder = null, isHomeTeam = true)
+
+        // then
+        assertThat(violation).isNull()
+    }
+
+    @Test
+    fun `should not confuse home and away batting orders`() {
+        // given
+        val gameState = GameState(homeBattingOrder = 3, awayBattingOrder = 7)
+
+        // when: correct order for home team but wrong for away team
+        val homeViolation = gameState.validateBattingOrder(batterBattingOrder = 3, isHomeTeam = true)
+        val awayViolation = gameState.validateBattingOrder(batterBattingOrder = 3, isHomeTeam = false)
+
+        // then
+        assertThat(homeViolation).isNull()
+        assertThat(awayViolation).isNotNull()
+        assertThat(awayViolation!!.expectedBattingOrder).isEqualTo(7)
+        assertThat(awayViolation.actualBattingOrder).isEqualTo(3)
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -196,6 +196,93 @@ class PitchingRecordTest {
     }
 
     @Nested
+    @DisplayName("투구 수 제한 상태 확인 (D-20)")
+    inner class CheckPitchCountStatusTest {
+        @Test
+        fun `투구 수 미기록 시 null을 반환한다`() {
+            // given: pitchesThrown is null by default
+
+            // when
+            val status = pitchingRecord.checkPitchCountStatus(limit = 100)
+
+            // then
+            assertThat(status).isNull()
+        }
+
+        @Test
+        fun `투구 수가 제한 미만이고 경고 범위 밖이면 null을 반환한다`() {
+            // given: 100구 제한, 10구 경고 임박 기준, 현재 85구 (경고 범위 밖)
+            pitchingRecord.recordPitchCount(totalPitches = 85, strikes = 50)
+
+            // when
+            val status = pitchingRecord.checkPitchCountStatus(limit = 100, warningThreshold = 10)
+
+            // then
+            assertThat(status).isNull()
+        }
+
+        @Test
+        fun `투구 수가 경고 임박 범위에 들어오면 APPROACHING_LIMIT을 반환한다`() {
+            // given: 100구 제한, 10구 경고 임박 기준, 현재 91구 (제한까지 9구 남음)
+            pitchingRecord.recordPitchCount(totalPitches = 91, strikes = 55)
+
+            // when
+            val status = pitchingRecord.checkPitchCountStatus(limit = 100, warningThreshold = 10)
+
+            // then
+            assertThat(status).isEqualTo(PitchCountStatus.APPROACHING_LIMIT)
+        }
+
+        @Test
+        fun `투구 수가 경고 임박 기준 경계값이면 APPROACHING_LIMIT을 반환한다`() {
+            // given: 100구 제한, 10구 경고 임박 기준, 현재 정확히 90구
+            pitchingRecord.recordPitchCount(totalPitches = 90, strikes = 55)
+
+            // when
+            val status = pitchingRecord.checkPitchCountStatus(limit = 100, warningThreshold = 10)
+
+            // then
+            assertThat(status).isEqualTo(PitchCountStatus.APPROACHING_LIMIT)
+        }
+
+        @Test
+        fun `투구 수가 제한에 도달하면 LIMIT_REACHED를 반환한다`() {
+            // given: 100구 제한, 현재 정확히 100구
+            pitchingRecord.recordPitchCount(totalPitches = 100, strikes = 65)
+
+            // when
+            val status = pitchingRecord.checkPitchCountStatus(limit = 100)
+
+            // then
+            assertThat(status).isEqualTo(PitchCountStatus.LIMIT_REACHED)
+        }
+
+        @Test
+        fun `투구 수가 제한을 초과하면 LIMIT_REACHED를 반환한다`() {
+            // given: 100구 제한, 현재 105구 (초과)
+            pitchingRecord.recordPitchCount(totalPitches = 105, strikes = 65)
+
+            // when
+            val status = pitchingRecord.checkPitchCountStatus(limit = 100)
+
+            // then
+            assertThat(status).isEqualTo(PitchCountStatus.LIMIT_REACHED)
+        }
+
+        @Test
+        fun `기본 경고 임박 기준은 10구이다`() {
+            // given: 80구 제한, 현재 72구 (제한까지 8구 남음 - 기본 10구 기준 내)
+            pitchingRecord.recordPitchCount(totalPitches = 72, strikes = 45)
+
+            // when: warningThreshold 기본값 사용
+            val status = pitchingRecord.checkPitchCountStatus(limit = 80)
+
+            // then
+            assertThat(status).isEqualTo(PitchCountStatus.APPROACHING_LIMIT)
+        }
+    }
+
+    @Nested
     @DisplayName("이닝 계산")
     inner class InningsCalculationTest {
         @Test

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -7,15 +7,20 @@ import com.nextup.common.exception.InvalidGameStateException
 import com.nextup.common.exception.NoEventToUndoException
 import com.nextup.common.exception.PitchingRecordNotFoundException
 import com.nextup.common.exception.UndoNotAvailableException
+import com.nextup.core.domain.event.BattingOrderViolationEvent
 import com.nextup.core.domain.event.GameResultConfirmedEvent
+import com.nextup.core.domain.event.PitchCountWarningEvent
+import com.nextup.core.domain.event.PitchCountWarningType
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlateAppearanceUndoneEvent
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.GameResult
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.domain.game.PitchCountStatus
 import com.nextup.core.domain.game.PitchingDecisionCalculator
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
@@ -26,7 +31,9 @@ import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.BoxScoreService
 import com.nextup.core.service.game.GameScorerService
 import com.nextup.core.service.game.dto.GameEndReason
+import com.nextup.core.service.game.dto.PlateAppearanceRecordResult
 import com.nextup.core.service.game.dto.PlateAppearanceRequest
+import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -46,6 +53,8 @@ class GameScorerServiceImpl(
     private val pitchingRecordRepository: PitchingRecordRepositoryPort,
     private val eventPublisher: ApplicationEventPublisher,
 ) : GameScorerService {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     @Transactional
     override fun startGame(gameId: Long): Game {
         val game = findGame(gameId)
@@ -60,7 +69,7 @@ class GameScorerServiceImpl(
     override fun recordPlateAppearance(
         gameId: Long,
         request: PlateAppearanceRequest,
-    ): Game {
+    ): PlateAppearanceRecordResult {
         val game = findGame(gameId)
 
         // 경기가 진행 중인지 확인
@@ -75,6 +84,12 @@ class GameScorerServiceImpl(
         val pitcher =
             gamePlayerRepository.findByIdOrNull(request.pitcherId)
                 ?: throw GamePlayerNotFoundException(request.pitcherId)
+
+        // 경고 수집
+        val warnings = mutableListOf<String>()
+
+        // 타순 위반 감지 (차단하지 않음 — 사회인 야구 유연성)
+        detectBattingOrderViolation(game, batter, warnings)
 
         // 주자 이동 처리
         val scoredRunnerIds = mutableListOf<Long>()
@@ -132,11 +147,38 @@ class GameScorerServiceImpl(
             ),
         )
 
+        // 현재 주자 상태 스냅샷 (이벤트 기록용)
+        val outCountBefore = game.gameState.outs
+        val runnersBeforeJson = buildRunnersJson(game)
+
         // 다음 타자로 진행
         game.advanceBatter()
         game.resetCount()
 
-        return gameRepository.save(game)
+        val savedGame = gameRepository.save(game)
+
+        // D-15: 타석 이벤트 기록 (득점 주자 ID 포함)
+        val gameEvent =
+            GameEvent.createPlateAppearance(
+                game = savedGame,
+                batter = batter,
+                pitcher = pitcher,
+                result = request.result,
+                description = buildPlateAppearanceDescription(request.result, batter, scoredRunnerIds),
+                outCountBefore = outCountBefore,
+                outCountAfter = savedGame.gameState.outs,
+                runnersBeforeJson = runnersBeforeJson,
+                runnersAfterJson = buildRunnersJson(savedGame),
+                runsScored = scoredRunnerIds.size,
+                rbis = request.getActualRbis(),
+                scoringRunnerIds = scoredRunnerIds,
+            )
+        gameEventRepository.save(gameEvent)
+
+        // 투구 수 경고 감지 (저장 후 현재 투수 기록 기반으로 확인) (D-20)
+        detectPitchCountWarning(savedGame, pitcher, warnings)
+
+        return PlateAppearanceRecordResult(game = savedGame, warnings = warnings)
     }
 
     @Transactional
@@ -255,7 +297,7 @@ class GameScorerServiceImpl(
             GameEventType.PLATE_APPEARANCE -> undoPlateAppearance(game, lastEvent)
             GameEventType.INNING_CHANGE -> undoInningChange(game, lastEvent)
             else -> {
-                // GAME_STATUS, BASE_RUNNING 등은 단순 마킹만 처리
+                // GAME_STATUS, BASE_RUNNING, POSITION_CHANGE 등은 단순 마킹만 처리
             }
         }
 
@@ -397,6 +439,142 @@ class GameScorerServiceImpl(
         return savedGame
     }
 
+    /**
+     * 타순 위반을 감지하고 경고를 추가합니다 (D-17).
+     *
+     * 사회인 야구의 유연성을 위해 차단하지 않고 경고 이벤트를 발행합니다.
+     *
+     * @param game 현재 경기
+     * @param batter 타자 GamePlayer
+     * @param warnings 경고 메시지 수집 목록
+     */
+    private fun detectBattingOrderViolation(
+        game: Game,
+        batter: GamePlayer,
+        warnings: MutableList<String>,
+    ) {
+        val isHomeTeam = !game.isTopInning
+        val violation =
+            game.gameState.validateBattingOrder(
+                batterBattingOrder = batter.battingOrder,
+                isHomeTeam = isHomeTeam,
+            ) ?: return
+
+        val message =
+            "타순 위반 감지: 예상 타순 ${violation.expectedBattingOrder}번, " +
+                "실제 타자 타순 ${violation.actualBattingOrder}번 (타자 GamePlayer ID: ${batter.id})"
+        log.warn(message)
+        warnings.add(
+            "타순 위반: 예상 타순 ${violation.expectedBattingOrder}번이지만 " +
+                "${violation.actualBattingOrder}번 타자가 타석에 들어섰습니다.",
+        )
+
+        eventPublisher.publishEvent(
+            BattingOrderViolationEvent(
+                gameId = game.id,
+                gamePlayerId = batter.id,
+                playerId = batter.player.id,
+                expectedBattingOrder = violation.expectedBattingOrder,
+                actualBattingOrder = violation.actualBattingOrder,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+            ),
+        )
+    }
+
+    /**
+     * 현재 투수의 투구 수 경고를 감지합니다 (D-20).
+     *
+     * pitchesThrown이 기록된 경우에만 검사합니다.
+     * GameRules의 pitchCountLimit을 우선 사용하고, 없으면 기본값을 사용합니다.
+     *
+     * @param game 현재 경기
+     * @param pitcher 현재 투수 GamePlayer
+     * @param warnings 경고 메시지 수집 목록
+     */
+    private fun detectPitchCountWarning(
+        game: Game,
+        pitcher: GamePlayer,
+        warnings: MutableList<String>,
+    ) {
+        val pitchingRecord =
+            pitchingRecordRepository.findByGamePlayer(pitcher)
+                ?: return
+        val pitchesThrown = pitchingRecord.pitchesThrown ?: return
+
+        val gameRules = game.competition.gameRules
+        val limit = gameRules.pitchCountLimit ?: DEFAULT_PITCH_COUNT_WARNING_THRESHOLD
+        val threshold = gameRules.pitchCountWarningThreshold
+
+        val status = pitchingRecord.checkPitchCountStatus(limit, threshold) ?: return
+
+        when (status) {
+            PitchCountStatus.LIMIT_REACHED -> {
+                val logMessage =
+                    "투구 수 경고: 투수(ID: ${pitcher.id}) 투구 수 ${pitchesThrown}구 — 제한(${limit}구) 도달"
+                log.warn(logMessage)
+                warnings.add(
+                    "투구 수 경고: 현재 투수가 ${pitchesThrown}구를 던졌습니다. 투구 수 제한(${limit}구)에 도달했습니다.",
+                )
+                eventPublisher.publishEvent(
+                    PitchCountWarningEvent(
+                        gameId = game.id,
+                        gamePlayerId = pitcher.id,
+                        playerId = pitcher.player.id,
+                        pitchesThrown = pitchesThrown,
+                        pitchCountLimit = limit,
+                        warningType = PitchCountWarningType.LIMIT_REACHED,
+                    ),
+                )
+            }
+            PitchCountStatus.APPROACHING_LIMIT -> {
+                val remaining = limit - pitchesThrown
+                warnings.add(
+                    "투구 수 주의: 현재 투수가 ${pitchesThrown}구를 던졌습니다. " +
+                        "제한(${limit}구)까지 ${remaining}구 남았습니다.",
+                )
+                eventPublisher.publishEvent(
+                    PitchCountWarningEvent(
+                        gameId = game.id,
+                        gamePlayerId = pitcher.id,
+                        playerId = pitcher.player.id,
+                        pitchesThrown = pitchesThrown,
+                        pitchCountLimit = limit,
+                        warningType = PitchCountWarningType.APPROACHING_LIMIT,
+                    ),
+                )
+            }
+        }
+    }
+
+    /**
+     * 현재 주자 상태를 JSON 문자열로 직렬화합니다.
+     * 형식: "1루:playerId,2루:playerId,3루:playerId"
+     */
+    private fun buildRunnersJson(game: Game): String? {
+        val parts = mutableListOf<String>()
+        game.gameState.runnerOnFirstId?.let { parts.add("1루:$it") }
+        game.gameState.runnerOnSecondId?.let { parts.add("2루:$it") }
+        game.gameState.runnerOnThirdId?.let { parts.add("3루:$it") }
+        return if (parts.isEmpty()) null else parts.joinToString(",")
+    }
+
+    /**
+     * 타석 결과 이벤트 설명 문자열을 생성합니다.
+     */
+    private fun buildPlateAppearanceDescription(
+        result: com.nextup.core.domain.game.PlateAppearanceResult,
+        batter: GamePlayer,
+        scoredRunnerIds: List<Long>,
+    ): String {
+        val base = "${batter.player.name} - ${result.displayName}"
+        return if (scoredRunnerIds.isNotEmpty()) {
+            "$base (득점: ${scoredRunnerIds.size}점)"
+        } else {
+            base
+        }
+    }
+
     private fun publishGameResultEvent(gameId: Long) {
         val gameTeams = gameTeamRepository.findAllByGameId(gameId)
         val homeTeam = gameTeams.find { it.homeAway == HomeAway.HOME } ?: return
@@ -415,4 +593,12 @@ class GameScorerServiceImpl(
     private fun findGame(id: Long): Game =
         gameRepository.findByIdOrNull(id)
             ?: throw GameNotFoundException(id)
+
+    companion object {
+        /** 투구 수 경고 기본 임계값 (D-20: 사회인 야구 기준 100구) */
+        const val DEFAULT_PITCH_COUNT_WARNING_THRESHOLD = 100
+
+        /** 투구 수 접근 경고 임계값 (임계값까지 이 구수 이하 남으면 주의 경고) */
+        const val PITCH_COUNT_APPROACHING_THRESHOLD = 20
+    }
 }

--- a/nextup-infrastructure/src/main/resources/db/migration/V023__add_position_history_to_game_players.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V023__add_position_history_to_game_players.sql
@@ -1,0 +1,7 @@
+-- V023: game_players 테이블에 포지션 이력 컬럼 추가
+-- 이슈 #229: 수비 이닝 이력 추적
+
+ALTER TABLE game_players
+    ADD COLUMN IF NOT EXISTS position_history TEXT;
+
+COMMENT ON COLUMN game_players.position_history IS '포지션 변경 이력 (형식: "이닝:포지션명,이닝:포지션명", 예: "1:PITCHER,3:FIRST_BASE")';

--- a/nextup-infrastructure/src/main/resources/db/migration/V024__add_record_detail_improvements.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V024__add_record_detail_improvements.sql
@@ -1,0 +1,25 @@
+-- V024: 기록 상세화 (D-15 타점 경로, D-17 타순 위반, D-19 수비 이닝 이력, D-20 투구 수 제한)
+-- Issue #229
+
+-- D-15: 타점 경로 - game_events에 득점 주자 ID 목록 컬럼 추가
+ALTER TABLE game_events
+    ADD COLUMN IF NOT EXISTS scoring_runner_ids TEXT;
+
+COMMENT ON COLUMN game_events.scoring_runner_ids IS '득점 주자 ID 목록 (CSV 형식: playerId1,playerId2,...). 타석별 득점 경로 추적용.';
+
+-- D-20: 투구 수 제한 - competitions 테이블의 game_rules에 투구 수 제한 컬럼 추가
+ALTER TABLE competitions
+    ADD COLUMN IF NOT EXISTS pitch_count_limit INTEGER,
+    ADD COLUMN IF NOT EXISTS pitch_count_warning_threshold INTEGER NOT NULL DEFAULT 10;
+
+COMMENT ON COLUMN competitions.pitch_count_limit IS '투구 수 제한 (NULL이면 무제한). 사회인 야구 투수 보호 규칙.';
+COMMENT ON COLUMN competitions.pitch_count_warning_threshold IS '투구 수 경고 임박 기준 (제한 대비 몇 구 전에 경고할지, 기본 10구).';
+
+-- D-20: pitch_count_limit 유효성 제약
+ALTER TABLE competitions
+    ADD CONSTRAINT chk_pitch_count_limit_positive
+        CHECK (pitch_count_limit IS NULL OR pitch_count_limit > 0);
+
+ALTER TABLE competitions
+    ADD CONSTRAINT chk_pitch_count_warning_threshold_positive
+        CHECK (pitch_count_warning_threshold > 0);

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceConcurrencyTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceConcurrencyTest.kt
@@ -63,6 +63,9 @@ class GameScorerServiceConcurrencyTest {
         battingRecordRepository = mockk()
         pitchingRecordRepository = mockk()
         eventPublisher = mockk(relaxed = true)
+        every { gameTeamRepository.findAllByGameId(any()) } returns emptyList()
+        every { pitchingRecordRepository.findByGamePlayer(any()) } returns null
+        every { gameEventRepository.save(any()) } answers { firstArg() }
         gameScorerService =
             GameScorerServiceImpl(
                 gameRepository,
@@ -801,6 +804,7 @@ class GameScorerServiceConcurrencyTest {
     private fun createGamePlayer(id: Long): GamePlayer {
         val gamePlayer = mockk<GamePlayer>(relaxed = true)
         every { gamePlayer.id } returns id
+        every { gamePlayer.battingOrder } returns 1
         return gamePlayer
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceEventPublishingTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceEventPublishingTest.kt
@@ -59,6 +59,9 @@ class GameScorerServiceEventPublishingTest {
         battingRecordRepository = mockk()
         pitchingRecordRepository = mockk()
         eventPublisher = mockk(relaxed = true)
+        every { gameTeamRepository.findAllByGameId(any()) } returns emptyList()
+        every { pitchingRecordRepository.findByGamePlayer(any()) } returns null
+        every { gameEventRepository.save(any()) } answers { firstArg() }
         gameScorerService =
             GameScorerServiceImpl(
                 gameRepository,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -15,6 +15,7 @@ import com.nextup.core.domain.game.GameResult
 import com.nextup.core.domain.game.GameState
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.domain.game.PitchCountStatus
 import com.nextup.core.domain.game.PitchingDecision
 import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.domain.game.PlateAppearanceResult
@@ -67,6 +68,8 @@ class GameScorerServiceImplTest {
         eventPublisher = mockk(relaxed = true)
         every { gameTeamRepository.findAllByGameId(any()) } returns emptyList()
         every { pitchingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { pitchingRecordRepository.findByGamePlayer(any()) } returns null
+        every { gameEventRepository.save(any()) } answers { firstArg() }
         gameScorerService =
             GameScorerServiceImpl(
                 gameRepository,
@@ -362,7 +365,7 @@ class GameScorerServiceImplTest {
             val result = gameScorerService.recordPlateAppearance(1L, request)
 
             // then
-            assertThat(result.gameState.runnerOnFirstId).isEqualTo(10L)
+            assertThat(result.game.gameState.runnerOnFirstId).isEqualTo(10L)
             verify { boxScoreService.updateOnPlateAppearance(any(), any(), any(), any(), any(), any(), any()) }
         }
 
@@ -392,7 +395,7 @@ class GameScorerServiceImplTest {
             val result = gameScorerService.recordPlateAppearance(1L, request)
 
             // then
-            assertThat(result.gameState.runnerOnSecondId).isEqualTo(10L)
+            assertThat(result.game.gameState.runnerOnSecondId).isEqualTo(10L)
         }
 
         @Test
@@ -421,7 +424,7 @@ class GameScorerServiceImplTest {
             val result = gameScorerService.recordPlateAppearance(1L, request)
 
             // then
-            assertThat(result.gameState.runnerOnThirdId).isEqualTo(10L)
+            assertThat(result.game.gameState.runnerOnThirdId).isEqualTo(10L)
         }
 
         @Test
@@ -489,7 +492,7 @@ class GameScorerServiceImplTest {
             val result = gameScorerService.recordPlateAppearance(1L, request)
 
             // then
-            assertThat(result.gameState.runnerOnFirstId).isEqualTo(10L)
+            assertThat(result.game.gameState.runnerOnFirstId).isEqualTo(10L)
         }
 
         @Test
@@ -518,7 +521,7 @@ class GameScorerServiceImplTest {
             val result = gameScorerService.recordPlateAppearance(1L, request)
 
             // then
-            assertThat(result.gameState.outs).isEqualTo(1)
+            assertThat(result.game.gameState.outs).isEqualTo(1)
         }
 
         @Test
@@ -610,7 +613,7 @@ class GameScorerServiceImplTest {
             val result = gameScorerService.recordPlateAppearance(1L, request)
 
             // then
-            assertThat(result.gameState.outs).isEqualTo(1)
+            assertThat(result.game.gameState.outs).isEqualTo(1)
         }
 
         @Test
@@ -650,8 +653,177 @@ class GameScorerServiceImplTest {
             val result = gameScorerService.recordPlateAppearance(1L, request)
 
             // then
-            assertThat(result.gameState.runnerOnThirdId).isEqualTo(5L)
-            assertThat(result.gameState.runnerOnFirstId).isEqualTo(10L)
+            assertThat(result.game.gameState.runnerOnThirdId).isEqualTo(5L)
+            assertThat(result.game.gameState.runnerOnFirstId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should return no warnings when batting order is correct`() {
+            // given
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    isTopInning = true
+                    gameState.awayBattingOrder = 3
+                }
+            val batter = createGamePlayer(10L)
+            every { batter.battingOrder } returns 3
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns null
+
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.SINGLE,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.warnings).isEmpty()
+        }
+
+        @Test
+        fun `should return batting order warning when batter order does not match expected`() {
+            // given
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    isTopInning = true
+                    gameState.awayBattingOrder = 3
+                }
+            val batter = createGamePlayer(10L)
+            every { batter.battingOrder } returns 5 // expected 3, actual 5
+            val pitcher = createGamePlayer(20L)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns null
+
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.SINGLE,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.warnings).isNotEmpty()
+            assertThat(result.warnings[0]).contains("타순 위반")
+            assertThat(result.warnings[0]).contains("3")
+            assertThat(result.warnings[0]).contains("5")
+        }
+
+        @Test
+        fun `should return pitch count warning when pitcher exceeds threshold`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val pitchingRecord = mockk<PitchingRecord>(relaxed = true)
+            every { pitchingRecord.pitchesThrown } returns 105
+            every { pitchingRecord.checkPitchCountStatus(any(), any()) } returns PitchCountStatus.LIMIT_REACHED
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.warnings).isNotEmpty()
+            assertThat(result.warnings[0]).contains("투구 수 경고")
+            assertThat(result.warnings[0]).contains("105")
+        }
+
+        @Test
+        fun `should return pitch count approaching warning when pitcher is near threshold`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val pitchingRecord = mockk<PitchingRecord>(relaxed = true)
+            every { pitchingRecord.pitchesThrown } returns 95 // 100 - 95 = 5 remaining (< threshold 10)
+            every { pitchingRecord.checkPitchCountStatus(any(), any()) } returns PitchCountStatus.APPROACHING_LIMIT
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.warnings).isNotEmpty()
+            assertThat(result.warnings[0]).contains("투구 수 주의")
+            assertThat(result.warnings[0]).contains("5")
+        }
+
+        @Test
+        fun `should return no pitch count warning when pitcher has no pitch count recorded`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val batter = createGamePlayer(10L)
+            val pitcher = createGamePlayer(20L)
+            val pitchingRecord = mockk<PitchingRecord>(relaxed = true)
+            every { pitchingRecord.pitchesThrown } returns null
+            every { pitchingRecord.checkPitchCountStatus(any(), any()) } returns null
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayer(pitcher) } returns pitchingRecord
+
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.SINGLE,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                )
+
+            // when
+            val result = gameScorerService.recordPlateAppearance(1L, request)
+
+            // then
+            assertThat(result.warnings).isEmpty()
         }
     }
 
@@ -1149,6 +1321,7 @@ class GameScorerServiceImplTest {
     private fun createGamePlayer(id: Long): GamePlayer {
         val gamePlayer = mockk<GamePlayer>(relaxed = true)
         every { gamePlayer.id } returns id
+        every { gamePlayer.battingOrder } returns 1
         return gamePlayer
     }
 

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -32,6 +32,8 @@ class GameScorerController(
 
     /**
      * 타석 결과를 입력합니다.
+     *
+     * 응답에 경고 메시지(투구 수 경고, 타순 위반 경고)가 포함될 수 있습니다.
      */
     @PostMapping("/{gameId}/plate-appearances")
     @ResponseStatus(HttpStatus.OK)
@@ -39,8 +41,8 @@ class GameScorerController(
         @PathVariable gameId: Long,
         @RequestBody @Valid request: PlateAppearanceRequestDto
     ): ApiResponse<GameResponse> {
-        val game = gameScorerService.recordPlateAppearance(gameId, request.toDomain())
-        return ApiResponse.success(game.toResponse())
+        val result = gameScorerService.recordPlateAppearance(gameId, request.toDomain())
+        return ApiResponse.success(result.game.toResponse(warnings = result.warnings))
     }
 
     /**

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameMapper.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameMapper.kt
@@ -5,8 +5,10 @@ import com.nextup.core.domain.game.GameState
 
 /**
  * Game Entity를 GameResponse DTO로 변환합니다.
+ *
+ * @param warnings 경고 메시지 목록 (투구 수 경고, 타순 위반 경고 등)
  */
-fun Game.toResponse(): GameResponse {
+fun Game.toResponse(warnings: List<String> = emptyList()): GameResponse {
     return GameResponse(
         id = this.id,
         competitionId = this.competition.id,
@@ -17,7 +19,8 @@ fun Game.toResponse(): GameResponse {
         gameState = this.gameState.toResponse(),
         scheduledAt = this.scheduledAt,
         startedAt = this.startedAt,
-        endedAt = this.endedAt
+        endedAt = this.endedAt,
+        warnings = warnings,
     )
 }
 

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameResponse.kt
@@ -16,7 +16,8 @@ data class GameResponse(
     val gameState: GameStateResponse,
     val scheduledAt: LocalDateTime,
     val startedAt: LocalDateTime?,
-    val endedAt: LocalDateTime?
+    val endedAt: LocalDateTime?,
+    val warnings: List<String> = emptyList(),
 )
 
 /**

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -14,6 +14,7 @@ import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
 import com.nextup.core.service.game.GameScorerService
 import com.nextup.core.service.game.dto.GameEndReason
+import com.nextup.core.service.game.dto.PlateAppearanceRecordResult
 import com.nextup.scorer.dto.game.GameEndRequestDto
 import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
 import com.nextup.scorer.dto.game.RunnerMovementDto
@@ -101,7 +102,7 @@ class GameScorerControllerTest {
                     isTopInning = false
                     gameState.runnerOnFirstId = 10L
                 }
-            every { gameScorerService.recordPlateAppearance(gameId, any()) } returns game
+            every { gameScorerService.recordPlateAppearance(gameId, any()) } returns PlateAppearanceRecordResult(game)
 
             // when & then
             mockMvc.perform(
@@ -147,7 +148,7 @@ class GameScorerControllerTest {
                     gameState.runnerOnSecondId = 10L
                     gameState.runnerOnThirdId = 5L
                 }
-            every { gameScorerService.recordPlateAppearance(gameId, any()) } returns game
+            every { gameScorerService.recordPlateAppearance(gameId, any()) } returns PlateAppearanceRecordResult(game)
 
             // when & then
             mockMvc.perform(
@@ -184,7 +185,7 @@ class GameScorerControllerTest {
                     isTopInning = true
                     gameState.outs = 1
                 }
-            every { gameScorerService.recordPlateAppearance(gameId, any()) } returns game
+            every { gameScorerService.recordPlateAppearance(gameId, any()) } returns PlateAppearanceRecordResult(game)
 
             // when & then
             mockMvc.perform(


### PR DESCRIPTION
## Summary

>- close #229

기록 상세화 4개 항목을 구현합니다: 투구 수 경고, 타순 위반 감지, 수비 이력, 타점 경로 추적.

## Tasks

- 투구 수 제한/경고: PitchingRecord.checkPitchCountStatus() + PitchCountWarningEvent 도메인 이벤트
- 타순 위반 감지: GameState.validateBattingOrder() + BattingOrderViolationEvent 도메인 이벤트
- 수비 이닝 이력: GamePlayer.positionHistory (CSV 저장) + changePosition() 메서드
- 타점 경로 추적: GameEvent.scoringRunnerIds (CSV 저장) + 득점 주자 ID 기록
- Flyway 마이그레이션 V023, V024 추가
- 기존 테스트 호환성 유지

## To Reviewer

- 4개 항목 모두 독립적으로 구현되어 있어 개별 검토 가능
- GameRules에 pitchCountLimit, pitchCountWarningThreshold 필드 추가
- CSV 기반 저장 방식은 별도 테이블 없이 경량 구현