### PR TITLE
feat(#256): 단일 예약 상세 조회 API 추가

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/BookingController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/BookingController.kt
@@ -1,5 +1,6 @@
 package com.nextup.api.controller.stadium
 
+import com.nextup.api.dto.stadium.BookingDetailResponse
 import com.nextup.api.dto.stadium.BookingResponse
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.domain.stadium.BookingStatus
@@ -14,6 +15,17 @@ import org.springframework.web.bind.annotation.*
 class BookingController(
     private val stadiumService: StadiumService,
 ) {
+    /**
+     * 예약 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getBookingDetail(
+        @PathVariable id: Long,
+    ): ApiResponse<BookingDetailResponse> {
+        val booking = stadiumService.getBookingById(id)
+        return ApiResponse.success(BookingDetailResponse.from(booking))
+    }
+
     /**
      * 팀의 예약 목록을 조회합니다.
      */

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/BookingDetailResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/BookingDetailResponse.kt
@@ -1,0 +1,67 @@
+package com.nextup.api.dto.stadium
+
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.domain.stadium.StadiumBooking
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 구장 예약 상세 조회 응답 DTO
+ *
+ * GET /api/v1/bookings/{id} 에서 사용됩니다.
+ * 구장 정보, 슬롯 시간, 예약 상태를 포함합니다.
+ */
+data class BookingDetailResponse(
+    val id: Long,
+    val status: BookingStatus,
+    val teamId: Long,
+    val bookedBy: Long,
+    val bookedAt: Instant,
+    val stadium: StadiumInfo,
+    val slot: SlotInfo,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    data class StadiumInfo(
+        val id: Long,
+        val name: String,
+        val address: String,
+    )
+
+    data class SlotInfo(
+        val id: Long,
+        val date: LocalDate,
+        val startTime: LocalTime,
+        val endTime: LocalTime,
+        val price: BigDecimal?,
+    )
+
+    companion object {
+        fun from(booking: StadiumBooking): BookingDetailResponse =
+            BookingDetailResponse(
+                id = booking.id,
+                status = booking.status,
+                teamId = booking.teamId,
+                bookedBy = booking.bookedBy,
+                bookedAt = booking.bookedAt,
+                stadium =
+                    StadiumInfo(
+                        id = booking.slot.stadium.id,
+                        name = booking.slot.stadium.name,
+                        address = booking.slot.stadium.address,
+                    ),
+                slot =
+                    SlotInfo(
+                        id = booking.slot.id,
+                        date = booking.slot.date,
+                        startTime = booking.slot.startTime,
+                        endTime = booking.slot.endTime,
+                        price = booking.slot.price,
+                    ),
+                createdAt = booking.createdAt,
+                updatedAt = booking.updatedAt,
+            )
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingControllerTest.kt
@@ -36,6 +36,45 @@ class BookingControllerTest {
     }
 
     @Nested
+    @DisplayName("GET /api/v1/bookings/{id}")
+    inner class GetBookingDetail {
+        @Test
+        fun `should return booking detail successfully`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장")
+            val slot = createSlot(1L, stadium)
+            val booking = createBooking(1L, slot, 100L, 200L)
+            every { stadiumService.getBookingById(1L) } returns booking
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/bookings/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.teamId").value(100))
+                .andExpect(jsonPath("$.data.bookedBy").value(200))
+                .andExpect(jsonPath("$.data.status").value("CONFIRMED"))
+                .andExpect(jsonPath("$.data.stadium.id").value(1))
+                .andExpect(jsonPath("$.data.stadium.name").value("잠실 야구장"))
+                .andExpect(jsonPath("$.data.slot.id").value(1))
+        }
+
+        @Test
+        fun `should return 404 when booking not found`() {
+            // given
+            every { stadiumService.getBookingById(999L) } throws
+                com.nextup.common.exception.BookingNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/bookings/999"))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+
+    @Nested
     @DisplayName("GET /api/v1/bookings/team/{teamId}")
     inner class GetTeamBookings {
         @Test

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumService.kt
@@ -154,6 +154,13 @@ class StadiumService(
     }
 
     /**
+     * ID로 예약을 조회합니다.
+     */
+    fun getBookingById(bookingId: Long): StadiumBooking =
+        bookingRepository.findByIdOrNull(bookingId)
+            ?: throw BookingNotFoundException(bookingId)
+
+    /**
      * 팀의 예약 목록을 조회합니다.
      */
     fun getTeamBookings(

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/StadiumServiceTest.kt
@@ -310,6 +310,39 @@ class StadiumServiceTest {
     }
 
     @Nested
+    @DisplayName("getBookingById")
+    inner class GetBookingById {
+        @Test
+        fun `should return booking when found`() {
+            // given
+            val stadium = createStadium(1L, "잠실 야구장", 37.5121, 127.0717)
+            val slot = createSlot(1L, stadium, LocalDate.of(2024, 12, 25))
+            val booking = createBooking(1L, slot, 100L, 200L)
+            every { bookingRepository.findByIdOrNull(1L) } returns booking
+
+            // when
+            val result = stadiumService.getBookingById(1L)
+
+            // then
+            assertThat(result.id).isEqualTo(1L)
+            assertThat(result.teamId).isEqualTo(100L)
+            assertThat(result.bookedBy).isEqualTo(200L)
+            assertThat(result.status).isEqualTo(BookingStatus.CONFIRMED)
+        }
+
+        @Test
+        fun `should throw BookingNotFoundException when not found`() {
+            // given
+            every { bookingRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                stadiumService.getBookingById(999L)
+            }.isInstanceOf(BookingNotFoundException::class.java)
+        }
+    }
+
+    @Nested
     @DisplayName("getTeamBookings")
     inner class GetTeamBookings {
         @Test


### PR DESCRIPTION
## Summary

>- close #256

`BookingController`에 `GET /api/v1/bookings/{id}` 엔드포인트를 추가하여 단일 예약 상세 조회 기능을 구현합니다.

## Tasks

- `StadiumService`에 `getBookingById()` 메서드 추가
- `BookingDetailResponse` DTO 생성 (구장 정보, 슬롯 시간, 예약 상태 포함)
- `BookingController`에 `GET /{id}` 엔드포인트 추가
- `StadiumServiceTest`에 단위 테스트 2건 추가
- `BookingControllerTest`에 단위 테스트 2건 추가
- `./gradlew clean build` 통과 확인

## To Reviewer

- Zero Entity Leak 준수: `BookingDetailResponse` DTO로 변환하여 반환
- `ApiResponse.success()` 래핑 적용
- 권한 검증은 현재 미적용 상태 (인증 시스템 연동 후 추가 예정)
- 5개 파일 변경, 158줄 추가