### PR TITLE
feat(#260): 경기 중단(SUSPENDED) → 재개(Resume) 상태 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -237,11 +237,37 @@ class Game private constructor(
     }
 
     /**
+     * 경기를 중단합니다.
+     *
+     * 진행 중인 경기를 우천/조명 고장 등의 사유로 중단합니다.
+     * 현재 이닝, 아웃카운트, 주자 상태 등 GameState가 그대로 보존됩니다.
+     *
+     * @param reason 중단 사유 (선택)
+     */
+    fun suspend(reason: String? = null) {
+        require(status.isOngoing()) { "진행 중인 경기만 중단할 수 있습니다." }
+        status = GameStatus.SUSPENDED
+        if (reason != null) {
+            note = (note?.let { "$it\n" } ?: "") + "중단 사유: $reason"
+        }
+    }
+
+    /**
+     * 중단된 경기를 재개합니다.
+     *
+     * 중단 시점의 이닝, 아웃카운트, 주자 상태부터 이어서 진행합니다.
+     */
+    fun resume() {
+        require(status.isSuspended()) { "중단된 경기만 재개할 수 있습니다. 현재 상태: ${status.displayName}" }
+        status = GameStatus.IN_PROGRESS
+    }
+
+    /**
      * 경기를 취소합니다.
      */
     fun cancel(reason: String? = null) {
-        require(status == GameStatus.SCHEDULED || status == GameStatus.POSTPONED) {
-            "예정 또는 연기 상태의 경기만 취소할 수 있습니다."
+        require(status == GameStatus.SCHEDULED || status == GameStatus.POSTPONED || status == GameStatus.SUSPENDED) {
+            "예정, 연기, 또는 중단 상태의 경기만 취소할 수 있습니다."
         }
         status = GameStatus.CANCELLED
         if (reason != null) {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameStatus.kt
@@ -27,6 +27,9 @@ enum class GameStatus(
 
     /** 콜드게임 */
     CALLED("콜드게임", "점수차 또는 기상 조건으로 조기 종료된 경기"),
+
+    /** 경기 중단 (우천 등으로 도중 중단, 이어서 재개 가능) */
+    SUSPENDED("중단", "경기 도중 중단된 상태 (재개 가능)"),
     ;
 
     /**
@@ -48,4 +51,9 @@ enum class GameStatus(
      * 경기가 취소/연기된 상태인지 확인합니다.
      */
     fun isCancelledOrPostponed(): Boolean = this in listOf(CANCELLED, POSTPONED)
+
+    /**
+     * 경기가 중단된 상태인지 확인합니다.
+     */
+    fun isSuspended(): Boolean = this == SUSPENDED
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameSuspendCoverageTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameSuspendCoverageTest.kt
@@ -1,0 +1,83 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("Game 중단/취소 커버리지 보완 테스트")
+class GameSuspendCoverageTest {
+    private lateinit var competition: Competition
+    private lateinit var league: League
+
+    @BeforeEach
+    fun setUp() {
+        val association = Association(name = "서울시야구협회", region = "서울")
+        league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춨계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+            )
+    }
+
+    private fun createGame(status: GameStatus = GameStatus.SCHEDULED): Game {
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        return Game.createForTest(
+            competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            status = status,
+        )
+    }
+
+    @Test
+    fun `기존 note가 있는 경기를 중단하면 사유가 추가된다`() {
+        // given
+        val game =
+            Game.createForTest(
+                competition = competition,
+                homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L),
+                awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L),
+                scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                status = GameStatus.IN_PROGRESS,
+                note = "기존 메모",
+            )
+
+        // when
+        game.suspend(reason = "우천")
+
+        // then
+        assertThat(game.status).isEqualTo(GameStatus.SUSPENDED)
+        assertThat(game.note).contains("기존 메모")
+        assertThat(game.note).contains("중단 사유: 우천")
+    }
+
+    @Test
+    fun `연기 상태의 경기를 취소할 수 있다`() {
+        // given
+        val game = createGame(status = GameStatus.POSTPONED)
+
+        // when
+        game.cancel(reason = "일정 불가")
+
+        // then
+        assertThat(game.status).isEqualTo(GameStatus.CANCELLED)
+        assertThat(game.note).contains("취소 사유: 일정 불가")
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -1095,4 +1095,99 @@ class GameTest {
             assertThat(game.status).isEqualTo(GameStatus.SCHEDULED)
         }
     }
+
+    @Nested
+    @DisplayName("경기 중단/재개")
+    inner class SuspendAndResume {
+        @Test
+        fun `진행 중인 경기를 중단할 수 있다`() {
+            // given
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+
+            // when
+            game.suspend(reason = "우천")
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.SUSPENDED)
+            assertThat(game.note).contains("중단 사유: 우천")
+        }
+
+        @Test
+        fun `중단 시 사유 없이도 가능하다`() {
+            // given
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+
+            // when
+            game.suspend()
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.SUSPENDED)
+        }
+
+        @Test
+        fun `진행 중이 아닌 경기는 중단할 수 없다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+
+            // when & then
+            assertThatThrownBy { game.suspend() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("진행 중인 경기만 중단할 수 있습니다")
+        }
+
+        @Test
+        fun `중단된 경기를 재개할 수 있다`() {
+            // given
+            val game = createGame(status = GameStatus.SUSPENDED)
+
+            // when
+            game.resume()
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.IN_PROGRESS)
+        }
+
+        @Test
+        fun `중단되지 않은 경기는 재개할 수 없다`() {
+            // given
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+
+            // when & then
+            assertThatThrownBy { game.resume() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("중단된 경기만 재개할 수 있습니다")
+        }
+
+        @Test
+        fun `중단된 경기를 취소할 수 있다`() {
+            // given
+            val game = createGame(status = GameStatus.SUSPENDED)
+
+            // when
+            game.cancel(reason = "재개 불가")
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.CANCELLED)
+            assertThat(game.note).contains("취소 사유: 재개 불가")
+        }
+
+        @Test
+        fun `중단 시 게임 상태가 보존된다`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = false
+                    gameState.restoreOuts(2)
+                }
+
+            // when
+            game.suspend(reason = "우천")
+
+            // then
+            assertThat(game.currentInning).isEqualTo(5)
+            assertThat(game.isTopInning).isFalse()
+            assertThat(game.gameState.outs).isEqualTo(2)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

> - Closes #260

GameStatus에 `SUSPENDED` 상태를 추가하고, Game에 `suspend(reason)` / `resume()` 메서드 구현

## Tasks

- GameStatus에 SUSPENDED 추가 및 isSuspended() 메서드
- Game.suspend() - 진행 중 경기 중단 (사유 선택적 기록)
- Game.resume() - 중단 경기 재개 (IN_PROGRESS로 복원)
- Game.cancel() 확장 - SUSPENDED 상태에서도 취소 가능
- 누락 분기 커버리지 테스트 추가

## To Reviewer

- DB 마이그레이션 불필요 (`@Enumerated(EnumType.STRING)` 사용)
- GameState가 그대로 보존되므로 재개 시 중단 시점부터 이어서 진행 가능
- 향후 scorer 모듈에 중단/재개 API 엔드포인트 추가 필요