### PR TITLE
fix(#265): 기록 정정 시 순위 캐시 무효화 누락 수정

### DIFF
--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
@@ -8,7 +8,9 @@ import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import com.nextup.infrastructure.config.CacheConfig
 import org.slf4j.LoggerFactory
+import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
@@ -27,6 +29,7 @@ class RecordCorrectionEventListener(
     private val careerBattingStatsRepository: CareerBattingStatsRepositoryPort,
     private val careerPitchingStatsRepository: CareerPitchingStatsRepositoryPort,
     private val gameRepository: GameRepositoryPort,
+    private val cacheManager: CacheManager,
 ) {
     private val logger = LoggerFactory.getLogger(RecordCorrectionEventListener::class.java)
 
@@ -59,6 +62,9 @@ class RecordCorrectionEventListener(
             CorrectionType.PITCHING -> applyPitchingCorrection(event.playerId, year, event.fieldName, delta)
         }
 
+        // 순위 캐시 무효화
+        evictStandingsCache(event.gameId)
+
         logger.info(
             "기록 정정 스탯 반영 완료 (gameId={}, playerId={}, field={}, delta={})",
             event.gameId,
@@ -66,6 +72,13 @@ class RecordCorrectionEventListener(
             event.fieldName,
             delta,
         )
+    }
+
+    private fun evictStandingsCache(gameId: Long) {
+        val game = gameRepository.findByIdOrNull(gameId) ?: return
+        val competitionId = game.competition.id
+        cacheManager.getCache(CacheConfig.STANDINGS_CACHE)?.evict(competitionId)
+        logger.debug("기록 정정 후 순위 캐시 무효화 완료 (competitionId={}, gameId={})", competitionId, gameId)
     }
 
     private fun applyBattingCorrection(

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
 import java.time.LocalDateTime
 
 @DisplayName("RecordCorrectionEventListener 테스트")
@@ -35,6 +37,8 @@ class RecordCorrectionEventListenerTest {
     private val careerBattingStatsRepository = mockk<CareerBattingStatsRepositoryPort>()
     private val careerPitchingStatsRepository = mockk<CareerPitchingStatsRepositoryPort>()
     private val gameRepository = mockk<GameRepositoryPort>()
+    private val cacheManager = mockk<CacheManager>()
+    private val standingsCache = mockk<Cache>()
 
     private val listener =
         RecordCorrectionEventListener(
@@ -43,6 +47,7 @@ class RecordCorrectionEventListenerTest {
             careerBattingStatsRepository = careerBattingStatsRepository,
             careerPitchingStatsRepository = careerPitchingStatsRepository,
             gameRepository = gameRepository,
+            cacheManager = cacheManager,
         )
 
     private val testPlayer =
@@ -56,10 +61,16 @@ class RecordCorrectionEventListenerTest {
 
     private val mockGame = mockk<Game>()
 
+    private val mockCompetition = mockk<com.nextup.core.domain.competition.Competition>()
+
     @BeforeEach
     fun setUp() {
         every { mockGame.scheduledAt } returns LocalDateTime.of(2024, 5, 15, 18, 0)
+        every { mockGame.competition } returns mockCompetition
+        every { mockCompetition.id } returns 100L
         every { gameRepository.findByIdOrNull(any()) } returns mockGame
+        every { cacheManager.getCache(any()) } returns standingsCache
+        every { standingsCache.evict(any()) } returns Unit
     }
 
     @Nested
@@ -284,6 +295,58 @@ class RecordCorrectionEventListenerTest {
 
             // then: delta = 1 - 3 = -2, earnedRuns = 10 - 2 = 8
             assertThat(seasonStats.earnedRuns).isEqualTo(8)
+        }
+    }
+
+    @Nested
+    @DisplayName("순위 캐시 무효화")
+    inner class StandingsCacheEviction {
+        @Test
+        fun `기록 정정 시 해당 대회의 순위 캐시가 무효화됨`() {
+            // given
+            val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("hits", 10)
+
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "2",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then
+            verify(exactly = 1) { cacheManager.getCache("standings") }
+            verify(exactly = 1) { standingsCache.evict(100L) }
+        }
+
+        @Test
+        fun `델타가 0이면 캐시 무효화도 건너뜀`() {
+            // given
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "3",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then
+            verify(exactly = 0) { cacheManager.getCache(any()) }
         }
     }
 


### PR DESCRIPTION
## Summary
- RecordCorrectionEventListener에서 스탯 정정 반영 후 해당 대회의 standings 캐시를 evict하도록 수정
- GameResultEventListener의 캐시 무효화 패턴과 동일하게 CacheManager를 주입하여 competitionId 기준으로 캐시 제거
- 캐시 무효화 검증 테스트 2건 추가 (정상 무효화, 델타 0 시 건너뜀)

## Tasks
- Closes #265

## To Reviewer
- `RecordCorrectionEventListener`에 `CacheManager` 의존성 추가
- `evictStandingsCache()` private 메서드로 캐시 무효화 로직 분리
- 델타가 0인 경우 early return으로 캐시 무효화도 건너뜀

## Screenshot
N/A