### PR TITLE
feat(#262): 매치 요청 만료 자동 처리 스케줄러 추가

### DIFF
--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/SchedulingConfig.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/SchedulingConfig.kt
@@ -1,0 +1,8 @@
+package com.nextup.infrastructure.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+class SchedulingConfig

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/scheduler/MatchRequestExpirationScheduler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/scheduler/MatchRequestExpirationScheduler.kt
@@ -1,0 +1,39 @@
+package com.nextup.infrastructure.scheduler
+
+import com.nextup.core.port.repository.MatchRequestRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 매치 요청 만료 자동 처리 스케줄러
+ *
+ * 매일 새벽 3시에 실행되어, 30일이 경과한 OPEN 상태의 매치 요청을
+ * 자동으로 EXPIRED 상태로 전환합니다.
+ */
+@Component
+class MatchRequestExpirationScheduler(
+    private val matchRequestRepository: MatchRequestRepositoryPort,
+) {
+    private val logger = LoggerFactory.getLogger(MatchRequestExpirationScheduler::class.java)
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    fun expireOldMatchRequests() {
+        val openRequests = matchRequestRepository.findAllOpen()
+        val expiredRequests = openRequests.filter { it.isExpired() }
+
+        if (expiredRequests.isEmpty()) {
+            logger.debug("만료 대상 매치 요청 없음")
+            return
+        }
+
+        expiredRequests.forEach { request ->
+            request.expire()
+            matchRequestRepository.save(request)
+        }
+
+        logger.info("매치 요청 만료 처리 완료: {}건", expiredRequests.size)
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/scheduler/MatchRequestExpirationSchedulerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/scheduler/MatchRequestExpirationSchedulerTest.kt
@@ -1,0 +1,105 @@
+package com.nextup.infrastructure.scheduler
+
+import com.nextup.core.domain.match.MatchRequest
+import com.nextup.core.domain.match.MatchRequestStatus
+import com.nextup.core.domain.match.SkillLevel
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.MatchRequestRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+@DisplayName("MatchRequestExpirationScheduler 테스트")
+class MatchRequestExpirationSchedulerTest {
+    private val matchRequestRepository = mockk<MatchRequestRepositoryPort>()
+    private val scheduler = MatchRequestExpirationScheduler(matchRequestRepository)
+
+    private val testTeam = mockk<Team>()
+
+    @BeforeEach
+    fun setUp() {
+        every { matchRequestRepository.save(any()) } answers { firstArg() }
+    }
+
+    @Test
+    fun `30일 이상 경과한 OPEN 요청이 EXPIRED로 전환됨`() {
+        // given
+        val expiredRequest = createMatchRequestWithAge(31)
+        every { matchRequestRepository.findAllOpen() } returns listOf(expiredRequest)
+
+        // when
+        scheduler.expireOldMatchRequests()
+
+        // then
+        assertThat(expiredRequest.status).isEqualTo(MatchRequestStatus.EXPIRED)
+        verify(exactly = 1) { matchRequestRepository.save(expiredRequest) }
+    }
+
+    @Test
+    fun `30일 미만인 OPEN 요청은 만료되지 않음`() {
+        // given
+        val recentRequest = createMatchRequestWithAge(10)
+        every { matchRequestRepository.findAllOpen() } returns listOf(recentRequest)
+
+        // when
+        scheduler.expireOldMatchRequests()
+
+        // then
+        assertThat(recentRequest.status).isEqualTo(MatchRequestStatus.OPEN)
+        verify(exactly = 0) { matchRequestRepository.save(any()) }
+    }
+
+    @Test
+    fun `만료 대상이 없으면 저장하지 않음`() {
+        // given
+        every { matchRequestRepository.findAllOpen() } returns emptyList()
+
+        // when
+        scheduler.expireOldMatchRequests()
+
+        // then
+        verify(exactly = 0) { matchRequestRepository.save(any()) }
+    }
+
+    @Test
+    fun `복수 만료 요청이 모두 처리됨`() {
+        // given
+        val expired1 = createMatchRequestWithAge(31)
+        val expired2 = createMatchRequestWithAge(60)
+        val recent = createMatchRequestWithAge(5)
+        every { matchRequestRepository.findAllOpen() } returns listOf(expired1, expired2, recent)
+
+        // when
+        scheduler.expireOldMatchRequests()
+
+        // then
+        assertThat(expired1.status).isEqualTo(MatchRequestStatus.EXPIRED)
+        assertThat(expired2.status).isEqualTo(MatchRequestStatus.EXPIRED)
+        assertThat(recent.status).isEqualTo(MatchRequestStatus.OPEN)
+        verify(exactly = 2) { matchRequestRepository.save(any()) }
+    }
+
+    private fun createMatchRequestWithAge(daysOld: Long): MatchRequest {
+        val request =
+            MatchRequest.create(
+                team = testTeam,
+                preferredDate = LocalDate.now().plusDays(7),
+                preferredTime = "14:00",
+                preferredLocation = "서울 잠실구장",
+                message = null,
+                skillLevel = SkillLevel.INTERMEDIATE,
+            )
+        // createdAt을 과거로 설정 (리플렉션)
+        val field = request.javaClass.superclass.getDeclaredField("createdAt")
+        field.isAccessible = true
+        field.set(request, Instant.now().minus(daysOld, ChronoUnit.DAYS))
+        return request
+    }
+}


### PR DESCRIPTION
## Summary
- `@EnableScheduling` 설정 추가 (SchedulingConfig)
- `MatchRequestExpirationScheduler`: 매일 새벽 3시(cron) 실행
- 30일 경과한 OPEN 상태 매치 요청을 자동으로 EXPIRED 전환
- 기존 도메인 메서드 `isExpired()`, `expire()` 활용
- 단위 테스트 4건 추가

## Tasks
- closes #262

## To Reviewer
- 기존 `MatchRequest.isExpired()`(30일 기준)와 `expire()` 메서드가 이미 구현되어 있어, 스케줄러는 이를 호출만 합니다
- `findAllOpen()` 후 in-memory 필터링 — 소규모 사회인 야구 서비스 특성상 성능 문제 없음
- 프로젝트 최초 `@Scheduled` 사용이므로 `SchedulingConfig` 신규 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)