### PR TITLE
refactor(#274): PitchingRecord 중복 recordOut() 메서드 이름 분리

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
@@ -413,9 +413,11 @@ class PitchingRecord(
     }
 
     /**
-     * 아웃 카운트를 기록합니다 (이닝 소화).
+     * 아웃 카운트를 기록합니다 (이닝 소화 전용).
+     * battersFaced는 증가시키지 않으므로, applyBatterFaced()와 함께 사용합니다.
+     * 단독으로 아웃을 기록하려면 recordOut(isStrikeout)을 사용하세요.
      */
-    fun recordOut() {
+    fun recordInningOut() {
         inningsPitchedOuts++
     }
 
@@ -480,8 +482,9 @@ class PitchingRecord(
 
     /**
      * 아웃 카운트를 롤백합니다 (Undo용).
+     * recordInningOut()의 역연산입니다.
      */
-    fun revertOut() {
+    fun revertInningOut() {
         require(inningsPitchedOuts > 0) { "롤백할 아웃 카운트가 없습니다." }
         inningsPitchedOuts--
     }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -786,12 +786,12 @@ class PitchingRecordTest {
     }
 
     @Nested
-    @DisplayName("recordOut - 아웃 카운트 기록")
-    inner class RecordOutOnlyTest {
+    @DisplayName("recordInningOut - 이닝 아웃 카운트 기록")
+    inner class RecordInningOutTest {
         @Test
-        fun `recordOut()은 이닝 아웃만 증가시킨다`() {
+        fun `recordInningOut()은 이닝 아웃만 증가시킨다`() {
             // when
-            pitchingRecord.recordOut()
+            pitchingRecord.recordInningOut()
 
             // then
             assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(1)
@@ -959,21 +959,21 @@ class PitchingRecordTest {
     }
 
     @Nested
-    @DisplayName("revertOut - 아웃 카운트 롤백")
-    inner class RevertOutTest {
+    @DisplayName("revertInningOut - 이닝 아웃 카운트 롤백")
+    inner class RevertInningOutTest {
         @Test
         fun `아웃 카운트를 롤백할 수 있다`() {
-            pitchingRecord.recordOut()
+            pitchingRecord.recordInningOut()
             assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(1)
 
-            pitchingRecord.revertOut()
+            pitchingRecord.revertInningOut()
             assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(0)
         }
 
         @Test
         fun `롤백할 아웃 카운트가 없으면 예외가 발생한다`() {
             assertThatThrownBy {
-                pitchingRecord.revertOut()
+                pitchingRecord.revertInningOut()
             }.isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("롤백할 아웃 카운트가 없습니다")
         }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImpl.kt
@@ -86,7 +86,7 @@ class BoxScoreServiceImpl(
 
         // 아웃인 경우 아웃 카운트 증가
         if (!result.isOnBase) {
-            pitchingRecord.recordOut()
+            pitchingRecord.recordInningOut()
         }
 
         // 득점이 발생한 경우 팀 점수 및 이닝별 점수 갱신

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImpl.kt
@@ -378,7 +378,7 @@ class GameScorerServiceImpl(
 
             // 아웃이었으면 아웃 카운트도 롤백
             if (!result.isOnBase) {
-                pitchingRecord.revertOut()
+                pitchingRecord.revertInningOut()
             }
 
             // 득점이 있었으면 투수 실점도 롤백

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImplTest.kt
@@ -414,7 +414,7 @@ class BoxScoreServiceImplTest {
             )
 
             // then
-            verify { pitchingRecord.recordOut() }
+            verify { pitchingRecord.recordInningOut() }
         }
 
         @Test


### PR DESCRIPTION
## Summary

> - close #274

~~PitchingRecord의 중복된 `recordOut()` 메서드 이름을 분리하여 명확성을 개선합니다.~~

**CLOSED**: 이미 PR #284에서 동일한 변경이 develop에 머지되었습니다.