### PR TITLE
feat(#254): 기록 정정 후 시즌/커리어 스탯 재집계 트리거 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/RecordCorrectedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/RecordCorrectedEvent.kt
@@ -1,0 +1,18 @@
+package com.nextup.core.domain.event
+
+import com.nextup.core.domain.game.CorrectionType
+
+/**
+ * 기록 정정 도메인 이벤트
+ *
+ * 관리자가 타격/투수 기록을 정정했을 때 발행됩니다.
+ * 이벤트 리스너에서 해당 선수의 시즌/커리어 스탯을 재집계합니다.
+ */
+data class RecordCorrectedEvent(
+    val gameId: Long,
+    val correctionType: CorrectionType,
+    val playerId: Long,
+    val fieldName: String,
+    val oldValue: String,
+    val newValue: String,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
@@ -230,6 +230,37 @@ class CareerBattingStats(
     }
 
     /**
+     * 기록 정정에 따른 필드별 델타를 적용합니다.
+     *
+     * @param fieldName 정정된 필드명
+     * @param delta 변경량 (양수: 증가, 음수: 감소)
+     */
+    fun applyFieldCorrection(
+        fieldName: String,
+        delta: Int
+    ) {
+        when (fieldName) {
+            "plateAppearances" -> plateAppearances = maxOf(0, plateAppearances + delta)
+            "atBats" -> atBats = maxOf(0, atBats + delta)
+            "hits" -> hits = maxOf(0, hits + delta)
+            "doubles" -> doubles = maxOf(0, doubles + delta)
+            "triples" -> triples = maxOf(0, triples + delta)
+            "homeRuns" -> homeRuns = maxOf(0, homeRuns + delta)
+            "runs" -> runs = maxOf(0, runs + delta)
+            "runsBattedIn" -> runsBattedIn = maxOf(0, runsBattedIn + delta)
+            "walks" -> walks = maxOf(0, walks + delta)
+            "intentionalWalks" -> intentionalWalks = maxOf(0, intentionalWalks + delta)
+            "hitByPitch" -> hitByPitch = maxOf(0, hitByPitch + delta)
+            "strikeouts" -> strikeouts = maxOf(0, strikeouts + delta)
+            "sacrificeBunts" -> sacrificeBunts = maxOf(0, sacrificeBunts + delta)
+            "sacrificeFlies" -> sacrificeFlies = maxOf(0, sacrificeFlies + delta)
+            "stolenBases" -> stolenBases = maxOf(0, stolenBases + delta)
+            "caughtStealing" -> caughtStealing = maxOf(0, caughtStealing + delta)
+            "groundedIntoDoublePlays" -> groundedIntoDoublePlays = maxOf(0, groundedIntoDoublePlays + delta)
+        }
+    }
+
+    /**
      * 기록 유효성을 검증합니다.
      */
     fun validate() {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
@@ -289,6 +289,33 @@ class CareerPitchingStats(
     }
 
     /**
+     * 기록 정정에 따른 필드별 델타를 적용합니다.
+     *
+     * @param fieldName 정정된 필드명
+     * @param delta 변경량 (양수: 증가, 음수: 감소)
+     */
+    fun applyFieldCorrection(
+        fieldName: String,
+        delta: Int
+    ) {
+        when (fieldName) {
+            "inningsPitchedOuts" -> inningsPitchedOuts = maxOf(0, inningsPitchedOuts + delta)
+            "earnedRuns" -> earnedRuns = maxOf(0, earnedRuns + delta)
+            "runsAllowed" -> runsAllowed = maxOf(0, runsAllowed + delta)
+            "hitsAllowed" -> hitsAllowed = maxOf(0, hitsAllowed + delta)
+            "walksAllowed" -> walksAllowed = maxOf(0, walksAllowed + delta)
+            "strikeouts" -> strikeouts = maxOf(0, strikeouts + delta)
+            "homeRunsAllowed" -> homeRunsAllowed = maxOf(0, homeRunsAllowed + delta)
+            "hitBatsmen" -> hitBatsmen = maxOf(0, hitBatsmen + delta)
+            "wildPitches" -> wildPitches = maxOf(0, wildPitches + delta)
+            "balks" -> balks = maxOf(0, balks + delta)
+            "battersFaced" -> battersFaced = maxOf(0, battersFaced + delta)
+            "pitchesThrown" -> pitchesThrown = maxOf(0, (pitchesThrown ?: 0) + delta)
+            "strikesThrown" -> strikesThrown = maxOf(0, (strikesThrown ?: 0) + delta)
+        }
+    }
+
+    /**
      * 기록 유효성을 검증합니다.
      */
     fun validate() {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
@@ -323,6 +323,37 @@ class SeasonBattingStats(
     }
 
     /**
+     * 기록 정정에 따른 필드별 델타를 적용합니다.
+     *
+     * @param fieldName 정정된 필드명
+     * @param delta 변경량 (양수: 증가, 음수: 감소)
+     */
+    fun applyFieldCorrection(
+        fieldName: String,
+        delta: Int
+    ) {
+        when (fieldName) {
+            "plateAppearances" -> plateAppearances = maxOf(0, plateAppearances + delta)
+            "atBats" -> atBats = maxOf(0, atBats + delta)
+            "hits" -> hits = maxOf(0, hits + delta)
+            "doubles" -> doubles = maxOf(0, doubles + delta)
+            "triples" -> triples = maxOf(0, triples + delta)
+            "homeRuns" -> homeRuns = maxOf(0, homeRuns + delta)
+            "runs" -> runs = maxOf(0, runs + delta)
+            "runsBattedIn" -> runsBattedIn = maxOf(0, runsBattedIn + delta)
+            "walks" -> walks = maxOf(0, walks + delta)
+            "intentionalWalks" -> intentionalWalks = maxOf(0, intentionalWalks + delta)
+            "hitByPitch" -> hitByPitch = maxOf(0, hitByPitch + delta)
+            "strikeouts" -> strikeouts = maxOf(0, strikeouts + delta)
+            "sacrificeBunts" -> sacrificeBunts = maxOf(0, sacrificeBunts + delta)
+            "sacrificeFlies" -> sacrificeFlies = maxOf(0, sacrificeFlies + delta)
+            "stolenBases" -> stolenBases = maxOf(0, stolenBases + delta)
+            "caughtStealing" -> caughtStealing = maxOf(0, caughtStealing + delta)
+            "groundedIntoDoublePlays" -> groundedIntoDoublePlays = maxOf(0, groundedIntoDoublePlays + delta)
+        }
+    }
+
+    /**
      * 기록 유효성을 검증합니다.
      */
     fun validate() {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
@@ -328,6 +328,33 @@ class SeasonPitchingStats(
     }
 
     /**
+     * 기록 정정에 따른 필드별 델타를 적용합니다.
+     *
+     * @param fieldName 정정된 필드명
+     * @param delta 변경량 (양수: 증가, 음수: 감소)
+     */
+    fun applyFieldCorrection(
+        fieldName: String,
+        delta: Int
+    ) {
+        when (fieldName) {
+            "inningsPitchedOuts" -> inningsPitchedOuts = maxOf(0, inningsPitchedOuts + delta)
+            "earnedRuns" -> earnedRuns = maxOf(0, earnedRuns + delta)
+            "runsAllowed" -> runsAllowed = maxOf(0, runsAllowed + delta)
+            "hitsAllowed" -> hitsAllowed = maxOf(0, hitsAllowed + delta)
+            "walksAllowed" -> walksAllowed = maxOf(0, walksAllowed + delta)
+            "strikeouts" -> strikeouts = maxOf(0, strikeouts + delta)
+            "homeRunsAllowed" -> homeRunsAllowed = maxOf(0, homeRunsAllowed + delta)
+            "hitBatsmen" -> hitBatsmen = maxOf(0, hitBatsmen + delta)
+            "wildPitches" -> wildPitches = maxOf(0, wildPitches + delta)
+            "balks" -> balks = maxOf(0, balks + delta)
+            "battersFaced" -> battersFaced = maxOf(0, battersFaced + delta)
+            "pitchesThrown" -> pitchesThrown = maxOf(0, (pitchesThrown ?: 0) + delta)
+            "strikesThrown" -> strikesThrown = maxOf(0, (strikesThrown ?: 0) + delta)
+        }
+    }
+
+    /**
      * 기록 유효성을 검증합니다.
      */
     fun validate() {

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/event/RecordCorrectedEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/event/RecordCorrectedEventTest.kt
@@ -1,0 +1,45 @@
+package com.nextup.core.domain.event
+
+import com.nextup.core.domain.game.CorrectionType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("RecordCorrectedEvent 테스트")
+class RecordCorrectedEventTest {
+    @Test
+    fun `이벤트 생성 시 모든 필드가 올바르게 설정됨`() {
+        val event =
+            RecordCorrectedEvent(
+                gameId = 10L,
+                correctionType = CorrectionType.BATTING,
+                playerId = 1L,
+                fieldName = "hits",
+                oldValue = "2",
+                newValue = "3",
+            )
+
+        assertThat(event.gameId).isEqualTo(10L)
+        assertThat(event.correctionType).isEqualTo(CorrectionType.BATTING)
+        assertThat(event.playerId).isEqualTo(1L)
+        assertThat(event.fieldName).isEqualTo("hits")
+        assertThat(event.oldValue).isEqualTo("2")
+        assertThat(event.newValue).isEqualTo("3")
+    }
+
+    @Test
+    fun `투수 정정 이벤트 생성`() {
+        val event =
+            RecordCorrectedEvent(
+                gameId = 20L,
+                correctionType = CorrectionType.PITCHING,
+                playerId = 2L,
+                fieldName = "earnedRuns",
+                oldValue = "3",
+                newValue = "1",
+            )
+
+        assertThat(event.correctionType).isEqualTo(CorrectionType.PITCHING)
+        assertThat(event.fieldName).isEqualTo("earnedRuns")
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/BattingStatsApplyFieldCorrectionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/BattingStatsApplyFieldCorrectionTest.kt
@@ -1,0 +1,219 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("타격 통계 applyFieldCorrection 테스트")
+class BattingStatsApplyFieldCorrectionTest {
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
+
+    @Nested
+    @DisplayName("SeasonBattingStats")
+    inner class SeasonBattingStatsFieldCorrection {
+        @Test
+        fun `모든 필드에 양수 델타가 올바르게 적용됨`() {
+            val stats = SeasonBattingStats.create(testPlayer, 2024)
+
+            stats.applyFieldCorrection("plateAppearances", 10)
+            stats.applyFieldCorrection("atBats", 8)
+            stats.applyFieldCorrection("hits", 3)
+            stats.applyFieldCorrection("doubles", 1)
+            stats.applyFieldCorrection("triples", 1)
+            stats.applyFieldCorrection("homeRuns", 1)
+            stats.applyFieldCorrection("runs", 2)
+            stats.applyFieldCorrection("runsBattedIn", 3)
+            stats.applyFieldCorrection("walks", 1)
+            stats.applyFieldCorrection("intentionalWalks", 1)
+            stats.applyFieldCorrection("hitByPitch", 1)
+            stats.applyFieldCorrection("strikeouts", 2)
+            stats.applyFieldCorrection("sacrificeBunts", 1)
+            stats.applyFieldCorrection("sacrificeFlies", 1)
+            stats.applyFieldCorrection("stolenBases", 2)
+            stats.applyFieldCorrection("caughtStealing", 1)
+            stats.applyFieldCorrection("groundedIntoDoublePlays", 1)
+
+            assertThat(stats.plateAppearances).isEqualTo(10)
+            assertThat(stats.atBats).isEqualTo(8)
+            assertThat(stats.hits).isEqualTo(3)
+            assertThat(stats.doubles).isEqualTo(1)
+            assertThat(stats.triples).isEqualTo(1)
+            assertThat(stats.homeRuns).isEqualTo(1)
+            assertThat(stats.runs).isEqualTo(2)
+            assertThat(stats.runsBattedIn).isEqualTo(3)
+            assertThat(stats.walks).isEqualTo(1)
+            assertThat(stats.intentionalWalks).isEqualTo(1)
+            assertThat(stats.hitByPitch).isEqualTo(1)
+            assertThat(stats.strikeouts).isEqualTo(2)
+            assertThat(stats.sacrificeBunts).isEqualTo(1)
+            assertThat(stats.sacrificeFlies).isEqualTo(1)
+            assertThat(stats.stolenBases).isEqualTo(2)
+            assertThat(stats.caughtStealing).isEqualTo(1)
+            assertThat(stats.groundedIntoDoublePlays).isEqualTo(1)
+        }
+
+        @Test
+        fun `음수 델타 적용 시 0 미만으로 내려가지 않음`() {
+            val stats = SeasonBattingStats.create(testPlayer, 2024)
+            stats.applyFieldCorrection("plateAppearances", 2)
+            stats.applyFieldCorrection("atBats", 2)
+            stats.applyFieldCorrection("hits", 2)
+            stats.applyFieldCorrection("doubles", 2)
+            stats.applyFieldCorrection("triples", 2)
+            stats.applyFieldCorrection("homeRuns", 2)
+            stats.applyFieldCorrection("runs", 2)
+            stats.applyFieldCorrection("runsBattedIn", 2)
+            stats.applyFieldCorrection("walks", 2)
+            stats.applyFieldCorrection("intentionalWalks", 2)
+            stats.applyFieldCorrection("hitByPitch", 2)
+            stats.applyFieldCorrection("strikeouts", 2)
+            stats.applyFieldCorrection("sacrificeBunts", 2)
+            stats.applyFieldCorrection("sacrificeFlies", 2)
+            stats.applyFieldCorrection("stolenBases", 2)
+            stats.applyFieldCorrection("caughtStealing", 2)
+            stats.applyFieldCorrection("groundedIntoDoublePlays", 2)
+
+            // 모든 필드에 -10 적용 (현재값 2보다 큰 음수)
+            stats.applyFieldCorrection("plateAppearances", -10)
+            stats.applyFieldCorrection("atBats", -10)
+            stats.applyFieldCorrection("hits", -10)
+            stats.applyFieldCorrection("doubles", -10)
+            stats.applyFieldCorrection("triples", -10)
+            stats.applyFieldCorrection("homeRuns", -10)
+            stats.applyFieldCorrection("runs", -10)
+            stats.applyFieldCorrection("runsBattedIn", -10)
+            stats.applyFieldCorrection("walks", -10)
+            stats.applyFieldCorrection("intentionalWalks", -10)
+            stats.applyFieldCorrection("hitByPitch", -10)
+            stats.applyFieldCorrection("strikeouts", -10)
+            stats.applyFieldCorrection("sacrificeBunts", -10)
+            stats.applyFieldCorrection("sacrificeFlies", -10)
+            stats.applyFieldCorrection("stolenBases", -10)
+            stats.applyFieldCorrection("caughtStealing", -10)
+            stats.applyFieldCorrection("groundedIntoDoublePlays", -10)
+
+            assertThat(stats.plateAppearances).isZero()
+            assertThat(stats.atBats).isZero()
+            assertThat(stats.hits).isZero()
+            assertThat(stats.doubles).isZero()
+            assertThat(stats.triples).isZero()
+            assertThat(stats.homeRuns).isZero()
+            assertThat(stats.runs).isZero()
+            assertThat(stats.runsBattedIn).isZero()
+            assertThat(stats.walks).isZero()
+            assertThat(stats.intentionalWalks).isZero()
+            assertThat(stats.hitByPitch).isZero()
+            assertThat(stats.strikeouts).isZero()
+            assertThat(stats.sacrificeBunts).isZero()
+            assertThat(stats.sacrificeFlies).isZero()
+            assertThat(stats.stolenBases).isZero()
+            assertThat(stats.caughtStealing).isZero()
+            assertThat(stats.groundedIntoDoublePlays).isZero()
+        }
+
+        @Test
+        fun `존재하지 않는 필드명은 무시됨`() {
+            val stats = SeasonBattingStats.create(testPlayer, 2024)
+            stats.applyFieldCorrection("unknownField", 5)
+            assertThat(stats.plateAppearances).isZero()
+        }
+    }
+
+    @Nested
+    @DisplayName("CareerBattingStats")
+    inner class CareerBattingStatsFieldCorrection {
+        @Test
+        fun `모든 필드에 양수 델타가 올바르게 적용됨`() {
+            val stats = CareerBattingStats.create(testPlayer)
+
+            stats.applyFieldCorrection("plateAppearances", 10)
+            stats.applyFieldCorrection("atBats", 8)
+            stats.applyFieldCorrection("hits", 3)
+            stats.applyFieldCorrection("doubles", 1)
+            stats.applyFieldCorrection("triples", 1)
+            stats.applyFieldCorrection("homeRuns", 1)
+            stats.applyFieldCorrection("runs", 2)
+            stats.applyFieldCorrection("runsBattedIn", 3)
+            stats.applyFieldCorrection("walks", 1)
+            stats.applyFieldCorrection("intentionalWalks", 1)
+            stats.applyFieldCorrection("hitByPitch", 1)
+            stats.applyFieldCorrection("strikeouts", 2)
+            stats.applyFieldCorrection("sacrificeBunts", 1)
+            stats.applyFieldCorrection("sacrificeFlies", 1)
+            stats.applyFieldCorrection("stolenBases", 2)
+            stats.applyFieldCorrection("caughtStealing", 1)
+            stats.applyFieldCorrection("groundedIntoDoublePlays", 1)
+
+            assertThat(stats.plateAppearances).isEqualTo(10)
+            assertThat(stats.atBats).isEqualTo(8)
+            assertThat(stats.hits).isEqualTo(3)
+            assertThat(stats.doubles).isEqualTo(1)
+            assertThat(stats.triples).isEqualTo(1)
+            assertThat(stats.homeRuns).isEqualTo(1)
+            assertThat(stats.runs).isEqualTo(2)
+            assertThat(stats.runsBattedIn).isEqualTo(3)
+            assertThat(stats.walks).isEqualTo(1)
+            assertThat(stats.intentionalWalks).isEqualTo(1)
+            assertThat(stats.hitByPitch).isEqualTo(1)
+            assertThat(stats.strikeouts).isEqualTo(2)
+            assertThat(stats.sacrificeBunts).isEqualTo(1)
+            assertThat(stats.sacrificeFlies).isEqualTo(1)
+            assertThat(stats.stolenBases).isEqualTo(2)
+            assertThat(stats.caughtStealing).isEqualTo(1)
+            assertThat(stats.groundedIntoDoublePlays).isEqualTo(1)
+        }
+
+        @Test
+        fun `음수 델타 적용 시 0 미만으로 내려가지 않음`() {
+            val stats = CareerBattingStats.create(testPlayer)
+
+            stats.applyFieldCorrection("plateAppearances", -5)
+            stats.applyFieldCorrection("atBats", -5)
+            stats.applyFieldCorrection("hits", -5)
+            stats.applyFieldCorrection("doubles", -5)
+            stats.applyFieldCorrection("triples", -5)
+            stats.applyFieldCorrection("homeRuns", -5)
+            stats.applyFieldCorrection("runs", -5)
+            stats.applyFieldCorrection("runsBattedIn", -5)
+            stats.applyFieldCorrection("walks", -5)
+            stats.applyFieldCorrection("intentionalWalks", -5)
+            stats.applyFieldCorrection("hitByPitch", -5)
+            stats.applyFieldCorrection("strikeouts", -5)
+            stats.applyFieldCorrection("sacrificeBunts", -5)
+            stats.applyFieldCorrection("sacrificeFlies", -5)
+            stats.applyFieldCorrection("stolenBases", -5)
+            stats.applyFieldCorrection("caughtStealing", -5)
+            stats.applyFieldCorrection("groundedIntoDoublePlays", -5)
+
+            assertThat(stats.plateAppearances).isZero()
+            assertThat(stats.atBats).isZero()
+            assertThat(stats.hits).isZero()
+            assertThat(stats.doubles).isZero()
+            assertThat(stats.triples).isZero()
+            assertThat(stats.homeRuns).isZero()
+            assertThat(stats.runs).isZero()
+            assertThat(stats.runsBattedIn).isZero()
+            assertThat(stats.walks).isZero()
+            assertThat(stats.intentionalWalks).isZero()
+            assertThat(stats.hitByPitch).isZero()
+            assertThat(stats.strikeouts).isZero()
+            assertThat(stats.sacrificeBunts).isZero()
+            assertThat(stats.sacrificeFlies).isZero()
+            assertThat(stats.stolenBases).isZero()
+            assertThat(stats.caughtStealing).isZero()
+            assertThat(stats.groundedIntoDoublePlays).isZero()
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/PitchingStatsApplyFieldCorrectionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/PitchingStatsApplyFieldCorrectionTest.kt
@@ -1,0 +1,182 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("투수 통계 applyFieldCorrection 테스트")
+class PitchingStatsApplyFieldCorrectionTest {
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.STARTING_PITCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
+
+    @Nested
+    @DisplayName("SeasonPitchingStats")
+    inner class SeasonPitchingStatsFieldCorrection {
+        @Test
+        fun `모든 필드에 양수 델타가 올바르게 적용됨`() {
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            stats.applyFieldCorrection("inningsPitchedOuts", 18)
+            stats.applyFieldCorrection("earnedRuns", 3)
+            stats.applyFieldCorrection("runsAllowed", 4)
+            stats.applyFieldCorrection("hitsAllowed", 6)
+            stats.applyFieldCorrection("walksAllowed", 2)
+            stats.applyFieldCorrection("strikeouts", 7)
+            stats.applyFieldCorrection("homeRunsAllowed", 1)
+            stats.applyFieldCorrection("hitBatsmen", 1)
+            stats.applyFieldCorrection("wildPitches", 1)
+            stats.applyFieldCorrection("balks", 1)
+            stats.applyFieldCorrection("battersFaced", 25)
+            stats.applyFieldCorrection("pitchesThrown", 90)
+            stats.applyFieldCorrection("strikesThrown", 60)
+
+            assertThat(stats.inningsPitchedOuts).isEqualTo(18)
+            assertThat(stats.earnedRuns).isEqualTo(3)
+            assertThat(stats.runsAllowed).isEqualTo(4)
+            assertThat(stats.hitsAllowed).isEqualTo(6)
+            assertThat(stats.walksAllowed).isEqualTo(2)
+            assertThat(stats.strikeouts).isEqualTo(7)
+            assertThat(stats.homeRunsAllowed).isEqualTo(1)
+            assertThat(stats.hitBatsmen).isEqualTo(1)
+            assertThat(stats.wildPitches).isEqualTo(1)
+            assertThat(stats.balks).isEqualTo(1)
+            assertThat(stats.battersFaced).isEqualTo(25)
+            assertThat(stats.pitchesThrown).isEqualTo(90)
+            assertThat(stats.strikesThrown).isEqualTo(60)
+        }
+
+        @Test
+        fun `음수 델타 적용 시 0 미만으로 내려가지 않음`() {
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.applyFieldCorrection("inningsPitchedOuts", 3)
+            stats.applyFieldCorrection("earnedRuns", 3)
+            stats.applyFieldCorrection("runsAllowed", 3)
+            stats.applyFieldCorrection("hitsAllowed", 3)
+            stats.applyFieldCorrection("walksAllowed", 3)
+            stats.applyFieldCorrection("strikeouts", 3)
+            stats.applyFieldCorrection("homeRunsAllowed", 3)
+            stats.applyFieldCorrection("hitBatsmen", 3)
+            stats.applyFieldCorrection("wildPitches", 3)
+            stats.applyFieldCorrection("balks", 3)
+            stats.applyFieldCorrection("battersFaced", 3)
+            stats.applyFieldCorrection("pitchesThrown", 3)
+            stats.applyFieldCorrection("strikesThrown", 3)
+
+            stats.applyFieldCorrection("inningsPitchedOuts", -10)
+            stats.applyFieldCorrection("earnedRuns", -10)
+            stats.applyFieldCorrection("runsAllowed", -10)
+            stats.applyFieldCorrection("hitsAllowed", -10)
+            stats.applyFieldCorrection("walksAllowed", -10)
+            stats.applyFieldCorrection("strikeouts", -10)
+            stats.applyFieldCorrection("homeRunsAllowed", -10)
+            stats.applyFieldCorrection("hitBatsmen", -10)
+            stats.applyFieldCorrection("wildPitches", -10)
+            stats.applyFieldCorrection("balks", -10)
+            stats.applyFieldCorrection("battersFaced", -10)
+            stats.applyFieldCorrection("pitchesThrown", -10)
+            stats.applyFieldCorrection("strikesThrown", -10)
+
+            assertThat(stats.inningsPitchedOuts).isZero()
+            assertThat(stats.earnedRuns).isZero()
+            assertThat(stats.runsAllowed).isZero()
+            assertThat(stats.hitsAllowed).isZero()
+            assertThat(stats.walksAllowed).isZero()
+            assertThat(stats.strikeouts).isZero()
+            assertThat(stats.homeRunsAllowed).isZero()
+            assertThat(stats.hitBatsmen).isZero()
+            assertThat(stats.wildPitches).isZero()
+            assertThat(stats.balks).isZero()
+            assertThat(stats.battersFaced).isZero()
+            assertThat(stats.pitchesThrown).isZero()
+            assertThat(stats.strikesThrown).isZero()
+        }
+
+        @Test
+        fun `존재하지 않는 필드명은 무시됨`() {
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.applyFieldCorrection("unknownField", 5)
+            assertThat(stats.inningsPitchedOuts).isZero()
+        }
+    }
+
+    @Nested
+    @DisplayName("CareerPitchingStats")
+    inner class CareerPitchingStatsFieldCorrection {
+        @Test
+        fun `모든 필드에 양수 델타가 올바르게 적용됨`() {
+            val stats = CareerPitchingStats.create(testPlayer)
+
+            stats.applyFieldCorrection("inningsPitchedOuts", 18)
+            stats.applyFieldCorrection("earnedRuns", 3)
+            stats.applyFieldCorrection("runsAllowed", 4)
+            stats.applyFieldCorrection("hitsAllowed", 6)
+            stats.applyFieldCorrection("walksAllowed", 2)
+            stats.applyFieldCorrection("strikeouts", 7)
+            stats.applyFieldCorrection("homeRunsAllowed", 1)
+            stats.applyFieldCorrection("hitBatsmen", 1)
+            stats.applyFieldCorrection("wildPitches", 1)
+            stats.applyFieldCorrection("balks", 1)
+            stats.applyFieldCorrection("battersFaced", 25)
+            stats.applyFieldCorrection("pitchesThrown", 90)
+            stats.applyFieldCorrection("strikesThrown", 60)
+
+            assertThat(stats.inningsPitchedOuts).isEqualTo(18)
+            assertThat(stats.earnedRuns).isEqualTo(3)
+            assertThat(stats.runsAllowed).isEqualTo(4)
+            assertThat(stats.hitsAllowed).isEqualTo(6)
+            assertThat(stats.walksAllowed).isEqualTo(2)
+            assertThat(stats.strikeouts).isEqualTo(7)
+            assertThat(stats.homeRunsAllowed).isEqualTo(1)
+            assertThat(stats.hitBatsmen).isEqualTo(1)
+            assertThat(stats.wildPitches).isEqualTo(1)
+            assertThat(stats.balks).isEqualTo(1)
+            assertThat(stats.battersFaced).isEqualTo(25)
+            assertThat(stats.pitchesThrown).isEqualTo(90)
+            assertThat(stats.strikesThrown).isEqualTo(60)
+        }
+
+        @Test
+        fun `음수 델타 적용 시 0 미만으로 내려가지 않음`() {
+            val stats = CareerPitchingStats.create(testPlayer)
+
+            stats.applyFieldCorrection("inningsPitchedOuts", -5)
+            stats.applyFieldCorrection("earnedRuns", -5)
+            stats.applyFieldCorrection("runsAllowed", -5)
+            stats.applyFieldCorrection("hitsAllowed", -5)
+            stats.applyFieldCorrection("walksAllowed", -5)
+            stats.applyFieldCorrection("strikeouts", -5)
+            stats.applyFieldCorrection("homeRunsAllowed", -5)
+            stats.applyFieldCorrection("hitBatsmen", -5)
+            stats.applyFieldCorrection("wildPitches", -5)
+            stats.applyFieldCorrection("balks", -5)
+            stats.applyFieldCorrection("battersFaced", -5)
+            stats.applyFieldCorrection("pitchesThrown", -5)
+            stats.applyFieldCorrection("strikesThrown", -5)
+
+            assertThat(stats.inningsPitchedOuts).isZero()
+            assertThat(stats.earnedRuns).isZero()
+            assertThat(stats.runsAllowed).isZero()
+            assertThat(stats.hitsAllowed).isZero()
+            assertThat(stats.walksAllowed).isZero()
+            assertThat(stats.strikeouts).isZero()
+            assertThat(stats.homeRunsAllowed).isZero()
+            assertThat(stats.hitBatsmen).isZero()
+            assertThat(stats.wildPitches).isZero()
+            assertThat(stats.balks).isZero()
+            assertThat(stats.battersFaced).isZero()
+            assertThat(stats.pitchesThrown).isZero()
+            assertThat(stats.strikesThrown).isZero()
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
@@ -1,0 +1,131 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.event.RecordCorrectedEvent
+import com.nextup.core.domain.game.CorrectionType
+import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * 기록 정정 이벤트 리스너
+ *
+ * RecordCorrectedEvent 수신 시 해당 선수의 시즌/커리어 스탯에
+ * 정정 델타(newValue - oldValue)를 반영합니다.
+ */
+@Component
+class RecordCorrectionEventListener(
+    private val seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort,
+    private val seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort,
+    private val careerBattingStatsRepository: CareerBattingStatsRepositoryPort,
+    private val careerPitchingStatsRepository: CareerPitchingStatsRepositoryPort,
+    private val gameRepository: GameRepositoryPort,
+) {
+    private val logger = LoggerFactory.getLogger(RecordCorrectionEventListener::class.java)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional
+    fun onRecordCorrected(event: RecordCorrectedEvent) {
+        val delta = event.newValue.toInt() - event.oldValue.toInt()
+        if (delta == 0) {
+            logger.debug(
+                "기록 정정 델타 0 - 스탯 갱신 건너뜀 (gameId={}, playerId={}, field={})",
+                event.gameId,
+                event.playerId,
+                event.fieldName,
+            )
+            return
+        }
+
+        val year = resolveYear(event.gameId)
+
+        logger.info(
+            "기록 정정 스탯 반영 시작 (gameId={}, playerId={}, field={}, delta={})",
+            event.gameId,
+            event.playerId,
+            event.fieldName,
+            delta,
+        )
+
+        when (event.correctionType) {
+            CorrectionType.BATTING -> applyBattingCorrection(event.playerId, year, event.fieldName, delta)
+            CorrectionType.PITCHING -> applyPitchingCorrection(event.playerId, year, event.fieldName, delta)
+        }
+
+        logger.info(
+            "기록 정정 스탯 반영 완료 (gameId={}, playerId={}, field={}, delta={})",
+            event.gameId,
+            event.playerId,
+            event.fieldName,
+            delta,
+        )
+    }
+
+    private fun applyBattingCorrection(
+        playerId: Long,
+        year: Int,
+        fieldName: String,
+        delta: Int,
+    ) {
+        // 시즌 타격 스탯 갱신
+        val seasonStats = seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year)
+        if (seasonStats != null) {
+            seasonStats.applyFieldCorrection(fieldName, delta)
+            seasonBattingStatsRepository.save(seasonStats)
+            logger.debug("시즌 타격 통계 정정 반영 완료 (playerId={}, year={})", playerId, year)
+        } else {
+            logger.debug("시즌 타격 통계 없음 - 정정 건너뜀 (playerId={}, year={})", playerId, year)
+        }
+
+        // 커리어 타격 스탯 갱신
+        val careerStats = careerBattingStatsRepository.findByPlayerId(playerId)
+        if (careerStats != null) {
+            careerStats.applyFieldCorrection(fieldName, delta)
+            careerBattingStatsRepository.save(careerStats)
+            logger.debug("커리어 타격 통계 정정 반영 완료 (playerId={})", playerId)
+        } else {
+            logger.debug("커리어 타격 통계 없음 - 정정 건너뜀 (playerId={})", playerId)
+        }
+    }
+
+    private fun applyPitchingCorrection(
+        playerId: Long,
+        year: Int,
+        fieldName: String,
+        delta: Int,
+    ) {
+        // 시즌 투수 스탯 갱신
+        val seasonStats = seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year)
+        if (seasonStats != null) {
+            seasonStats.applyFieldCorrection(fieldName, delta)
+            seasonPitchingStatsRepository.save(seasonStats)
+            logger.debug("시즌 투수 통계 정정 반영 완료 (playerId={}, year={})", playerId, year)
+        } else {
+            logger.debug("시즌 투수 통계 없음 - 정정 건너뜀 (playerId={}, year={})", playerId, year)
+        }
+
+        // 커리어 투수 스탯 갱신
+        val careerStats = careerPitchingStatsRepository.findByPlayerId(playerId)
+        if (careerStats != null) {
+            careerStats.applyFieldCorrection(fieldName, delta)
+            careerPitchingStatsRepository.save(careerStats)
+            logger.debug("커리어 투수 통계 정정 반영 완료 (playerId={})", playerId)
+        } else {
+            logger.debug("커리어 투수 통계 없음 - 정정 건너뜀 (playerId={})", playerId)
+        }
+    }
+
+    private fun resolveYear(gameId: Long): Int {
+        val game =
+            gameRepository.findByIdOrNull(gameId)
+                ?: throw GameNotFoundException(gameId)
+        return game.scheduledAt.year
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImpl.kt
@@ -4,6 +4,7 @@ import com.nextup.common.exception.BattingRecordNotFoundByIdException
 import com.nextup.common.exception.GameNotFoundException
 import com.nextup.common.exception.PitchingRecordNotFoundByIdException
 import com.nextup.core.domain.audit.AuditLog
+import com.nextup.core.domain.event.RecordCorrectedEvent
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.domain.game.PitchingRecord
@@ -17,6 +18,7 @@ import com.nextup.core.service.game.correction.BattingCorrectionRequest
 import com.nextup.core.service.game.correction.PitchingCorrectionRequest
 import com.nextup.core.service.game.correction.RecordCorrectionDto
 import com.nextup.core.service.game.correction.RecordCorrectionService
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -34,6 +36,7 @@ class RecordCorrectionServiceImpl(
     private val recordCorrectionRepository: RecordCorrectionRepositoryPort,
     private val auditLogRepository: AuditLogRepositoryPort,
     private val gameRepository: GameRepositoryPort,
+    private val eventPublisher: ApplicationEventPublisher,
 ) : RecordCorrectionService {
     /**
      * 타격 기록을 정정합니다.
@@ -82,6 +85,18 @@ class RecordCorrectionServiceImpl(
                         "oldValue=$oldValue, newValue=${request.newValue}, reason=${request.reason}",
             )
         auditLogRepository.save(auditLog)
+
+        // 시즌/커리어 스탯 재집계 이벤트 발행
+        eventPublisher.publishEvent(
+            RecordCorrectedEvent(
+                gameId = gameId,
+                correctionType = CorrectionType.BATTING,
+                playerId = battingRecord.gamePlayer.player.id,
+                fieldName = request.fieldName,
+                oldValue = oldValue,
+                newValue = request.newValue,
+            ),
+        )
 
         return battingRecord
     }
@@ -133,6 +148,18 @@ class RecordCorrectionServiceImpl(
                         "oldValue=$oldValue, newValue=${request.newValue}, reason=${request.reason}",
             )
         auditLogRepository.save(auditLog)
+
+        // 시즌/커리어 스탯 재집계 이벤트 발행
+        eventPublisher.publishEvent(
+            RecordCorrectedEvent(
+                gameId = gameId,
+                correctionType = CorrectionType.PITCHING,
+                playerId = pitchingRecord.gamePlayer.player.id,
+                fieldName = request.fieldName,
+                oldValue = oldValue,
+                newValue = request.newValue,
+            ),
+        )
 
         return pitchingRecord
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
@@ -1,0 +1,314 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.event.RecordCorrectedEvent
+import com.nextup.core.domain.game.CorrectionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.domain.stats.CareerBattingStats
+import com.nextup.core.domain.stats.CareerPitchingStats
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+@DisplayName("RecordCorrectionEventListener 테스트")
+class RecordCorrectionEventListenerTest {
+    private val seasonBattingStatsRepository = mockk<SeasonBattingStatsRepositoryPort>()
+    private val seasonPitchingStatsRepository = mockk<SeasonPitchingStatsRepositoryPort>()
+    private val careerBattingStatsRepository = mockk<CareerBattingStatsRepositoryPort>()
+    private val careerPitchingStatsRepository = mockk<CareerPitchingStatsRepositoryPort>()
+    private val gameRepository = mockk<GameRepositoryPort>()
+
+    private val listener =
+        RecordCorrectionEventListener(
+            seasonBattingStatsRepository = seasonBattingStatsRepository,
+            seasonPitchingStatsRepository = seasonPitchingStatsRepository,
+            careerBattingStatsRepository = careerBattingStatsRepository,
+            careerPitchingStatsRepository = careerPitchingStatsRepository,
+            gameRepository = gameRepository,
+        )
+
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
+
+    private val mockGame = mockk<Game>()
+
+    @BeforeEach
+    fun setUp() {
+        every { mockGame.scheduledAt } returns LocalDateTime.of(2024, 5, 15, 18, 0)
+        every { gameRepository.findByIdOrNull(any()) } returns mockGame
+    }
+
+    @Nested
+    @DisplayName("타격 기록 정정 이벤트")
+    inner class BattingCorrectionEvent {
+        @Test
+        fun `타격 기록 정정 시 시즌 및 커리어 통계에 델타가 반영됨`() {
+            // given
+            val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            val careerStats = CareerBattingStats.create(testPlayer)
+            // 기존 값 설정: hits = 10 (addGameRecord 대신 applyFieldCorrection으로 세팅)
+            seasonStats.applyFieldCorrection("hits", 10)
+            careerStats.applyFieldCorrection("hits", 10)
+
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns careerStats
+            every { careerBattingStatsRepository.save(any()) } answers { firstArg() }
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "2",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: delta = 3 - 2 = 1, so hits = 10 + 1 = 11
+            assertThat(seasonStats.hits).isEqualTo(11)
+            assertThat(careerStats.hits).isEqualTo(11)
+            verify(exactly = 1) { seasonBattingStatsRepository.save(seasonStats) }
+            verify(exactly = 1) { careerBattingStatsRepository.save(careerStats) }
+        }
+
+        @Test
+        fun `음수 델타 적용 시 통계가 감소됨`() {
+            // given
+            val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("homeRuns", 5)
+
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "homeRuns",
+                    oldValue = "3",
+                    newValue = "1",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: delta = 1 - 3 = -2, so homeRuns = 5 - 2 = 3
+            assertThat(seasonStats.homeRuns).isEqualTo(3)
+        }
+
+        @Test
+        fun `델타가 0이면 스탯 갱신을 건너뜀`() {
+            // given
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "3",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: 아무 repository 호출도 없어야 함
+            verify(exactly = 0) { seasonBattingStatsRepository.findByPlayerIdAndYear(any(), any()) }
+            verify(exactly = 0) { careerBattingStatsRepository.findByPlayerId(any()) }
+        }
+
+        @Test
+        fun `시즌 통계가 없으면 시즌 스탯 갱신을 건너뜀`() {
+            // given
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns null
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "2",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then
+            verify(exactly = 0) { seasonBattingStatsRepository.save(any()) }
+            verify(exactly = 0) { careerBattingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `음수 방지로 0 미만이 되지 않음`() {
+            // given
+            val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("walks", 1)
+
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "walks",
+                    oldValue = "5",
+                    newValue = "1",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: delta = 1 - 5 = -4, walks = maxOf(0, 1 - 4) = 0
+            assertThat(seasonStats.walks).isEqualTo(0)
+        }
+    }
+
+    @Nested
+    @DisplayName("투수 기록 정정 이벤트")
+    inner class PitchingCorrectionEvent {
+        @Test
+        fun `투수 기록 정정 시 시즌 및 커리어 통계에 델타가 반영됨`() {
+            // given
+            val seasonStats = SeasonPitchingStats.create(testPlayer, 2024)
+            val careerStats = CareerPitchingStats.create(testPlayer)
+            seasonStats.applyFieldCorrection("strikeouts", 20)
+            careerStats.applyFieldCorrection("strikeouts", 20)
+
+            every { seasonPitchingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonPitchingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerPitchingStatsRepository.findByPlayerId(1L) } returns careerStats
+            every { careerPitchingStatsRepository.save(any()) } answers { firstArg() }
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.PITCHING,
+                    playerId = 1L,
+                    fieldName = "strikeouts",
+                    oldValue = "5",
+                    newValue = "7",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: delta = 7 - 5 = 2, so strikeouts = 20 + 2 = 22
+            assertThat(seasonStats.strikeouts).isEqualTo(22)
+            assertThat(careerStats.strikeouts).isEqualTo(22)
+            verify(exactly = 1) { seasonPitchingStatsRepository.save(seasonStats) }
+            verify(exactly = 1) { careerPitchingStatsRepository.save(careerStats) }
+        }
+
+        @Test
+        fun `투수 시즌 통계가 없으면 스탯 갱신을 건너뜀`() {
+            // given
+            every { seasonPitchingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns null
+            every { careerPitchingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.PITCHING,
+                    playerId = 1L,
+                    fieldName = "earnedRuns",
+                    oldValue = "2",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then
+            verify(exactly = 0) { seasonPitchingStatsRepository.save(any()) }
+            verify(exactly = 0) { careerPitchingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `자책점 감소 정정이 올바르게 반영됨`() {
+            // given
+            val seasonStats = SeasonPitchingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("earnedRuns", 10)
+
+            every { seasonPitchingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonPitchingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerPitchingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.PITCHING,
+                    playerId = 1L,
+                    fieldName = "earnedRuns",
+                    oldValue = "3",
+                    newValue = "1",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: delta = 1 - 3 = -2, earnedRuns = 10 - 2 = 8
+            assertThat(seasonStats.earnedRuns).isEqualTo(8)
+        }
+    }
+
+    @Nested
+    @DisplayName("공통 예외 처리")
+    inner class CommonExceptionHandling {
+        @Test
+        fun `경기를 찾을 수 없으면 GameNotFoundException이 발생함`() {
+            // given
+            every { gameRepository.findByIdOrNull(any()) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 999L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "2",
+                    newValue = "3",
+                )
+
+            // when & then
+            assertThrows<GameNotFoundException> {
+                listener.onRecordCorrected(event)
+            }
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImplTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 
 @DisplayName("RecordCorrectionServiceImpl")
 class RecordCorrectionServiceImplTest {
@@ -33,6 +34,7 @@ class RecordCorrectionServiceImplTest {
     private lateinit var recordCorrectionRepository: RecordCorrectionRepositoryPort
     private lateinit var auditLogRepository: AuditLogRepositoryPort
     private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var service: RecordCorrectionServiceImpl
 
     private val gameId = 1L
@@ -46,6 +48,7 @@ class RecordCorrectionServiceImplTest {
         recordCorrectionRepository = mockk()
         auditLogRepository = mockk()
         gameRepository = mockk()
+        eventPublisher = mockk(relaxed = true)
 
         service =
             RecordCorrectionServiceImpl(
@@ -54,6 +57,7 @@ class RecordCorrectionServiceImplTest {
                 recordCorrectionRepository = recordCorrectionRepository,
                 auditLogRepository = auditLogRepository,
                 gameRepository = gameRepository,
+                eventPublisher = eventPublisher,
             )
     }
 
@@ -97,6 +101,7 @@ class RecordCorrectionServiceImplTest {
             verify(exactly = 1) { mockBattingRecord.correctField("hits", "3") }
             verify(exactly = 1) { recordCorrectionRepository.save(any()) }
             verify(exactly = 1) { auditLogRepository.save(any()) }
+            verify(exactly = 1) { eventPublisher.publishEvent(any<Any>()) }
         }
 
         @Test
@@ -177,6 +182,7 @@ class RecordCorrectionServiceImplTest {
             verify(exactly = 1) { mockPitchingRecord.correctField("strikeouts", "5") }
             verify(exactly = 1) { recordCorrectionRepository.save(any()) }
             verify(exactly = 1) { auditLogRepository.save(any()) }
+            verify(exactly = 1) { eventPublisher.publishEvent(any<Any>()) }
         }
 
         @Test


### PR DESCRIPTION
## Summary

>- close #254

기록 정정(RecordCorrection) 시 시즌/커리어 통계에 변경분(delta)이 자동으로 반영되도록 이벤트 기반 재집계 트리거를 추가합니다.

## Tasks

- `RecordCorrectedEvent` 도메인 이벤트 생성 (Core)
- 4개 스탯 엔티티에 `applyFieldCorrection(fieldName, delta)` 메서드 추가
  - `SeasonBattingStats`, `CareerBattingStats` (타격 17개 필드)
  - `SeasonPitchingStats`, `CareerPitchingStats` (투구 13개 필드)
- `RecordCorrectionServiceImpl`에서 정정 후 `RecordCorrectedEvent` 발행
- `RecordCorrectionEventListener` 생성 (delta 계산 → 시즌/커리어 스탯 반영)
- 단위 테스트 9개 추가 (양수/음수 델타, 0 스킵, 누락 스탯, 음수 방지, 예외 처리)
- `RecordCorrectionServiceImplTest`에 `eventPublisher` mock 및 검증 추가

## To Reviewer

- 델타 기반 접근: `newValue - oldValue`로 변경분만 계산하여 기존 누적 통계에 가감합니다.
- 모든 스탯 필드는 `maxOf(0, value + delta)`로 음수 방지 처리됩니다.
- 기존 `StatsEventListener`(경기 결과 확정)와는 별도 리스너로 분리하여 책임을 명확히 했습니다.