### PR TITLE
refactor(#272): Controller의 Infrastructure Repository 직접 주입을 Port로 교체

### DIFF
--- a/.claude/skills/verify-custom-exception/SKILL.md
+++ b/.claude/skills/verify-custom-exception/SKILL.md
@@ -107,7 +107,8 @@ Kotlin의 `require()`, `check()` 함수도 내부적으로 `IllegalArgumentExcep
 
 ## Exceptions
 
-1. **Entity init 블록의 require/check** — 도메인 불변조건을 보호하기 위한 `require()`, `check()`는 허용 (Entity 생성 시 빠른 실패)
+1. **Entity/data class init 블록의 require/check** — 도메인 불변조건을 보호하기 위한 `require()`, `check()`는 허용 (Entity 생성 시 빠른 실패, `PageCommand` 등 Value Object/data class도 포함)
 2. **테스트 코드** — `src/test/` 내 파일은 테스트 편의를 위해 표준 예외를 사용할 수 있음
 3. **프레임워크 어댑터 코드** — Spring Security 등 프레임워크가 요구하는 특정 예외 타입은 허용
 4. **companion object의 팩토리 메서드** — Entity의 `create()` 등에서 입력 검증에 `require()`를 사용하는 것은 허용
+5. **Core common 유틸 클래스** — `PageCommand`, `PageResult` 등 Core 공통 타입의 init 블록에서 `require()`를 사용하는 것은 허용 (입력 범위 검증)

--- a/.claude/skills/verify-dependency/SKILL.md
+++ b/.claude/skills/verify-dependency/SKILL.md
@@ -114,7 +114,43 @@ api ↔ backoffice ↔ scorer 간 상호 import가 없는지 검사합니다.
 **PASS 기준:** 매칭 결과 0건
 **FAIL 기준:** 1건 이상 매칭 시 의존성 방향 위반 (🔴 즉시 REJECT)
 
-### Step 5: Gradle 의존성 검사
+### Step 5: Core → Spring Data 프레임워크 의존 검사
+
+`nextup-core`가 Spring Data를 import하는지 검사합니다. Core는 프레임워크에 독립적이어야 합니다.
+
+**도구:** Grep
+
+**패턴:**
+```
+^import org\.springframework\.data
+```
+
+**대상:** `nextup-core/src/main/kotlin/**/*.kt`
+
+**PASS 기준:** 매칭 결과 0건 (Core가 Spring Data를 사용하지 않음)
+**FAIL 기준:** 1건 이상 매칭 시 프레임워크 의존성 위반 (🔴 즉시 REJECT)
+
+**수정 방법:** `Page`/`Pageable` → Core의 `PageCommand`/`PageResult` 커스텀 타입 사용, `JpaRepository` → `RepositoryPort` 인터페이스 사용
+
+### Step 6: Core Gradle에서 Spring Data 의존성 금지 검사
+
+`nextup-core/build.gradle.kts`에 `spring-boot-starter-data-jpa` 또는 `spring-data` 계열 의존성이 없는지 검사합니다.
+
+**도구:** Grep
+
+**패턴:**
+```
+spring-boot-starter-data-jpa|spring-data
+```
+
+**대상:** `nextup-core/build.gradle.kts`
+
+**PASS 기준:** 매칭 결과 0건
+**FAIL 기준:** Spring Data 계열 의존성 발견 (🔴 즉시 REJECT)
+
+**수정 방법:** `spring-boot-starter-data-jpa` → `jakarta.persistence-api` + `hibernate-core` + `spring-tx` + `spring-context`로 교체
+
+### Step 7: Gradle 프로젝트 의존성 검사
 
 각 모듈의 `build.gradle.kts`에서 금지된 프로젝트 의존성이 없는지 검사합니다.
 

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BattingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BattingRecordController.kt
@@ -5,8 +5,8 @@ import com.nextup.api.dto.game.CreateBattingRecordRequest
 import com.nextup.api.mapper.game.toResponse
 import com.nextup.common.dto.ApiResponse
 import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.BattingRecordService
-import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/games/{gameId}/batting-records")
 class BattingRecordController(
     private val battingRecordService: BattingRecordService,
-    private val gamePlayerRepository: GamePlayerRepository,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
     @GetMapping
     fun getBattingRecordsByGame(

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/PitchingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/PitchingRecordController.kt
@@ -5,8 +5,8 @@ import com.nextup.api.dto.game.PitchingRecordResponse
 import com.nextup.api.mapper.game.toResponse
 import com.nextup.common.dto.ApiResponse
 import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.PitchingRecordService
-import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/games/{gameId}/pitching-records")
 class PitchingRecordController(
     private val pitchingRecordService: PitchingRecordService,
-    private val gamePlayerRepository: GamePlayerRepository,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
     @GetMapping
     fun getPitchingRecordsByGame(

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BattingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BattingRecordControllerTest.kt
@@ -7,8 +7,8 @@ import com.nextup.api.exception.GlobalExceptionHandler
 import com.nextup.common.exception.RecordAlreadyExistsException
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.BattingRecordService
-import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
@@ -27,7 +27,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 class BattingRecordControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var battingRecordService: BattingRecordService
-    private lateinit var gamePlayerRepository: GamePlayerRepository
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var objectMapper: ObjectMapper
 
     private val gameId = 1L

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
@@ -8,8 +8,8 @@ import com.nextup.common.exception.RecordAlreadyExistsException
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.PitchingDecision
 import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.PitchingRecordService
-import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
@@ -28,7 +28,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 class PitchingRecordControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var pitchingRecordService: PitchingRecordService
-    private lateinit var gamePlayerRepository: GamePlayerRepository
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var objectMapper: ObjectMapper
 
     private val gameId = 1L

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerController.kt
@@ -2,8 +2,8 @@ package com.nextup.scorer.controller.fielding
 
 import com.nextup.common.dto.ApiResponse
 import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.FieldingRecordService
-import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import com.nextup.scorer.dto.fielding.FieldingEventRequest
 import com.nextup.scorer.dto.fielding.FieldingEventType
 import com.nextup.scorer.dto.fielding.FieldingRecordResponse
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/scorer/games/{gameId}/fielding")
 class FieldingRecordScorerController(
     private val fieldingRecordService: FieldingRecordService,
-    private val gamePlayerRepository: GamePlayerRepository,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
     /**
      * 수비 기록을 생성합니다 (경기 시작 시 선수별 초기화).

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerControllerTest.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nextup.core.domain.game.FieldingRecord
 import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.FieldingRecordService
-import com.nextup.infrastructure.repository.game.GamePlayerRepository
 import com.nextup.scorer.dto.fielding.FieldingEventRequest
 import com.nextup.scorer.dto.fielding.FieldingEventType
 import com.nextup.scorer.exception.GlobalExceptionHandler
@@ -28,7 +28,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 class FieldingRecordScorerControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var fieldingRecordService: FieldingRecordService
-    private lateinit var gamePlayerRepository: GamePlayerRepository
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var objectMapper: ObjectMapper
 
     private val gameId = 1L


### PR DESCRIPTION
## Summary

>- close #272

Controller에서 Infrastructure의 `GamePlayerRepository`를 직접 주입하던 것을 Core의 `GamePlayerRepositoryPort`로 교체하여 Hexagonal Architecture 의존성 방향 규칙을 준수하도록 수정했습니다.

## Tasks

- PitchingRecordController: `GamePlayerRepository` → `GamePlayerRepositoryPort` 교체
- BattingRecordController: `GamePlayerRepository` → `GamePlayerRepositoryPort` 교체
- FieldingRecordScorerController: `GamePlayerRepository` → `GamePlayerRepositoryPort` 교체
- 각 Controller 테스트 파일도 동일하게 Port 타입으로 변경
- verify-dependency, verify-custom-exception 스킬 업데이트

## To Reviewer

- `GamePlayerRepository`는 이미 `GamePlayerRepositoryPort`를 구현하고 있어 런타임 동작 변경 없이 import/타입만 변경되었습니다.
- `TeamMemberAdminController`의 `CustomUserDetails` import는 Spring Security 어댑터 패턴으로, API→Infra 의존이 허용되므로 본 PR 범위에서 제외했습니다.
