### PR TITLE
refactor(#270, #271): Core 모듈 Spring Data JPA 의존성 제거

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
@@ -11,6 +11,7 @@ import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.notification.NotificationService
 import com.nextup.core.service.notification.dto.RegisterDeviceRequest
 import com.nextup.core.service.notification.dto.UpdatePreferenceRequest
+import com.nextup.infrastructure.common.toPageCommand
 import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
@@ -70,7 +71,7 @@ class NotificationController(
         @AuthenticationPrincipal userId: Long,
         @PageableDefault(size = 20) pageable: Pageable,
     ): ApiResponse<PagedResponse<NotificationResponse>> {
-        val notifications = notificationService.getUserNotifications(userId, pageable)
+        val notifications = notificationService.getUserNotifications(userId, pageable.toPageCommand())
         return ApiResponse.success(PagedResponse.from(notifications.map { NotificationResponse.from(it) }))
     }
 

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/player/PlayerController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/player/PlayerController.kt
@@ -5,10 +5,11 @@ import com.nextup.api.dto.player.PlayerSearchResponse
 import com.nextup.api.dto.player.toDetailResponse
 import com.nextup.api.dto.player.toSearchResponse
 import com.nextup.common.dto.ApiResponse
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.player.Position
 import com.nextup.core.service.player.PlayerService
 import com.nextup.core.service.player.PlayerTeamService
-import org.springframework.data.domain.Page
+import com.nextup.infrastructure.common.toPageCommand
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
@@ -48,13 +49,13 @@ class PlayerController(
         @RequestParam(required = false) position: Position?,
         @PageableDefault(size = 20, sort = ["name"], direction = Sort.Direction.ASC)
         pageable: Pageable,
-    ): ApiResponse<Page<PlayerSearchResponse>> {
+    ): ApiResponse<PageResult<PlayerSearchResponse>> {
         val players =
             playerService.search(
                 name = name,
                 teamId = teamId,
                 position = position,
-                pageable = pageable,
+                pageCommand = pageable.toPageCommand(),
             )
         val result =
             players.map { player ->

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/StadiumController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/StadiumController.kt
@@ -1,13 +1,14 @@
 package com.nextup.api.controller.stadium
 
+import com.nextup.api.dto.common.PagedResponse
 import com.nextup.api.dto.stadium.BookingResponse
 import com.nextup.api.dto.stadium.StadiumResponse
 import com.nextup.api.dto.stadium.StadiumSlotResponse
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.stadium.StadiumService
 import com.nextup.core.service.stadium.dto.BookSlotRequest
+import com.nextup.infrastructure.common.toPageCommand
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.format.annotation.DateTimeFormat
@@ -44,9 +45,9 @@ class StadiumController(
         @RequestParam longitude: Double,
         @RequestParam(defaultValue = "10") radiusKm: Double,
         @PageableDefault(size = 20) pageable: Pageable,
-    ): ApiResponse<Page<StadiumResponse>> {
-        val page = stadiumService.findNearbyStadiums(latitude, longitude, radiusKm, pageable)
-        return ApiResponse.success(page.map { StadiumResponse.from(it) })
+    ): ApiResponse<PagedResponse<StadiumResponse>> {
+        val page = stadiumService.findNearbyStadiums(latitude, longitude, radiusKm, pageable.toPageCommand())
+        return ApiResponse.success(PagedResponse.from(page.map { StadiumResponse.from(it) }))
     }
 
     /**

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/common/PagedResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/common/PagedResponse.kt
@@ -1,11 +1,12 @@
 package com.nextup.api.dto.common
 
+import com.nextup.core.common.PageResult
 import org.springframework.data.domain.Page
 
 /**
  * 페이징된 목록 응답 래퍼
  *
- * Spring Data [Page]를 클라이언트 친화적인 형태로 변환합니다.
+ * Spring Data [Page] 또는 Core [PageResult]를 클라이언트 친화적인 형태로 변환합니다.
  *
  * @param T 응답 데이터 원소 타입
  * @property content 현재 페이지의 데이터 목록
@@ -35,6 +36,19 @@ data class PagedResponse<T>(
                 currentPage = page.number,
                 size = page.size,
                 hasNext = page.hasNext(),
+            )
+
+        /**
+         * Core [PageResult]로부터 [PagedResponse]를 생성합니다.
+         */
+        fun <T> from(pageResult: PageResult<T>): PagedResponse<T> =
+            PagedResponse(
+                content = pageResult.content,
+                totalElements = pageResult.totalElements,
+                totalPages = pageResult.totalPages,
+                currentPage = pageResult.page,
+                size = pageResult.size,
+                hasNext = pageResult.hasNext,
             )
     }
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/notification/NotificationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/notification/NotificationControllerTest.kt
@@ -9,6 +9,7 @@ import com.nextup.api.exception.GlobalExceptionHandler
 import com.nextup.common.exception.DeviceTokenNotFoundException
 import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.NotificationNotFoundException
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.notification.*
 import com.nextup.core.service.notification.NotificationService
 import io.mockk.every
@@ -17,8 +18,6 @@ import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -173,10 +172,16 @@ class NotificationControllerTest {
     @Test
     fun `should get notifications successfully`() {
         // given
-        val pageable = PageRequest.of(0, 20)
-        val page = PageImpl(listOf(mockNotification), pageable, 1)
+        val pageResult =
+            PageResult(
+                content = listOf(mockNotification),
+                page = 0,
+                size = 20,
+                totalElements = 1L,
+                totalPages = 1,
+            )
 
-        every { notificationService.getUserNotifications(authenticatedUserId, any()) } returns page
+        every { notificationService.getUserNotifications(authenticatedUserId, any()) } returns pageResult
 
         // when & then
         mockMvc

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/player/PlayerControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/player/PlayerControllerTest.kt
@@ -1,5 +1,6 @@
 package com.nextup.api.controller.player
 
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.service.player.PlayerService
@@ -10,9 +11,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -50,18 +48,23 @@ class PlayerControllerTest {
                     createPlayer(1L, "김철수", Position.STARTING_PITCHER),
                     createPlayer(2L, "이영희", Position.CATCHER),
                 )
-            val pageable =
-                PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "name"))
-            val page = PageImpl(players, pageable, 2)
+            val pageResult =
+                PageResult(
+                    content = players,
+                    page = 0,
+                    size = 20,
+                    totalElements = 2L,
+                    totalPages = 1,
+                )
 
             every {
                 playerService.search(
                     name = null,
                     teamId = null,
                     position = null,
-                    pageable = any(),
+                    pageCommand = any(),
                 )
-            } returns page
+            } returns pageResult
             every { playerTeamService.getActiveAffiliationsByPlayer(any()) } returns emptyList()
 
             // when & then
@@ -81,18 +84,23 @@ class PlayerControllerTest {
                 listOf(
                     createPlayer(1L, "김철수", Position.STARTING_PITCHER),
                 )
-            val pageable =
-                PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "name"))
-            val page = PageImpl(players, pageable, 1)
+            val pageResult =
+                PageResult(
+                    content = players,
+                    page = 0,
+                    size = 20,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
 
             every {
                 playerService.search(
                     name = "김철수",
                     teamId = null,
                     position = null,
-                    pageable = any(),
+                    pageCommand = any(),
                 )
-            } returns page
+            } returns pageResult
             every { playerTeamService.getActiveAffiliationsByPlayer(any()) } returns emptyList()
 
             // when & then

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/StadiumControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/StadiumControllerTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nextup.api.exception.GlobalExceptionHandler
 import com.nextup.common.exception.InvalidInputException
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.stadium.Stadium
 import com.nextup.core.domain.stadium.StadiumBooking
 import com.nextup.core.domain.stadium.StadiumSlot
@@ -16,9 +17,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -61,9 +59,15 @@ class StadiumControllerTest {
                     createStadium(1L, "잠실 야구장", 37.5121, 127.0717),
                     createStadium(2L, "고척 야구장", 37.4981, 126.8671),
                 )
-            val pageable = PageRequest.of(0, 20)
-            val page = PageImpl(stadiums, pageable, 2)
-            every { stadiumService.findNearbyStadiums(37.5, 127.0, 10.0, any<Pageable>()) } returns page
+            val pageResult =
+                PageResult(
+                    content = stadiums,
+                    page = 0,
+                    size = 20,
+                    totalElements = 2L,
+                    totalPages = 1,
+                )
+            every { stadiumService.findNearbyStadiums(37.5, 127.0, 10.0, any()) } returns pageResult
 
             // when & then
             mockMvc
@@ -83,9 +87,15 @@ class StadiumControllerTest {
         @Test
         fun `should use default radiusKm of 10 when not provided`() {
             // given
-            val pageable = PageRequest.of(0, 20)
-            val page = PageImpl(emptyList<Stadium>(), pageable, 0)
-            every { stadiumService.findNearbyStadiums(37.5, 127.0, 10.0, any<Pageable>()) } returns page
+            val pageResult =
+                PageResult(
+                    content = emptyList<Stadium>(),
+                    page = 0,
+                    size = 20,
+                    totalElements = 0L,
+                    totalPages = 0,
+                )
+            every { stadiumService.findNearbyStadiums(37.5, 127.0, 10.0, any()) } returns pageResult
 
             // when & then
             mockMvc
@@ -101,7 +111,7 @@ class StadiumControllerTest {
         fun `should return 400 when invalid latitude is provided`() {
             // given
             every {
-                stadiumService.findNearbyStadiums(91.0, 127.0, 10.0, any<Pageable>())
+                stadiumService.findNearbyStadiums(91.0, 127.0, 10.0, any())
             } throws InvalidInputException("INVALID_LATITUDE", "위도는 -90 ~ 90 범위여야 합니다: 91.0")
 
             // when & then
@@ -120,7 +130,7 @@ class StadiumControllerTest {
         fun `should return 400 when invalid longitude is provided`() {
             // given
             every {
-                stadiumService.findNearbyStadiums(37.5, 181.0, 10.0, any<Pageable>())
+                stadiumService.findNearbyStadiums(37.5, 181.0, 10.0, any())
             } throws InvalidInputException("INVALID_LONGITUDE", "경도는 -180 ~ 180 범위여야 합니다: 181.0")
 
             // when & then
@@ -139,7 +149,7 @@ class StadiumControllerTest {
         fun `should return 400 when radiusKm is zero`() {
             // given
             every {
-                stadiumService.findNearbyStadiums(37.5, 127.0, 0.0, any<Pageable>())
+                stadiumService.findNearbyStadiums(37.5, 127.0, 0.0, any())
             } throws InvalidInputException("INVALID_RADIUS", "검색 반경은 0보다 커야 합니다: 0.0")
 
             // when & then

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/audit/AuditLogAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/audit/AuditLogAdminController.kt
@@ -2,8 +2,9 @@ package com.nextup.backoffice.controller.audit
 
 import com.nextup.backoffice.dto.audit.AuditLogResponse
 import com.nextup.common.dto.ApiResponse
+import com.nextup.core.common.PageResult
 import com.nextup.core.service.audit.AuditLogQueryService
-import org.springframework.data.domain.Page
+import com.nextup.infrastructure.common.toPageCommand
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
@@ -35,7 +36,7 @@ class AuditLogAdminController(
         toDate: Instant?,
         @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC)
         pageable: Pageable,
-    ): ApiResponse<Page<AuditLogResponse>> {
+    ): ApiResponse<PageResult<AuditLogResponse>> {
         val page =
             auditLogQueryService.findAll(
                 adminUserId = adminUserId,
@@ -43,7 +44,7 @@ class AuditLogAdminController(
                 targetEntity = targetEntity,
                 fromDate = fromDate,
                 toDate = toDate,
-                pageable = pageable,
+                pageCommand = pageable.toPageCommand(),
             )
         return ApiResponse.success(page.map { AuditLogResponse.from(it) })
     }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminController.kt
@@ -5,13 +5,14 @@ import com.nextup.backoffice.dto.team.UpdateMemberStatusRequest
 import com.nextup.common.dto.ApiResponse
 import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.TeamMemberNotFoundException
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.team.TeamMemberStatus
 import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.audit.AuditService
 import com.nextup.core.service.team.TeamMembershipService
+import com.nextup.infrastructure.common.toPageCommand
 import com.nextup.infrastructure.security.userdetails.CustomUserDetails
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -36,19 +37,24 @@ class TeamMemberAdminController(
         @PathVariable teamId: Long,
         @RequestParam(required = false) status: TeamMemberStatus?,
         @PageableDefault(size = 20) pageable: Pageable,
-    ): ApiResponse<Page<TeamMemberAdminResponse>> {
+    ): ApiResponse<PageResult<TeamMemberAdminResponse>> {
+        val pageCommand = pageable.toPageCommand()
         val members =
             if (status != null) {
                 val list = teamMemberRepository.findByTeamIdAndStatus(teamId, status)
-                val start = pageable.offset.toInt()
-                val end = minOf(start + pageable.pageSize, list.size)
-                org.springframework.data.domain.PageImpl(
-                    if (start < list.size) list.subList(start, end) else emptyList(),
-                    pageable,
-                    list.size.toLong(),
+                val start = pageCommand.page * pageCommand.size
+                val end = minOf(start + pageCommand.size, list.size)
+                val totalPages =
+                    if (pageCommand.size == 0) 0 else (list.size + pageCommand.size - 1) / pageCommand.size
+                PageResult(
+                    content = if (start < list.size) list.subList(start, end) else emptyList(),
+                    page = pageCommand.page,
+                    size = pageCommand.size,
+                    totalElements = list.size.toLong(),
+                    totalPages = totalPages,
                 )
             } else {
-                teamMemberRepository.findByTeamIdWithUserAndPlayer(teamId, pageable)
+                teamMemberRepository.findByTeamIdWithUserAndPlayer(teamId, pageCommand)
             }
         return ApiResponse.success(members.map { TeamMemberAdminResponse.from(it) })
     }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/user/UserAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/user/UserAdminController.kt
@@ -6,12 +6,13 @@ import com.nextup.backoffice.dto.user.UpdateUserRequest
 import com.nextup.backoffice.dto.user.UserAdminResponse
 import com.nextup.backoffice.dto.user.UserListResponse
 import com.nextup.common.dto.ApiResponse
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.user.Role
 import com.nextup.core.service.audit.AuditService
 import com.nextup.core.service.user.UserService
+import com.nextup.infrastructure.common.toPageCommand
 import com.nextup.infrastructure.security.userdetails.CustomUserDetails
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
@@ -39,9 +40,13 @@ class UserAdminController(
     fun getAllUsers(
         @PageableDefault(size = 20) pageable: Pageable,
         @RequestParam(required = false) isActive: Boolean?,
-    ): ApiResponse<Page<UserListResponse>> {
+    ): ApiResponse<PageResult<UserListResponse>> {
         val users =
-            if (isActive != null) userService.getAllByStatus(isActive, pageable) else userService.getAll(pageable)
+            if (isActive != null) {
+                userService.getAllByStatus(isActive, pageable.toPageCommand())
+            } else {
+                userService.getAll(pageable.toPageCommand())
+            }
         return ApiResponse.success(users.map { UserListResponse.from(it) })
     }
 
@@ -49,16 +54,18 @@ class UserAdminController(
     fun searchUsers(
         @RequestParam keyword: String,
         @PageableDefault(size = 20) pageable: Pageable,
-    ): ApiResponse<Page<UserListResponse>> =
-        ApiResponse.success(userService.search(keyword, pageable).map { UserListResponse.from(it) })
+    ): ApiResponse<PageResult<UserListResponse>> =
+        ApiResponse.success(userService.search(keyword, pageable.toPageCommand()).map { UserListResponse.from(it) })
 
     @GetMapping("/by-role/{role}")
     fun getUsersByRole(
         @PathVariable role: String,
         @PageableDefault(size = 20) pageable: Pageable,
-    ): ApiResponse<Page<UserListResponse>> =
+    ): ApiResponse<PageResult<UserListResponse>> =
         ApiResponse.success(
-            userService.getAllByRole(Role.valueOf(role.uppercase()), pageable).map { UserListResponse.from(it) },
+            userService.getAllByRole(Role.valueOf(role.uppercase()), pageable.toPageCommand()).map {
+                UserListResponse.from(it)
+            },
         )
 
     @GetMapping("/{id}")

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/audit/AuditLogAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/audit/AuditLogAdminControllerTest.kt
@@ -2,6 +2,7 @@ package com.nextup.backoffice.controller.audit
 
 import com.nextup.backoffice.exception.GlobalExceptionHandler
 import com.nextup.common.exception.AuditLogNotFoundException
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.audit.AuditLog
 import com.nextup.core.service.audit.AuditLogQueryService
 import io.mockk.every
@@ -10,8 +11,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -64,10 +63,17 @@ class AuditLogAdminControllerTest {
         @Test
         fun `감사 로그 목록을 페이징 조회할 수 있다`() {
             val log = createAuditLog(id = 1L)
-            val page = PageImpl(listOf(log), PageRequest.of(0, 20), 1)
+            val pageResult =
+                PageResult(
+                    content = listOf(log),
+                    page = 0,
+                    size = 20,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
             every {
                 auditLogQueryService.findAll(null, null, null, null, null, any())
-            } returns page
+            } returns pageResult
 
             mockMvc
                 .perform(get("/api/backoffice/audit-logs"))
@@ -81,10 +87,17 @@ class AuditLogAdminControllerTest {
         @Test
         fun `adminUserId 필터로 조회할 수 있다`() {
             val log = createAuditLog(id = 1L, adminUserId = 5L)
-            val page = PageImpl(listOf(log), PageRequest.of(0, 20), 1)
+            val pageResult =
+                PageResult(
+                    content = listOf(log),
+                    page = 0,
+                    size = 20,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
             every {
                 auditLogQueryService.findAll(5L, null, null, null, null, any())
-            } returns page
+            } returns pageResult
 
             mockMvc
                 .perform(get("/api/backoffice/audit-logs").param("adminUserId", "5"))
@@ -96,10 +109,17 @@ class AuditLogAdminControllerTest {
         @Test
         fun `action 필터로 조회할 수 있다`() {
             val log = createAuditLog(id = 2L, action = "DELETE_USER")
-            val page = PageImpl(listOf(log), PageRequest.of(0, 20), 1)
+            val pageResult =
+                PageResult(
+                    content = listOf(log),
+                    page = 0,
+                    size = 20,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
             every {
                 auditLogQueryService.findAll(null, "DELETE_USER", null, null, null, any())
-            } returns page
+            } returns pageResult
 
             mockMvc
                 .perform(get("/api/backoffice/audit-logs").param("action", "DELETE_USER"))
@@ -111,10 +131,17 @@ class AuditLogAdminControllerTest {
         @Test
         fun `targetEntity 필터로 조회할 수 있다`() {
             val log = createAuditLog(id = 3L, targetEntity = "Team")
-            val page = PageImpl(listOf(log), PageRequest.of(0, 20), 1)
+            val pageResult =
+                PageResult(
+                    content = listOf(log),
+                    page = 0,
+                    size = 20,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
             every {
                 auditLogQueryService.findAll(null, null, "Team", null, null, any())
-            } returns page
+            } returns pageResult
 
             mockMvc
                 .perform(get("/api/backoffice/audit-logs").param("targetEntity", "Team"))
@@ -125,10 +152,17 @@ class AuditLogAdminControllerTest {
 
         @Test
         fun `결과가 없으면 빈 페이지를 반환한다`() {
-            val page = PageImpl(emptyList<AuditLog>(), PageRequest.of(0, 20), 0)
+            val pageResult =
+                PageResult(
+                    content = emptyList<AuditLog>(),
+                    page = 0,
+                    size = 20,
+                    totalElements = 0L,
+                    totalPages = 0,
+                )
             every {
                 auditLogQueryService.findAll(null, null, null, null, null, any())
-            } returns page
+            } returns pageResult
 
             mockMvc
                 .perform(get("/api/backoffice/audit-logs"))

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminControllerTest.kt
@@ -2,6 +2,7 @@ package com.nextup.backoffice.controller.team
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nextup.backoffice.dto.team.UpdateMemberStatusRequest
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.team.Team
@@ -21,8 +22,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -94,9 +93,15 @@ class TeamMemberAdminControllerTest {
     inner class GetAllMembers {
         @Test
         fun `should return paged members without status filter`() {
-            val pageable = PageRequest.of(0, 20)
-            val page = PageImpl(listOf(member), pageable, 1)
-            every { teamMemberRepository.findByTeamIdWithUserAndPlayer(1L, any()) } returns page
+            val pageResult =
+                PageResult(
+                    content = listOf(member),
+                    page = 0,
+                    size = 20,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
+            every { teamMemberRepository.findByTeamIdWithUserAndPlayer(1L, any()) } returns pageResult
 
             mockMvc.perform(get("/api/backoffice/teams/1/members"))
                 .andExpect(status().isOk)

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/user/UserAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/user/UserAdminControllerTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.nextup.backoffice.dto.user.CreateUserRequest
 import com.nextup.backoffice.dto.user.RoleChangeRequest
 import com.nextup.backoffice.dto.user.UpdateUserRequest
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.user.Role
 import com.nextup.core.domain.user.User
 import com.nextup.core.service.audit.AuditService
@@ -15,8 +16,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver
 import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -73,8 +72,15 @@ class UserAdminControllerTest {
         @Test
         fun `모든 사용자를 페이징 조회할 수 있다`() {
             val user = createUser(1L, "test@example.com", "테스터")
-            val page = PageImpl(listOf(user), PageRequest.of(0, 20), 1)
-            every { userService.getAll(any()) } returns page
+            val pageResult =
+                PageResult(
+                    content = listOf(user),
+                    page = 0,
+                    size = 20,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
+            every { userService.getAll(any()) } returns pageResult
 
             mockMvc.perform(get("/api/backoffice/users"))
                 .andExpect(status().isOk)
@@ -85,8 +91,15 @@ class UserAdminControllerTest {
         @Test
         fun `활성 상태로 필터링하여 조회할 수 있다`() {
             val user = createUser(1L, "test@example.com", "테스터")
-            val page = PageImpl(listOf(user), PageRequest.of(0, 20), 1)
-            every { userService.getAllByStatus(true, any()) } returns page
+            val pageResult =
+                PageResult(
+                    content = listOf(user),
+                    page = 0,
+                    size = 20,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
+            every { userService.getAllByStatus(true, any()) } returns pageResult
 
             mockMvc.perform(get("/api/backoffice/users").param("isActive", "true"))
                 .andExpect(status().isOk)
@@ -100,8 +113,15 @@ class UserAdminControllerTest {
         @Test
         fun `키워드로 사용자를 검색할 수 있다`() {
             val user = createUser(1L, "test@example.com", "테스터")
-            val page = PageImpl(listOf(user), PageRequest.of(0, 20), 1)
-            every { userService.search("test", any()) } returns page
+            val pageResult =
+                PageResult(
+                    content = listOf(user),
+                    page = 0,
+                    size = 20,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
+            every { userService.search("test", any()) } returns pageResult
 
             mockMvc.perform(get("/api/backoffice/users/search").param("keyword", "test"))
                 .andExpect(status().isOk)

--- a/nextup-core/build.gradle.kts
+++ b/nextup-core/build.gradle.kts
@@ -33,7 +33,10 @@ dependencies {
     api(project(":nextup-common"))
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    api("jakarta.persistence:jakarta.persistence-api")
+    implementation("org.hibernate.orm:hibernate-core")
+    implementation("org.springframework:spring-tx")
+    implementation("org.springframework:spring-context")
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/nextup-core/src/main/kotlin/com/nextup/core/common/BaseTimeEntity.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/common/BaseTimeEntity.kt
@@ -1,23 +1,30 @@
 package com.nextup.core.common
 
 import jakarta.persistence.Column
-import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
-import org.springframework.data.annotation.CreatedDate
-import org.springframework.data.annotation.LastModifiedDate
-import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
 import java.time.Instant
 
 @MappedSuperclass
-@EntityListeners(AuditingEntityListener::class)
 abstract class BaseTimeEntity {
-    @CreatedDate
     @Column(nullable = false, updatable = false)
     var createdAt: Instant = Instant.now()
         protected set
 
-    @LastModifiedDate
     @Column(nullable = false)
     var updatedAt: Instant = Instant.now()
         protected set
+
+    @PrePersist
+    fun onPrePersist() {
+        val now = Instant.now()
+        createdAt = now
+        updatedAt = now
+    }
+
+    @PreUpdate
+    fun onPreUpdate() {
+        updatedAt = Instant.now()
+    }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/common/PageCommand.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/common/PageCommand.kt
@@ -1,0 +1,26 @@
+package com.nextup.core.common
+
+/**
+ * Core 모듈용 페이징 요청 객체.
+ * Spring Data의 Pageable을 대체하여 Core가 Spring에 의존하지 않도록 합니다.
+ */
+data class PageCommand(
+    val page: Int = 0,
+    val size: Int = 20,
+    val sorts: List<SortOrder> = emptyList(),
+) {
+    init {
+        require(page >= 0) { "Page must be non-negative" }
+        require(size > 0) { "Size must be positive" }
+    }
+}
+
+data class SortOrder(
+    val property: String,
+    val direction: SortDirection = SortDirection.ASC,
+)
+
+enum class SortDirection {
+    ASC,
+    DESC,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/common/PageResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/common/PageResult.kt
@@ -1,0 +1,25 @@
+package com.nextup.core.common
+
+/**
+ * Core 모듈용 페이징 결과 객체.
+ * Spring Data의 Page를 대체하여 Core가 Spring에 의존하지 않도록 합니다.
+ */
+data class PageResult<T>(
+    val content: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+) {
+    val hasNext: Boolean get() = page + 1 < totalPages
+    val hasPrevious: Boolean get() = page > 0
+
+    fun <R> map(transform: (T) -> R): PageResult<R> =
+        PageResult(
+            content = content.map(transform),
+            page = page,
+            size = size,
+            totalElements = totalElements,
+            totalPages = totalPages,
+        )
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/AuditLogRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/AuditLogRepositoryPort.kt
@@ -1,8 +1,8 @@
 package com.nextup.core.port.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.audit.AuditLog
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import java.time.Instant
 
 interface AuditLogRepositoryPort {
@@ -23,6 +23,6 @@ interface AuditLogRepositoryPort {
         targetEntity: String?,
         fromDate: Instant?,
         toDate: Instant?,
-        pageable: Pageable,
-    ): Page<AuditLog>
+        pageCommand: PageCommand,
+    ): PageResult<AuditLog>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/NotificationRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/NotificationRepositoryPort.kt
@@ -1,8 +1,8 @@
 package com.nextup.core.port.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.notification.Notification
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 
 interface NotificationRepositoryPort {
     fun save(notification: Notification): Notification
@@ -11,8 +11,8 @@ interface NotificationRepositoryPort {
 
     fun findByUserId(
         userId: Long,
-        pageable: Pageable,
-    ): Page<Notification>
+        pageCommand: PageCommand,
+    ): PageResult<Notification>
 
     fun findByUserId(userId: Long): List<Notification>
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PlayerRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PlayerRepositoryPort.kt
@@ -1,9 +1,9 @@
 package com.nextup.core.port.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import java.time.LocalDate
 
 /**
@@ -44,6 +44,6 @@ interface PlayerRepositoryPort {
         name: String?,
         teamId: Long?,
         position: Position?,
-        pageable: Pageable,
-    ): Page<Player>
+        pageCommand: PageCommand,
+    ): PageResult<Player>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumRepositoryPort.kt
@@ -1,8 +1,8 @@
 package com.nextup.core.port.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.stadium.Stadium
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 
 /**
  * 구장 리포지토리 포트 인터페이스
@@ -36,13 +36,13 @@ interface StadiumRepositoryPort {
      * @param latitude 위도 (-90 ~ 90)
      * @param longitude 경도 (-180 ~ 180)
      * @param radiusKm 검색 반경 (킬로미터, 0 초과)
-     * @param pageable 페이징 정보
+     * @param pageCommand 페이징 정보
      * @return 거리 순으로 정렬된 구장 페이지
      */
     fun findNearbyStadiums(
         latitude: Double,
         longitude: Double,
         radiusKm: Double,
-        pageable: Pageable,
-    ): Page<Stadium>
+        pageCommand: PageCommand,
+    ): PageResult<Stadium>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamBlacklistRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamBlacklistRepositoryPort.kt
@@ -1,8 +1,8 @@
 package com.nextup.core.port.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.team.TeamBlacklist
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 
 /**
  * TeamBlacklist Repository Port
@@ -15,8 +15,8 @@ interface TeamBlacklistRepositoryPort {
 
     fun findByTeamId(
         teamId: Long,
-        pageable: Pageable,
-    ): Page<TeamBlacklist>
+        pageCommand: PageCommand,
+    ): PageResult<TeamBlacklist>
 
     fun findByTeamIdAndUserId(
         teamId: Long,

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamJoinRequestRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamJoinRequestRepositoryPort.kt
@@ -1,9 +1,9 @@
 package com.nextup.core.port.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.team.JoinRequestStatus
 import com.nextup.core.domain.team.TeamJoinRequest
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 
 /**
  * TeamJoinRequest Repository Port
@@ -19,8 +19,8 @@ interface TeamJoinRequestRepositoryPort {
     fun findByTeamIdAndStatus(
         teamId: Long,
         status: JoinRequestStatus,
-        pageable: Pageable,
-    ): Page<TeamJoinRequest>
+        pageCommand: PageCommand,
+    ): PageResult<TeamJoinRequest>
 
     fun findByUserId(userId: Long): List<TeamJoinRequest>
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamMemberRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamMemberRepositoryPort.kt
@@ -1,9 +1,9 @@
 package com.nextup.core.port.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.team.TeamMember
 import com.nextup.core.domain.team.TeamMemberStatus
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 
 /**
  * TeamMember Repository Port
@@ -37,8 +37,8 @@ interface TeamMemberRepositoryPort {
 
     fun findByTeamIdWithUserAndPlayer(
         teamId: Long,
-        pageable: Pageable,
-    ): Page<TeamMember>
+        pageCommand: PageCommand,
+    ): PageResult<TeamMember>
 
     fun existsByTeamIdAndUserId(
         teamId: Long,

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/UserRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/UserRepositoryPort.kt
@@ -1,9 +1,9 @@
 package com.nextup.core.port.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.user.Role
 import com.nextup.core.domain.user.User
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 
 /**
  * User Repository Port
@@ -22,27 +22,27 @@ interface UserRepositoryPort {
 
     fun deleteById(id: Long)
 
-    fun findAllActive(pageable: Pageable): Page<User>
+    fun findAllActive(pageCommand: PageCommand): PageResult<User>
 
     fun findAllByIsActive(
         isActive: Boolean,
-        pageable: Pageable,
-    ): Page<User>
+        pageCommand: PageCommand,
+    ): PageResult<User>
 
     fun searchByKeyword(
         keyword: String,
-        pageable: Pageable,
-    ): Page<User>
+        pageCommand: PageCommand,
+    ): PageResult<User>
 
     fun findAllByRole(
         role: Role,
-        pageable: Pageable,
-    ): Page<User>
+        pageCommand: PageCommand,
+    ): PageResult<User>
 
     fun findAllByRolesIn(
         roles: Set<Role>,
-        pageable: Pageable,
-    ): Page<User>
+        pageCommand: PageCommand,
+    ): PageResult<User>
 
     fun findByPlayerId(playerId: Long): User?
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/audit/AuditLogQueryService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/audit/AuditLogQueryService.kt
@@ -1,8 +1,8 @@
 package com.nextup.core.service.audit
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.audit.AuditLog
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import java.time.Instant
 
 interface AuditLogQueryService {
@@ -12,8 +12,8 @@ interface AuditLogQueryService {
         targetEntity: String?,
         fromDate: Instant?,
         toDate: Instant?,
-        pageable: Pageable,
-    ): Page<AuditLog>
+        pageCommand: PageCommand,
+    ): PageResult<AuditLog>
 
     fun findById(id: Long): AuditLog
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
@@ -3,6 +3,8 @@ package com.nextup.core.service.notification
 import com.nextup.common.exception.DeviceTokenNotFoundException
 import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.NotificationNotFoundException
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.notification.DeviceToken
 import com.nextup.core.domain.notification.Notification
 import com.nextup.core.domain.notification.NotificationPreference
@@ -12,8 +14,6 @@ import com.nextup.core.port.repository.NotificationRepositoryPort
 import com.nextup.core.service.notification.dto.RegisterDeviceRequest
 import com.nextup.core.service.notification.dto.SendNotificationRequest
 import com.nextup.core.service.notification.dto.UpdatePreferenceRequest
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -52,8 +52,8 @@ class NotificationService(
      */
     fun getUserNotifications(
         userId: Long,
-        pageable: Pageable,
-    ): Page<Notification> = notificationRepository.findByUserId(userId, pageable)
+        pageCommand: PageCommand,
+    ): PageResult<Notification> = notificationRepository.findByUserId(userId, pageCommand)
 
     /**
      * 사용자의 알림 목록을 조회합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/player/PlayerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/player/PlayerService.kt
@@ -1,11 +1,11 @@
 package com.nextup.core.service.player
 
 import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.port.repository.PlayerRepositoryPort
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -52,19 +52,19 @@ class PlayerService(
      * @param name 이름 부분 검색 (null이면 조건 무시)
      * @param teamId 팀 ID 필터 (null이면 조건 무시)
      * @param position 포지션 필터 (null이면 조건 무시)
-     * @param pageable 페이징 정보
+     * @param pageCommand 페이징 정보
      * @return 검색 결과 페이지
      */
     fun search(
         name: String?,
         teamId: Long?,
         position: Position?,
-        pageable: Pageable,
-    ): Page<Player> =
+        pageCommand: PageCommand,
+    ): PageResult<Player> =
         playerRepository.search(
             name = name,
             teamId = teamId,
             position = position,
-            pageable = pageable,
+            pageCommand = pageCommand,
         )
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumService.kt
@@ -4,6 +4,8 @@ import com.nextup.common.exception.BookingNotFoundException
 import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.SlotNotFoundException
 import com.nextup.common.exception.StadiumNotFoundException
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.stadium.BookingStatus
 import com.nextup.core.domain.stadium.SlotStatus
 import com.nextup.core.domain.stadium.Stadium
@@ -13,8 +15,6 @@ import com.nextup.core.port.repository.StadiumBookingRepositoryPort
 import com.nextup.core.port.repository.StadiumRepositoryPort
 import com.nextup.core.port.repository.StadiumSlotRepositoryPort
 import com.nextup.core.service.stadium.dto.BookSlotRequest
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -46,15 +46,15 @@ class StadiumService(
      * @param latitude 위도 (-90 ~ 90)
      * @param longitude 경도 (-180 ~ 180)
      * @param radiusKm 검색 반경 킬로미터 (0 초과)
-     * @param pageable 페이징 정보
+     * @param pageCommand 페이징 정보
      * @return 거리 순으로 정렬된 구장 페이지
      */
     fun findNearbyStadiums(
         latitude: Double,
         longitude: Double,
         radiusKm: Double,
-        pageable: Pageable,
-    ): Page<Stadium> {
+        pageCommand: PageCommand,
+    ): PageResult<Stadium> {
         if (latitude !in -90.0..90.0) {
             throw InvalidInputException(
                 "INVALID_LATITUDE",
@@ -73,7 +73,7 @@ class StadiumService(
                 "검색 반경은 0보다 커야 합니다: $radiusKm",
             )
         }
-        return stadiumRepository.findNearbyStadiums(latitude, longitude, radiusKm, pageable)
+        return stadiumRepository.findNearbyStadiums(latitude, longitude, radiusKm, pageCommand)
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/user/UserService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/user/UserService.kt
@@ -1,13 +1,13 @@
 package com.nextup.core.service.user
 
 import com.nextup.common.exception.*
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.Role
 import com.nextup.core.domain.user.User
 import com.nextup.core.port.repository.OAuthAccountRepositoryPort
 import com.nextup.core.port.repository.UserRepositoryPort
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -131,36 +131,36 @@ class UserService(
     /**
      * 활성화된 모든 사용자를 페이징으로 조회합니다.
      */
-    fun getAllActive(pageable: Pageable): Page<User> = userRepository.findAllActive(pageable)
+    fun getAllActive(pageCommand: PageCommand): PageResult<User> = userRepository.findAllActive(pageCommand)
 
     /**
      * 모든 사용자를 페이징으로 조회합니다 (관리자용).
      */
-    fun getAll(pageable: Pageable): Page<User> = userRepository.findAllByIsActive(true, pageable)
+    fun getAll(pageCommand: PageCommand): PageResult<User> = userRepository.findAllByIsActive(true, pageCommand)
 
     /**
      * 활성 상태별로 사용자를 조회합니다 (관리자용).
      */
     fun getAllByStatus(
         isActive: Boolean,
-        pageable: Pageable,
-    ): Page<User> = userRepository.findAllByIsActive(isActive, pageable)
+        pageCommand: PageCommand,
+    ): PageResult<User> = userRepository.findAllByIsActive(isActive, pageCommand)
 
     /**
      * 키워드로 사용자를 검색합니다 (관리자용).
      */
     fun search(
         keyword: String,
-        pageable: Pageable,
-    ): Page<User> = userRepository.searchByKeyword(keyword, pageable)
+        pageCommand: PageCommand,
+    ): PageResult<User> = userRepository.searchByKeyword(keyword, pageCommand)
 
     /**
      * 역할별로 사용자를 조회합니다 (관리자용).
      */
     fun getAllByRole(
         role: Role,
-        pageable: Pageable,
-    ): Page<User> = userRepository.findAllByRole(role, pageable)
+        pageCommand: PageCommand,
+    ): PageResult<User> = userRepository.findAllByRole(role, pageCommand)
 
     // ========== UPDATE ==========
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/common/BaseTimeEntityTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/common/BaseTimeEntityTest.kt
@@ -1,0 +1,77 @@
+package com.nextup.core.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+@DisplayName("BaseTimeEntity 테스트")
+class BaseTimeEntityTest {
+    private class TestEntity : BaseTimeEntity()
+
+    @Nested
+    @DisplayName("onPrePersist")
+    inner class OnPrePersist {
+        @Test
+        fun `onPrePersist 호출 시 createdAt이 설정된다`() {
+            val entity = TestEntity()
+            val before = Instant.now()
+
+            entity.onPrePersist()
+
+            val after = Instant.now()
+            assertThat(entity.createdAt).isAfterOrEqualTo(before)
+            assertThat(entity.createdAt).isBeforeOrEqualTo(after)
+        }
+
+        @Test
+        fun `onPrePersist 호출 시 updatedAt이 설정된다`() {
+            val entity = TestEntity()
+            val before = Instant.now()
+
+            entity.onPrePersist()
+
+            val after = Instant.now()
+            assertThat(entity.updatedAt).isAfterOrEqualTo(before)
+            assertThat(entity.updatedAt).isBeforeOrEqualTo(after)
+        }
+
+        @Test
+        fun `onPrePersist 호출 시 createdAt과 updatedAt이 동일한 시각으로 설정된다`() {
+            val entity = TestEntity()
+
+            entity.onPrePersist()
+
+            assertThat(entity.createdAt).isEqualTo(entity.updatedAt)
+        }
+    }
+
+    @Nested
+    @DisplayName("onPreUpdate")
+    inner class OnPreUpdate {
+        @Test
+        fun `onPreUpdate 호출 시 updatedAt이 갱신된다`() {
+            val entity = TestEntity()
+            entity.onPrePersist()
+
+            val persistedUpdatedAt = entity.updatedAt
+            Thread.sleep(10)
+            entity.onPreUpdate()
+
+            assertThat(entity.updatedAt).isAfter(persistedUpdatedAt)
+        }
+
+        @Test
+        fun `onPreUpdate 호출 후 createdAt은 변경되지 않는다`() {
+            val entity = TestEntity()
+            entity.onPrePersist()
+
+            val persistedCreatedAt = entity.createdAt
+            Thread.sleep(10)
+            entity.onPreUpdate()
+
+            assertThat(entity.createdAt).isEqualTo(persistedCreatedAt)
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/common/PageCommandTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/common/PageCommandTest.kt
@@ -1,0 +1,130 @@
+package com.nextup.core.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("PageCommand 테스트")
+class PageCommandTest {
+    @Nested
+    @DisplayName("기본 생성")
+    inner class Creation {
+        @Test
+        fun `기본값으로 생성 시 page=0, size=20, sorts 빈 목록`() {
+            val command = PageCommand()
+
+            assertThat(command.page).isEqualTo(0)
+            assertThat(command.size).isEqualTo(20)
+            assertThat(command.sorts).isEmpty()
+        }
+
+        @Test
+        fun `커스텀 값으로 생성 가능`() {
+            val command = PageCommand(page = 2, size = 10)
+
+            assertThat(command.page).isEqualTo(2)
+            assertThat(command.size).isEqualTo(10)
+        }
+
+        @Test
+        fun `sorts가 있는 경우 정상 생성`() {
+            val sorts =
+                listOf(
+                    SortOrder(property = "name", direction = SortDirection.ASC),
+                    SortOrder(property = "createdAt", direction = SortDirection.DESC),
+                )
+            val command = PageCommand(page = 0, size = 10, sorts = sorts)
+
+            assertThat(command.sorts).hasSize(2)
+            assertThat(command.sorts[0].property).isEqualTo("name")
+            assertThat(command.sorts[0].direction).isEqualTo(SortDirection.ASC)
+            assertThat(command.sorts[1].property).isEqualTo("createdAt")
+            assertThat(command.sorts[1].direction).isEqualTo(SortDirection.DESC)
+        }
+    }
+
+    @Nested
+    @DisplayName("유효성 검증")
+    inner class Validation {
+        @Test
+        fun `page가 음수이면 예외 발생`() {
+            assertThatThrownBy {
+                PageCommand(page = -1, size = 20)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("Page must be non-negative")
+        }
+
+        @Test
+        fun `size가 0이면 예외 발생`() {
+            assertThatThrownBy {
+                PageCommand(page = 0, size = 0)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("Size must be positive")
+        }
+
+        @Test
+        fun `size가 음수이면 예외 발생`() {
+            assertThatThrownBy {
+                PageCommand(page = 0, size = -5)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("Size must be positive")
+        }
+
+        @Test
+        fun `page가 0이면 정상 생성`() {
+            val command = PageCommand(page = 0, size = 1)
+
+            assertThat(command.page).isEqualTo(0)
+        }
+
+        @Test
+        fun `size가 1이면 정상 생성`() {
+            val command = PageCommand(page = 0, size = 1)
+
+            assertThat(command.size).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("SortOrder 생성")
+    inner class SortOrderCreation {
+        @Test
+        fun `SortOrder 기본 방향은 ASC`() {
+            val sortOrder = SortOrder(property = "name")
+
+            assertThat(sortOrder.property).isEqualTo("name")
+            assertThat(sortOrder.direction).isEqualTo(SortDirection.ASC)
+        }
+
+        @Test
+        fun `SortOrder DESC 방향으로 생성 가능`() {
+            val sortOrder = SortOrder(property = "createdAt", direction = SortDirection.DESC)
+
+            assertThat(sortOrder.property).isEqualTo("createdAt")
+            assertThat(sortOrder.direction).isEqualTo(SortDirection.DESC)
+        }
+    }
+
+    @Nested
+    @DisplayName("SortDirection enum")
+    inner class SortDirectionEnum {
+        @Test
+        fun `SortDirection은 ASC와 DESC 두 값을 가진다`() {
+            val values = SortDirection.entries
+
+            assertThat(values).containsExactlyInAnyOrder(SortDirection.ASC, SortDirection.DESC)
+        }
+
+        @Test
+        fun `SortDirection ASC 이름 확인`() {
+            assertThat(SortDirection.ASC.name).isEqualTo("ASC")
+        }
+
+        @Test
+        fun `SortDirection DESC 이름 확인`() {
+            assertThat(SortDirection.DESC.name).isEqualTo("DESC")
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/common/PageResultTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/common/PageResultTest.kt
@@ -1,0 +1,183 @@
+package com.nextup.core.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("PageResult 테스트")
+class PageResultTest {
+    @Nested
+    @DisplayName("기본 생성 및 필드 확인")
+    inner class Creation {
+        @Test
+        fun `PageResult 생성 시 모든 필드가 설정된다`() {
+            val content = listOf("a", "b", "c")
+            val result =
+                PageResult(
+                    content = content,
+                    page = 0,
+                    size = 10,
+                    totalElements = 3L,
+                    totalPages = 1,
+                )
+
+            assertThat(result.content).isEqualTo(content)
+            assertThat(result.page).isEqualTo(0)
+            assertThat(result.size).isEqualTo(10)
+            assertThat(result.totalElements).isEqualTo(3L)
+            assertThat(result.totalPages).isEqualTo(1)
+        }
+
+        @Test
+        fun `빈 content로 PageResult 생성 가능`() {
+            val result =
+                PageResult(
+                    content = emptyList<String>(),
+                    page = 0,
+                    size = 20,
+                    totalElements = 0L,
+                    totalPages = 0,
+                )
+
+            assertThat(result.content).isEmpty()
+            assertThat(result.totalElements).isEqualTo(0L)
+        }
+    }
+
+    @Nested
+    @DisplayName("hasNext 계산")
+    inner class HasNext {
+        @Test
+        fun `현재 페이지가 마지막 페이지보다 작으면 hasNext = true`() {
+            val result =
+                PageResult(
+                    content = listOf(1, 2, 3),
+                    page = 0,
+                    size = 3,
+                    totalElements = 9L,
+                    totalPages = 3,
+                )
+
+            assertThat(result.hasNext).isTrue()
+        }
+
+        @Test
+        fun `현재 페이지가 마지막 페이지이면 hasNext = false`() {
+            val result =
+                PageResult(
+                    content = listOf(7, 8, 9),
+                    page = 2,
+                    size = 3,
+                    totalElements = 9L,
+                    totalPages = 3,
+                )
+
+            assertThat(result.hasNext).isFalse()
+        }
+
+        @Test
+        fun `totalPages가 0이면 hasNext = false`() {
+            val result =
+                PageResult(
+                    content = emptyList<Int>(),
+                    page = 0,
+                    size = 10,
+                    totalElements = 0L,
+                    totalPages = 0,
+                )
+
+            assertThat(result.hasNext).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("hasPrevious 계산")
+    inner class HasPrevious {
+        @Test
+        fun `첫 번째 페이지이면 hasPrevious = false`() {
+            val result =
+                PageResult(
+                    content = listOf(1, 2, 3),
+                    page = 0,
+                    size = 3,
+                    totalElements = 9L,
+                    totalPages = 3,
+                )
+
+            assertThat(result.hasPrevious).isFalse()
+        }
+
+        @Test
+        fun `두 번째 이후 페이지이면 hasPrevious = true`() {
+            val result =
+                PageResult(
+                    content = listOf(4, 5, 6),
+                    page = 1,
+                    size = 3,
+                    totalElements = 9L,
+                    totalPages = 3,
+                )
+
+            assertThat(result.hasPrevious).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("map 변환")
+    inner class MapTransform {
+        @Test
+        fun `map으로 content 타입을 변환할 수 있다`() {
+            val result =
+                PageResult(
+                    content = listOf(1, 2, 3),
+                    page = 0,
+                    size = 10,
+                    totalElements = 3L,
+                    totalPages = 1,
+                )
+
+            val mapped = result.map { it.toString() }
+
+            assertThat(mapped.content).containsExactly("1", "2", "3")
+            assertThat(mapped.page).isEqualTo(result.page)
+            assertThat(mapped.size).isEqualTo(result.size)
+            assertThat(mapped.totalElements).isEqualTo(result.totalElements)
+            assertThat(mapped.totalPages).isEqualTo(result.totalPages)
+        }
+
+        @Test
+        fun `map으로 변환해도 페이징 메타데이터는 유지된다`() {
+            val result =
+                PageResult(
+                    content = listOf("hello", "world"),
+                    page = 2,
+                    size = 5,
+                    totalElements = 12L,
+                    totalPages = 3,
+                )
+
+            val mapped = result.map { it.length }
+
+            assertThat(mapped.content).containsExactly(5, 5)
+            assertThat(mapped.hasNext).isEqualTo(result.hasNext)
+            assertThat(mapped.hasPrevious).isEqualTo(result.hasPrevious)
+        }
+
+        @Test
+        fun `빈 content에 map 적용 시 빈 목록 반환`() {
+            val result =
+                PageResult(
+                    content = emptyList<String>(),
+                    page = 0,
+                    size = 10,
+                    totalElements = 0L,
+                    totalPages = 0,
+                )
+
+            val mapped = result.map { it.length }
+
+            assertThat(mapped.content).isEmpty()
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServiceTest.kt
@@ -3,6 +3,8 @@ package com.nextup.core.service.notification
 import com.nextup.common.exception.DeviceTokenNotFoundException
 import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.NotificationNotFoundException
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.notification.DevicePlatform
 import com.nextup.core.domain.notification.DeviceToken
 import com.nextup.core.domain.notification.Notification
@@ -21,8 +23,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 
 class NotificationServiceTest {
     private lateinit var notificationRepository: NotificationRepositoryPort
@@ -101,7 +101,7 @@ class NotificationServiceTest {
     fun `사용자의 알림 목록을 페이징으로 조회할 수 있다`() {
         // given
         val userId = 1L
-        val pageable = PageRequest.of(0, 10)
+        val pageCommand = PageCommand(page = 0, size = 10)
 
         val notifications =
             listOf(
@@ -119,12 +119,17 @@ class NotificationServiceTest {
                 ),
             )
 
-        val page = PageImpl(notifications, pageable, notifications.size.toLong())
-
-        every { notificationRepository.findByUserId(userId, pageable) } returns page
+        every { notificationRepository.findByUserId(userId, pageCommand) } returns
+            PageResult(
+                content = notifications,
+                page = 0,
+                size = 10,
+                totalElements = notifications.size.toLong(),
+                totalPages = 1,
+            )
 
         // when
-        val result = notificationService.getUserNotifications(userId, pageable)
+        val result = notificationService.getUserNotifications(userId, pageCommand)
 
         // then
         assertThat(result.content).hasSize(2)
@@ -132,20 +137,26 @@ class NotificationServiceTest {
         assertThat(result.content[1].title).isEqualTo("알림 2")
         assertThat(result.totalElements).isEqualTo(2)
 
-        verify(exactly = 1) { notificationRepository.findByUserId(userId, pageable) }
+        verify(exactly = 1) { notificationRepository.findByUserId(userId, pageCommand) }
     }
 
     @Test
     fun `알림이 없는 사용자의 페이징 조회는 빈 페이지를 반환한다`() {
         // given
         val userId = 1L
-        val pageable = PageRequest.of(0, 10)
-        val emptyPage = PageImpl<Notification>(emptyList(), pageable, 0)
+        val pageCommand = PageCommand(page = 0, size = 10)
 
-        every { notificationRepository.findByUserId(userId, pageable) } returns emptyPage
+        every { notificationRepository.findByUserId(userId, pageCommand) } returns
+            PageResult(
+                content = emptyList(),
+                page = 0,
+                size = 10,
+                totalElements = 0,
+                totalPages = 0,
+            )
 
         // when
-        val result = notificationService.getUserNotifications(userId, pageable)
+        val result = notificationService.getUserNotifications(userId, pageCommand)
 
         // then
         assertThat(result.content).isEmpty()

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/player/PlayerServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/player/PlayerServiceTest.kt
@@ -1,6 +1,8 @@
 package com.nextup.core.service.player
 
 import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.port.repository.PlayerRepositoryPort
@@ -12,8 +14,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 
 @DisplayName("PlayerService")
 class PlayerServiceTest {
@@ -37,17 +37,23 @@ class PlayerServiceTest {
                     name = "김철수",
                     primaryPosition = Position.STARTING_PITCHER,
                 )
-            val pageable = PageRequest.of(0, 20)
-            val page = PageImpl(listOf(player), pageable, 1)
+            val pageCommand = PageCommand(page = 0, size = 20)
 
             every {
                 playerRepository.search(
                     name = "김",
                     teamId = null,
                     position = null,
-                    pageable = pageable,
+                    pageCommand = pageCommand,
                 )
-            } returns page
+            } returns
+                PageResult(
+                    content = listOf(player),
+                    page = 0,
+                    size = 20,
+                    totalElements = 1,
+                    totalPages = 1,
+                )
 
             // when
             val result =
@@ -55,7 +61,7 @@ class PlayerServiceTest {
                     name = "김",
                     teamId = null,
                     position = null,
-                    pageable = pageable,
+                    pageCommand = pageCommand,
                 )
 
             // then
@@ -66,17 +72,23 @@ class PlayerServiceTest {
         @Test
         fun `should pass all filter parameters to repository`() {
             // given
-            val pageable = PageRequest.of(0, 10)
-            val page = PageImpl<Player>(emptyList(), pageable, 0)
+            val pageCommand = PageCommand(page = 0, size = 10)
 
             every {
                 playerRepository.search(
                     name = "이",
                     teamId = 5L,
                     position = Position.SHORTSTOP,
-                    pageable = pageable,
+                    pageCommand = pageCommand,
                 )
-            } returns page
+            } returns
+                PageResult(
+                    content = emptyList(),
+                    page = 0,
+                    size = 10,
+                    totalElements = 0,
+                    totalPages = 0,
+                )
 
             // when
             val result =
@@ -84,7 +96,7 @@ class PlayerServiceTest {
                     name = "이",
                     teamId = 5L,
                     position = Position.SHORTSTOP,
-                    pageable = pageable,
+                    pageCommand = pageCommand,
                 )
 
             // then

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumServiceTest.kt
@@ -4,6 +4,8 @@ import com.nextup.common.exception.BookingNotFoundException
 import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.SlotNotFoundException
 import com.nextup.common.exception.StadiumNotFoundException
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.stadium.BookingStatus
 import com.nextup.core.domain.stadium.SlotStatus
 import com.nextup.core.domain.stadium.Stadium
@@ -22,8 +24,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -53,12 +53,18 @@ class StadiumServiceTest {
                     createStadium(1L, "잠실 야구장", 37.5121, 127.0717),
                     createStadium(2L, "고척 야구장", 37.4981, 126.8671),
                 )
-            val pageable = PageRequest.of(0, 20)
-            val page = PageImpl(stadiums, pageable, 2)
-            every { stadiumRepository.findNearbyStadiums(37.5, 127.0, 10.0, pageable) } returns page
+            val pageCommand = PageCommand(page = 0, size = 20)
+            every { stadiumRepository.findNearbyStadiums(37.5, 127.0, 10.0, pageCommand) } returns
+                PageResult(
+                    content = stadiums,
+                    page = 0,
+                    size = 20,
+                    totalElements = 2,
+                    totalPages = 1,
+                )
 
             // when
-            val result = stadiumService.findNearbyStadiums(37.5, 127.0, 10.0, pageable)
+            val result = stadiumService.findNearbyStadiums(37.5, 127.0, 10.0, pageCommand)
 
             // then
             assertThat(result.content).hasSize(2)
@@ -69,11 +75,11 @@ class StadiumServiceTest {
         @Test
         fun `should throw InvalidInputException when latitude is out of range`() {
             // given
-            val pageable = PageRequest.of(0, 20)
+            val pageCommand = PageCommand(page = 0, size = 20)
 
             // when & then
             assertThatThrownBy {
-                stadiumService.findNearbyStadiums(91.0, 127.0, 10.0, pageable)
+                stadiumService.findNearbyStadiums(91.0, 127.0, 10.0, pageCommand)
             }.isInstanceOf(InvalidInputException::class.java)
                 .hasMessageContaining("위도는 -90 ~ 90 범위여야 합니다")
         }
@@ -81,11 +87,11 @@ class StadiumServiceTest {
         @Test
         fun `should throw InvalidInputException when longitude is out of range`() {
             // given
-            val pageable = PageRequest.of(0, 20)
+            val pageCommand = PageCommand(page = 0, size = 20)
 
             // when & then
             assertThatThrownBy {
-                stadiumService.findNearbyStadiums(37.5, 181.0, 10.0, pageable)
+                stadiumService.findNearbyStadiums(37.5, 181.0, 10.0, pageCommand)
             }.isInstanceOf(InvalidInputException::class.java)
                 .hasMessageContaining("경도는 -180 ~ 180 범위여야 합니다")
         }
@@ -93,11 +99,11 @@ class StadiumServiceTest {
         @Test
         fun `should throw InvalidInputException when radiusKm is zero`() {
             // given
-            val pageable = PageRequest.of(0, 20)
+            val pageCommand = PageCommand(page = 0, size = 20)
 
             // when & then
             assertThatThrownBy {
-                stadiumService.findNearbyStadiums(37.5, 127.0, 0.0, pageable)
+                stadiumService.findNearbyStadiums(37.5, 127.0, 0.0, pageCommand)
             }.isInstanceOf(InvalidInputException::class.java)
                 .hasMessageContaining("검색 반경은 0보다 커야 합니다")
         }
@@ -105,11 +111,11 @@ class StadiumServiceTest {
         @Test
         fun `should throw InvalidInputException when radiusKm is negative`() {
             // given
-            val pageable = PageRequest.of(0, 20)
+            val pageCommand = PageCommand(page = 0, size = 20)
 
             // when & then
             assertThatThrownBy {
-                stadiumService.findNearbyStadiums(37.5, 127.0, -5.0, pageable)
+                stadiumService.findNearbyStadiums(37.5, 127.0, -5.0, pageCommand)
             }.isInstanceOf(InvalidInputException::class.java)
                 .hasMessageContaining("검색 반경은 0보다 커야 합니다")
         }
@@ -117,12 +123,18 @@ class StadiumServiceTest {
         @Test
         fun `should accept boundary latitude values`() {
             // given
-            val pageable = PageRequest.of(0, 20)
-            val page = PageImpl(emptyList<Stadium>(), pageable, 0)
-            every { stadiumRepository.findNearbyStadiums(90.0, 180.0, 10.0, pageable) } returns page
+            val pageCommand = PageCommand(page = 0, size = 20)
+            every { stadiumRepository.findNearbyStadiums(90.0, 180.0, 10.0, pageCommand) } returns
+                PageResult(
+                    content = emptyList(),
+                    page = 0,
+                    size = 20,
+                    totalElements = 0,
+                    totalPages = 0,
+                )
 
             // when
-            val result = stadiumService.findNearbyStadiums(90.0, 180.0, 10.0, pageable)
+            val result = stadiumService.findNearbyStadiums(90.0, 180.0, 10.0, pageCommand)
 
             // then
             assertThat(result.content).isEmpty()

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/user/UserServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/user/UserServiceTest.kt
@@ -1,6 +1,8 @@
 package com.nextup.core.service.user
 
 import com.nextup.common.exception.*
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.user.OAuthAccount
 import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.Role
@@ -16,8 +18,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import java.util.*
 
 @DisplayName("UserService")
@@ -348,11 +348,18 @@ class UserServiceTest {
                     createTestUser(1L, "user1@example.com"),
                     createTestUser(2L, "user2@example.com"),
                 )
-            val pageable = PageRequest.of(0, 10)
-            every { userRepository.findAllActive(pageable) } returns PageImpl(users)
+            val pageCommand = PageCommand(page = 0, size = 10)
+            every { userRepository.findAllActive(pageCommand) } returns
+                PageResult(
+                    content = users,
+                    page = 0,
+                    size = 10,
+                    totalElements = 2,
+                    totalPages = 1,
+                )
 
             // when
-            val result = userService.getAllActive(pageable)
+            val result = userService.getAllActive(pageCommand)
 
             // then
             assertThat(result.content).hasSize(2)
@@ -371,11 +378,18 @@ class UserServiceTest {
                     createTestUser(2L, "user2@example.com"),
                     createTestUser(3L, "user3@example.com"),
                 )
-            val pageable = PageRequest.of(0, 10)
-            every { userRepository.findAllByIsActive(true, pageable) } returns PageImpl(users)
+            val pageCommand = PageCommand(page = 0, size = 10)
+            every { userRepository.findAllByIsActive(true, pageCommand) } returns
+                PageResult(
+                    content = users,
+                    page = 0,
+                    size = 10,
+                    totalElements = 3,
+                    totalPages = 1,
+                )
 
             // when
-            val result = userService.getAll(pageable)
+            val result = userService.getAll(pageCommand)
 
             // then
             assertThat(result.content).hasSize(3)
@@ -389,11 +403,18 @@ class UserServiceTest {
         fun `should return active users only`() {
             // given
             val activeUsers = listOf(createTestUser(1L, "active@example.com"))
-            val pageable = PageRequest.of(0, 10)
-            every { userRepository.findAllByIsActive(true, pageable) } returns PageImpl(activeUsers)
+            val pageCommand = PageCommand(page = 0, size = 10)
+            every { userRepository.findAllByIsActive(true, pageCommand) } returns
+                PageResult(
+                    content = activeUsers,
+                    page = 0,
+                    size = 10,
+                    totalElements = 1,
+                    totalPages = 1,
+                )
 
             // when
-            val result = userService.getAllByStatus(true, pageable)
+            val result = userService.getAllByStatus(true, pageCommand)
 
             // then
             assertThat(result.content).hasSize(1)
@@ -406,11 +427,18 @@ class UserServiceTest {
                 listOf(
                     createTestUser(1L, "inactive@example.com").apply { deactivate() },
                 )
-            val pageable = PageRequest.of(0, 10)
-            every { userRepository.findAllByIsActive(false, pageable) } returns PageImpl(inactiveUsers)
+            val pageCommand = PageCommand(page = 0, size = 10)
+            every { userRepository.findAllByIsActive(false, pageCommand) } returns
+                PageResult(
+                    content = inactiveUsers,
+                    page = 0,
+                    size = 10,
+                    totalElements = 1,
+                    totalPages = 1,
+                )
 
             // when
-            val result = userService.getAllByStatus(false, pageable)
+            val result = userService.getAllByStatus(false, pageCommand)
 
             // then
             assertThat(result.content).hasSize(1)
@@ -424,11 +452,18 @@ class UserServiceTest {
         fun `should search users by keyword`() {
             // given
             val users = listOf(createTestUser(1L, "test@example.com"))
-            val pageable = PageRequest.of(0, 10)
-            every { userRepository.searchByKeyword("test", pageable) } returns PageImpl(users)
+            val pageCommand = PageCommand(page = 0, size = 10)
+            every { userRepository.searchByKeyword("test", pageCommand) } returns
+                PageResult(
+                    content = users,
+                    page = 0,
+                    size = 10,
+                    totalElements = 1,
+                    totalPages = 1,
+                )
 
             // when
-            val result = userService.search("test", pageable)
+            val result = userService.search("test", pageCommand)
 
             // then
             assertThat(result.content).hasSize(1)
@@ -445,11 +480,18 @@ class UserServiceTest {
                 listOf(
                     createTestUser(1L, "admin@example.com").apply { addRole(Role.ADMIN) },
                 )
-            val pageable = PageRequest.of(0, 10)
-            every { userRepository.findAllByRole(Role.ADMIN, pageable) } returns PageImpl(admins)
+            val pageCommand = PageCommand(page = 0, size = 10)
+            every { userRepository.findAllByRole(Role.ADMIN, pageCommand) } returns
+                PageResult(
+                    content = admins,
+                    page = 0,
+                    size = 10,
+                    totalElements = 1,
+                    totalPages = 1,
+                )
 
             // when
-            val result = userService.getAllByRole(Role.ADMIN, pageable)
+            val result = userService.getAllByRole(Role.ADMIN, pageCommand)
 
             // then
             assertThat(result.content).hasSize(1)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/common/PageExtensions.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/common/PageExtensions.kt
@@ -1,0 +1,57 @@
+package com.nextup.infrastructure.common
+
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
+import com.nextup.core.common.SortDirection
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+
+/**
+ * Core의 PageCommand를 Spring Data의 Pageable로 변환합니다.
+ */
+fun PageCommand.toPageable(): Pageable {
+    val sort =
+        if (sorts.isEmpty()) {
+            Sort.unsorted()
+        } else {
+            Sort.by(
+                sorts.map {
+                    Sort.Order(
+                        if (it.direction == SortDirection.ASC) Sort.Direction.ASC else Sort.Direction.DESC,
+                        it.property,
+                    )
+                },
+            )
+        }
+    return PageRequest.of(page, size, sort)
+}
+
+/**
+ * Spring Data의 Page를 Core의 PageResult로 변환합니다.
+ */
+fun <T> Page<T>.toPageResult(): PageResult<T> =
+    PageResult(
+        content = content,
+        page = number,
+        size = size,
+        totalElements = totalElements,
+        totalPages = totalPages,
+    )
+
+/**
+ * Spring Data의 Pageable을 Core의 PageCommand로 변환합니다.
+ */
+fun Pageable.toPageCommand(): PageCommand =
+    PageCommand(
+        page = pageNumber,
+        size = pageSize,
+        sorts =
+            sort.map {
+                com.nextup.core.common.SortOrder(
+                    property = it.property,
+                    direction = if (it.isAscending) SortDirection.ASC else SortDirection.DESC,
+                )
+            }.toList(),
+    )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumRepositoryAdapter.kt
@@ -1,9 +1,11 @@
 package com.nextup.infrastructure.persistence.stadium
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.stadium.Stadium
 import com.nextup.core.port.repository.StadiumRepositoryPort
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import com.nextup.infrastructure.common.toPageResult
+import com.nextup.infrastructure.common.toPageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
@@ -32,9 +34,14 @@ class StadiumRepositoryAdapter(
         latitude: Double,
         longitude: Double,
         radiusKm: Double,
-        pageable: Pageable,
-    ): Page<Stadium> {
+        pageCommand: PageCommand,
+    ): PageResult<Stadium> {
         val radiusMeters = radiusKm * 1000.0
-        return jpaRepository.findNearbyOrderByDistance(latitude, longitude, radiusMeters, pageable)
+        return jpaRepository.findNearbyOrderByDistance(
+            latitude,
+            longitude,
+            radiusMeters,
+            pageCommand.toPageable()
+        ).toPageResult()
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerRepository.kt
@@ -1,8 +1,12 @@
 package com.nextup.infrastructure.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.infrastructure.common.toPageResult
+import com.nextup.infrastructure.common.toPageable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -52,10 +56,17 @@ interface PlayerRepository :
         AND (:position IS NULL OR p.primaryPosition = :position)
     """,
     )
-    override fun search(
+    fun searchByPageable(
         @Param("name") name: String?,
         @Param("teamId") teamId: Long?,
         @Param("position") position: Position?,
         pageable: Pageable,
     ): Page<Player>
+
+    override fun search(
+        name: String?,
+        teamId: Long?,
+        position: Position?,
+        pageCommand: PageCommand,
+    ): PageResult<Player> = searchByPageable(name, teamId, position, pageCommand.toPageable()).toPageResult()
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamBlacklistRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamBlacklistRepositoryAdapter.kt
@@ -1,9 +1,11 @@
 package com.nextup.infrastructure.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.team.TeamBlacklist
 import com.nextup.core.port.repository.TeamBlacklistRepositoryPort
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import com.nextup.infrastructure.common.toPageResult
+import com.nextup.infrastructure.common.toPageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
@@ -22,8 +24,8 @@ class TeamBlacklistRepositoryAdapter(
 
     override fun findByTeamId(
         teamId: Long,
-        pageable: Pageable,
-    ): Page<TeamBlacklist> = jpaRepository.findByTeamId(teamId, pageable)
+        pageCommand: PageCommand,
+    ): PageResult<TeamBlacklist> = jpaRepository.findByTeamId(teamId, pageCommand.toPageable()).toPageResult()
 
     override fun findByTeamIdAndUserId(
         teamId: Long,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamJoinRequestRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamJoinRequestRepositoryAdapter.kt
@@ -1,10 +1,12 @@
 package com.nextup.infrastructure.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.team.JoinRequestStatus
 import com.nextup.core.domain.team.TeamJoinRequest
 import com.nextup.core.port.repository.TeamJoinRequestRepositoryPort
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import com.nextup.infrastructure.common.toPageResult
+import com.nextup.infrastructure.common.toPageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
@@ -25,8 +27,9 @@ class TeamJoinRequestRepositoryAdapter(
     override fun findByTeamIdAndStatus(
         teamId: Long,
         status: JoinRequestStatus,
-        pageable: Pageable,
-    ): Page<TeamJoinRequest> = jpaRepository.findByTeamIdAndStatus(teamId, status, pageable)
+        pageCommand: PageCommand,
+    ): PageResult<TeamJoinRequest> =
+        jpaRepository.findByTeamIdAndStatus(teamId, status, pageCommand.toPageable()).toPageResult()
 
     override fun findByUserId(userId: Long): List<TeamJoinRequest> = jpaRepository.findByUserId(userId)
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapter.kt
@@ -1,10 +1,12 @@
 package com.nextup.infrastructure.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.team.TeamMember
 import com.nextup.core.domain.team.TeamMemberStatus
 import com.nextup.core.port.repository.TeamMemberRepositoryPort
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import com.nextup.infrastructure.common.toPageResult
+import com.nextup.infrastructure.common.toPageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
@@ -43,8 +45,9 @@ class TeamMemberRepositoryAdapter(
 
     override fun findByTeamIdWithUserAndPlayer(
         teamId: Long,
-        pageable: Pageable,
-    ): Page<TeamMember> = jpaRepository.findByTeamIdWithUserAndPlayer(teamId, pageable)
+        pageCommand: PageCommand,
+    ): PageResult<TeamMember> =
+        jpaRepository.findByTeamIdWithUserAndPlayer(teamId, pageCommand.toPageable()).toPageResult()
 
     override fun existsByTeamIdAndUserId(
         teamId: Long,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/audit/AuditLogRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/audit/AuditLogRepository.kt
@@ -1,7 +1,11 @@
 package com.nextup.infrastructure.repository.audit
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.audit.AuditLog
 import com.nextup.core.port.repository.AuditLogRepositoryPort
+import com.nextup.infrastructure.common.toPageResult
+import com.nextup.infrastructure.common.toPageable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -35,7 +39,7 @@ interface AuditLogRepository :
         ORDER BY a.createdAt DESC
         """,
     )
-    override fun findAllByCondition(
+    fun findAllByConditionByPageable(
         @Param("adminUserId") adminUserId: Long?,
         @Param("action") action: String?,
         @Param("targetEntity") targetEntity: String?,
@@ -43,4 +47,21 @@ interface AuditLogRepository :
         @Param("toDate") toDate: Instant?,
         pageable: Pageable,
     ): Page<AuditLog>
+
+    override fun findAllByCondition(
+        adminUserId: Long?,
+        action: String?,
+        targetEntity: String?,
+        fromDate: Instant?,
+        toDate: Instant?,
+        pageCommand: PageCommand,
+    ): PageResult<AuditLog> =
+        findAllByConditionByPageable(
+            adminUserId,
+            action,
+            targetEntity,
+            fromDate,
+            toDate,
+            pageCommand.toPageable()
+        ).toPageResult()
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
@@ -1,7 +1,11 @@
 package com.nextup.infrastructure.repository.notification
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.notification.Notification
 import com.nextup.core.port.repository.NotificationRepositoryPort
+import com.nextup.infrastructure.common.toPageResult
+import com.nextup.infrastructure.common.toPageable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -11,12 +15,17 @@ import org.springframework.data.repository.query.Param
 interface NotificationRepository :
     JpaRepository<Notification, Long>,
     NotificationRepositoryPort {
-    override fun findByUserId(
+    fun findByUserId(
         userId: Long,
         pageable: Pageable,
     ): Page<Notification>
 
     override fun findByUserId(userId: Long): List<Notification>
+
+    override fun findByUserId(
+        userId: Long,
+        pageCommand: PageCommand,
+    ): PageResult<Notification> = findByUserId(userId, pageCommand.toPageable()).toPageResult()
 
     @Query(
         "SELECT COUNT(n) FROM Notification n " +

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/UserRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/UserRepository.kt
@@ -1,8 +1,12 @@
 package com.nextup.infrastructure.repository.user
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.user.Role
 import com.nextup.core.domain.user.User
 import com.nextup.core.port.repository.UserRepositoryPort
+import com.nextup.infrastructure.common.toPageResult
+import com.nextup.infrastructure.common.toPageable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -16,13 +20,21 @@ interface UserRepository :
     override fun existsByEmail(email: String): Boolean
 
     @Query("SELECT u FROM User u WHERE u.isActive = true")
-    override fun findAllActive(pageable: Pageable): Page<User>
+    fun findAllActiveByPageable(pageable: Pageable): Page<User>
+
+    override fun findAllActive(pageCommand: PageCommand): PageResult<User> =
+        findAllActiveByPageable(pageCommand.toPageable()).toPageResult()
 
     @Query("SELECT u FROM User u WHERE u.isActive = :isActive")
-    override fun findAllByIsActive(
+    fun findAllByIsActiveByPageable(
         isActive: Boolean,
         pageable: Pageable,
     ): Page<User>
+
+    override fun findAllByIsActive(
+        isActive: Boolean,
+        pageCommand: PageCommand,
+    ): PageResult<User> = findAllByIsActiveByPageable(isActive, pageCommand.toPageable()).toPageResult()
 
     @Query(
         """
@@ -31,10 +43,15 @@ interface UserRepository :
         OR u.email LIKE %:keyword%
     """,
     )
-    override fun searchByKeyword(
+    fun searchByKeywordByPageable(
         keyword: String,
         pageable: Pageable,
     ): Page<User>
+
+    override fun searchByKeyword(
+        keyword: String,
+        pageCommand: PageCommand,
+    ): PageResult<User> = searchByKeywordByPageable(keyword, pageCommand.toPageable()).toPageResult()
 
     @Query(
         """
@@ -43,10 +60,15 @@ interface UserRepository :
         WHERE r = :role
     """,
     )
-    override fun findAllByRole(
+    fun findAllByRoleByPageable(
         role: Role,
         pageable: Pageable,
     ): Page<User>
+
+    override fun findAllByRole(
+        role: Role,
+        pageCommand: PageCommand,
+    ): PageResult<User> = findAllByRoleByPageable(role, pageCommand.toPageable()).toPageResult()
 
     @Query(
         """
@@ -55,10 +77,15 @@ interface UserRepository :
         WHERE r IN :roles
     """,
     )
-    override fun findAllByRolesIn(
+    fun findAllByRolesInByPageable(
         roles: Set<Role>,
         pageable: Pageable,
     ): Page<User>
+
+    override fun findAllByRolesIn(
+        roles: Set<Role>,
+        pageCommand: PageCommand,
+    ): PageResult<User> = findAllByRolesInByPageable(roles, pageCommand.toPageable()).toPageResult()
 
     @Query("SELECT u FROM User u WHERE u.player.id = :playerId")
     override fun findByPlayerId(playerId: Long): User?

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/audit/AuditLogQueryServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/audit/AuditLogQueryServiceImpl.kt
@@ -1,11 +1,11 @@
 package com.nextup.infrastructure.service.audit
 
 import com.nextup.common.exception.AuditLogNotFoundException
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.audit.AuditLog
 import com.nextup.core.port.repository.AuditLogRepositoryPort
 import com.nextup.core.service.audit.AuditLogQueryService
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -21,15 +21,15 @@ class AuditLogQueryServiceImpl(
         targetEntity: String?,
         fromDate: Instant?,
         toDate: Instant?,
-        pageable: Pageable,
-    ): Page<AuditLog> =
+        pageCommand: PageCommand,
+    ): PageResult<AuditLog> =
         auditLogRepository.findAllByCondition(
             adminUserId = adminUserId,
             action = action,
             targetEntity = targetEntity,
             fromDate = fromDate,
             toDate = toDate,
-            pageable = pageable,
+            pageCommand = pageCommand,
         )
 
     override fun findById(id: Long): AuditLog =

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/common/PageExtensionsTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/common/PageExtensionsTest.kt
@@ -1,0 +1,183 @@
+package com.nextup.infrastructure.common
+
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.SortDirection
+import com.nextup.core.common.SortOrder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+
+@DisplayName("PageExtensions 테스트")
+class PageExtensionsTest {
+    @Nested
+    @DisplayName("PageCommand.toPageable()")
+    inner class ToPageable {
+        @Test
+        fun `sorts가 비어있으면 unsorted Pageable 반환`() {
+            val command = PageCommand(page = 0, size = 20, sorts = emptyList())
+
+            val pageable = command.toPageable()
+
+            assertThat(pageable.pageNumber).isEqualTo(0)
+            assertThat(pageable.pageSize).isEqualTo(20)
+            assertThat(pageable.sort.isSorted).isFalse()
+        }
+
+        @Test
+        fun `ASC sort가 있으면 ASC 방향의 Pageable 반환`() {
+            val command =
+                PageCommand(
+                    page = 1,
+                    size = 10,
+                    sorts = listOf(SortOrder(property = "name", direction = SortDirection.ASC)),
+                )
+
+            val pageable = command.toPageable()
+
+            assertThat(pageable.pageNumber).isEqualTo(1)
+            assertThat(pageable.pageSize).isEqualTo(10)
+            val order = pageable.sort.getOrderFor("name")
+            assertThat(order).isNotNull
+            assertThat(order!!.direction).isEqualTo(Sort.Direction.ASC)
+        }
+
+        @Test
+        fun `DESC sort가 있으면 DESC 방향의 Pageable 반환`() {
+            val command =
+                PageCommand(
+                    page = 0,
+                    size = 5,
+                    sorts = listOf(SortOrder(property = "createdAt", direction = SortDirection.DESC)),
+                )
+
+            val pageable = command.toPageable()
+
+            val order = pageable.sort.getOrderFor("createdAt")
+            assertThat(order).isNotNull
+            assertThat(order!!.direction).isEqualTo(Sort.Direction.DESC)
+        }
+
+        @Test
+        fun `복수의 sort 조건이 모두 변환된다`() {
+            val command =
+                PageCommand(
+                    page = 0,
+                    size = 20,
+                    sorts =
+                        listOf(
+                            SortOrder(property = "name", direction = SortDirection.ASC),
+                            SortOrder(property = "createdAt", direction = SortDirection.DESC),
+                        ),
+                )
+
+            val pageable = command.toPageable()
+
+            val nameOrder = pageable.sort.getOrderFor("name")
+            val createdAtOrder = pageable.sort.getOrderFor("createdAt")
+            assertThat(nameOrder!!.direction).isEqualTo(Sort.Direction.ASC)
+            assertThat(createdAtOrder!!.direction).isEqualTo(Sort.Direction.DESC)
+        }
+    }
+
+    @Nested
+    @DisplayName("Page<T>.toPageResult()")
+    inner class ToPageResult {
+        @Test
+        fun `Spring Page를 PageResult로 변환한다`() {
+            val content = listOf("a", "b", "c")
+            val pageable = PageRequest.of(0, 10)
+            val springPage = PageImpl(content, pageable, 3L)
+
+            val result = springPage.toPageResult()
+
+            assertThat(result.content).isEqualTo(content)
+            assertThat(result.page).isEqualTo(0)
+            assertThat(result.size).isEqualTo(10)
+            assertThat(result.totalElements).isEqualTo(3L)
+            assertThat(result.totalPages).isEqualTo(1)
+        }
+
+        @Test
+        fun `빈 Spring Page를 PageResult로 변환한다`() {
+            val pageable = PageRequest.of(0, 20)
+            val springPage = PageImpl(emptyList<String>(), pageable, 0L)
+
+            val result = springPage.toPageResult()
+
+            assertThat(result.content).isEmpty()
+            assertThat(result.totalElements).isEqualTo(0L)
+            assertThat(result.hasNext).isFalse()
+            assertThat(result.hasPrevious).isFalse()
+        }
+
+        @Test
+        fun `다음 페이지가 있는 경우 hasNext = true`() {
+            val content = listOf(1, 2, 3)
+            val pageable = PageRequest.of(0, 3)
+            val springPage = PageImpl(content, pageable, 9L)
+
+            val result = springPage.toPageResult()
+
+            assertThat(result.hasNext).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("Pageable.toPageCommand()")
+    inner class ToPageCommand {
+        @Test
+        fun `정렬 없는 Pageable을 PageCommand로 변환한다`() {
+            val pageable = PageRequest.of(2, 15)
+
+            val command = pageable.toPageCommand()
+
+            assertThat(command.page).isEqualTo(2)
+            assertThat(command.size).isEqualTo(15)
+            assertThat(command.sorts).isEmpty()
+        }
+
+        @Test
+        fun `ASC 정렬 Pageable을 PageCommand로 변환하면 ASC SortOrder`() {
+            val pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "name"))
+
+            val command = pageable.toPageCommand()
+
+            assertThat(command.sorts).hasSize(1)
+            assertThat(command.sorts[0].property).isEqualTo("name")
+            assertThat(command.sorts[0].direction).isEqualTo(SortDirection.ASC)
+        }
+
+        @Test
+        fun `DESC 정렬 Pageable을 PageCommand로 변환하면 DESC SortOrder`() {
+            val pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"))
+
+            val command = pageable.toPageCommand()
+
+            assertThat(command.sorts).hasSize(1)
+            assertThat(command.sorts[0].property).isEqualTo("createdAt")
+            assertThat(command.sorts[0].direction).isEqualTo(SortDirection.DESC)
+        }
+
+        @Test
+        fun `복수 정렬 Pageable을 PageCommand로 변환한다`() {
+            val pageable =
+                PageRequest.of(
+                    1,
+                    5,
+                    Sort.by(Sort.Order.asc("name"), Sort.Order.desc("createdAt")),
+                )
+
+            val command = pageable.toPageCommand()
+
+            assertThat(command.sorts).hasSize(2)
+            val nameSort = command.sorts.find { it.property == "name" }
+            val createdAtSort = command.sorts.find { it.property == "createdAt" }
+            assertThat(nameSort!!.direction).isEqualTo(SortDirection.ASC)
+            assertThat(createdAtSort!!.direction).isEqualTo(SortDirection.DESC)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumRepositoryAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.nextup.infrastructure.persistence.stadium
 
+import com.nextup.core.common.PageCommand
 import com.nextup.core.domain.stadium.Stadium
 import io.mockk.every
 import io.mockk.mockk
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 
 @DisplayName("StadiumRepositoryAdapter")
@@ -150,33 +150,33 @@ class StadiumRepositoryAdapterTest {
         fun `should convert km to meters and return paged result`() {
             // given
             val stadiums = listOf(createStadium("잠실 야구장", 37.5121, 127.0717))
-            val pageable = PageRequest.of(0, 20)
-            val page = PageImpl(stadiums, pageable, 1)
+            val pageCommand = PageCommand(page = 0, size = 20)
+            val page = PageImpl(stadiums)
             // 10km -> 10000.0 meters
             every {
-                jpaRepository.findNearbyOrderByDistance(37.5, 127.0, 10000.0, pageable)
+                jpaRepository.findNearbyOrderByDistance(37.5, 127.0, 10000.0, any())
             } returns page
 
             // when
-            val result = adapter.findNearbyStadiums(37.5, 127.0, 10.0, pageable)
+            val result = adapter.findNearbyStadiums(37.5, 127.0, 10.0, pageCommand)
 
             // then
             assertThat(result.content).hasSize(1)
             assertThat(result.totalElements).isEqualTo(1)
-            verify { jpaRepository.findNearbyOrderByDistance(37.5, 127.0, 10000.0, pageable) }
+            verify { jpaRepository.findNearbyOrderByDistance(37.5, 127.0, 10000.0, any()) }
         }
 
         @Test
         fun `should return empty page when no stadiums found`() {
             // given
-            val pageable = PageRequest.of(0, 20)
-            val emptyPage = PageImpl(emptyList<Stadium>(), pageable, 0)
+            val pageCommand = PageCommand(page = 0, size = 20)
+            val emptyPage = PageImpl(emptyList<Stadium>())
             every {
-                jpaRepository.findNearbyOrderByDistance(37.5, 127.0, 1000.0, pageable)
+                jpaRepository.findNearbyOrderByDistance(37.5, 127.0, 1000.0, any())
             } returns emptyPage
 
             // when
-            val result = adapter.findNearbyStadiums(37.5, 127.0, 1.0, pageable)
+            val result = adapter.findNearbyStadiums(37.5, 127.0, 1.0, pageCommand)
 
             // then
             assertThat(result.content).isEmpty()

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamBlacklistRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamBlacklistRepositoryAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.nextup.infrastructure.repository
 
+import com.nextup.core.common.PageCommand
 import com.nextup.core.domain.team.TeamBlacklist
 import io.mockk.every
 import io.mockk.justRun
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDateTime
 
@@ -73,18 +73,18 @@ class TeamBlacklistRepositoryAdapterTest {
     @DisplayName("findByTeamId - teamId로 페이지 조회 시 JPA repository에 위임한다")
     fun `should delegate findByTeamId to jpa repository`() {
         // given
-        val pageable = mockk<Pageable>()
+        val pageCommand = PageCommand(page = 0, size = 10)
         val blacklist = mockk<TeamBlacklist>()
         val page = PageImpl(listOf(blacklist))
-        every { jpaRepository.findByTeamId(1L, pageable) } returns page
+        every { jpaRepository.findByTeamId(1L, any()) } returns page
 
         // when
-        val result = adapter.findByTeamId(1L, pageable)
+        val result = adapter.findByTeamId(1L, pageCommand)
 
         // then
         assertThat(result.content).hasSize(1)
         assertThat(result.content[0]).isEqualTo(blacklist)
-        verify(exactly = 1) { jpaRepository.findByTeamId(1L, pageable) }
+        verify(exactly = 1) { jpaRepository.findByTeamId(1L, any()) }
     }
 
     @Test

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamJoinRequestRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamJoinRequestRepositoryAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.nextup.infrastructure.repository
 
+import com.nextup.core.common.PageCommand
 import com.nextup.core.domain.team.JoinRequestStatus
 import com.nextup.core.domain.team.TeamJoinRequest
 import io.mockk.every
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 
 @DisplayName("TeamJoinRequestRepositoryAdapter 테스트")
@@ -88,21 +88,21 @@ class TeamJoinRequestRepositoryAdapterTest {
     @DisplayName("findByTeamIdAndStatus - teamId와 status로 페이지 조회 시 JPA repository에 위임한다")
     fun `should delegate findByTeamIdAndStatus to jpa repository`() {
         // given
-        val pageable = mockk<Pageable>()
+        val pageCommand = PageCommand(page = 0, size = 10)
         val request = mockk<TeamJoinRequest>()
         val page = PageImpl(listOf(request))
         every {
-            jpaRepository.findByTeamIdAndStatus(1L, JoinRequestStatus.PENDING, pageable)
+            jpaRepository.findByTeamIdAndStatus(1L, JoinRequestStatus.PENDING, any())
         } returns page
 
         // when
-        val result = adapter.findByTeamIdAndStatus(1L, JoinRequestStatus.PENDING, pageable)
+        val result = adapter.findByTeamIdAndStatus(1L, JoinRequestStatus.PENDING, pageCommand)
 
         // then
         assertThat(result.content).hasSize(1)
         assertThat(result.content[0]).isEqualTo(request)
         verify(exactly = 1) {
-            jpaRepository.findByTeamIdAndStatus(1L, JoinRequestStatus.PENDING, pageable)
+            jpaRepository.findByTeamIdAndStatus(1L, JoinRequestStatus.PENDING, any())
         }
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.nextup.infrastructure.repository
 
+import com.nextup.core.common.PageCommand
 import com.nextup.core.domain.team.TeamMember
 import com.nextup.core.domain.team.TeamMemberStatus
 import io.mockk.every
@@ -12,7 +13,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 
 @DisplayName("TeamMemberRepositoryAdapter 테스트")
@@ -167,18 +167,18 @@ class TeamMemberRepositoryAdapterTest {
     @DisplayName("findByTeamIdWithUserAndPlayer - 페이지 조회 시 JPA repository에 위임한다")
     fun `should delegate findByTeamIdWithUserAndPlayer to jpa repository`() {
         // given
-        val pageable = mockk<Pageable>()
+        val pageCommand = PageCommand(page = 0, size = 10)
         val member = mockk<TeamMember>()
         val page = PageImpl(listOf(member))
-        every { jpaRepository.findByTeamIdWithUserAndPlayer(1L, pageable) } returns page
+        every { jpaRepository.findByTeamIdWithUserAndPlayer(1L, any()) } returns page
 
         // when
-        val result = adapter.findByTeamIdWithUserAndPlayer(1L, pageable)
+        val result = adapter.findByTeamIdWithUserAndPlayer(1L, pageCommand)
 
         // then
         assertThat(result.content).hasSize(1)
         assertThat(result.content[0]).isEqualTo(member)
-        verify(exactly = 1) { jpaRepository.findByTeamIdWithUserAndPlayer(1L, pageable) }
+        verify(exactly = 1) { jpaRepository.findByTeamIdWithUserAndPlayer(1L, any()) }
     }
 
     @Test

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/audit/AuditLogQueryServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/audit/AuditLogQueryServiceImplTest.kt
@@ -1,6 +1,8 @@
 package com.nextup.infrastructure.service.audit
 
 import com.nextup.common.exception.AuditLogNotFoundException
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.audit.AuditLog
 import com.nextup.core.port.repository.AuditLogRepositoryPort
 import io.mockk.every
@@ -11,8 +13,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 
 @DisplayName("AuditLogQueryServiceImpl")
 class AuditLogQueryServiceImplTest {
@@ -30,9 +30,16 @@ class AuditLogQueryServiceImplTest {
     inner class FindAll {
         @Test
         fun `조건에 맞는 감사 로그를 페이지로 반환한다`() {
-            val pageable = PageRequest.of(0, 10)
+            val pageCommand = PageCommand(page = 0, size = 10)
             val auditLog = mockk<AuditLog>()
-            val page = PageImpl(listOf(auditLog), pageable, 1)
+            val pageResult =
+                PageResult(
+                    content = listOf(auditLog),
+                    page = 0,
+                    size = 10,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
 
             every {
                 auditLogRepository.findAllByCondition(
@@ -41,9 +48,9 @@ class AuditLogQueryServiceImplTest {
                     targetEntity = "Team",
                     fromDate = null,
                     toDate = null,
-                    pageable = pageable,
+                    pageCommand = pageCommand,
                 )
-            } returns page
+            } returns pageResult
 
             val result =
                 service.findAll(
@@ -52,7 +59,7 @@ class AuditLogQueryServiceImplTest {
                     targetEntity = "Team",
                     fromDate = null,
                     toDate = null,
-                    pageable = pageable,
+                    pageCommand = pageCommand,
                 )
 
             assertThat(result.content).hasSize(1)
@@ -61,8 +68,15 @@ class AuditLogQueryServiceImplTest {
 
         @Test
         fun `모든 조건이 null이어도 정상 동작한다`() {
-            val pageable = PageRequest.of(0, 10)
-            val page = PageImpl<AuditLog>(emptyList(), pageable, 0)
+            val pageCommand = PageCommand(page = 0, size = 10)
+            val pageResult =
+                PageResult<AuditLog>(
+                    content = emptyList(),
+                    page = 0,
+                    size = 10,
+                    totalElements = 0L,
+                    totalPages = 0,
+                )
 
             every {
                 auditLogRepository.findAllByCondition(
@@ -71,9 +85,9 @@ class AuditLogQueryServiceImplTest {
                     targetEntity = null,
                     fromDate = null,
                     toDate = null,
-                    pageable = pageable,
+                    pageCommand = pageCommand,
                 )
-            } returns page
+            } returns pageResult
 
             val result =
                 service.findAll(
@@ -82,7 +96,7 @@ class AuditLogQueryServiceImplTest {
                     targetEntity = null,
                     fromDate = null,
                     toDate = null,
-                    pageable = pageable,
+                    pageCommand = pageCommand,
                 )
 
             assertThat(result.content).isEmpty()


### PR DESCRIPTION
## Summary

>- close #270 
>- close #271

**Core 모듈에서 `spring-boot-starter-data-jpa` 의존성을 제거하여 Hexagonal Architecture의 의존성 방향 규칙(Outside → Inside)을 준수하도록 개선합니다.**

Core 모듈이 Spring Data에 직접 의존하던 것이 모든 아키텍처 위반의 ROOT CAUSE였으며, 이를 해소하여 Core가 프레임워크에 독립적인 순수 도메인 계층이 되도록 합니다.

## Tasks

### #270 - Core 모듈 Spring Data JPA 의존성 제거
- `spring-boot-starter-data-jpa` → `jakarta.persistence-api` + `hibernate-core` + `spring-tx` + `spring-context`로 교체
- `BaseTimeEntity`: Spring Data `@CreatedDate`/`@LastModifiedDate`/`AuditingEntityListener` → JPA `@PrePersist`/`@PreUpdate` 콜백으로 전환
- Core `main` 소스에서 `org.springframework.data` import **0건** 달성

### #271 - RepositoryPort Page/Pageable → 커스텀 타입 교체
- `PageCommand` / `PageResult<T>` 커스텀 페이징 타입 신규 도입 (Core 모듈)
- `PageExtensions.kt` 변환 유틸리티 신규 도입 (Infrastructure 모듈)
- 8개 RepositoryPort 인터페이스 시그니처 변경
- 5개 Core Service + `AuditLogQueryService` 인터페이스 변경
- 8개 Infrastructure Adapter에 변환 함수 적용
- 6개 API/Backoffice Controller에서 `pageable.toPageCommand()` 변환 적용
- 전체 테스트 코드 일괄 수정 (15개 테스트 파일)

### 변경 규모
- **49 files changed** (+4,532 / -4,127)
- 신규 파일 3개: `PageCommand.kt`, `PageResult.kt`, `PageExtensions.kt`

## To Reviewer

- Core 모듈에 `@Service`, `@Transactional` 등 Spring 어노테이션이 아직 남아있습니다. 이는 별도 이슈 #276 (Core 구체 서비스 → 인터페이스+Impl 패턴 통일)에서 해결 예정입니다.
- `spring-tx`와 `spring-context`는 #276 완료 전까지 임시로 Core에 명시적 의존성으로 유지합니다.
- `@PageableDefault` 등 Controller의 Spring MVC 바인딩은 그대로 유지하고, 서비스 호출 시점에서 `toPageCommand()`로 변환합니다.