### PR TITLE
refactor(#280): GamePlayer.positionHistory 타입 안전 구조 전환

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GamePlayer.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GamePlayer.kt
@@ -70,11 +70,12 @@ class GamePlayer(
         protected set
 
     /**
-     * 포지션 변경 이력 (JSON 형식: "이닝:포지션,이닝:포지션,...")
-     * 예: "1:PITCHER,3:FIRST_BASE"
+     * 포지션 변경 이력
+     * DB에는 CSV 형식("이닝:포지션,이닝:포지션,...")으로 저장됩니다.
      */
+    @Convert(converter = PositionHistoryConverter::class)
     @Column(name = "position_history", columnDefinition = "TEXT")
-    var positionHistory: String? = null
+    var positionHistory: List<PositionHistoryEntry> = emptyList()
         protected set
 
     /**
@@ -151,42 +152,18 @@ class GamePlayer(
 
     /**
      * 포지션 이력을 추가합니다.
-     * 형식: "이닝:포지션명" (예: "1:PITCHER,3:FIRST_BASE")
      */
     private fun recordPositionHistory(
         inning: Int,
         previousPosition: Position,
     ) {
-        val entry = "$inning:${previousPosition.name}"
-        positionHistory =
-            if (positionHistory.isNullOrBlank()) {
-                entry
-            } else {
-                "$positionHistory,$entry"
-            }
+        positionHistory = positionHistory + PositionHistoryEntry(inning, previousPosition)
     }
 
     /**
-     * 포지션 이력을 파싱하여 반환합니다.
-     * @return 이닝-포지션 쌍의 목록 (이닝 오름차순)
+     * 포지션 이력을 이닝 오름차순으로 반환합니다.
      */
-    fun getPositionHistoryList(): List<Pair<Int, Position>> {
-        if (positionHistory.isNullOrBlank()) return emptyList()
-        return positionHistory!!
-            .split(",")
-            .mapNotNull { entry ->
-                val parts = entry.split(":")
-                if (parts.size == 2) {
-                    val inning = parts[0].trim().toIntOrNull() ?: return@mapNotNull null
-                    val position =
-                        runCatching { Position.valueOf(parts[1].trim()) }.getOrNull() ?: return@mapNotNull null
-                    Pair(inning, position)
-                } else {
-                    null
-                }
-            }
-            .sortedBy { it.first }
-    }
+    fun getPositionHistoryList(): List<PositionHistoryEntry> = positionHistory.sortedBy { it.inning }
 
     /**
      * 타순을 변경합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PositionHistoryConverter.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PositionHistoryConverter.kt
@@ -1,0 +1,37 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.player.Position
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+/**
+ * PositionHistoryEntry 리스트 ↔ CSV 문자열 변환기
+ *
+ * DB 컬럼(TEXT)에 "이닝:포지션,이닝:포지션,..." 형식으로 저장합니다.
+ * 기존 CSV 형식과 완전 호환됩니다.
+ */
+@Converter
+class PositionHistoryConverter : AttributeConverter<List<PositionHistoryEntry>, String?> {
+    override fun convertToDatabaseColumn(attribute: List<PositionHistoryEntry>?): String? {
+        if (attribute.isNullOrEmpty()) return null
+        return attribute.joinToString(",") { "${it.inning}:${it.position.name}" }
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): List<PositionHistoryEntry> {
+        if (dbData.isNullOrBlank()) return emptyList()
+        return dbData
+            .split(",")
+            .mapNotNull { entry ->
+                val parts = entry.split(":")
+                if (parts.size == 2) {
+                    val inning = parts[0].trim().toIntOrNull() ?: return@mapNotNull null
+                    val position =
+                        runCatching { Position.valueOf(parts[1].trim()) }.getOrNull()
+                            ?: return@mapNotNull null
+                    PositionHistoryEntry(inning, position)
+                } else {
+                    null
+                }
+            }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PositionHistoryEntry.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PositionHistoryEntry.kt
@@ -1,0 +1,20 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.player.Position
+
+/**
+ * 포지션 변경 이력 항목 (Value Object)
+ *
+ * 특정 이닝에서의 포지션 변경을 나타냅니다.
+ *
+ * @property inning 포지션이 변경된 이닝
+ * @property position 해당 이닝에서의 포지션
+ */
+data class PositionHistoryEntry(
+    val inning: Int,
+    val position: Position,
+) {
+    init {
+        require(inning >= 1) { "이닝은 1 이상이어야 합니다." }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GamePlayerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GamePlayerTest.kt
@@ -509,7 +509,9 @@ class GamePlayerTest {
             gamePlayer.changePosition(Position.SECOND_BASE, currentInning = 3)
 
             assertThat(gamePlayer.position).isEqualTo(Position.SECOND_BASE)
-            assertThat(gamePlayer.positionHistory).isEqualTo("3:SHORTSTOP")
+            assertThat(gamePlayer.positionHistory).containsExactly(
+                PositionHistoryEntry(3, Position.SHORTSTOP),
+            )
         }
 
         @Test
@@ -526,7 +528,10 @@ class GamePlayerTest {
             gamePlayer.changePosition(Position.THIRD_BASE, currentInning = 6)
 
             assertThat(gamePlayer.position).isEqualTo(Position.THIRD_BASE)
-            assertThat(gamePlayer.positionHistory).isEqualTo("3:SHORTSTOP,6:SECOND_BASE")
+            assertThat(gamePlayer.positionHistory).containsExactly(
+                PositionHistoryEntry(3, Position.SHORTSTOP),
+                PositionHistoryEntry(6, Position.SECOND_BASE),
+            )
         }
 
         @Test
@@ -542,7 +547,7 @@ class GamePlayerTest {
             gamePlayer.changePosition(Position.SECOND_BASE)
 
             assertThat(gamePlayer.position).isEqualTo(Position.SECOND_BASE)
-            assertThat(gamePlayer.positionHistory).isNull()
+            assertThat(gamePlayer.positionHistory).isEmpty()
         }
     }
 
@@ -563,7 +568,7 @@ class GamePlayerTest {
         }
 
         @Test
-        fun `포지션 이력을 이닝-포지션 쌍으로 반환한다`() {
+        fun `포지션 이력을 PositionHistoryEntry 목록으로 반환한다`() {
             val gamePlayer =
                 GamePlayer.createStarter(
                     gameTeam = gameTeam,
@@ -578,8 +583,8 @@ class GamePlayerTest {
             val history = gamePlayer.getPositionHistoryList()
 
             assertThat(history).hasSize(2)
-            assertThat(history[0]).isEqualTo(Pair(3, Position.SHORTSTOP))
-            assertThat(history[1]).isEqualTo(Pair(6, Position.SECOND_BASE))
+            assertThat(history[0]).isEqualTo(PositionHistoryEntry(3, Position.SHORTSTOP))
+            assertThat(history[1]).isEqualTo(PositionHistoryEntry(6, Position.SECOND_BASE))
         }
 
         @Test
@@ -597,8 +602,8 @@ class GamePlayerTest {
 
             val history = gamePlayer.getPositionHistoryList()
 
-            assertThat(history[0].first).isEqualTo(3)
-            assertThat(history[1].first).isEqualTo(6)
+            assertThat(history[0].inning).isEqualTo(3)
+            assertThat(history[1].inning).isEqualTo(6)
         }
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PositionHistoryConverterTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PositionHistoryConverterTest.kt
@@ -1,0 +1,120 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.player.Position
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("PositionHistoryConverter")
+class PositionHistoryConverterTest {
+    private val converter = PositionHistoryConverter()
+
+    @Nested
+    @DisplayName("convertToDatabaseColumn")
+    inner class ConvertToDatabaseColumnTest {
+        @Test
+        fun `null이면 null을 반환한다`() {
+            assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        }
+
+        @Test
+        fun `빈 리스트이면 null을 반환한다`() {
+            assertThat(converter.convertToDatabaseColumn(emptyList())).isNull()
+        }
+
+        @Test
+        fun `단일 항목을 CSV로 변환한다`() {
+            val entries = listOf(PositionHistoryEntry(3, Position.SHORTSTOP))
+
+            assertThat(converter.convertToDatabaseColumn(entries)).isEqualTo("3:SHORTSTOP")
+        }
+
+        @Test
+        fun `여러 항목을 CSV로 변환한다`() {
+            val entries = listOf(
+                PositionHistoryEntry(3, Position.SHORTSTOP),
+                PositionHistoryEntry(6, Position.SECOND_BASE),
+            )
+
+            assertThat(converter.convertToDatabaseColumn(entries))
+                .isEqualTo("3:SHORTSTOP,6:SECOND_BASE")
+        }
+    }
+
+    @Nested
+    @DisplayName("convertToEntityAttribute")
+    inner class ConvertToEntityAttributeTest {
+        @Test
+        fun `null이면 빈 리스트를 반환한다`() {
+            assertThat(converter.convertToEntityAttribute(null)).isEmpty()
+        }
+
+        @Test
+        fun `빈 문자열이면 빈 리스트를 반환한다`() {
+            assertThat(converter.convertToEntityAttribute("")).isEmpty()
+        }
+
+        @Test
+        fun `공백 문자열이면 빈 리스트를 반환한다`() {
+            assertThat(converter.convertToEntityAttribute("  ")).isEmpty()
+        }
+
+        @Test
+        fun `단일 CSV 항목을 파싱한다`() {
+            val result = converter.convertToEntityAttribute("3:SHORTSTOP")
+
+            assertThat(result).containsExactly(
+                PositionHistoryEntry(3, Position.SHORTSTOP),
+            )
+        }
+
+        @Test
+        fun `여러 CSV 항목을 파싱한다`() {
+            val result = converter.convertToEntityAttribute("3:SHORTSTOP,6:SECOND_BASE")
+
+            assertThat(result).containsExactly(
+                PositionHistoryEntry(3, Position.SHORTSTOP),
+                PositionHistoryEntry(6, Position.SECOND_BASE),
+            )
+        }
+
+        @Test
+        fun `잘못된 형식의 항목은 건너뛴다`() {
+            val result = converter.convertToEntityAttribute("3:SHORTSTOP,invalid,6:SECOND_BASE")
+
+            assertThat(result).containsExactly(
+                PositionHistoryEntry(3, Position.SHORTSTOP),
+                PositionHistoryEntry(6, Position.SECOND_BASE),
+            )
+        }
+
+        @Test
+        fun `이닝이 숫자가 아닌 항목은 건너뛴다`() {
+            val result = converter.convertToEntityAttribute("abc:SHORTSTOP,3:SECOND_BASE")
+
+            assertThat(result).containsExactly(
+                PositionHistoryEntry(3, Position.SECOND_BASE),
+            )
+        }
+
+        @Test
+        fun `존재하지 않는 포지션 항목은 건너뛴다`() {
+            val result = converter.convertToEntityAttribute("3:INVALID_POS,6:SHORTSTOP")
+
+            assertThat(result).containsExactly(
+                PositionHistoryEntry(6, Position.SHORTSTOP),
+            )
+        }
+
+        @Test
+        fun `공백이 포함된 CSV도 정상 파싱한다`() {
+            val result = converter.convertToEntityAttribute(" 3 : SHORTSTOP , 6 : SECOND_BASE ")
+
+            assertThat(result).containsExactly(
+                PositionHistoryEntry(3, Position.SHORTSTOP),
+                PositionHistoryEntry(6, Position.SECOND_BASE),
+            )
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PositionHistoryConverterTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PositionHistoryConverterTest.kt
@@ -32,10 +32,11 @@ class PositionHistoryConverterTest {
 
         @Test
         fun `여러 항목을 CSV로 변환한다`() {
-            val entries = listOf(
-                PositionHistoryEntry(3, Position.SHORTSTOP),
-                PositionHistoryEntry(6, Position.SECOND_BASE),
-            )
+            val entries =
+                listOf(
+                    PositionHistoryEntry(3, Position.SHORTSTOP),
+                    PositionHistoryEntry(6, Position.SECOND_BASE),
+                )
 
             assertThat(converter.convertToDatabaseColumn(entries))
                 .isEqualTo("3:SHORTSTOP,6:SECOND_BASE")

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PositionHistoryEntryTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PositionHistoryEntryTest.kt
@@ -1,0 +1,59 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.player.Position
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("PositionHistoryEntry")
+class PositionHistoryEntryTest {
+    @Nested
+    @DisplayName("생성")
+    inner class CreateTest {
+        @Test
+        fun `유효한 이닝과 포지션으로 생성할 수 있다`() {
+            val entry = PositionHistoryEntry(1, Position.SHORTSTOP)
+
+            assertThat(entry.inning).isEqualTo(1)
+            assertThat(entry.position).isEqualTo(Position.SHORTSTOP)
+        }
+
+        @Test
+        fun `이닝이 0이면 예외가 발생한다`() {
+            assertThatThrownBy {
+                PositionHistoryEntry(0, Position.SHORTSTOP)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이닝은 1 이상")
+        }
+
+        @Test
+        fun `이닝이 음수이면 예외가 발생한다`() {
+            assertThatThrownBy {
+                PositionHistoryEntry(-1, Position.SHORTSTOP)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이닝은 1 이상")
+        }
+    }
+
+    @Nested
+    @DisplayName("동등성")
+    inner class EqualityTest {
+        @Test
+        fun `같은 이닝과 포지션이면 동등하다`() {
+            val entry1 = PositionHistoryEntry(3, Position.SHORTSTOP)
+            val entry2 = PositionHistoryEntry(3, Position.SHORTSTOP)
+
+            assertThat(entry1).isEqualTo(entry2)
+        }
+
+        @Test
+        fun `이닝이 다르면 동등하지 않다`() {
+            val entry1 = PositionHistoryEntry(3, Position.SHORTSTOP)
+            val entry2 = PositionHistoryEntry(5, Position.SHORTSTOP)
+
+            assertThat(entry1).isNotEqualTo(entry2)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

> - Closes #280

`GamePlayer.positionHistory`를 `String?`에서 `List<PositionHistoryEntry>`로 타입 안전 구조로 전환

## Tasks

- `PositionHistoryEntry` Value Object 생성 (inning, position 불변식 검증)
- `PositionHistoryConverter` JPA AttributeConverter로 기존 CSV TEXT 컬럼과 완전 호환
- CSV 파싱 로직(`getPositionHistoryList()`)을 Converter로 이동하여 Entity 단순화
- `PositionHistoryConverter`, `PositionHistoryEntry` 단위 테스트 추가

## To Reviewer

- DB 스키마 변경 없음 (동일 TEXT 컬럼, 동일 CSV 형식)
- 기존 데이터와 완전 호환 (Converter가 동일 형식으로 직렬화/역직렬화)
- `getPositionHistoryList()`는 정렬만 담당하도록 단순화