### PR TITLE
fix(#252): 팀 가입 요청 목록 API 실제 구현

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMembershipController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamMembershipController.kt
@@ -6,6 +6,7 @@ import com.nextup.api.mapper.team.toResponse
 import com.nextup.common.dto.ApiResponse
 import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.TeamMemberNotFoundException
+import com.nextup.core.domain.team.JoinRequestStatus
 import com.nextup.core.service.team.TeamMembershipService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -45,13 +46,13 @@ class TeamMembershipController(
      * 가입 신청 목록을 조회합니다.
      */
     @GetMapping("/join-requests")
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun getJoinRequests(
         @PathVariable teamId: Long,
-        @AuthenticationPrincipal userId: Long,
+        @RequestParam(required = false) status: JoinRequestStatus?,
     ): ApiResponse<List<JoinRequestResponse>> {
-        // TODO: 실제 구현에서는 TeamJoinRequestRepository에서 페이징 조회 필요
-        // 현재는 간단한 구현으로 대체
-        return ApiResponse.success(emptyList())
+        val joinRequests = teamMembershipService.getJoinRequests(teamId, status)
+        return ApiResponse.success(joinRequests.map { it.toResponse() })
     }
 
     /**

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamMembershipControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamMembershipControllerTest.kt
@@ -118,9 +118,41 @@ class TeamMembershipControllerTest {
     @DisplayName("GET /api/v1/teams/{teamId}/join-requests")
     inner class GetJoinRequests {
         @Test
-        fun `should return empty list`() {
+        fun `should return all join requests when no status filter`() {
+            // given
+            val requests = listOf(createMockJoinRequest(1L), createMockJoinRequest(2L))
+            every { teamMembershipService.getJoinRequests(1L, null) } returns requests
+
             // when
-            val response = controller.getJoinRequests(teamId = 1L, userId = 10L)
+            val response = controller.getJoinRequests(teamId = 1L, status = null)
+
+            // then
+            assertThat(response.data).hasSize(2)
+        }
+
+        @Test
+        fun `should return filtered join requests when status provided`() {
+            // given
+            val pendingRequest = createMockJoinRequest(1L, JoinRequestStatus.PENDING)
+            every {
+                teamMembershipService.getJoinRequests(1L, JoinRequestStatus.PENDING)
+            } returns listOf(pendingRequest)
+
+            // when
+            val response = controller.getJoinRequests(teamId = 1L, status = JoinRequestStatus.PENDING)
+
+            // then
+            assertThat(response.data).hasSize(1)
+            assertThat(response.data?.first()?.status).isEqualTo(JoinRequestStatus.PENDING)
+        }
+
+        @Test
+        fun `should return empty list when no join requests`() {
+            // given
+            every { teamMembershipService.getJoinRequests(1L, null) } returns emptyList()
+
+            // when
+            val response = controller.getJoinRequests(teamId = 1L, status = null)
 
             // then
             assertThat(response.data).isEmpty()

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
@@ -117,7 +117,7 @@ interface TeamMembershipService {
      */
     fun getJoinRequests(
         teamId: Long,
-        status: JoinRequestStatus? = null,
+        status: JoinRequestStatus?,
     ): List<TeamJoinRequest>
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.service.team
 
+import com.nextup.core.domain.team.JoinRequestStatus
 import com.nextup.core.domain.team.Team
 import com.nextup.core.domain.team.TeamJoinRequest
 import com.nextup.core.domain.team.TeamMember
@@ -106,6 +107,18 @@ interface TeamMembershipService {
         newRole: TeamMemberRole,
         changerUserId: Long,
     ): TeamMember
+
+    /**
+     * 팀의 가입 신청 목록을 조회합니다.
+     *
+     * @param teamId 팀 ID
+     * @param status 필터링할 상태 (null이면 전체 조회)
+     * @return 가입 신청 목록
+     */
+    fun getJoinRequests(
+        teamId: Long,
+        status: JoinRequestStatus? = null,
+    ): List<TeamJoinRequest>
 
     /**
      * 팀 로스터를 조회합니다.

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
@@ -256,6 +256,18 @@ class TeamMembershipServiceImpl(
         return teamMemberRepository.save(member)
     }
 
+    override fun getJoinRequests(
+        teamId: Long,
+        status: JoinRequestStatus?,
+    ): List<TeamJoinRequest> {
+        val requests = teamJoinRequestRepository.findByTeamId(teamId)
+        return if (status != null) {
+            requests.filter { it.status == status }
+        } else {
+            requests
+        }
+    }
+
     override fun getRoster(teamId: Long): List<TeamMember> {
         // ACTIVE 상태의 멤버만 조회
         return teamMemberRepository.findByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE)

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
@@ -719,6 +719,19 @@ class TeamMembershipServiceImplTest {
             // then
             assertThat(result).isEmpty()
         }
+
+        @Test
+        fun `should use default null status when status parameter omitted`() {
+            // given
+            val request = TeamJoinRequest.create(team, user, player, 7)
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns listOf(request)
+
+            // when: default parameter 사용 (status 생략)
+            val result = service.getJoinRequests(1L)
+
+            // then
+            assertThat(result).hasSize(1)
+        }
     }
 
     @Nested

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
@@ -719,7 +719,6 @@ class TeamMembershipServiceImplTest {
             // then
             assertThat(result).isEmpty()
         }
-
     }
 
     @Nested

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
@@ -720,18 +720,6 @@ class TeamMembershipServiceImplTest {
             assertThat(result).isEmpty()
         }
 
-        @Test
-        fun `should use default null status when status parameter omitted`() {
-            // given
-            val request = TeamJoinRequest.create(team, user, player, 7)
-            every { teamJoinRequestRepository.findByTeamId(1L) } returns listOf(request)
-
-            // when: default parameter 사용 (status 생략)
-            val result = service.getJoinRequests(1L)
-
-            // then
-            assertThat(result).hasSize(1)
-        }
     }
 
     @Nested

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
@@ -671,6 +671,57 @@ class TeamMembershipServiceImplTest {
     }
 
     @Nested
+    @DisplayName("getJoinRequests")
+    inner class GetJoinRequests {
+        @Test
+        fun `should return all join requests when status is null`() {
+            // given
+            val pendingRequest = TeamJoinRequest.create(team, user, player, 7)
+            val approvedRequest = TeamJoinRequest.create(team, user, player, 8)
+            approvedRequest.approve(owner, "환영합니다")
+
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns
+                listOf(pendingRequest, approvedRequest)
+
+            // when
+            val result = service.getJoinRequests(1L, null)
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+
+        @Test
+        fun `should return filtered join requests when status is provided`() {
+            // given
+            val pendingRequest = TeamJoinRequest.create(team, user, player, 7)
+            val approvedRequest = TeamJoinRequest.create(team, user, player, 8)
+            approvedRequest.approve(owner, "환영합니다")
+
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns
+                listOf(pendingRequest, approvedRequest)
+
+            // when
+            val result = service.getJoinRequests(1L, JoinRequestStatus.PENDING)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result.first().status).isEqualTo(JoinRequestStatus.PENDING)
+        }
+
+        @Test
+        fun `should return empty list when no join requests`() {
+            // given
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+
+            // when
+            val result = service.getJoinRequests(1L, null)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
     @DisplayName("getRoster")
     inner class GetRoster {
         @Test


### PR DESCRIPTION
## Summary

>- close #252

`GET /api/v1/teams/{teamId}/join-requests` 엔드포인트가 하드코딩된 `emptyList()`를 반환하던 P0 버그를 수정하여, 실제 가입 신청 데이터를 조회하도록 구현했습니다.

## Tasks

- `TeamMembershipService`에 `getJoinRequests(teamId, status?)` 메서드 추가
- `TeamMembershipServiceImpl`에서 `TeamJoinRequestRepositoryPort.findByTeamId()`를 활용한 구현
- 상태 필터링 지원 (`?status=PENDING`, `?status=APPROVED`, `?status=REJECTED`)
- `@PreAuthorize("@teamSecurity.isOwnerOrManager")` 권한 제한 추가
- 컨트롤러 및 서비스 단위 테스트 추가 (6개 테스트 케이스)

## To Reviewer

- 페이징은 기존 `findByTeamIdAndStatus(teamId, status, pageCommand)` 메서드가 존재하므로, 추후 필요 시 확장 가능합니다.
- 현재는 팀 단위 가입 신청 건수가 적으므로 `findByTeamId` + in-memory 필터링으로 구현했습니다.