### PR TITLE
feat(#251): 수비 기록(Fielding) 스탯 이벤트 리스너 구현

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonFieldingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonFieldingStats.kt
@@ -109,6 +109,19 @@ class SeasonFieldingStats(
     }
 
     /**
+     * 경기 수비 기록을 롤백합니다 (경기 취소 시).
+     */
+    fun revertGameRecord(record: FieldingRecord) {
+        gamesPlayed--
+        putOuts -= record.putOuts
+        assists -= record.assists
+        errors -= record.errors
+        doublePlays -= record.doublePlays
+        passedBalls -= record.passedBalls
+        validate()
+    }
+
+    /**
      * 기록 유효성을 검증합니다.
      */
     fun validate() {

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonFieldingStatsRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonFieldingStatsRepositoryPort.kt
@@ -26,4 +26,10 @@ interface SeasonFieldingStatsRepositoryPort {
      * 특정 연도의 모든 시즌 수비 통계를 조회합니다.
      */
     fun findAllByYear(year: Int): List<SeasonFieldingStats>
+
+    /**
+     * 경기 ID로 해당 경기에 참여한 선수들의 시즌 수비 통계를 조회합니다.
+     * 경기 취소 시 롤백용으로 사용합니다.
+     */
+    fun findAllByGameId(gameId: Long): List<SeasonFieldingStats>
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonFieldingStatsRevertGameRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonFieldingStatsRevertGameRecordTest.kt
@@ -1,0 +1,131 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("SeasonFieldingStats.revertGameRecord 테스트")
+class SeasonFieldingStatsRevertGameRecordTest {
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
+
+    private fun createMockFieldingRecord(
+        putOuts: Int = 0,
+        assists: Int = 0,
+        errors: Int = 0,
+        doublePlays: Int = 0,
+        passedBalls: Int = 0,
+    ): FieldingRecord {
+        val record = mockk<FieldingRecord>()
+        every { record.putOuts } returns putOuts
+        every { record.assists } returns assists
+        every { record.errors } returns errors
+        every { record.doublePlays } returns doublePlays
+        every { record.passedBalls } returns passedBalls
+        return record
+    }
+
+    @Nested
+    @DisplayName("경기 수비 기여분 롤백")
+    inner class RevertGameRecord {
+        private lateinit var stats: SeasonFieldingStats
+
+        @BeforeEach
+        fun setUp() {
+            stats = SeasonFieldingStats.create(testPlayer, 2024)
+        }
+
+        @Test
+        fun `경기 기록이 반영된 시즌 통계에서 정확히 차감됨`() {
+            // given: 2경기 기록이 반영된 시즌 통계
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val record1 = FieldingRecord(gamePlayer)
+            record1.recordPutOut()
+            record1.recordPutOut()
+            record1.recordAssist()
+            record1.recordError()
+
+            val record2 = FieldingRecord(gamePlayer)
+            record2.recordPutOut()
+            record2.recordDoublePlay()
+            record2.recordPassedBall()
+
+            stats.addGameRecord(record1)
+            stats.addGameRecord(record2)
+
+            assertThat(stats.gamesPlayed).isEqualTo(2)
+            assertThat(stats.putOuts).isEqualTo(3)
+            assertThat(stats.assists).isEqualTo(1)
+            assertThat(stats.errors).isEqualTo(1)
+
+            // when: 첫 번째 경기 기록 롤백
+            stats.revertGameRecord(record1)
+
+            // then: 두 번째 경기 기록만 남음
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+            assertThat(stats.putOuts).isEqualTo(1)
+            assertThat(stats.assists).isZero
+            assertThat(stats.errors).isZero
+            assertThat(stats.doublePlays).isEqualTo(1)
+            assertThat(stats.passedBalls).isEqualTo(1)
+        }
+
+        @Test
+        fun `gamesPlayed가 1 감소함`() {
+            // given
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val record = FieldingRecord(gamePlayer)
+            stats.addGameRecord(record)
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.gamesPlayed).isZero
+        }
+
+        @Test
+        fun `모든 수비 필드가 정확히 차감됨`() {
+            // given
+            val record =
+                createMockFieldingRecord(
+                    putOuts = 3,
+                    assists = 2,
+                    errors = 1,
+                    doublePlays = 1,
+                    passedBalls = 1,
+                )
+
+            stats.addGameRecord(record)
+            assertThat(stats.putOuts).isEqualTo(3)
+            assertThat(stats.assists).isEqualTo(2)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.putOuts).isZero
+            assertThat(stats.assists).isZero
+            assertThat(stats.errors).isZero
+            assertThat(stats.doublePlays).isZero
+            assertThat(stats.passedBalls).isZero
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
@@ -2,8 +2,10 @@ package com.nextup.infrastructure.listener
 
 import com.nextup.core.domain.event.GameCancelledEvent
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -26,8 +28,10 @@ import org.springframework.transaction.event.TransactionalEventListener
 class GameCancelEventListener(
     private val seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort,
     private val seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort,
+    private val seasonFieldingStatsRepository: SeasonFieldingStatsRepositoryPort,
     private val battingRecordRepository: BattingRecordRepositoryPort,
     private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+    private val fieldingRecordRepository: FieldingRecordRepositoryPort,
 ) {
     private val logger = LoggerFactory.getLogger(GameCancelEventListener::class.java)
 
@@ -45,8 +49,9 @@ class GameCancelEventListener(
 
         val battingRecords = battingRecordRepository.findAllByGameId(gameId)
         val pitchingRecords = pitchingRecordRepository.findAllByGameId(gameId)
+        val fieldingRecords = fieldingRecordRepository.findAllByGameId(gameId)
 
-        if (battingRecords.isEmpty() && pitchingRecords.isEmpty()) {
+        if (battingRecords.isEmpty() && pitchingRecords.isEmpty() && fieldingRecords.isEmpty()) {
             logger.info(
                 "경기 취소 스탯 롤백 완료 - 롤백할 기록 없음 (gameId={})",
                 gameId,
@@ -108,11 +113,39 @@ class GameCancelEventListener(
             }
         }
 
+        // 수비 스탯 롤백
+        if (fieldingRecords.isNotEmpty()) {
+            val seasonFieldingStatsList = seasonFieldingStatsRepository.findAllByGameId(gameId)
+            val statsByPlayerId = seasonFieldingStatsList.associateBy { it.player.id }
+
+            for (fieldingRecord in fieldingRecords) {
+                val playerId = fieldingRecord.gamePlayer.player.id
+                val stats = statsByPlayerId[playerId]
+
+                if (stats == null) {
+                    logger.debug(
+                        "시즌 수비 통계 없음 - 롤백 건너뜀 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                } else {
+                    stats.revertGameRecord(fieldingRecord)
+                    seasonFieldingStatsRepository.save(stats)
+                    logger.debug(
+                        "시즌 수비 통계 롤백 완료 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                }
+            }
+        }
+
         logger.info(
-            "경기 취소 스탯 롤백 완료 (gameId={}, battingRecords={}, pitchingRecords={})",
+            "경기 취소 스탯 롤백 완료 (gameId={}, battingRecords={}, pitchingRecords={}, fieldingRecords={})",
             gameId,
             battingRecords.size,
             pitchingRecords.size,
+            fieldingRecords.size,
         )
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
@@ -5,14 +5,19 @@ import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlateAppearanceUndoneEvent
 import com.nextup.core.domain.stats.CareerBattingStats
+import com.nextup.core.domain.stats.CareerFieldingStats
 import com.nextup.core.domain.stats.CareerPitchingStats
+import com.nextup.core.domain.stats.SeasonFieldingStats
 import com.nextup.core.domain.stats.SeasonPitchingStats
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -31,10 +36,13 @@ import org.springframework.transaction.event.TransactionalEventListener
 class StatsEventListener(
     private val seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort,
     private val seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort,
+    private val seasonFieldingStatsRepository: SeasonFieldingStatsRepositoryPort,
     private val careerBattingStatsRepository: CareerBattingStatsRepositoryPort,
     private val careerPitchingStatsRepository: CareerPitchingStatsRepositoryPort,
+    private val careerFieldingStatsRepository: CareerFieldingStatsRepositoryPort,
     private val battingRecordRepository: BattingRecordRepositoryPort,
     private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+    private val fieldingRecordRepository: FieldingRecordRepositoryPort,
     private val gameRepository: GameRepositoryPort,
 ) {
     private val logger = LoggerFactory.getLogger(StatsEventListener::class.java)
@@ -190,11 +198,47 @@ class StatsEventListener(
             )
         }
 
+        // 수비 스탯 집계: SeasonFieldingStats + CareerFieldingStats
+        val fieldingRecords = fieldingRecordRepository.findAllByGameId(gameId)
+        for (fieldingRecord in fieldingRecords) {
+            val player = fieldingRecord.gamePlayer.player
+            val playerId = player.id
+
+            val existingSeasonFielding =
+                seasonFieldingStatsRepository.findByPlayerIdAndYear(playerId, year)
+            val isFirstFieldingSeason = existingSeasonFielding == null
+
+            // SeasonFieldingStats 갱신
+            val seasonFieldingStats =
+                existingSeasonFielding ?: SeasonFieldingStats.create(player = player, year = year)
+            seasonFieldingStats.addGameRecord(fieldingRecord)
+            seasonFieldingStatsRepository.save(seasonFieldingStats)
+
+            // CareerFieldingStats 갱신
+            val careerFieldingStats =
+                careerFieldingStatsRepository.findByPlayerId(playerId)
+                    ?: CareerFieldingStats.create(player = player)
+
+            if (isFirstFieldingSeason) {
+                careerFieldingStats.addSeason()
+            }
+            careerFieldingStats.addGameRecord(fieldingRecord)
+            careerFieldingStatsRepository.save(careerFieldingStats)
+
+            logger.debug(
+                "수비 통계 갱신 완료 (playerId={}, year={}, isFirstSeason={})",
+                playerId,
+                year,
+                isFirstFieldingSeason,
+            )
+        }
+
         logger.info(
-            "경기 결과 확정 스탯 집계 완료 (gameId={}, battingRecords={}, pitchingRecords={})",
+            "경기 결과 확정 스탯 집계 완료 (gameId={}, battingRecords={}, pitchingRecords={}, fieldingRecords={})",
             gameId,
             battingRecords.size,
             pitchingRecords.size,
+            fieldingRecords.size,
         )
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonFieldingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonFieldingStatsRepository.kt
@@ -33,4 +33,24 @@ interface SeasonFieldingStatsRepository :
     override fun findAllByYear(
         @Param("year") year: Int,
     ): List<SeasonFieldingStats>
+
+    /**
+     * 경기 ID로 해당 경기에 참여한 선수들의 시즌 수비 통계를 조회합니다.
+     * FieldingRecord → GamePlayer → Player → SeasonFieldingStats 조인.
+     */
+    @Query(
+        """
+        SELECT DISTINCT sfs FROM SeasonFieldingStats sfs
+        WHERE sfs.player.id IN (
+            SELECT fr.gamePlayer.player.id FROM FieldingRecord fr
+            WHERE fr.gamePlayer.game.id = :gameId
+        )
+        AND sfs.year = (
+            SELECT FUNCTION('YEAR', g.scheduledAt) FROM Game g WHERE g.id = :gameId
+        )
+    """,
+    )
+    override fun findAllByGameId(
+        @Param("gameId") gameId: Long,
+    ): List<SeasonFieldingStats>
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
@@ -2,6 +2,7 @@ package com.nextup.infrastructure.listener
 
 import com.nextup.core.domain.event.GameCancelledEvent
 import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.FieldingRecord
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.PitchingDecision
 import com.nextup.core.domain.game.PitchingRecord
@@ -10,10 +11,13 @@ import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.player.ThrowingHand
 import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonFieldingStats
 import com.nextup.core.domain.stats.SeasonPitchingStats
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import io.mockk.every
 import io.mockk.mockk
@@ -28,15 +32,19 @@ import org.junit.jupiter.api.Test
 class GameCancelEventListenerTest {
     private val seasonBattingStatsRepository = mockk<SeasonBattingStatsRepositoryPort>()
     private val seasonPitchingStatsRepository = mockk<SeasonPitchingStatsRepositoryPort>()
+    private val seasonFieldingStatsRepository = mockk<SeasonFieldingStatsRepositoryPort>()
     private val battingRecordRepository = mockk<BattingRecordRepositoryPort>()
     private val pitchingRecordRepository = mockk<PitchingRecordRepositoryPort>()
+    private val fieldingRecordRepository = mockk<FieldingRecordRepositoryPort>()
 
     private val listener =
         GameCancelEventListener(
             seasonBattingStatsRepository = seasonBattingStatsRepository,
             seasonPitchingStatsRepository = seasonPitchingStatsRepository,
+            seasonFieldingStatsRepository = seasonFieldingStatsRepository,
             battingRecordRepository = battingRecordRepository,
             pitchingRecordRepository = pitchingRecordRepository,
+            fieldingRecordRepository = fieldingRecordRepository,
         )
 
     private val testBatter =
@@ -59,8 +67,10 @@ class GameCancelEventListenerTest {
 
     private val mockBattingRecord = mockk<BattingRecord>(relaxed = true)
     private val mockPitchingRecord = mockk<PitchingRecord>(relaxed = true)
+    private val mockFieldingRecord = mockk<FieldingRecord>(relaxed = true)
     private val mockBatterGamePlayer = mockk<GamePlayer>()
     private val mockPitcherGamePlayer = mockk<GamePlayer>()
+    private val mockFielderGamePlayer = mockk<GamePlayer>()
 
     private val gameId = 100L
     private val cancelEvent = GameCancelledEvent(gameId = gameId)
@@ -71,11 +81,20 @@ class GameCancelEventListenerTest {
         every { mockBatterGamePlayer.player } returns testBatter
         every { mockPitchingRecord.gamePlayer } returns mockPitcherGamePlayer
         every { mockPitcherGamePlayer.player } returns testPitcher
+        every { mockFieldingRecord.gamePlayer } returns mockFielderGamePlayer
+        every { mockFielderGamePlayer.player } returns testBatter
     }
 
     @Nested
     @DisplayName("onGameCancelled - 경기 취소 이벤트 처리")
     inner class OnGameCancelled {
+        @BeforeEach
+        fun setUpFieldingDefault() {
+            // 기본적으로 수비 기록 없음 (수비 테스트에서만 오버라이드)
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonFieldingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+        }
+
         @Test
         fun `타격 기록이 있는 경우 시즌 타격 통계가 롤백됨`() {
             // given
@@ -125,7 +144,7 @@ class GameCancelEventListenerTest {
         }
 
         @Test
-        fun `타격 및 투구 기록이 없는 경우 아무것도 저장하지 않음`() {
+        fun `모든 기록이 없는 경우 아무것도 저장하지 않음`() {
             // given
             every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
             every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
@@ -136,6 +155,7 @@ class GameCancelEventListenerTest {
             // then
             verify(exactly = 0) { seasonBattingStatsRepository.save(any()) }
             verify(exactly = 0) { seasonPitchingStatsRepository.save(any()) }
+            verify(exactly = 0) { seasonFieldingStatsRepository.save(any()) }
         }
 
         @Test
@@ -200,6 +220,56 @@ class GameCancelEventListenerTest {
 
             // then
             verify { seasonPitchingStatsRepository.save(pitchingStats) }
+        }
+
+        @Test
+        fun `수비 기록이 있는 경우 시즌 수비 통계가 롤백됨`() {
+            // given
+            val fieldingStats = SeasonFieldingStats.create(testBatter, 2024)
+            // 경기 기여분을 추가
+            fieldingStats.addGameRecord(
+                FieldingRecord(mockFielderGamePlayer).also {
+                    it.recordPutOut()
+                    it.recordAssist()
+                },
+            )
+            val initialGamesPlayed = fieldingStats.gamesPlayed
+            val initialPutOuts = fieldingStats.putOuts
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
+            every { seasonFieldingStatsRepository.findAllByGameId(gameId) } returns listOf(fieldingStats)
+            every { seasonFieldingStatsRepository.save(any()) } returns fieldingStats
+
+            every { mockFieldingRecord.putOuts } returns 1
+            every { mockFieldingRecord.assists } returns 1
+            every { mockFieldingRecord.errors } returns 0
+            every { mockFieldingRecord.doublePlays } returns 0
+            every { mockFieldingRecord.passedBalls } returns 0
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            assertThat(fieldingStats.gamesPlayed).isEqualTo(initialGamesPlayed - 1)
+            assertThat(fieldingStats.putOuts).isEqualTo(initialPutOuts - 1)
+            verify { seasonFieldingStatsRepository.save(fieldingStats) }
+        }
+
+        @Test
+        fun `시즌 수비 통계가 없는 선수는 건너뜀`() {
+            // given
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
+            every { seasonFieldingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then: 통계가 없으므로 save 호출 없음
+            verify(exactly = 0) { seasonFieldingStatsRepository.save(any()) }
         }
 
         @Test

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
@@ -621,6 +621,26 @@ class StatsEventListenerTest {
         }
 
         @Test
+        fun `CareerFieldingStats가 없으면 신규 생성됨`() {
+            // given: careerFieldingStatsRepository.findByPlayerId returns null
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
+            every {
+                seasonFieldingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns null
+            every { seasonFieldingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerFieldingStatsRepository.findByPlayerId(testPlayer.id) } returns null
+            every { careerFieldingStatsRepository.save(any()) } answers { firstArg() }
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: 새 CareerFieldingStats 생성 및 저장
+            verify(exactly = 1) { careerFieldingStatsRepository.save(any()) }
+        }
+
+        @Test
         fun `기존 시즌 수비 기록 시 CareerFieldingStats에 addSeason 호출되지 않음`() {
             // given: 시즌 통계 이미 존재
             val existingSeason = SeasonFieldingStats.create(testPlayer, 2024)

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
@@ -5,6 +5,7 @@ import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlateAppearanceUndoneEvent
 import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.FieldingRecord
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.PitchingRecord
@@ -14,15 +15,20 @@ import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.player.ThrowingHand
 import com.nextup.core.domain.stats.CareerBattingStats
+import com.nextup.core.domain.stats.CareerFieldingStats
 import com.nextup.core.domain.stats.CareerPitchingStats
 import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonFieldingStats
 import com.nextup.core.domain.stats.SeasonPitchingStats
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import io.mockk.every
 import io.mockk.mockk
@@ -39,20 +45,26 @@ import java.time.LocalDateTime
 class StatsEventListenerTest {
     private val seasonBattingStatsRepository = mockk<SeasonBattingStatsRepositoryPort>()
     private val seasonPitchingStatsRepository = mockk<SeasonPitchingStatsRepositoryPort>()
+    private val seasonFieldingStatsRepository = mockk<SeasonFieldingStatsRepositoryPort>()
     private val careerBattingStatsRepository = mockk<CareerBattingStatsRepositoryPort>()
     private val careerPitchingStatsRepository = mockk<CareerPitchingStatsRepositoryPort>()
+    private val careerFieldingStatsRepository = mockk<CareerFieldingStatsRepositoryPort>()
     private val battingRecordRepository = mockk<BattingRecordRepositoryPort>()
     private val pitchingRecordRepository = mockk<PitchingRecordRepositoryPort>()
+    private val fieldingRecordRepository = mockk<FieldingRecordRepositoryPort>()
     private val gameRepository = mockk<GameRepositoryPort>()
 
     private val listener =
         StatsEventListener(
             seasonBattingStatsRepository = seasonBattingStatsRepository,
             seasonPitchingStatsRepository = seasonPitchingStatsRepository,
+            seasonFieldingStatsRepository = seasonFieldingStatsRepository,
             careerBattingStatsRepository = careerBattingStatsRepository,
             careerPitchingStatsRepository = careerPitchingStatsRepository,
+            careerFieldingStatsRepository = careerFieldingStatsRepository,
             battingRecordRepository = battingRecordRepository,
             pitchingRecordRepository = pitchingRecordRepository,
+            fieldingRecordRepository = fieldingRecordRepository,
             gameRepository = gameRepository,
         )
 
@@ -327,8 +339,10 @@ class StatsEventListenerTest {
     inner class OnGameResultConfirmed {
         private val mockBattingRecord = mockk<BattingRecord>(relaxed = true)
         private val mockPitchingRecord = mockk<PitchingRecord>(relaxed = true)
+        private val mockFieldingRecord = mockk<FieldingRecord>(relaxed = true)
         private val mockGamePlayer = mockk<GamePlayer>()
         private val mockPitcherGamePlayer = mockk<GamePlayer>()
+        private val mockFielderGamePlayer = mockk<GamePlayer>()
 
         private val gameId = 10L
         private val event =
@@ -346,6 +360,10 @@ class StatsEventListenerTest {
             every { mockGamePlayer.player } returns testPlayer
             every { mockPitchingRecord.gamePlayer } returns mockPitcherGamePlayer
             every { mockPitcherGamePlayer.player } returns testPitcher
+            every { mockFieldingRecord.gamePlayer } returns mockFielderGamePlayer
+            every { mockFielderGamePlayer.player } returns testPlayer
+            // 기본적으로 수비 기록 없음 (수비 테스트에서만 오버라이드)
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns emptyList()
         }
 
         @Test
@@ -531,7 +549,105 @@ class StatsEventListenerTest {
         }
 
         @Test
-        fun `타격 기록과 투수 기록이 모두 없는 경우 아무것도 저장하지 않음`() {
+        fun `경기 종료 시 SeasonFieldingStats가 신규 생성되고 기록이 누적됨`() {
+            // given
+            val careerFielding = CareerFieldingStats.create(testPlayer)
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
+            every {
+                seasonFieldingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns null
+            every { seasonFieldingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerFieldingStatsRepository.findByPlayerId(testPlayer.id) } returns careerFielding
+            every { careerFieldingStatsRepository.save(any()) } answers { firstArg() }
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: 새 SeasonFieldingStats 생성 및 저장 확인
+            verify(exactly = 1) { seasonFieldingStatsRepository.save(any()) }
+            verify(exactly = 1) { careerFieldingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `경기 종료 시 기존 SeasonFieldingStats에 기록이 누적됨`() {
+            // given
+            val seasonFielding = SeasonFieldingStats.create(testPlayer, 2024)
+            val careerFielding = CareerFieldingStats.create(testPlayer)
+            careerFielding.addSeason()
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
+            every {
+                seasonFieldingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns seasonFielding
+            every { seasonFieldingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerFieldingStatsRepository.findByPlayerId(testPlayer.id) } returns careerFielding
+            every { careerFieldingStatsRepository.save(any()) } answers { firstArg() }
+
+            val initialGames = seasonFielding.gamesPlayed
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: gamesPlayed 가 1 증가함
+            assertThat(seasonFielding.gamesPlayed).isEqualTo(initialGames + 1)
+            verify(exactly = 1) { seasonFieldingStatsRepository.save(seasonFielding) }
+        }
+
+        @Test
+        fun `첫 시즌 수비 기록 시 CareerFieldingStats에 addSeason 호출됨`() {
+            // given: 시즌 통계 없음(첫 시즌)
+            val careerFielding = CareerFieldingStats.create(testPlayer)
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
+            every {
+                seasonFieldingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns null
+            every { seasonFieldingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerFieldingStatsRepository.findByPlayerId(testPlayer.id) } returns careerFielding
+            every { careerFieldingStatsRepository.save(any()) } answers { firstArg() }
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: 첫 시즌이므로 seasonsPlayed = 1
+            assertThat(careerFielding.seasonsPlayed).isEqualTo(1)
+        }
+
+        @Test
+        fun `기존 시즌 수비 기록 시 CareerFieldingStats에 addSeason 호출되지 않음`() {
+            // given: 시즌 통계 이미 존재
+            val existingSeason = SeasonFieldingStats.create(testPlayer, 2024)
+            val careerFielding = CareerFieldingStats.create(testPlayer)
+            careerFielding.addSeason()
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
+            every {
+                seasonFieldingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns existingSeason
+            every { seasonFieldingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerFieldingStatsRepository.findByPlayerId(testPlayer.id) } returns careerFielding
+            every { careerFieldingStatsRepository.save(any()) } answers { firstArg() }
+
+            val initialSeasons = careerFielding.seasonsPlayed
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then: addSeason 호출 안 됨 - seasonsPlayed 변화 없음
+            assertThat(careerFielding.seasonsPlayed).isEqualTo(initialSeasons)
+        }
+
+        @Test
+        fun `모든 기록이 없는 경우 아무것도 저장하지 않음`() {
             // given
             every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
             every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
@@ -543,6 +659,8 @@ class StatsEventListenerTest {
             verify(exactly = 0) { seasonPitchingStatsRepository.save(any()) }
             verify(exactly = 0) { careerBattingStatsRepository.save(any()) }
             verify(exactly = 0) { careerPitchingStatsRepository.save(any()) }
+            verify(exactly = 0) { seasonFieldingStatsRepository.save(any()) }
+            verify(exactly = 0) { careerFieldingStatsRepository.save(any()) }
         }
 
         @Test


### PR DESCRIPTION
## Summary

>- close #251

경기 결과 확정/취소 시 수비(Fielding) 통계를 자동 집계/롤백하는 이벤트 리스너를 구현합니다.
기존 타격/투구 통계 처리 패턴과 동일한 구조로 수비 통계를 추가했습니다.

## Tasks

- StatsEventListener.onGameResultConfirmed()에 수비 통계 집계 로직 추가 (SeasonFieldingStats + CareerFieldingStats)
- GameCancelEventListener.onGameCancelled()에 수비 통계 롤백 로직 추가
- SeasonFieldingStats에 revertGameRecord() 메서드 추가 (경기 취소 시 역산)
- SeasonFieldingStatsRepositoryPort에 findAllByGameId() 메서드 추가 및 구현
- StatsEventListenerTest에 수비 통계 집계 테스트 4개 추가
- GameCancelEventListenerTest에 수비 통계 롤백 테스트 2개 추가

## To Reviewer

기존 타격(Batting)/투구(Pitching) 통계 집계 패턴을 그대로 따릅니다:
- 경기 결과 확정 시: Season + Career 통계 누적, 첫 시즌 여부에 따라 addSeason() 호출
- 경기 취소 시: Season 통계에서 해당 경기 기여분 차감 (revertGameRecord)