### PR TITLE
feat(#296): Schedule → Game 변환 서비스 및 backoffice API 구현

### DIFF
--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/PitchEventControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/PitchEventControllerTest.kt
@@ -8,7 +8,6 @@ import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.GameStatus
-import com.nextup.core.domain.game.GameTeam
 import com.nextup.core.domain.game.HomeAway
 import com.nextup.core.domain.game.PitchEvent
 import com.nextup.core.domain.game.PitchResult
@@ -63,24 +62,26 @@ class PitchEventControllerTest {
                 id = 1L,
             )
 
+        val homeTeam =
+            Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam =
+            Team(league = league, name = "원정팀", city = "서울", foundedYear = 2020, id = 2L)
+
         game =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
                 scheduledAt = LocalDateTime.of(2024, 6, 1, 14, 0),
                 status = GameStatus.IN_PROGRESS,
                 currentInning = 1,
                 id = 1L,
             )
 
-        val homeTeam =
-            Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
-        val awayTeam =
-            Team(league = league, name = "원정팀", city = "서울", foundedYear = 2020, id = 2L)
-
         val homeGameTeam =
-            GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME, id = 1L)
+            game.gameTeams.first { it.homeAway == HomeAway.HOME }
         val awayGameTeam =
-            GameTeam(game = game, team = awayTeam, homeAway = HomeAway.AWAY, id = 2L)
+            game.gameTeams.first { it.homeAway == HomeAway.AWAY }
 
         val pitcherPlayer =
             Player(

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/schedule/ScheduleAdminController.kt
@@ -1,5 +1,6 @@
 package com.nextup.backoffice.controller.schedule
 
+import com.nextup.backoffice.dto.schedule.CreateGameFromScheduleRequest
 import com.nextup.backoffice.dto.schedule.CreateScheduleRequest
 import com.nextup.backoffice.dto.schedule.PostponeBulkRequest
 import com.nextup.backoffice.dto.schedule.RescheduleRequest
@@ -153,6 +154,27 @@ class ScheduleAdminController(
                 reason = request.reason,
             )
         return ApiResponse.success(schedules.map { ScheduleAdminResponse.from(it) })
+    }
+
+    /**
+     * 대진표에서 경기를 생성합니다.
+     *
+     * 대진표의 대회/홈팀/원정팀/일정 정보를 기반으로 Game을 생성하고 연결합니다.
+     */
+    @PostMapping("/{id}/create-game")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createGameFromSchedule(
+        @PathVariable competitionId: Long,
+        @PathVariable id: Long,
+        @Valid @RequestBody(required = false) request: CreateGameFromScheduleRequest?,
+    ): ApiResponse<ScheduleAdminResponse> {
+        val schedule =
+            scheduleService.createGameFromSchedule(
+                scheduleId = id,
+                location = request?.location,
+                fieldName = request?.fieldName,
+            )
+        return ApiResponse.success(ScheduleAdminResponse.from(schedule))
     }
 
     /**

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/CreateGameFromScheduleRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/schedule/CreateGameFromScheduleRequest.kt
@@ -1,0 +1,16 @@
+package com.nextup.backoffice.dto.schedule
+
+import jakarta.validation.constraints.Size
+
+/**
+ * 대진표에서 경기 생성 요청 DTO
+ *
+ * 대진표의 기본 정보(대회, 홈팀, 원정팀, 일정)를 사용하되,
+ * 장소와 구장명은 선택적으로 재지정할 수 있습니다.
+ */
+data class CreateGameFromScheduleRequest(
+    @field:Size(max = 255)
+    val location: String? = null,
+    @field:Size(max = 255)
+    val fieldName: String? = null,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -2,6 +2,7 @@ package com.nextup.core.domain.game
 
 import com.nextup.core.common.BaseTimeEntity
 import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.team.Team
 import jakarta.persistence.*
 import java.time.LocalDateTime
 
@@ -22,7 +23,7 @@ import java.time.LocalDateTime
         Index(name = "idx_games_competition_date", columnList = "competition_id, scheduled_at"),
     ],
 )
-class Game(
+class Game private constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "competition_id", nullable = false)
     val competition: Competition,
@@ -59,6 +60,10 @@ class Game(
 ) : BaseTimeEntity() {
     @Version
     var version: Long = 0
+
+    @OneToMany(mappedBy = "game", cascade = [CascadeType.ALL], orphanRemoval = true)
+    private val _gameTeams: MutableList<GameTeam> = mutableListOf()
+    val gameTeams: List<GameTeam> get() = _gameTeams.toList()
 
     /**
      * 경기를 시작합니다.
@@ -317,6 +322,86 @@ class Game(
 
         /** 투수 교체 시 최소 대면 타자 수 기본값 */
         const val DEFAULT_MIN_BATTERS_FACED = 1
+
+        /**
+         * 프로덕션 팩토리 메서드.
+         *
+         * 홈팀/원정팀 [GameTeam] 2개를 자동 생성하며,
+         * [competition]의 [GameRules.defaultInnings]를 totalInnings로 설정합니다.
+         */
+        fun create(
+            competition: Competition,
+            homeTeam: Team,
+            awayTeam: Team,
+            scheduledAt: LocalDateTime,
+            location: String? = null,
+            fieldName: String? = null,
+            gameNumber: Int? = null,
+        ): Game {
+            require(homeTeam.id != awayTeam.id) { "홈팀과 원정팀은 같을 수 없습니다." }
+
+            val game =
+                Game(
+                    competition = competition,
+                    scheduledAt = scheduledAt,
+                    location = location,
+                    fieldName = fieldName,
+                    gameNumber = gameNumber,
+                    totalInnings = competition.gameRules.defaultInnings,
+                )
+            game._gameTeams.add(GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME))
+            game._gameTeams.add(GameTeam(game = game, team = awayTeam, homeAway = HomeAway.AWAY))
+            return game
+        }
+
+        /**
+         * 테스트 전용 팩토리 메서드.
+         *
+         * 특정 상태(status, currentInning 등)의 Game을 생성할 때 사용합니다.
+         * 프로덕션 코드에서는 반드시 [create]를 사용하세요.
+         */
+        @Suppress("LongParameterList")
+        fun createForTest(
+            competition: Competition,
+            homeTeam: Team,
+            awayTeam: Team,
+            scheduledAt: LocalDateTime = LocalDateTime.now(),
+            location: String? = null,
+            fieldName: String? = null,
+            gameNumber: Int? = null,
+            status: GameStatus = GameStatus.SCHEDULED,
+            currentInning: Int = 0,
+            isTopInning: Boolean = true,
+            totalInnings: Int = competition.gameRules.defaultInnings,
+            startedAt: LocalDateTime? = null,
+            endedAt: LocalDateTime? = null,
+            note: String? = null,
+            forfeitReason: String? = null,
+            gameState: GameState = GameState(),
+            id: Long = 0L,
+        ): Game {
+            val game =
+                Game(
+                    competition = competition,
+                    scheduledAt = scheduledAt,
+                    location = location,
+                    fieldName = fieldName,
+                    gameNumber = gameNumber,
+                    status = status,
+                    currentInning = currentInning,
+                    isTopInning = isTopInning,
+                    totalInnings = totalInnings,
+                    startedAt = startedAt,
+                    endedAt = endedAt,
+                    note = note,
+                    forfeitReason = forfeitReason,
+                    gameState = gameState,
+                    id = id,
+                )
+            game._gameTeams.add(GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME, id = id * 100 + 1))
+            game._gameTeams.add(GameTeam(game = game, team = awayTeam, homeAway = HomeAway.AWAY, id = id * 100 + 2))
+            return game
+        }
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/LeagueSchedule.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/schedule/LeagueSchedule.kt
@@ -71,6 +71,11 @@ class LeagueSchedule private constructor(
         protected set
 
     /**
+     * 경기 연결이 가능한 상태인지 확인합니다.
+     */
+    fun canLinkGame(): Boolean = status == ScheduleStatus.SCHEDULED || status == ScheduleStatus.POSTPONED
+
+    /**
      * 경기를 연결합니다.
      */
     fun linkGame(game: Game) {

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/schedule/LeagueScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/schedule/LeagueScheduleService.kt
@@ -4,11 +4,13 @@ import com.nextup.common.exception.CompetitionNotFoundException
 import com.nextup.common.exception.InvalidScheduleStateException
 import com.nextup.common.exception.ScheduleNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.schedule.LeagueSchedule
 import com.nextup.core.domain.schedule.RoundRobinScheduleGenerator
 import com.nextup.core.domain.schedule.ScheduleConflict
 import com.nextup.core.domain.schedule.ScheduleConflictDetector
 import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.LeagueScheduleRepositoryPort
 import com.nextup.core.port.repository.TeamRepositoryPort
 import org.springframework.stereotype.Service
@@ -28,6 +30,7 @@ class LeagueScheduleService(
     private val scheduleRepository: LeagueScheduleRepositoryPort,
     private val competitionRepository: CompetitionRepositoryPort,
     private val teamRepository: TeamRepositoryPort,
+    private val gameRepository: GameRepositoryPort,
 ) {
     private val conflictDetector = ScheduleConflictDetector()
     private val scheduleGenerator = RoundRobinScheduleGenerator()
@@ -294,6 +297,46 @@ class LeagueScheduleService(
         }
 
         return schedules
+    }
+
+    /**
+     * 대진표에서 경기를 생성합니다.
+     *
+     * Schedule의 대회/홈팀/원정팀/일정 정보를 기반으로 Game을 생성하고,
+     * Schedule에 연결합니다. (상태: SCHEDULED/POSTPONED → GAME_CREATED)
+     */
+    @Transactional
+    fun createGameFromSchedule(
+        scheduleId: Long,
+        location: String? = null,
+        fieldName: String? = null,
+    ): LeagueSchedule {
+        val schedule = getById(scheduleId)
+
+        if (!schedule.canLinkGame()) {
+            throw InvalidScheduleStateException(
+                "예정 또는 연기 상태의 대진표만 경기를 생성할 수 있습니다. (현재: ${schedule.status})",
+            )
+        }
+
+        val scheduledAt =
+            schedule.scheduledDate
+                .atTime(schedule.scheduledTime ?: java.time.LocalTime.of(0, 0))
+
+        val game =
+            Game.create(
+                competition = schedule.competition,
+                homeTeam = schedule.homeTeam,
+                awayTeam = schedule.awayTeam,
+                scheduledAt = scheduledAt,
+                location = location ?: schedule.venue,
+                fieldName = fieldName,
+            )
+
+        val savedGame = gameRepository.save(game)
+        schedule.linkGame(savedGame)
+
+        return schedule
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
@@ -5,6 +5,7 @@ import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -366,8 +367,13 @@ class GameEventTest {
                 idField.set(this, 1L)
             }
 
-        return Game(
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 10L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 20L)
+
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실구장",
             fieldName = "1구장",
@@ -377,10 +383,7 @@ class GameEventTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
-        ).apply {
-            val idField = Game::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, 1L)
-        }
+            id = 1L,
+        )
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameParticipationTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameParticipationTest.kt
@@ -31,7 +31,15 @@ class GameParticipationTest {
         team = Team(league = league, name = "타이거즈", city = "서울", foundedYear = 2015)
 
         val competition = mockk<com.nextup.core.domain.competition.Competition>()
-        game = Game(competition = competition, scheduledAt = LocalDateTime.now().plusDays(7))
+        val awayTeam = Team(league = league, name = "이글스", city = "부산", foundedYear = 2015)
+        game =
+            Game.createForTest(
+                competition = competition,
+                homeTeam = team,
+                awayTeam = awayTeam,
+                scheduledAt = LocalDateTime.now().plusDays(7),
+                totalInnings = 9,
+            )
 
         val user = User.createLocalUser("member@example.com", "password", "회원")
         val player = Player(name = "회원", primaryPosition = Position.SHORTSTOP)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -4,6 +4,7 @@ import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.competition.GameRules
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.team.Team
 import org.assertj.core.api.Assertions.assertThat
@@ -36,13 +37,18 @@ class GameTest {
             )
     }
 
-    private fun createGame(status: GameStatus = GameStatus.SCHEDULED): Game =
-        Game(
+    private fun createGame(status: GameStatus = GameStatus.SCHEDULED): Game {
+        val homeTeam = createTeam("홈팀", id = 1L)
+        val awayTeam = createTeam("원정팀", city = "부산", id = 2L)
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실야구장",
             status = status,
         )
+    }
 
     private fun createTeam(
         name: String,
@@ -541,30 +547,18 @@ class GameTest {
     @Nested
     @DisplayName("몰수패")
     inner class Forfeit {
-        private lateinit var homeTeam: Team
-        private lateinit var awayTeam: Team
-
-        @BeforeEach
-        fun setUpTeams() {
-            homeTeam = createTeam("홈팀", id = 1L)
-            awayTeam = createTeam("원정팀", city = "부산", id = 2L)
-        }
-
-        private fun createGameTeams(game: Game): List<GameTeam> =
-            listOf(
-                GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME),
-                GameTeam(game = game, team = awayTeam, homeAway = HomeAway.AWAY),
-            )
+        private val homeTeamId = 1L
+        private val awayTeamId = 2L
 
         @Test
         fun `예정된 경기를 몰수 처리하면 7대0 점수가 반영된다`() {
             // given
             val game = createGame(status = GameStatus.SCHEDULED)
-            val gameTeams = createGameTeams(game)
+            val gameTeams = game.gameTeams
 
             // when
             game.forfeit(
-                winnerTeamId = homeTeam.id,
+                winnerTeamId = homeTeamId,
                 reason = "상대팀 불참",
                 gameTeams = gameTeams,
             )
@@ -575,8 +569,8 @@ class GameTest {
             assertThat(game.note).contains("상대팀 불참")
             assertThat(game.endedAt).isNotNull()
 
-            val winnerGameTeam = gameTeams.first { it.team.id == homeTeam.id }
-            val loserGameTeam = gameTeams.first { it.team.id == awayTeam.id }
+            val winnerGameTeam = gameTeams.first { it.team.id == homeTeamId }
+            val loserGameTeam = gameTeams.first { it.team.id == awayTeamId }
 
             assertThat(winnerGameTeam.totalScore).isEqualTo(7)
             assertThat(winnerGameTeam.result).isEqualTo(GameResult.WIN)
@@ -588,19 +582,19 @@ class GameTest {
         fun `진행 중인 경기도 몰수 처리할 수 있다`() {
             // given
             val game = createGame(status = GameStatus.IN_PROGRESS)
-            val gameTeams = createGameTeams(game)
+            val gameTeams = game.gameTeams
 
             // when
             game.forfeit(
-                winnerTeamId = awayTeam.id,
+                winnerTeamId = awayTeamId,
                 reason = "홈팀 규정 위반",
                 gameTeams = gameTeams,
             )
 
             // then
             assertThat(game.status).isEqualTo(GameStatus.FORFEITED)
-            val winnerGameTeam = gameTeams.first { it.team.id == awayTeam.id }
-            val loserGameTeam = gameTeams.first { it.team.id == homeTeam.id }
+            val winnerGameTeam = gameTeams.first { it.team.id == awayTeamId }
+            val loserGameTeam = gameTeams.first { it.team.id == homeTeamId }
 
             assertThat(winnerGameTeam.totalScore).isEqualTo(7)
             assertThat(winnerGameTeam.result).isEqualTo(GameResult.WIN)
@@ -612,12 +606,12 @@ class GameTest {
         fun `이미 종료된 경기는 몰수 처리할 수 없다`() {
             // given
             val game = createGame(status = GameStatus.FINISHED)
-            val gameTeams = createGameTeams(game)
+            val gameTeams = game.gameTeams
 
             // when & then
             assertThatThrownBy {
                 game.forfeit(
-                    winnerTeamId = homeTeam.id,
+                    winnerTeamId = homeTeamId,
                     reason = "사유",
                     gameTeams = gameTeams,
                 )
@@ -628,12 +622,12 @@ class GameTest {
         fun `취소된 경기는 몰수 처리할 수 없다`() {
             // given
             val game = createGame(status = GameStatus.CANCELLED)
-            val gameTeams = createGameTeams(game)
+            val gameTeams = game.gameTeams
 
             // when & then
             assertThatThrownBy {
                 game.forfeit(
-                    winnerTeamId = homeTeam.id,
+                    winnerTeamId = homeTeamId,
                     reason = "사유",
                     gameTeams = gameTeams,
                 )
@@ -644,7 +638,7 @@ class GameTest {
         fun `참여하지 않는 팀을 승리팀으로 지정하면 예외가 발생한다`() {
             // given
             val game = createGame(status = GameStatus.SCHEDULED)
-            val gameTeams = createGameTeams(game)
+            val gameTeams = game.gameTeams
 
             // when & then
             assertThatThrownBy {
@@ -661,11 +655,11 @@ class GameTest {
         fun `몰수 사유가 forfeitReason 필드에 기록된다`() {
             // given
             val game = createGame(status = GameStatus.SCHEDULED)
-            val gameTeams = createGameTeams(game)
+            val gameTeams = game.gameTeams
 
             // when
             game.forfeit(
-                winnerTeamId = homeTeam.id,
+                winnerTeamId = homeTeamId,
                 reason = "인원 미달로 경기 불가",
                 gameTeams = gameTeams,
             )
@@ -993,6 +987,112 @@ class GameTest {
             assertThatThrownBy { game.addStrike() }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("진행 중인 경기만")
+        }
+    }
+
+    @Nested
+    @DisplayName("Game.create() 팩토리 메서드")
+    inner class CreateFactory {
+        private lateinit var homeTeam: Team
+        private lateinit var awayTeam: Team
+
+        @BeforeEach
+        fun setUpTeams() {
+            homeTeam = createTeam("홈팀", id = 1L)
+            awayTeam = createTeam("원정팀", city = "부산", id = 2L)
+        }
+
+        @Test
+        fun `create() 호출 시 GameTeam 2개가 자동 생성된다`() {
+            // when
+            val game =
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                )
+
+            // then
+            assertThat(game.gameTeams).hasSize(2)
+        }
+
+        @Test
+        fun `create() 시 HOME과 AWAY GameTeam이 각 1개씩 생성된다`() {
+            // when
+            val game =
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                )
+
+            // then
+            val homeGameTeam = game.gameTeams.find { it.homeAway == HomeAway.HOME }
+            val awayGameTeam = game.gameTeams.find { it.homeAway == HomeAway.AWAY }
+
+            assertThat(homeGameTeam).isNotNull
+            assertThat(awayGameTeam).isNotNull
+            assertThat(homeGameTeam!!.team.id).isEqualTo(homeTeam.id)
+            assertThat(awayGameTeam!!.team.id).isEqualTo(awayTeam.id)
+        }
+
+        @Test
+        fun `create() 시 totalInnings가 competition의 defaultInnings로 설정된다`() {
+            // given
+            val customRules = GameRules(defaultInnings = 7)
+            val comp =
+                Competition(
+                    league = league,
+                    name = "7이닝 대회",
+                    year = 2025,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    gameRules = customRules,
+                )
+
+            // when
+            val game =
+                Game.create(
+                    competition = comp,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                )
+
+            // then
+            assertThat(game.totalInnings).isEqualTo(7)
+        }
+
+        @Test
+        fun `홈팀과 원정팀이 같으면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = homeTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("홈팀과 원정팀은 같을 수 없습니다")
+        }
+
+        @Test
+        fun `create() 시 기본 상태는 SCHEDULED이다`() {
+            // when
+            val game =
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                )
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.SCHEDULED)
         }
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupEntryTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupEntryTest.kt
@@ -41,14 +41,17 @@ class LineupEntryTest {
                 startDate = LocalDate.of(2025, 3, 1),
                 status = CompetitionStatus.IN_PROGRESS,
             )
+        team = Team(league = league, name = "테스트팀", city = "서울", foundedYear = 2020)
+        val awayTeam = Team(league = league, name = "상대팀", city = "부산", foundedYear = 2020)
         game =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = team,
+                awayTeam = awayTeam,
                 scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
                 location = "잠실야구장",
                 status = GameStatus.SCHEDULED,
             )
-        team = Team(league = league, name = "테스트팀", city = "서울", foundedYear = 2020)
         user =
             User.createLocalUser(
                 email = "test@example.com",

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupSubmissionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupSubmissionTest.kt
@@ -491,8 +491,12 @@ class LineupSubmissionTest {
                         .now()
                         .plusDays(30),
             )
-        return Game(
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020)
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.now().plusDays(1),
             location = "서울야구장",
         )

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
@@ -497,13 +497,16 @@ class LineupValidatorTest {
                 year = 2024,
                 startDate = LocalDate.now().minusDays(30),
             )
+        val team = Team(league = league, name = "Tigers", city = "서울", foundedYear = 2020)
+        val awayTeam = Team(league = league, name = "Eagles", city = "부산", foundedYear = 2020)
         val game =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = team,
+                awayTeam = awayTeam,
                 scheduledAt = LocalDateTime.now().plusDays(1),
                 location = "서울야구장",
             )
-        val team = Team(league = league, name = "Tigers", city = "서울", foundedYear = 2020)
         val user = User.createLocalUser(email = "manager@test.com", encodedPassword = "encoded", nickname = "감독")
         return LineupSubmission.create(game, team, user)
     }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchEventTest.kt
@@ -236,9 +236,13 @@ class PitchEventTest {
                 startDate = LocalDate.of(2024, 3, 1),
                 id = 1L,
             )
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
 
-        return Game(
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2024, 6, 1, 14, 0),
             status = GameStatus.IN_PROGRESS,
             currentInning = 1,
@@ -246,29 +250,9 @@ class PitchEventTest {
         )
     }
 
-    private fun createHomeTeam(game: Game): GameTeam {
-        val association = Association(name = "테스트 협회", id = 1L)
-        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
-        val team = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
-        return GameTeam(
-            game = game,
-            team = team,
-            homeAway = HomeAway.HOME,
-            id = 1L,
-        )
-    }
+    private fun createHomeTeam(game: Game): GameTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
 
-    private fun createAwayTeam(game: Game): GameTeam {
-        val association = Association(name = "테스트 협회", id = 2L)
-        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 2L)
-        val team = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
-        return GameTeam(
-            game = game,
-            team = team,
-            homeAway = HomeAway.AWAY,
-            id = 2L,
-        )
-    }
+    private fun createAwayTeam(game: Game): GameTeam = game.gameTeams.first { it.homeAway == HomeAway.AWAY }
 
     private fun createPitcher(game: Game): GamePlayer {
         val awayTeam = createAwayTeam(game)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitcherChangeWarningTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitcherChangeWarningTest.kt
@@ -6,6 +6,7 @@ import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.competition.GameRules
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -19,6 +20,8 @@ import java.time.LocalDateTime
 class PitcherChangeWarningTest {
     private lateinit var competition: Competition
     private lateinit var league: League
+    private lateinit var homeTeam: Team
+    private lateinit var awayTeam: Team
 
     @BeforeEach
     fun setUp() {
@@ -35,12 +38,16 @@ class PitcherChangeWarningTest {
                 status = CompetitionStatus.IN_PROGRESS,
                 gameRules = GameRules(),
             )
+        homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
     }
 
     private fun createInProgressGame(outs: Int = 0): Game {
         val game =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
                 scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
                 status = GameStatus.IN_PROGRESS,
                 currentInning = 3,
@@ -154,8 +161,10 @@ class PitcherChangeWarningTest {
         fun `진행 중이 아닌 경기에서 투수 교체 확인 시 예외가 발생한다`() {
             // given
             val game =
-                Game(
+                Game.createForTest(
                     competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
                     scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
                     status = GameStatus.SCHEDULED,
                 )

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/TiebreakerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/TiebreakerTest.kt
@@ -7,8 +7,6 @@ import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.competition.GameRules
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.team.Team
-import io.mockk.every
-import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -49,27 +47,16 @@ class TiebreakerTest {
         isTopInning: Boolean,
         totalInnings: Int = 9,
     ): Game =
-        Game(
+        Game.createForTest(
             competition = competition,
+            homeTeam = team1,
+            awayTeam = team2,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             status = GameStatus.IN_PROGRESS,
             currentInning = currentInning,
             isTopInning = isTopInning,
             totalInnings = totalInnings,
         )
-
-    // ─── GameTeam 목 생성 헬퍼 ───────────────────────────────────────────────────
-    private fun mockGameTeam(
-        game: Game,
-        team: Team,
-        homeAway: HomeAway
-    ): GameTeam {
-        val gt = mockk<GameTeam>(relaxed = true)
-        every { gt.team } returns team
-        every { gt.homeAway } returns homeAway
-        every { gt.game } returns game
-        return gt
-    }
 
     @Nested
     @DisplayName("타이브레이크 미적용 (일반 이닝 전환)")
@@ -238,11 +225,8 @@ class TiebreakerTest {
             // 11회말 (9 + 2 = 11이닝, 이 말이 끝나면 무승부)
             val game = createGame(competition, currentInning = 11, isTopInning = false)
 
-            val homeGameTeam = mockGameTeam(game, team1, HomeAway.HOME)
-            val awayGameTeam = mockGameTeam(game, team2, HomeAway.AWAY)
-
             // when
-            val result = game.nextHalfInning(gameTeams = listOf(homeGameTeam, awayGameTeam))
+            val result = game.nextHalfInning(gameTeams = game.gameTeams)
 
             // then
             assertThat(result).isEqualTo(TiebreakerResult.DRAW_BY_INNINGS_LIMIT)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/schedule/LeagueScheduleTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/schedule/LeagueScheduleTest.kt
@@ -272,8 +272,10 @@ class LeagueScheduleTest {
     }
 
     private fun createGame(): Game =
-        Game(
+        Game.createForTest(
             competition = createCompetition(),
+            homeTeam = createTeam("홈팀", 10L),
+            awayTeam = createTeam("원정팀", 20L),
             scheduledAt = LocalDateTime.now().plusDays(7),
             location = "서울야구장",
         )

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/appeal/AppealServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/appeal/AppealServiceTest.kt
@@ -13,6 +13,7 @@ import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.AppealRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.service.appeal.dto.CreateAppealRequest
@@ -522,8 +523,26 @@ class AppealServiceTest {
         val league = createLeague(1L, "1부 리그", association)
         val competition = createCompetition(1L, league)
 
-        return Game(
+        val homeTeam =
+            Team(
+                league = league,
+                name = "홈팀",
+                city = "서울",
+                foundedYear = 2020,
+                id = 10L,
+            )
+        val awayTeam =
+            Team(
+                league = league,
+                name = "원정팀",
+                city = "부산",
+                foundedYear = 2020,
+                id = 20L,
+            )
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.now().plusDays(1),
             status = GameStatus.SCHEDULED,
             currentInning = 0,

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/lineup/LineupServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/lineup/LineupServiceTest.kt
@@ -86,8 +86,16 @@ class LineupServiceTest {
                 endDate = LocalDate.now().plusDays(30),
             )
 
-        game = Game(competition = competition, scheduledAt = LocalDateTime.now().plusDays(1), location = "서울야구장")
         team = Team(league = league, name = "Tigers", city = "서울", foundedYear = 2020)
+        val awayTeam = Team(league = league, name = "Eagles", city = "부산", foundedYear = 2020)
+        game =
+            Game.createForTest(
+                competition = competition,
+                homeTeam = team,
+                awayTeam = awayTeam,
+                scheduledAt = LocalDateTime.now().plusDays(1),
+                location = "서울야구장",
+            )
         user = User.createLocalUser(email = "test@test.com", encodedPassword = "encoded", nickname = "테스트")
         player =
             mockk<Player>().apply {

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/schedule/LeagueScheduleServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/schedule/LeagueScheduleServiceTest.kt
@@ -6,10 +6,13 @@ import com.nextup.common.exception.ScheduleNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.schedule.LeagueSchedule
+import com.nextup.core.domain.schedule.ScheduleStatus
 import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.LeagueScheduleRepositoryPort
 import com.nextup.core.port.repository.TeamRepositoryPort
 import io.mockk.every
@@ -26,6 +29,7 @@ class LeagueScheduleServiceTest {
     private lateinit var scheduleRepository: LeagueScheduleRepositoryPort
     private lateinit var competitionRepository: CompetitionRepositoryPort
     private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var gameRepository: GameRepositoryPort
     private lateinit var service: LeagueScheduleService
 
     @BeforeEach
@@ -33,7 +37,14 @@ class LeagueScheduleServiceTest {
         scheduleRepository = mockk()
         competitionRepository = mockk()
         teamRepository = mockk()
-        service = LeagueScheduleService(scheduleRepository, competitionRepository, teamRepository)
+        gameRepository = mockk()
+        service =
+            LeagueScheduleService(
+                scheduleRepository,
+                competitionRepository,
+                teamRepository,
+                gameRepository,
+            )
     }
 
     @Test
@@ -711,6 +722,99 @@ class LeagueScheduleServiceTest {
                 service.rescheduleGame(1L, newDate)
             }
         assertThat(exception.message).contains("충돌이 감지되었습니다")
+    }
+
+    @Test
+    fun `should create game from schedule successfully`() {
+        // given
+        val schedule = createLeagueSchedule()
+        every { scheduleRepository.findByIdOrNull(1L) } returns schedule
+        every { gameRepository.save(any<Game>()) } answers { firstArg() }
+
+        // when
+        val result =
+            service.createGameFromSchedule(
+                scheduleId = 1L,
+                location = "서울야구장",
+                fieldName = "1구장",
+            )
+
+        // then
+        assertThat(result.status).isEqualTo(ScheduleStatus.GAME_CREATED)
+        assertThat(result.game).isNotNull()
+        verify { gameRepository.save(any<Game>()) }
+    }
+
+    @Test
+    fun `should create game from schedule using schedule venue when location is null`() {
+        // given
+        val schedule = createLeagueSchedule()
+        every { scheduleRepository.findByIdOrNull(1L) } returns schedule
+        every { gameRepository.save(any<Game>()) } answers { firstArg() }
+
+        // when
+        val result = service.createGameFromSchedule(scheduleId = 1L)
+
+        // then
+        assertThat(result.status).isEqualTo(ScheduleStatus.GAME_CREATED)
+        assertThat(result.game).isNotNull()
+        assertThat(result.game!!.location).isEqualTo("서울야구장")
+    }
+
+    @Test
+    fun `should throw ScheduleNotFoundException when creating game for non-existent schedule`() {
+        // given
+        every { scheduleRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<ScheduleNotFoundException> {
+            service.createGameFromSchedule(scheduleId = 999L)
+        }
+    }
+
+    @Test
+    fun `should throw InvalidScheduleStateException when creating game for cancelled schedule`() {
+        // given
+        val schedule = createLeagueSchedule()
+        schedule.cancel()
+        every { scheduleRepository.findByIdOrNull(1L) } returns schedule
+
+        // when & then
+        assertThrows<InvalidScheduleStateException> {
+            service.createGameFromSchedule(scheduleId = 1L)
+        }
+    }
+
+    @Test
+    fun `should throw InvalidScheduleStateException when schedule already has game`() {
+        // given
+        val schedule = createLeagueSchedule()
+        every { scheduleRepository.findByIdOrNull(1L) } returns schedule
+        every { gameRepository.save(any<Game>()) } answers { firstArg() }
+
+        // create game first
+        service.createGameFromSchedule(scheduleId = 1L)
+
+        // when & then - try to create again
+        assertThrows<InvalidScheduleStateException> {
+            service.createGameFromSchedule(scheduleId = 1L)
+        }
+    }
+
+    @Test
+    fun `should create game from postponed schedule`() {
+        // given
+        val schedule = createLeagueSchedule()
+        schedule.postpone("우천")
+        every { scheduleRepository.findByIdOrNull(1L) } returns schedule
+        every { gameRepository.save(any<Game>()) } answers { firstArg() }
+
+        // when
+        val result = service.createGameFromSchedule(scheduleId = 1L)
+
+        // then
+        assertThat(result.status).isEqualTo(ScheduleStatus.GAME_CREATED)
+        assertThat(result.game).isNotNull()
     }
 
     // ========== Helper Methods ==========

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameResultEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameResultEventListenerTest.kt
@@ -1,12 +1,15 @@
 package com.nextup.infrastructure.listener
 
 import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.CompetitionRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.infrastructure.config.CacheConfig
@@ -241,15 +244,18 @@ class GameResultEventListenerTest {
         competition: Competition,
         status: GameStatus,
     ): Game {
-        val game =
-            Game(
-                competition = competition,
-                scheduledAt = LocalDateTime.of(2025, 5, 10, 14, 0),
-                status = status,
-            )
-        val idField = Game::class.java.getDeclaredField("id")
-        idField.isAccessible = true
-        idField.set(game, id)
-        return game
+        val association = Association(name = "서울시야구협회", region = "서울")
+        val league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        return Game.createForTest(
+            competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
+            scheduledAt = LocalDateTime.of(2025, 5, 10, 14, 0),
+            status = status,
+            totalInnings = 9,
+            id = id,
+        )
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/PitchEventServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/PitchEventServiceImplTest.kt
@@ -350,9 +350,13 @@ class PitchEventServiceImplTest {
                 startDate = LocalDate.of(2024, 3, 1),
                 id = 1L,
             )
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
 
-        return Game(
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2024, 6, 1, 14, 0),
             status = GameStatus.IN_PROGRESS,
             currentInning = 1,
@@ -360,22 +364,8 @@ class PitchEventServiceImplTest {
         )
     }
 
-    private fun createHomeTeam(game: Game): GameTeam {
-        val association = Association(name = "테스트 협회", id = 1L)
-        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
-        val team = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
-        return GameTeam(game = game, team = team, homeAway = HomeAway.HOME, id = 1L)
-    }
-
-    private fun createAwayTeam(game: Game): GameTeam {
-        val association = Association(name = "테스트 협회", id = 2L)
-        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 2L)
-        val team = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
-        return GameTeam(game = game, team = team, homeAway = HomeAway.AWAY, id = 2L)
-    }
-
     private fun createPitcher(game: Game): GamePlayer {
-        val awayTeam = createAwayTeam(game)
+        val awayTeam = game.gameTeams.first { it.homeAway == HomeAway.AWAY }
         val player =
             Player(
                 name = "투수",
@@ -391,7 +381,7 @@ class PitchEventServiceImplTest {
     }
 
     private fun createBatter(game: Game): GamePlayer {
-        val homeTeam = createHomeTeam(game)
+        val homeTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
         val player =
             Player(
                 name = "타자",

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImplTest.kt
@@ -68,17 +68,19 @@ class BoxScoreServiceImplTest {
                 startDate = LocalDate.of(2025, 3, 1),
                 status = CompetitionStatus.IN_PROGRESS,
             )
+        homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
         game =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
                 scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
                 location = "잠실야구장",
                 status = GameStatus.IN_PROGRESS,
             )
-        homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020)
-        awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020)
-        homeGameTeam = GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME)
-        awayGameTeam = GameTeam(game = game, team = awayTeam, homeAway = HomeAway.AWAY)
+        homeGameTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
+        awayGameTeam = game.gameTeams.first { it.homeAway == HomeAway.AWAY }
     }
 
     private fun createPlayer(name: String): Player =

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameParticipationServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameParticipationServiceImplTest.kt
@@ -63,8 +63,17 @@ class GameParticipationServiceImplTest {
         setTeamId(team, 1L)
 
         val competition = mockk<com.nextup.core.domain.competition.Competition>()
-        game = Game(competition = competition, scheduledAt = LocalDateTime.now().plusDays(7))
-        setGameId(game, 100L)
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        game =
+            Game.createForTest(
+                competition = competition,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledAt = LocalDateTime.now().plusDays(7),
+                totalInnings = 9,
+                id = 100L,
+            )
 
         val user = User.createLocalUser("member@example.com", "password", "회원")
         setUserId(user, 10L)
@@ -404,12 +413,17 @@ class GameParticipationServiceImplTest {
         fun `should return game scheduled time`() {
             // given
             val scheduledTime = LocalDateTime.of(2026, 3, 15, 14, 0)
+            val association = Association(name = "서울시야구협회", region = "서울")
+            val league = League(association = association, name = "1부 리그", foundedYear = 2020)
             val futureGame =
-                Game(
+                Game.createForTest(
                     competition = mockk<com.nextup.core.domain.competition.Competition>(),
+                    homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L),
+                    awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L),
                     scheduledAt = scheduledTime,
+                    totalInnings = 9,
+                    id = 100L,
                 )
-            setGameId(futureGame, 100L)
 
             every { gameRepository.findByIdOrNull(100L) } returns futureGame
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceBaseRunningTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceBaseRunningTest.kt
@@ -16,6 +16,7 @@ import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.GameState
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
@@ -434,9 +435,13 @@ class GameScorerServiceBaseRunningTest {
         val association = createAssociation(1L)
         val league = createLeague(1L, association)
         val competition = createCompetition(1L, league)
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
 
-        return Game(
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실구장",
             fieldName = "1구장",
@@ -446,10 +451,7 @@ class GameScorerServiceBaseRunningTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
-        ).apply {
-            val idField = Game::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, id)
-        }
+            id = id,
+        )
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceConcurrencyTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceConcurrencyTest.kt
@@ -16,6 +16,7 @@ import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
@@ -899,8 +900,27 @@ class GameScorerServiceConcurrencyTest {
                 idField.set(this, 1L)
             }
 
-        return Game(
+        val homeTeam =
+            Team(
+                league = league,
+                name = "홈팀",
+                city = "서울",
+                foundedYear = 2020,
+                id = 10L,
+            )
+        val awayTeam =
+            Team(
+                league = league,
+                name = "원정팀",
+                city = "부산",
+                foundedYear = 2020,
+                id = 11L,
+            )
+
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실구장",
             fieldName = "1구장",
@@ -910,11 +930,8 @@ class GameScorerServiceConcurrencyTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
-        ).apply {
-            val idField = Game::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, id)
-        }
+            id = id,
+        )
     }
 
     private fun createSingleRequest(

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceEventPublishingTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceEventPublishingTest.kt
@@ -16,6 +16,7 @@ import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
@@ -503,9 +504,13 @@ class GameScorerServiceEventPublishingTest {
         val association = createAssociation(1L)
         val league = createLeague(1L, association)
         val competition = createCompetition(1L, league)
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
 
-        return Game(
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실구장",
             fieldName = "1구장",
@@ -515,6 +520,7 @@ class GameScorerServiceEventPublishingTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
-        ).apply { setEntityId(this, id) }
+            id = id,
+        )
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -21,6 +21,7 @@ import com.nextup.core.domain.game.PitchingDecision
 import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
@@ -1522,9 +1523,27 @@ class GameScorerServiceImplTest {
         val association = createAssociation(1L)
         val league = createLeague(1L, association)
         val competition = createCompetition(1L, league)
+        val homeTeam =
+            Team(
+                league = league,
+                name = "홈팀",
+                city = "서울",
+                foundedYear = 2020,
+                id = 10L,
+            )
+        val awayTeam =
+            Team(
+                league = league,
+                name = "원정팀",
+                city = "부산",
+                foundedYear = 2020,
+                id = 11L,
+            )
 
-        return Game(
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실구장",
             fieldName = "1구장",
@@ -1534,10 +1553,7 @@ class GameScorerServiceImplTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
-        ).apply {
-            val idField = Game::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, id)
-        }
+            id = id,
+        )
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
@@ -15,6 +15,7 @@ import com.nextup.core.domain.game.GameState
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
@@ -431,11 +432,7 @@ class GameScorerServiceSubstitutionTest {
                 description = null,
                 logoUrl = null,
                 websiteUrl = null,
-            ).apply {
-                val f = Association::class.java.getDeclaredField("id")
-                f.isAccessible = true
-                f.set(this, 1L)
-            }
+            )
         val league =
             League(
                 association = association,
@@ -445,11 +442,7 @@ class GameScorerServiceSubstitutionTest {
                 divisionLevel = 1,
                 description = null,
                 logoUrl = null,
-            ).apply {
-                val f = League::class.java.getDeclaredField("id")
-                f.isAccessible = true
-                f.set(this, 1L)
-            }
+            )
         val competition =
             Competition(
                 league = league,
@@ -462,13 +455,13 @@ class GameScorerServiceSubstitutionTest {
                 status = CompetitionStatus.IN_PROGRESS,
                 description = null,
                 maxTeams = null,
-            ).apply {
-                val f = Competition::class.java.getDeclaredField("id")
-                f.isAccessible = true
-                f.set(this, 1L)
-            }
-        return Game(
+            )
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실구장",
             fieldName = "1구장",
@@ -478,11 +471,8 @@ class GameScorerServiceSubstitutionTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
-        ).apply {
-            val f = Game::class.java.getDeclaredField("id")
-            f.isAccessible = true
-            f.set(this, id)
-        }
+            id = id,
+        )
     }
 
     private fun createStartingPlayer(

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceUndoTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceUndoTest.kt
@@ -16,6 +16,7 @@ import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
@@ -488,9 +489,13 @@ class GameScorerServiceUndoTest {
         val association = createAssociation(1L)
         val league = createLeague(1L, association)
         val competition = createCompetition(1L, league)
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
 
-        return Game(
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실구장",
             fieldName = "1구장",
@@ -500,8 +505,7 @@ class GameScorerServiceUndoTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
-        ).apply {
-            setEntityId(this, id)
-        }
+            id = id,
+        )
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/ScoresheetServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/ScoresheetServiceImplTest.kt
@@ -78,8 +78,10 @@ class ScoresheetServiceImplTest {
         awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
 
         game =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
                 scheduledAt = LocalDateTime.of(2024, 3, 15, 14, 0),
                 location = "서울",
                 fieldName = "잠실구장",
@@ -93,26 +95,14 @@ class ScoresheetServiceImplTest {
                 id = 100L,
             )
 
-        homeGameTeam =
-            GameTeam(
-                game = game,
-                team = homeTeam,
-                homeAway = HomeAway.HOME,
-                id = 1L,
-            )
+        homeGameTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
         homeGameTeam.updateScore(totalScore = 5, totalHits = 10, totalErrors = 1)
         homeGameTeam.updateResult(GameResult.WIN)
         for (i in 1..9) {
             homeGameTeam.recordInningScore(i, listOf(0, 2, 0, 1, 0, 0, 2, 0, 0)[i - 1])
         }
 
-        awayGameTeam =
-            GameTeam(
-                game = game,
-                team = awayTeam,
-                homeAway = HomeAway.AWAY,
-                id = 2L,
-            )
+        awayGameTeam = game.gameTeams.first { it.homeAway == HomeAway.AWAY }
         awayGameTeam.updateScore(totalScore = 3, totalHits = 8, totalErrors = 2)
         awayGameTeam.updateResult(GameResult.LOSS)
         for (i in 1..9) {

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/report/CompetitionReportServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/report/CompetitionReportServiceImplTest.kt
@@ -128,18 +128,48 @@ class CompetitionReportServiceImplTest {
                 every { id } returns 2L
                 every { name } returns "팀B"
             }
+        val fixtureTeamA =
+            Team(
+                league =
+                    com.nextup.core.domain.league.League(
+                        association = com.nextup.core.domain.association.Association(name = "협회", region = "서울"),
+                        name = "리그",
+                        foundedYear = 2020,
+                    ),
+                name = "홈팀",
+                city = "서울",
+                foundedYear = 2020,
+                id = 10L,
+            )
+        val fixtureTeamB =
+            Team(
+                league =
+                    com.nextup.core.domain.league.League(
+                        association = com.nextup.core.domain.association.Association(name = "협회", region = "서울"),
+                        name = "리그",
+                        foundedYear = 2020,
+                    ),
+                name = "원정팀",
+                city = "부산",
+                foundedYear = 2020,
+                id = 11L,
+            )
 
         val game1 =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = fixtureTeamA,
+                awayTeam = fixtureTeamB,
                 scheduledAt = LocalDateTime.of(2024, 3, 15, 14, 0),
                 status = GameStatus.FINISHED,
                 id = 1L,
             )
 
         val game2 =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = fixtureTeamA,
+                awayTeam = fixtureTeamB,
                 scheduledAt = LocalDateTime.of(2024, 3, 20, 14, 0),
                 status = GameStatus.FINISHED,
                 id = 2L,
@@ -244,38 +274,50 @@ class CompetitionReportServiceImplTest {
             )
         val team =
             Team(league = league, name = "팀A", city = "서울", foundedYear = 2020, id = 1L)
+        val opponentTeam =
+            Team(league = league, name = "팀B", city = "부산", foundedYear = 2020, id = 2L)
 
         val game1 =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = team,
+                awayTeam = opponentTeam,
                 scheduledAt = LocalDateTime.now().minusDays(5),
                 status = GameStatus.FINISHED,
                 id = 1L,
             )
         val game2 =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = team,
+                awayTeam = opponentTeam,
                 scheduledAt = LocalDateTime.now().minusDays(4),
                 status = GameStatus.FINISHED,
                 id = 2L,
             )
         val game3 =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = team,
+                awayTeam = opponentTeam,
                 scheduledAt = LocalDateTime.now().minusDays(3),
                 status = GameStatus.FINISHED,
                 id = 3L,
             )
         val game4 =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = team,
+                awayTeam = opponentTeam,
                 scheduledAt = LocalDateTime.now().minusDays(2),
                 status = GameStatus.FINISHED,
                 id = 4L,
             )
         val game5 =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = team,
+                awayTeam = opponentTeam,
                 scheduledAt = LocalDateTime.now().minusDays(1),
                 status = GameStatus.FINISHED,
                 id = 5L,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsServiceImplTest.kt
@@ -450,17 +450,33 @@ class StandingsServiceImplTest {
     private fun createGame(
         id: Long,
         competition: Competition,
-    ): Game =
-        Game(
+    ): Game {
+        val homeTeam =
+            com.nextup.core.domain.team.Team(
+                league = competition.league,
+                name = "홈팀$id",
+                city = "서울",
+                foundedYear = 2020,
+                id = 100L + id * 2,
+            )
+        val awayTeam =
+            com.nextup.core.domain.team.Team(
+                league = competition.league,
+                name = "원정팀$id",
+                city = "부산",
+                foundedYear = 2020,
+                id = 101L + id * 2,
+            )
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.now(),
             location = "서울야구장",
             status = GameStatus.SCHEDULED,
-        ).apply {
-            val idField = Game::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, id)
-        }
+            id = id,
+        )
+    }
 
     private fun createGameTeam(
         id: Long,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsSimulationServiceImplTest.kt
@@ -916,17 +916,33 @@ class StandingsSimulationServiceImplTest {
     private fun createGame(
         id: Long,
         competition: Competition,
-    ): Game =
-        Game(
+    ): Game {
+        val homeTeam =
+            com.nextup.core.domain.team.Team(
+                league = competition.league,
+                name = "홈팀$id",
+                city = "서울",
+                foundedYear = 2020,
+                id = 100L + id * 2,
+            )
+        val awayTeam =
+            com.nextup.core.domain.team.Team(
+                league = competition.league,
+                name = "원정팀$id",
+                city = "부산",
+                foundedYear = 2020,
+                id = 101L + id * 2,
+            )
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.now(),
             location = "서울야구장",
             status = GameStatus.SCHEDULED,
-        ).apply {
-            val idField = Game::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, id)
-        }
+            id = id,
+        )
+    }
 
     private fun createGameTeam(
         id: Long,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamDashboardServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamDashboardServiceImplTest.kt
@@ -78,20 +78,32 @@ class TeamDashboardServiceImplTest {
         id: Long,
         scheduledAt: LocalDateTime,
         status: GameStatus = GameStatus.SCHEDULED,
-    ): Game =
-        Game(
+    ): Game {
+        val homeTeam =
+            com.nextup.core.domain.team.Team(
+                league = league,
+                name = "홈팀$id",
+                city = "서울",
+                foundedYear = 2020,
+                id = 100L + id * 2,
+            )
+        val awayTeam =
+            com.nextup.core.domain.team.Team(
+                league = league,
+                name = "원정팀$id",
+                city = "부산",
+                foundedYear = 2020,
+                id = 101L + id * 2,
+            )
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = scheduledAt,
+            status = status,
             id = id,
-        ).also {
-            // Use reflection to set status for test purposes or rely on status from constructor default
-            if (status != GameStatus.SCHEDULED) {
-                // Status is set via business methods or directly for testing purposes
-                val field = Game::class.java.getDeclaredField("status")
-                field.isAccessible = true
-                field.set(it, status)
-            }
-        }
+        )
+    }
 
     private fun makeGameTeam(
         game: Game,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMatchupServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMatchupServiceImplTest.kt
@@ -352,8 +352,10 @@ class TeamMatchupServiceImplTest {
         status: GameStatus,
         scheduledAt: LocalDateTime = LocalDateTime.now(),
     ): Game =
-        Game(
+        Game.createForTest(
             competition = competition,
+            homeTeam = teamA,
+            awayTeam = teamB,
             scheduledAt = scheduledAt,
             status = status,
             id = id,

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/PitchEventRecordControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/PitchEventRecordControllerTest.kt
@@ -148,9 +148,13 @@ class PitchEventRecordControllerTest {
                 startDate = LocalDate.of(2024, 3, 1),
                 id = 1L,
             )
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
 
-        return Game(
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2024, 6, 1, 14, 0),
             status = GameStatus.IN_PROGRESS,
             currentInning = 1,
@@ -158,22 +162,8 @@ class PitchEventRecordControllerTest {
         )
     }
 
-    private fun createHomeTeam(game: Game): GameTeam {
-        val association = Association(name = "테스트 협회", id = 1L)
-        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 1L)
-        val team = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
-        return GameTeam(game = game, team = team, homeAway = HomeAway.HOME, id = 1L)
-    }
-
-    private fun createAwayTeam(game: Game): GameTeam {
-        val association = Association(name = "테스트 협회", id = 2L)
-        val league = League(association = association, name = "테스트 리그", foundedYear = 2020, id = 2L)
-        val team = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
-        return GameTeam(game = game, team = team, homeAway = HomeAway.AWAY, id = 2L)
-    }
-
     private fun createPitcher(game: Game): GamePlayer {
-        val awayTeam = createAwayTeam(game)
+        val awayTeam = game.gameTeams.first { it.homeAway == HomeAway.AWAY }
         val player =
             Player(
                 name = "투수",
@@ -189,7 +179,7 @@ class PitchEventRecordControllerTest {
     }
 
     private fun createBatter(game: Game): GamePlayer {
-        val homeTeam = createHomeTeam(game)
+        val homeTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
         val player =
             Player(
                 name = "타자",

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
@@ -13,6 +13,7 @@ import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.domain.game.GameState
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
 import com.nextup.core.service.game.BaseRunningRecordService
 import com.nextup.core.service.game.GameLifecycleService
 import com.nextup.core.service.game.GameSubstitutionService
@@ -278,8 +279,12 @@ class BaseRunningControllerTest {
         val league = createLeague(1L, "1부 리그", association)
         val competition = createCompetition(1L, "2025 춘계대회", league)
 
-        return Game(
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실구장",
             fieldName = "1구장",
@@ -288,12 +293,9 @@ class BaseRunningControllerTest {
             currentInning = 3,
             isTopInning = true,
             totalInnings = 9,
-            gameState = GameState()
-        ).apply {
-            val idField = Game::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, id)
-        }
+            gameState = GameState(),
+            id = id,
+        )
     }
 
     private fun createBaseRunningEvent(

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -16,6 +16,7 @@ import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
 import com.nextup.core.service.game.BaseRunningRecordService
 import com.nextup.core.service.game.GameLifecycleService
 import com.nextup.core.service.game.GameSubstitutionService
@@ -563,8 +564,12 @@ class GameScorerControllerTest {
         val league = createLeague(1L, "1부 리그", association)
         val competition = createCompetition(1L, "2025 춘계대회", league)
 
-        return Game(
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        return Game.createForTest(
             competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
             scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
             location = "잠실구장",
             fieldName = "1구장",
@@ -573,11 +578,8 @@ class GameScorerControllerTest {
             currentInning = 1,
             isTopInning = true,
             totalInnings = 9,
-            gameState = GameState()
-        ).apply {
-            val idField = Game::class.java.getDeclaredField("id")
-            idField.isAccessible = true
-            idField.set(this, id)
-        }
+            gameState = GameState(),
+            id = id,
+        )
     }
 }

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/websocket/mapper/GameStateMapperTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/websocket/mapper/GameStateMapperTest.kt
@@ -28,11 +28,15 @@ class GameStateMapperTest {
                 year = 2024,
                 startDate = LocalDate.now()
             )
+        val homeTeamEntity = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeamEntity = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
         val game =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = homeTeamEntity,
+                awayTeam = awayTeamEntity,
                 scheduledAt = LocalDateTime.now(),
-                location = "테스트구장"
+                location = "테스트구장",
             )
 
         val gameState =

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/websocket/mapper/ScoreboardMapperTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/websocket/mapper/ScoreboardMapperTest.kt
@@ -28,15 +28,16 @@ class ScoreboardMapperTest {
                 year = 2024,
                 startDate = LocalDate.now()
             )
+        val homeTeamEntity = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeamEntity = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
         val game =
-            Game(
+            Game.createForTest(
                 competition = competition,
+                homeTeam = homeTeamEntity,
+                awayTeam = awayTeamEntity,
                 scheduledAt = LocalDateTime.now(),
-                location = "테스트구장"
+                location = "테스트구장",
             )
-
-        val homeTeamEntity = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020)
-        val awayTeamEntity = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020)
 
         val homeTeam =
             GameTeam(game, homeTeamEntity, HomeAway.HOME).apply {


### PR DESCRIPTION
## Summary

>-  close #296
>-  Depends on #297

대진표(LeagueSchedule)에서 경기(Game)를 생성하는 서비스 및 backoffice API를 구현합니다.

## Tasks

- `LeagueScheduleService.createGameFromSchedule()` 서비스 메서드 추가
- `LeagueSchedule.canLinkGame()` 경기 연결 가능 상태 사전 검증 메서드 추가
- `POST /api/backoffice/competitions/{competitionId}/schedule/{id}/create-game` 엔드포인트 추가
- `CreateGameFromScheduleRequest` DTO 추가
- 단위 테스트 6개 추가

## To Reviewer

- Game 생성 전 `canLinkGame()`으로 상태 사전 검증 → 불필요한 Game 생성 방지
- location/fieldName은 요청으로 재지정 가능, 미지정 시 Schedule의 venue 사용
- scheduledTime이 null인 경우 00:00으로 기본값 설정

🤖 Generated with [Claude Code](https://claude.com/claude-code)