### PR TITLE
feat(#257): 선수 프로필 수정 API 추가

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/player/PlayerProfileController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/player/PlayerProfileController.kt
@@ -1,0 +1,66 @@
+package com.nextup.api.controller.player
+
+import com.nextup.api.dto.player.MyPlayerProfileResponse
+import com.nextup.api.dto.player.UpdatePlayerProfileRequest
+import com.nextup.api.dto.player.toMyProfileResponse
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.player.PlayerService
+import jakarta.validation.Valid
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 선수 프로필 API Controller
+ *
+ * 인증된 사용자가 본인의 선수 프로필을 조회/수정하는 API를 제공합니다.
+ *
+ * GET  /api/v1/players/me  - 내 선수 프로필 조회
+ * PUT  /api/v1/players/me  - 내 선수 프로필 수정
+ */
+@RestController
+@RequestMapping("/api/v1/players/me")
+class PlayerProfileController(
+    private val playerService: PlayerService,
+) {
+    /**
+     * 내 선수 프로필을 조회합니다.
+     *
+     * @param userId 인증된 사용자 ID
+     * @return 선수 프로필 정보
+     */
+    @GetMapping
+    fun getMyPlayerProfile(
+        @AuthenticationPrincipal userId: Long,
+    ): ApiResponse<MyPlayerProfileResponse> {
+        val player = playerService.getLinkedPlayer(userId)
+        return ApiResponse.success(player.toMyProfileResponse())
+    }
+
+    /**
+     * 내 선수 프로필을 수정합니다.
+     *
+     * @param userId 인증된 사용자 ID
+     * @param request 수정할 선수 프로필 정보
+     * @return 수정된 선수 프로필 정보
+     */
+    @PutMapping
+    fun updateMyPlayerProfile(
+        @AuthenticationPrincipal userId: Long,
+        @Valid @RequestBody request: UpdatePlayerProfileRequest,
+    ): ApiResponse<MyPlayerProfileResponse> {
+        val player =
+            playerService.updatePlayerProfile(
+                userId = userId,
+                primaryPosition = request.primaryPosition,
+                throwingHand = request.throwingHand,
+                battingHand = request.battingHand,
+                height = request.height,
+                weight = request.weight,
+            )
+        return ApiResponse.success(player.toMyProfileResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/player/PlayerProfileDto.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/player/PlayerProfileDto.kt
@@ -1,0 +1,58 @@
+package com.nextup.api.dto.player
+
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+
+/**
+ * 선수 프로필 수정 요청 DTO
+ *
+ * PUT /api/v1/players/me 에서 사용됩니다.
+ * 모든 필드가 nullable이며, null인 필드는 기존 값을 유지합니다.
+ * (단, throwingHand/battingHand/height/weight는 명시적으로 null 설정 가능)
+ */
+data class UpdatePlayerProfileRequest(
+    val primaryPosition: Position? = null,
+    val throwingHand: ThrowingHand? = null,
+    val battingHand: BattingHand? = null,
+    @field:Min(100, message = "키는 100cm 이상이어야 합니다.")
+    @field:Max(250, message = "키는 250cm 이하여야 합니다.")
+    val height: Int? = null,
+    @field:Min(30, message = "몸무게는 30kg 이상이어야 합니다.")
+    @field:Max(200, message = "몸무게는 200kg 이하여야 합니다.")
+    val weight: Int? = null,
+)
+
+/**
+ * 내 선수 프로필 응답 DTO
+ *
+ * 인증된 사용자의 선수 프로필 정보를 반환합니다.
+ */
+data class MyPlayerProfileResponse(
+    val id: Long,
+    val name: String,
+    val primaryPosition: String,
+    val throwingHand: String?,
+    val battingHand: String?,
+    val height: Int?,
+    val weight: Int?,
+    val profileImageUrl: String?,
+)
+
+/**
+ * Player 엔티티를 MyPlayerProfileResponse로 변환합니다.
+ */
+fun Player.toMyProfileResponse(): MyPlayerProfileResponse =
+    MyPlayerProfileResponse(
+        id = this.id,
+        name = this.name,
+        primaryPosition = this.primaryPosition.displayName,
+        throwingHand = this.throwingHand?.displayName,
+        battingHand = this.battingHand?.displayName,
+        height = this.height,
+        weight = this.weight,
+        profileImageUrl = this.profileImageUrl,
+    )

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/player/PlayerProfileControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/player/PlayerProfileControllerTest.kt
@@ -1,0 +1,199 @@
+package com.nextup.api.controller.player
+
+import com.nextup.common.exception.PlayerNotLinkedException
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.service.player.PlayerService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("PlayerProfileController 테스트")
+class PlayerProfileControllerTest {
+    private lateinit var playerService: PlayerService
+    private lateinit var controller: PlayerProfileController
+
+    @BeforeEach
+    fun setUp() {
+        playerService = mockk()
+        controller = PlayerProfileController(playerService)
+    }
+
+    private fun createPlayer(
+        id: Long = 1L,
+        name: String = "김철수",
+        position: Position = Position.STARTING_PITCHER,
+        throwingHand: ThrowingHand? = ThrowingHand.RIGHT,
+        battingHand: BattingHand? = BattingHand.RIGHT,
+        height: Int? = 180,
+        weight: Int? = 75,
+    ): Player =
+        Player(
+            name = name,
+            primaryPosition = position,
+            throwingHand = throwingHand,
+            battingHand = battingHand,
+            height = height,
+            weight = weight,
+        ).apply {
+            val idField = Player::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    @Nested
+    @DisplayName("GET /api/v1/players/me")
+    inner class GetMyPlayerProfile {
+        @Test
+        fun `should return my player profile successfully`() {
+            // given
+            val userId = 1L
+            val player = createPlayer()
+            every { playerService.getLinkedPlayer(userId) } returns player
+
+            // when
+            val response = controller.getMyPlayerProfile(userId)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.id).isEqualTo(1L)
+            assertThat(response.data?.name).isEqualTo("김철수")
+            assertThat(response.data?.primaryPosition).isEqualTo("선발투수")
+            assertThat(response.data?.throwingHand).isEqualTo("우투")
+            assertThat(response.data?.battingHand).isEqualTo("우타")
+            assertThat(response.data?.height).isEqualTo(180)
+            assertThat(response.data?.weight).isEqualTo(75)
+            verify { playerService.getLinkedPlayer(userId) }
+        }
+
+        @Test
+        fun `should throw PlayerNotLinkedException when no linked player`() {
+            // given
+            val userId = 1L
+            every { playerService.getLinkedPlayer(userId) } throws
+                PlayerNotLinkedException(userId)
+
+            // when & then
+            assertThatThrownBy { controller.getMyPlayerProfile(userId) }
+                .isInstanceOf(PlayerNotLinkedException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/players/me")
+    inner class UpdateMyPlayerProfile {
+        @Test
+        fun `should update player profile successfully`() {
+            // given
+            val userId = 1L
+            val updatedPlayer =
+                createPlayer(
+                    position = Position.CATCHER,
+                    throwingHand = ThrowingHand.LEFT,
+                    battingHand = BattingHand.SWITCH,
+                    height = 185,
+                    weight = 82,
+                )
+            every {
+                playerService.updatePlayerProfile(
+                    userId = userId,
+                    primaryPosition = Position.CATCHER,
+                    throwingHand = ThrowingHand.LEFT,
+                    battingHand = BattingHand.SWITCH,
+                    height = 185,
+                    weight = 82,
+                )
+            } returns updatedPlayer
+
+            val request =
+                com.nextup.api.dto.player.UpdatePlayerProfileRequest(
+                    primaryPosition = Position.CATCHER,
+                    throwingHand = ThrowingHand.LEFT,
+                    battingHand = BattingHand.SWITCH,
+                    height = 185,
+                    weight = 82,
+                )
+
+            // when
+            val response = controller.updateMyPlayerProfile(userId, request)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.primaryPosition).isEqualTo("포수")
+            assertThat(response.data?.throwingHand).isEqualTo("좌투")
+            assertThat(response.data?.battingHand).isEqualTo("양타")
+            assertThat(response.data?.height).isEqualTo(185)
+            assertThat(response.data?.weight).isEqualTo(82)
+        }
+
+        @Test
+        fun `should update with partial fields`() {
+            // given
+            val userId = 1L
+            val updatedPlayer =
+                createPlayer(
+                    position = Position.STARTING_PITCHER,
+                    throwingHand = ThrowingHand.RIGHT,
+                    battingHand = BattingHand.RIGHT,
+                    height = 185,
+                    weight = 75,
+                )
+            every {
+                playerService.updatePlayerProfile(
+                    userId = userId,
+                    primaryPosition = null,
+                    throwingHand = null,
+                    battingHand = null,
+                    height = 185,
+                    weight = null,
+                )
+            } returns updatedPlayer
+
+            val request =
+                com.nextup.api.dto.player.UpdatePlayerProfileRequest(
+                    height = 185,
+                )
+
+            // when
+            val response = controller.updateMyPlayerProfile(userId, request)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.height).isEqualTo(185)
+        }
+
+        @Test
+        fun `should throw PlayerNotLinkedException when no linked player`() {
+            // given
+            val userId = 1L
+            every {
+                playerService.updatePlayerProfile(
+                    userId = userId,
+                    primaryPosition = any(),
+                    throwingHand = any(),
+                    battingHand = any(),
+                    height = any(),
+                    weight = any(),
+                )
+            } throws PlayerNotLinkedException(userId)
+
+            val request =
+                com.nextup.api.dto.player.UpdatePlayerProfileRequest(
+                    primaryPosition = Position.CATCHER,
+                )
+
+            // when & then
+            assertThatThrownBy {
+                controller.updateMyPlayerProfile(userId, request)
+            }.isInstanceOf(PlayerNotLinkedException::class.java)
+        }
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/UserExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/UserExceptions.kt
@@ -69,3 +69,13 @@ class UserDeactivatedException(
         "USER_DEACTIVATED",
         "User is deactivated: $userId",
     )
+
+/**
+ * 사용자에게 연결된 선수 프로필이 없을 때 발생하는 예외
+ */
+class PlayerNotLinkedException(
+    userId: Long,
+) : InvalidStateException(
+        "PLAYER_NOT_LINKED",
+        "User does not have a linked player: $userId",
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/player/Player.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/player/Player.kt
@@ -72,6 +72,24 @@ class Player(
     }
 
     /**
+     * 선수 프로필 정보를 수정합니다.
+     * (포지션, 투타, 신체정보)
+     */
+    fun updatePlayerProfile(
+        primaryPosition: Position = this.primaryPosition,
+        throwingHand: ThrowingHand? = this.throwingHand,
+        battingHand: BattingHand? = this.battingHand,
+        height: Int? = this.height,
+        weight: Int? = this.weight,
+    ) {
+        this.primaryPosition = primaryPosition
+        this.throwingHand = throwingHand
+        this.battingHand = battingHand
+        this.height = height
+        this.weight = weight
+    }
+
+    /**
      * 선수의 나이를 계산합니다.
      */
     fun calculateAge(baseDate: LocalDate = LocalDate.now()): Int? =

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/player/PlayerService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/player/PlayerService.kt
@@ -1,11 +1,16 @@
 package com.nextup.core.service.player
 
 import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.common.exception.PlayerNotLinkedException
+import com.nextup.common.exception.UserNotFoundException
 import com.nextup.core.common.PageCommand
 import com.nextup.core.common.PageResult
+import com.nextup.core.domain.player.BattingHand
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
 import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.repository.UserRepositoryPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -18,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class PlayerService(
     private val playerRepository: PlayerRepositoryPort,
+    private val userRepository: UserRepositoryPort,
 ) {
     /**
      * ID로 선수를 조회합니다.
@@ -67,4 +73,51 @@ class PlayerService(
             position = position,
             pageCommand = pageCommand,
         )
+
+    /**
+     * 인증된 사용자의 연결된 선수를 조회합니다.
+     *
+     * @param userId 인증된 사용자 ID
+     * @return 연결된 선수
+     * @throws UserNotFoundException 사용자를 찾을 수 없는 경우
+     * @throws PlayerNotLinkedException 연결된 선수가 없는 경우
+     */
+    fun getLinkedPlayer(userId: Long): Player {
+        val user =
+            userRepository.findByIdOrNull(userId)
+                ?: throw UserNotFoundException(userId)
+        return user.player
+            ?: throw PlayerNotLinkedException(userId)
+    }
+
+    /**
+     * 인증된 사용자의 선수 프로필을 수정합니다.
+     *
+     * @param userId 인증된 사용자 ID
+     * @param primaryPosition 주 포지션
+     * @param throwingHand 투구 손
+     * @param battingHand 타격 손
+     * @param height 키 (cm)
+     * @param weight 몸무게 (kg)
+     * @return 수정된 선수
+     */
+    @Transactional
+    fun updatePlayerProfile(
+        userId: Long,
+        primaryPosition: Position?,
+        throwingHand: ThrowingHand?,
+        battingHand: BattingHand?,
+        height: Int?,
+        weight: Int?,
+    ): Player {
+        val player = getLinkedPlayer(userId)
+        player.updatePlayerProfile(
+            primaryPosition = primaryPosition ?: player.primaryPosition,
+            throwingHand = throwingHand,
+            battingHand = battingHand,
+            height = height,
+            weight = weight,
+        )
+        return player
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/player/PlayerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/player/PlayerTest.kt
@@ -127,6 +127,85 @@ class PlayerTest {
     }
 
     @Nested
+    @DisplayName("선수 프로필 수정")
+    inner class UpdatePlayerProfile {
+        @Test
+        fun `포지션, 투타, 신체정보를 수정할 수 있다`() {
+            // given
+            val player = createPlayer()
+
+            // when
+            player.updatePlayerProfile(
+                primaryPosition = Position.CATCHER,
+                throwingHand = ThrowingHand.RIGHT,
+                battingHand = BattingHand.LEFT,
+                height = 185,
+                weight = 82,
+            )
+
+            // then
+            assertThat(player.primaryPosition).isEqualTo(Position.CATCHER)
+            assertThat(player.throwingHand).isEqualTo(ThrowingHand.RIGHT)
+            assertThat(player.battingHand).isEqualTo(BattingHand.LEFT)
+            assertThat(player.height).isEqualTo(185)
+            assertThat(player.weight).isEqualTo(82)
+        }
+
+        @Test
+        fun `포지션만 수정하면 나머지는 기존값을 유지한다`() {
+            // given
+            val player =
+                createPlayer().apply {
+                    updatePlayerProfile(
+                        primaryPosition = Position.SHORTSTOP,
+                        throwingHand = ThrowingHand.RIGHT,
+                        battingHand = BattingHand.RIGHT,
+                        height = 180,
+                        weight = 75,
+                    )
+                }
+
+            // when
+            player.updatePlayerProfile(primaryPosition = Position.SECOND_BASE)
+
+            // then
+            assertThat(player.primaryPosition).isEqualTo(Position.SECOND_BASE)
+            assertThat(player.throwingHand).isEqualTo(ThrowingHand.RIGHT)
+            assertThat(player.battingHand).isEqualTo(BattingHand.RIGHT)
+            assertThat(player.height).isEqualTo(180)
+            assertThat(player.weight).isEqualTo(75)
+        }
+
+        @Test
+        fun `투타와 신체정보를 null로 설정할 수 있다`() {
+            // given
+            val player =
+                createPlayer().apply {
+                    updatePlayerProfile(
+                        throwingHand = ThrowingHand.RIGHT,
+                        battingHand = BattingHand.RIGHT,
+                        height = 180,
+                        weight = 75,
+                    )
+                }
+
+            // when
+            player.updatePlayerProfile(
+                throwingHand = null,
+                battingHand = null,
+                height = null,
+                weight = null,
+            )
+
+            // then
+            assertThat(player.throwingHand).isNull()
+            assertThat(player.battingHand).isNull()
+            assertThat(player.height).isNull()
+            assertThat(player.weight).isNull()
+        }
+    }
+
+    @Nested
     @DisplayName("나이 계산")
     inner class CalculateAge {
         @Test

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/player/PlayerServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/player/PlayerServiceTest.kt
@@ -1,11 +1,17 @@
 package com.nextup.core.service.player
 
 import com.nextup.common.exception.PlayerNotFoundException
+import com.nextup.common.exception.PlayerNotLinkedException
+import com.nextup.common.exception.UserNotFoundException
 import com.nextup.core.common.PageCommand
 import com.nextup.core.common.PageResult
+import com.nextup.core.domain.player.BattingHand
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.domain.user.User
 import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.repository.UserRepositoryPort
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -18,12 +24,58 @@ import org.junit.jupiter.api.Test
 @DisplayName("PlayerService")
 class PlayerServiceTest {
     private lateinit var playerRepository: PlayerRepositoryPort
+    private lateinit var userRepository: UserRepositoryPort
     private lateinit var playerService: PlayerService
 
     @BeforeEach
     fun setUp() {
         playerRepository = mockk()
-        playerService = PlayerService(playerRepository)
+        userRepository = mockk()
+        playerService = PlayerService(playerRepository, userRepository)
+    }
+
+    private fun createPlayer(
+        id: Long = 1L,
+        name: String = "김철수",
+        position: Position = Position.STARTING_PITCHER,
+    ): Player =
+        Player(
+            name = name,
+            primaryPosition = position,
+        ).apply {
+            val idField = Player::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createUserWithPlayer(
+        userId: Long = 1L,
+        player: Player,
+    ): User {
+        val user =
+            User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "encoded",
+                nickname = "테스터",
+            )
+        val idField = user.javaClass.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(user, userId)
+        user.linkPlayer(player)
+        return user
+    }
+
+    private fun createUserWithoutPlayer(userId: Long = 1L): User {
+        val user =
+            User.createLocalUser(
+                email = "test@example.com",
+                encodedPassword = "encoded",
+                nickname = "테스터",
+            )
+        val idField = user.javaClass.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(user, userId)
+        return user
     }
 
     @Nested
@@ -116,6 +168,118 @@ class PlayerServiceTest {
             // when & then
             assertThatThrownBy { playerService.getById(999L) }
                 .isInstanceOf(PlayerNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("getLinkedPlayer")
+    inner class GetLinkedPlayer {
+        @Test
+        fun `should return linked player when user has linked player`() {
+            // given
+            val player = createPlayer()
+            val user = createUserWithPlayer(userId = 1L, player = player)
+            every { userRepository.findByIdOrNull(1L) } returns user
+
+            // when
+            val result = playerService.getLinkedPlayer(1L)
+
+            // then
+            assertThat(result.id).isEqualTo(player.id)
+            assertThat(result.name).isEqualTo("김철수")
+        }
+
+        @Test
+        fun `should throw UserNotFoundException when user not found`() {
+            // given
+            every { userRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy { playerService.getLinkedPlayer(999L) }
+                .isInstanceOf(UserNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw PlayerNotLinkedException when user has no linked player`() {
+            // given
+            val user = createUserWithoutPlayer(userId = 1L)
+            every { userRepository.findByIdOrNull(1L) } returns user
+
+            // when & then
+            assertThatThrownBy { playerService.getLinkedPlayer(1L) }
+                .isInstanceOf(PlayerNotLinkedException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("updatePlayerProfile")
+    inner class UpdatePlayerProfile {
+        @Test
+        fun `should update player profile successfully`() {
+            // given
+            val player = createPlayer()
+            val user = createUserWithPlayer(userId = 1L, player = player)
+            every { userRepository.findByIdOrNull(1L) } returns user
+
+            // when
+            val result =
+                playerService.updatePlayerProfile(
+                    userId = 1L,
+                    primaryPosition = Position.CATCHER,
+                    throwingHand = ThrowingHand.RIGHT,
+                    battingHand = BattingHand.LEFT,
+                    height = 185,
+                    weight = 82,
+                )
+
+            // then
+            assertThat(result.primaryPosition).isEqualTo(Position.CATCHER)
+            assertThat(result.throwingHand).isEqualTo(ThrowingHand.RIGHT)
+            assertThat(result.battingHand).isEqualTo(BattingHand.LEFT)
+            assertThat(result.height).isEqualTo(185)
+            assertThat(result.weight).isEqualTo(82)
+        }
+
+        @Test
+        fun `should keep existing position when primaryPosition is null`() {
+            // given
+            val player = createPlayer(position = Position.SHORTSTOP)
+            val user = createUserWithPlayer(userId = 1L, player = player)
+            every { userRepository.findByIdOrNull(1L) } returns user
+
+            // when
+            val result =
+                playerService.updatePlayerProfile(
+                    userId = 1L,
+                    primaryPosition = null,
+                    throwingHand = ThrowingHand.LEFT,
+                    battingHand = null,
+                    height = null,
+                    weight = null,
+                )
+
+            // then
+            assertThat(result.primaryPosition).isEqualTo(Position.SHORTSTOP)
+            assertThat(result.throwingHand).isEqualTo(ThrowingHand.LEFT)
+        }
+
+        @Test
+        fun `should throw PlayerNotLinkedException when user has no linked player`() {
+            // given
+            val user = createUserWithoutPlayer(userId = 1L)
+            every { userRepository.findByIdOrNull(1L) } returns user
+
+            // when & then
+            assertThatThrownBy {
+                playerService.updatePlayerProfile(
+                    userId = 1L,
+                    primaryPosition = Position.CATCHER,
+                    throwingHand = null,
+                    battingHand = null,
+                    height = null,
+                    weight = null,
+                )
+            }.isInstanceOf(PlayerNotLinkedException::class.java)
         }
     }
 }


### PR DESCRIPTION
## Summary

>- close #257

일반 사용자가 자신의 선수 프로필(포지션, 투타, 신체정보)을 조회/수정할 수 있는 API를 추가합니다.

## Tasks

- `Player` 엔티티에 `updatePlayerProfile()` 비즈니스 메서드 추가 (Rich Domain Model)
- `PlayerNotLinkedException` 커스텀 예외 추가 (common 모듈)
- `PlayerService`에 `getLinkedPlayer()`, `updatePlayerProfile()` 메서드 추가
- `UpdatePlayerProfileRequest`, `MyPlayerProfileResponse` DTO 생성
- `PlayerProfileController` 생성 (`GET /api/v1/players/me`, `PUT /api/v1/players/me`)
- `PlayerTest` 단위 테스트 3건 추가
- `PlayerServiceTest` 단위 테스트 6건 추가
- `PlayerProfileControllerTest` 단위 테스트 5건 추가
- `./gradlew clean build` 통과 확인

## To Reviewer

- Zero Entity Leak 준수: `MyPlayerProfileResponse` DTO로 변환하여 반환
- Rich Domain Model: 프로필 수정 로직은 `Player.updatePlayerProfile()` 엔티티 메서드에 캡슐화
- `@AuthenticationPrincipal userId: Long`으로 인증된 사용자의 연결된 Player만 수정 가능
- 입력 검증: height(100~250), weight(30~200) 범위 제한
- 8개 파일 변경 (common 1, core 2, api 2, test 3)