### PR TITLE
feat(#269): PlateAppearanceResult에 INFIELD_FLY 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
@@ -231,6 +231,7 @@ class BattingRecord(
             }
             PlateAppearanceResult.GROUND_OUT,
             PlateAppearanceResult.FLY_OUT,
+            PlateAppearanceResult.INFIELD_FLY,
             PlateAppearanceResult.LINE_OUT,
             PlateAppearanceResult.FIELDERS_CHOICE,
             PlateAppearanceResult.ERROR,
@@ -344,6 +345,7 @@ class BattingRecord(
             }
             PlateAppearanceResult.GROUND_OUT,
             PlateAppearanceResult.FLY_OUT,
+            PlateAppearanceResult.INFIELD_FLY,
             PlateAppearanceResult.LINE_OUT,
             PlateAppearanceResult.FIELDERS_CHOICE,
             PlateAppearanceResult.ERROR,

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PlateAppearanceResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PlateAppearanceResult.kt
@@ -22,6 +22,7 @@ enum class PlateAppearanceResult(
     STRIKEOUT("삼진", "3스트라이크 아웃", true, false),
     GROUND_OUT("땅볼 아웃", "땅볼로 아웃", true, false),
     FLY_OUT("플라이 아웃", "뜬공으로 아웃", true, false),
+    INFIELD_FLY("인필드플라이", "인필드플라이 규칙 적용 아웃", true, false),
     LINE_OUT("라인 드라이브 아웃", "직선타로 아웃", true, false),
     FIELDERS_CHOICE("야수 선택", "야수 선택으로 출루", true, false),
     ERROR("실책", "수비 실책으로 출루", true, false),

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PlateAppearanceResultTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PlateAppearanceResultTest.kt
@@ -17,7 +17,7 @@ class PlateAppearanceResultTest {
             value = PlateAppearanceResult::class,
             names = [
                 "SINGLE", "DOUBLE", "TRIPLE", "HOME_RUN", "STRIKEOUT", "GROUND_OUT",
-                "FLY_OUT", "LINE_OUT", "FIELDERS_CHOICE", "ERROR", "DOUBLE_PLAY", "TRIPLE_PLAY",
+                "FLY_OUT", "INFIELD_FLY", "LINE_OUT", "FIELDERS_CHOICE", "ERROR", "DOUBLE_PLAY", "TRIPLE_PLAY",
             ],
         )
         fun `타수에 포함되는 결과를 반환한다`(result: PlateAppearanceResult) {
@@ -129,7 +129,7 @@ class PlateAppearanceResultTest {
         @EnumSource(
             value = PlateAppearanceResult::class,
             names = [
-                "STRIKEOUT", "GROUND_OUT", "FLY_OUT", "LINE_OUT",
+                "STRIKEOUT", "GROUND_OUT", "FLY_OUT", "INFIELD_FLY", "LINE_OUT",
                 "SACRIFICE_BUNT", "SACRIFICE_FLY", "DOUBLE_PLAY", "TRIPLE_PLAY",
             ],
         )


### PR DESCRIPTION
## Summary
- `PlateAppearanceResult`에 `INFIELD_FLY` 열거값 추가 (isAtBat=true, isHit=false)
- 인필드플라이 규칙 적용 아웃을 FLY_OUT과 구분하여 상세 기록 가능
- `BattingRecord`의 addResult/rollbackResult에 INFIELD_FLY 분기 추가
- 기존 테스트의 @EnumSource에 INFIELD_FLY 포함

## Tasks
- closes #269

## To Reviewer
- DB 마이그레이션 불필요: @Enumerated(EnumType.STRING) 사용으로 새 열거값 추가에 안전
- FIELDERS_CHOICE 세분화는 이슈에서 "GameEvent 보조 필드로 구분" 옵션 언급 — 현재는 기존 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)