### PR TITLE
feat(#268): 더블헤더 관리 개념 도입

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -35,6 +35,8 @@ class Game private constructor(
     var fieldName: String? = null,
     @Column(name = "game_number")
     var gameNumber: Int? = null,
+    @Column(name = "is_doubleheader", nullable = false)
+    var isDoubleheader: Boolean = false,
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     var status: GameStatus = GameStatus.SCHEDULED,
@@ -337,8 +339,14 @@ class Game private constructor(
             location: String? = null,
             fieldName: String? = null,
             gameNumber: Int? = null,
+            isDoubleheader: Boolean = false,
         ): Game {
             require(homeTeam.id != awayTeam.id) { "홈팀과 원정팀은 같을 수 없습니다." }
+            if (isDoubleheader) {
+                require(gameNumber != null && gameNumber in 1..2) {
+                    "더블헤더 경기는 gameNumber가 1 또는 2여야 합니다."
+                }
+            }
 
             val game =
                 Game(
@@ -347,6 +355,7 @@ class Game private constructor(
                     location = location,
                     fieldName = fieldName,
                     gameNumber = gameNumber,
+                    isDoubleheader = isDoubleheader,
                     totalInnings = competition.gameRules.defaultInnings,
                 )
             game._gameTeams.add(GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME))
@@ -369,6 +378,7 @@ class Game private constructor(
             location: String? = null,
             fieldName: String? = null,
             gameNumber: Int? = null,
+            isDoubleheader: Boolean = false,
             status: GameStatus = GameStatus.SCHEDULED,
             currentInning: Int = 0,
             isTopInning: Boolean = true,
@@ -387,6 +397,7 @@ class Game private constructor(
                     location = location,
                     fieldName = fieldName,
                     gameNumber = gameNumber,
+                    isDoubleheader = isDoubleheader,
                     status = status,
                     currentInning = currentInning,
                     isTopInning = isTopInning,
@@ -455,6 +466,18 @@ class Game private constructor(
      */
     val isExtraInning: Boolean
         get() = currentInning > totalInnings
+
+    /**
+     * 더블헤더 표시를 반환합니다 (예: "제1경기", "제2경기").
+     * 더블헤더가 아닌 경우 null을 반환합니다.
+     */
+    val doubleheaderDisplay: String?
+        get() =
+            if (isDoubleheader && gameNumber != null) {
+                "제${gameNumber}경기"
+            } else {
+                null
+            }
 
     /**
      * 아웃을 기록합니다.

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameDoubleheaderCoverageTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameDoubleheaderCoverageTest.kt
@@ -1,0 +1,90 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("Game 더블헤더 커버리지 보완 테스트")
+class GameDoubleheaderCoverageTest {
+    private lateinit var competition: Competition
+    private lateinit var league: League
+    private lateinit var homeTeam: Team
+    private lateinit var awayTeam: Team
+
+    @BeforeEach
+    fun setUp() {
+        val association = Association(name = "서울시야구협회", region = "서울")
+        league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춨계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+            )
+        homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+    }
+
+    @Test
+    fun `더블헤더 경기에 gameNumber가 3이면 예외가 발생한다`() {
+        assertThatThrownBy {
+            Game.create(
+                competition = competition,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                gameNumber = 3,
+                isDoubleheader = true,
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("gameNumber가 1 또는 2여야 합니다")
+    }
+
+    @Test
+    fun `더블헤더이지만 gameNumber가 null이면 doubleheaderDisplay는 null이다`() {
+        // given - createForTest로 isDoubleheader=true, gameNumber=null 조합 생성
+        val game =
+            Game.createForTest(
+                competition = competition,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                isDoubleheader = true,
+                gameNumber = null,
+            )
+
+        // then
+        assertThat(game.isDoubleheader).isTrue()
+        assertThat(game.doubleheaderDisplay).isNull()
+    }
+
+    @Test
+    fun `더블헤더가 아닌 경기는 isDoubleheader가 false이다`() {
+        // given
+        val game =
+            Game.create(
+                competition = competition,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            )
+
+        // then
+        assertThat(game.isDoubleheader).isFalse()
+        assertThat(game.doubleheaderDisplay).isNull()
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -1094,5 +1094,67 @@ class GameTest {
             // then
             assertThat(game.status).isEqualTo(GameStatus.SCHEDULED)
         }
+
+        @Test
+        fun `더블헤더 경기를 생성할 수 있다`() {
+            // when
+            val game1 =
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 10, 0),
+                    gameNumber = 1,
+                    isDoubleheader = true,
+                )
+            val game2 =
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                    gameNumber = 2,
+                    isDoubleheader = true,
+                )
+
+            // then
+            assertThat(game1.isDoubleheader).isTrue()
+            assertThat(game1.gameNumber).isEqualTo(1)
+            assertThat(game1.doubleheaderDisplay).isEqualTo("제1경기")
+            assertThat(game2.isDoubleheader).isTrue()
+            assertThat(game2.gameNumber).isEqualTo(2)
+            assertThat(game2.doubleheaderDisplay).isEqualTo("제2경기")
+        }
+
+        @Test
+        fun `더블헤더 경기에 gameNumber가 없으면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                    isDoubleheader = true,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("gameNumber가 1 또는 2여야 합니다")
+        }
+
+        @Test
+        fun `더블헤더가 아닌 경기의 doubleheaderDisplay는 null이다`() {
+            // when
+            val game =
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                )
+
+            // then
+            assertThat(game.isDoubleheader).isFalse()
+            assertThat(game.doubleheaderDisplay).isNull()
+        }
     }
 }

--- a/nextup-infrastructure/src/main/resources/db/migration/V036__add_is_doubleheader_to_games.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V036__add_is_doubleheader_to_games.sql
@@ -1,0 +1,2 @@
+-- #268: 더블헤더 관리 개념 도입
+ALTER TABLE games ADD COLUMN is_doubleheader BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary

> - Closes #268

Game에 `isDoubleheader` 필드를 추가하여 더블헤더 경기를 시스템적으로 식별하고, `doubleheaderDisplay` 프로퍼티로 "제1경기"/"제2경기" 표시

## Tasks

- Game에 isDoubleheader 필드 추가
- create() 팩토리에 더블헤더 검증 로직 추가 (gameNumber 1 또는 2 필수)
- doubleheaderDisplay 프로퍼티 구현
- V036 마이그레이션 추가
- 누락 분기 커버리지 테스트 추가

## To Reviewer

- 기존 `gameNumber` 필드를 활용하여 최소한의 변경으로 구현
- 더블헤더 이닝 수 조정은 대회 규칙(`GameRules`)에서 이미 설정 가능
- 향후 스케줄 API에서 더블헤더 일괄 생성 기능 추가 가능