### PR TITLE
feat(#261): 퇴장(EJECTION) 이벤트 타입 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -222,5 +222,28 @@ class GameEvent(
                 batter = incomingPlayer,
                 pitcher = outgoingPlayer,
             )
+
+        /**
+         * 퇴장 이벤트를 생성합니다.
+         *
+         * @param game 경기
+         * @param ejectedPlayer 퇴장 선수
+         * @param description 퇴장 사유 (예: "폭력", "항의", "기타")
+         */
+        fun createEjection(
+            game: Game,
+            ejectedPlayer: GamePlayer,
+            description: String,
+        ): GameEvent =
+            GameEvent(
+                game = game,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                outCountBefore = game.gameState.outs,
+                outCountAfter = game.gameState.outs,
+                eventType = GameEventType.EJECTION,
+                description = description,
+                batter = ejectedPlayer,
+            )
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
@@ -13,4 +13,5 @@ enum class GameEventType(
     INNING_CHANGE("이닝 전환"),
     GAME_STATUS("경기 상태 변경"),
     POSITION_CHANGE("포지션 변경"),
+    EJECTION("퇴장"),
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
@@ -281,6 +281,36 @@ class GameEventTest {
     }
 
     @Nested
+    @DisplayName("createEjection")
+    inner class CreateEjection {
+        @Test
+        fun `퇴장 이벤트를 생성한다`() {
+            // given
+            val ejectedPlayer = mockk<GamePlayer>(relaxed = true)
+
+            // when
+            val event =
+                GameEvent.createEjection(
+                    game = game,
+                    ejectedPlayer = ejectedPlayer,
+                    description = "3회초: 홍길동 퇴장 (항의)",
+                )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.EJECTION)
+            assertThat(event.description).isEqualTo("3회초: 홍길동 퇴장 (항의)")
+            assertThat(event.inning).isEqualTo(game.currentInning)
+            assertThat(event.isTopInning).isEqualTo(game.isTopInning)
+            assertThat(event.outCountBefore).isEqualTo(game.gameState.outs)
+            assertThat(event.outCountAfter).isEqualTo(game.gameState.outs)
+            assertThat(event.batter).isEqualTo(ejectedPlayer)
+            assertThat(event.pitcher).isNull()
+            assertThat(event.plateAppearanceResult).isNull()
+            assertThat(event.runsScored).isEqualTo(0)
+        }
+    }
+
+    @Nested
     @DisplayName("createGameStatus")
     inner class CreateGameStatus {
         @Test


### PR DESCRIPTION
## Summary

> - close #261

GameEventType에 `EJECTION("퇴장")` enum 값 및 `GameEvent.createEjection()` 팩토리 메서드 추가

## Tasks

- GameEventType에 EJECTION 추가
- GameEvent.createEjection() 팩토리 메서드 구현
- GameEventTest에 퇴장 이벤트 테스트 추가

## To Reviewer

- DB 마이그레이션 불필요 (`@Enumerated(EnumType.STRING)` 사용)
- `GameUndoServiceImpl`의 `when(eventType)`에 `else` 분기가 이미 존재하여 안전