### PR TITLE
fix(#279): applyFieldCorrection() 유효하지 않은 필드명 예외 처리

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
@@ -544,99 +544,26 @@ class PitchingRecord(
         fieldName: String,
         newValue: String,
     ): String {
+        val intValue =
+            newValue.toIntOrNull()
+                ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
+        require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
+
         val oldValue =
             when (fieldName) {
-                "inningsPitchedOuts" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    inningsPitchedOuts.also { inningsPitchedOuts = intValue }
-                }
-                "earnedRuns" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    earnedRuns.also { earnedRuns = intValue }
-                }
-                "runsAllowed" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    runsAllowed.also { runsAllowed = intValue }
-                }
-                "hitsAllowed" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    hitsAllowed.also { hitsAllowed = intValue }
-                }
-                "walksAllowed" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    walksAllowed.also { walksAllowed = intValue }
-                }
-                "strikeouts" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    strikeouts.also { strikeouts = intValue }
-                }
-                "homeRunsAllowed" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    homeRunsAllowed.also { homeRunsAllowed = intValue }
-                }
-                "hitBatsmen" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    hitBatsmen.also { hitBatsmen = intValue }
-                }
-                "wildPitches" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    wildPitches.also { wildPitches = intValue }
-                }
-                "balks" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    balks.also { balks = intValue }
-                }
-                "battersFaced" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    battersFaced.also { battersFaced = intValue }
-                }
-                "pitchesThrown" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    (pitchesThrown ?: 0).also { pitchesThrown = intValue }
-                }
-                "strikesThrown" -> {
-                    val intValue =
-                        newValue.toIntOrNull()
-                            ?: throw IllegalArgumentException("정정 값은 정수여야 합니다: $newValue")
-                    require(intValue >= 0) { "정정 값은 0 이상이어야 합니다: $intValue" }
-                    (strikesThrown ?: 0).also { strikesThrown = intValue }
-                }
+                "inningsPitchedOuts" -> inningsPitchedOuts.also { inningsPitchedOuts = intValue }
+                "earnedRuns" -> earnedRuns.also { earnedRuns = intValue }
+                "runsAllowed" -> runsAllowed.also { runsAllowed = intValue }
+                "hitsAllowed" -> hitsAllowed.also { hitsAllowed = intValue }
+                "walksAllowed" -> walksAllowed.also { walksAllowed = intValue }
+                "strikeouts" -> strikeouts.also { strikeouts = intValue }
+                "homeRunsAllowed" -> homeRunsAllowed.also { homeRunsAllowed = intValue }
+                "hitBatsmen" -> hitBatsmen.also { hitBatsmen = intValue }
+                "wildPitches" -> wildPitches.also { wildPitches = intValue }
+                "balks" -> balks.also { balks = intValue }
+                "battersFaced" -> battersFaced.also { battersFaced = intValue }
+                "pitchesThrown" -> (pitchesThrown ?: 0).also { pitchesThrown = intValue }
+                "strikesThrown" -> (strikesThrown ?: 0).also { strikesThrown = intValue }
                 else -> throw IllegalArgumentException("유효하지 않은 투수 기록 필드입니다: $fieldName")
             }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
@@ -257,6 +257,7 @@ class CareerBattingStats(
             "stolenBases" -> stolenBases = maxOf(0, stolenBases + delta)
             "caughtStealing" -> caughtStealing = maxOf(0, caughtStealing + delta)
             "groundedIntoDoublePlays" -> groundedIntoDoublePlays = maxOf(0, groundedIntoDoublePlays + delta)
+            else -> throw IllegalArgumentException("유효하지 않은 타격 통계 필드입니다: $fieldName")
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
@@ -312,6 +312,7 @@ class CareerPitchingStats(
             "battersFaced" -> battersFaced = maxOf(0, battersFaced + delta)
             "pitchesThrown" -> pitchesThrown = maxOf(0, (pitchesThrown ?: 0) + delta)
             "strikesThrown" -> strikesThrown = maxOf(0, (strikesThrown ?: 0) + delta)
+            else -> throw IllegalArgumentException("유효하지 않은 투수 통계 필드입니다: $fieldName")
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
@@ -350,6 +350,7 @@ class SeasonBattingStats(
             "stolenBases" -> stolenBases = maxOf(0, stolenBases + delta)
             "caughtStealing" -> caughtStealing = maxOf(0, caughtStealing + delta)
             "groundedIntoDoublePlays" -> groundedIntoDoublePlays = maxOf(0, groundedIntoDoublePlays + delta)
+            else -> throw IllegalArgumentException("유효하지 않은 타격 통계 필드입니다: $fieldName")
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
@@ -351,6 +351,7 @@ class SeasonPitchingStats(
             "battersFaced" -> battersFaced = maxOf(0, battersFaced + delta)
             "pitchesThrown" -> pitchesThrown = maxOf(0, (pitchesThrown ?: 0) + delta)
             "strikesThrown" -> strikesThrown = maxOf(0, (strikesThrown ?: 0) + delta)
+            else -> throw IllegalArgumentException("유효하지 않은 투수 통계 필드입니다: $fieldName")
         }
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/BattingStatsApplyFieldCorrectionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/BattingStatsApplyFieldCorrectionTest.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 @DisplayName("타격 통계 applyFieldCorrection 테스트")
 class BattingStatsApplyFieldCorrectionTest {
@@ -124,10 +125,11 @@ class BattingStatsApplyFieldCorrectionTest {
         }
 
         @Test
-        fun `존재하지 않는 필드명은 무시됨`() {
+        fun `존재하지 않는 필드명은 예외가 발생함`() {
             val stats = SeasonBattingStats.create(testPlayer, 2024)
-            stats.applyFieldCorrection("unknownField", 5)
-            assertThat(stats.plateAppearances).isZero()
+            assertThrows<IllegalArgumentException> {
+                stats.applyFieldCorrection("unknownField", 5)
+            }
         }
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/PitchingStatsApplyFieldCorrectionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/PitchingStatsApplyFieldCorrectionTest.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 @DisplayName("투수 통계 applyFieldCorrection 테스트")
 class PitchingStatsApplyFieldCorrectionTest {
@@ -103,10 +104,11 @@ class PitchingStatsApplyFieldCorrectionTest {
         }
 
         @Test
-        fun `존재하지 않는 필드명은 무시됨`() {
+        fun `존재하지 않는 필드명은 예외가 발생함`() {
             val stats = SeasonPitchingStats.create(testPlayer, 2024)
-            stats.applyFieldCorrection("unknownField", 5)
-            assertThat(stats.inningsPitchedOuts).isZero()
+            assertThrows<IllegalArgumentException> {
+                stats.applyFieldCorrection("unknownField", 5)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- 4개 Stats 클래스(SeasonBattingStats, CareerBattingStats, SeasonPitchingStats, CareerPitchingStats)의 `applyFieldCorrection()`에 `else -> throw IllegalArgumentException` 추가
- 존재하지 않는 필드명 전달 시 silent failure 대신 명시적 예외 발생
- PitchingRecord.correctField() 공통 검증 로직 추출하여 코드 중복 제거
- 테스트 업데이트: unknown field 무시 테스트를 예외 발생 검증으로 변경

## Tasks
- closes #279

## To Reviewer
- `validate()` 호출은 의도적으로 제외: 필드 단위 개별 정정 시 교차 불변식(earnedRuns <= runsAllowed 등)이 일시적으로 깨질 수 있어 부적합
- 교차 불변식 검증은 상위 레벨(서비스/리스너)에서 모든 정정 완료 후 수행하는 것이 적합

🤖 Generated with [Claude Code](https://claude.com/claude-code)