### PR TITLE
feat(#266): 대회 도중 팀 전체 탈퇴 시 연쇄 처리

### DIFF
--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminController.kt
@@ -3,9 +3,11 @@ package com.nextup.backoffice.controller.competition
 import com.nextup.backoffice.dto.competition.CompetitionAdminResponse
 import com.nextup.backoffice.dto.competition.CreateCompetitionRequest
 import com.nextup.backoffice.dto.competition.UpdateCompetitionRequest
+import com.nextup.backoffice.dto.competition.WithdrawTeamRequest
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.service.competition.CompetitionService
+import com.nextup.core.service.competition.dto.TeamWithdrawalResult
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -155,5 +157,20 @@ class CompetitionAdminController(
     ): ApiResponse<CompetitionAdminResponse> {
         val competition = competitionService.postpone(id)
         return ApiResponse.success(CompetitionAdminResponse.from(competition))
+    }
+
+    /**
+     * 대회에서 팀을 전체 탈퇴시킵니다.
+     *
+     * 잔여 경기 몰수승 처리, 선수 일괄 WITHDRAWN, 대진표 업데이트를 수행합니다.
+     */
+    @PostMapping("/{id}/teams/{teamId}/withdraw")
+    fun withdrawTeam(
+        @PathVariable id: Long,
+        @PathVariable teamId: Long,
+        @Valid @RequestBody request: WithdrawTeamRequest,
+    ): ApiResponse<TeamWithdrawalResult> {
+        val result = competitionService.withdrawTeam(id, teamId, request.reason)
+        return ApiResponse.success(result)
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/WithdrawTeamRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/WithdrawTeamRequest.kt
@@ -1,0 +1,11 @@
+package com.nextup.backoffice.dto.competition
+
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * 팀 대회 탈퇴 요청 DTO
+ */
+data class WithdrawTeamRequest(
+    @field:NotBlank(message = "탈퇴 사유는 필수입니다")
+    val reason: String,
+)

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminControllerTest.kt
@@ -4,12 +4,16 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.nextup.backoffice.dto.competition.CreateCompetitionRequest
 import com.nextup.backoffice.dto.competition.UpdateCompetitionRequest
+import com.nextup.backoffice.dto.competition.WithdrawTeamRequest
+import com.nextup.backoffice.exception.GlobalExceptionHandler
+import com.nextup.common.exception.InvalidCompetitionStateException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
 import com.nextup.core.service.competition.CompetitionService
+import com.nextup.core.service.competition.dto.TeamWithdrawalResult
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -38,7 +42,10 @@ class CompetitionAdminControllerTest {
     fun setUp() {
         competitionService = mockk()
         controller = CompetitionAdminController(competitionService)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+        mockMvc =
+            MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
         objectMapper = ObjectMapper().registerModule(JavaTimeModule())
     }
 
@@ -254,6 +261,70 @@ class CompetitionAdminControllerTest {
                 .andExpect(jsonPath("$.data.status").value("COMPLETED"))
 
             verify(exactly = 1) { competitionService.complete(1L, any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/backoffice/competitions/{id}/teams/{teamId}/withdraw")
+    inner class WithdrawTeam {
+        @Test
+        fun `should withdraw team from competition`() {
+            // given
+            val competitionId = 1L
+            val teamId = 10L
+            val request = WithdrawTeamRequest(reason = "팀 해산으로 인한 탈퇴")
+            val result =
+                TeamWithdrawalResult(
+                    competitionId = competitionId,
+                    teamId = teamId,
+                    teamName = "한강 타이거즈",
+                    withdrawnPlayerCount = 5,
+                    forfeitedGameCount = 3,
+                    updatedBracketEntryCount = 1,
+                    reason = request.reason,
+                )
+
+            every { competitionService.withdrawTeam(competitionId, teamId, request.reason) } returns result
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/backoffice/competitions/$competitionId/teams/$teamId/withdraw")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.competitionId").value(competitionId))
+                .andExpect(jsonPath("$.data.teamId").value(teamId))
+                .andExpect(jsonPath("$.data.teamName").value("한강 타이거즈"))
+                .andExpect(jsonPath("$.data.withdrawnPlayerCount").value(5))
+                .andExpect(jsonPath("$.data.forfeitedGameCount").value(3))
+                .andExpect(jsonPath("$.data.updatedBracketEntryCount").value(1))
+
+            verify(exactly = 1) { competitionService.withdrawTeam(competitionId, teamId, request.reason) }
+        }
+
+        @Test
+        fun `should return 400 when competition is not in progress`() {
+            // given
+            val competitionId = 1L
+            val teamId = 10L
+            val request = WithdrawTeamRequest(reason = "탈퇴 사유")
+
+            every { competitionService.withdrawTeam(competitionId, teamId, request.reason) } throws
+                InvalidCompetitionStateException("Team withdrawal is only allowed for in-progress competitions")
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/backoffice/competitions/$competitionId/teams/$teamId/withdraw")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_COMPETITION_STATE"))
+
+            verify(exactly = 1) { competitionService.withdrawTeam(competitionId, teamId, request.reason) }
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -307,8 +307,8 @@ class Game private constructor(
         reason: String,
         gameTeams: List<GameTeam>,
     ) {
-        require(status == GameStatus.SCHEDULED || status.isOngoing()) {
-            "예정 또는 진행 중인 경기만 몰수 처리할 수 있습니다."
+        require(status == GameStatus.SCHEDULED || status == GameStatus.POSTPONED || status.isOngoing()) {
+            "예정, 연기, 또는 진행 중인 경기만 몰수 처리할 수 있습니다."
         }
         require(gameTeams.size == 2) {
             "몰수 처리를 위해서는 정확히 2개의 GameTeam이 필요합니다."

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/competition/CompetitionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/competition/CompetitionService.kt
@@ -3,11 +3,18 @@ package com.nextup.core.service.competition
 import com.nextup.common.exception.CompetitionNotFoundException
 import com.nextup.common.exception.InvalidCompetitionStateException
 import com.nextup.common.exception.LeagueNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.port.repository.BracketEntryRepositoryPort
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.LeagueRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.competition.dto.TeamWithdrawalResult
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -22,6 +29,10 @@ import java.time.LocalDate
 class CompetitionService(
     private val competitionRepository: CompetitionRepositoryPort,
     private val leagueRepository: LeagueRepositoryPort,
+    private val competitionPlayerRepository: CompetitionPlayerRepositoryPort,
+    private val gameRepository: GameRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+    private val bracketEntryRepository: BracketEntryRepositoryPort,
 ) {
     /**
      * 대회를 생성합니다.
@@ -176,5 +187,104 @@ class CompetitionService(
             throw InvalidCompetitionStateException(e.message ?: "Cannot postpone competition")
         }
         return competition
+    }
+
+    /**
+     * 대회에서 팀 전체를 탈퇴시킵니다.
+     *
+     * 1. 해당 팀 소속 CompetitionPlayer 일괄 WITHDRAWN 처리
+     * 2. 잔여 경기(SCHEDULED/IN_PROGRESS) 자동 몰수승 처리
+     * 3. 대진표(BracketEntry) 부전승 처리
+     *
+     * @param competitionId 대회 ID
+     * @param teamId 탈퇴할 팀 ID
+     * @param reason 탈퇴 사유
+     * @return 처리 결과 요약
+     */
+    @Transactional
+    fun withdrawTeam(
+        competitionId: Long,
+        teamId: Long,
+        reason: String,
+    ): TeamWithdrawalResult {
+        val competition = getById(competitionId)
+        if (competition.status != CompetitionStatus.IN_PROGRESS) {
+            throw InvalidCompetitionStateException(
+                "Team withdrawal is only allowed for in-progress competitions. " +
+                    "Current status: ${competition.status}",
+            )
+        }
+
+        val team =
+            teamRepository.findByIdOrNull(teamId)
+                ?: throw TeamNotFoundException(teamId)
+
+        // 1. CompetitionPlayer 일괄 WITHDRAWN 처리
+        val players = competitionPlayerRepository.findByCompetitionIdAndTeamId(competitionId, teamId)
+        if (players.isEmpty()) {
+            throw InvalidCompetitionStateException(
+                "Team $teamId has no registered players in competition $competitionId",
+            )
+        }
+        var withdrawnPlayerCount = 0
+        players.forEach { player ->
+            if (player.status != com.nextup.core.domain.competition.CompetitionPlayerStatus.WITHDRAWN) {
+                player.withdraw()
+                withdrawnPlayerCount++
+            }
+        }
+        competitionPlayerRepository.saveAll(players)
+
+        // 2. 잔여 경기 몰수승 처리
+        val games = gameRepository.findByCompetitionId(competitionId)
+        var forfeitedGameCount = 0
+        games.forEach { game ->
+            if (game.status == GameStatus.SCHEDULED ||
+                game.status == GameStatus.IN_PROGRESS ||
+                game.status == GameStatus.POSTPONED
+            ) {
+                val gameTeams = game.gameTeams
+                val isTeamInGame = gameTeams.any { it.team.id == teamId }
+                if (isTeamInGame) {
+                    val opponentTeam = gameTeams.first { it.team.id != teamId }
+                    game.forfeit(
+                        winnerTeamId = opponentTeam.team.id,
+                        reason = "팀 대회 탈퇴: $reason",
+                        gameTeams = gameTeams,
+                    )
+                    gameRepository.save(game)
+                    forfeitedGameCount++
+                }
+            }
+        }
+
+        // 3. 대진표 부전승 처리
+        val bracketEntries = bracketEntryRepository.findByCompetitionId(competitionId)
+        var updatedBracketCount = 0
+        bracketEntries.forEach { entry ->
+            if (!entry.isCompleted()) {
+                val isTeam1 = entry.team1?.id == teamId
+                val isTeam2 = entry.team2?.id == teamId
+                if (isTeam1 && entry.team2 != null) {
+                    entry.recordWinner(entry.team2!!)
+                    bracketEntryRepository.save(entry)
+                    updatedBracketCount++
+                } else if (isTeam2 && entry.team1 != null) {
+                    entry.recordWinner(entry.team1!!)
+                    bracketEntryRepository.save(entry)
+                    updatedBracketCount++
+                }
+            }
+        }
+
+        return TeamWithdrawalResult(
+            competitionId = competitionId,
+            teamId = teamId,
+            teamName = team.name,
+            withdrawnPlayerCount = withdrawnPlayerCount,
+            forfeitedGameCount = forfeitedGameCount,
+            updatedBracketEntryCount = updatedBracketCount,
+            reason = reason,
+        )
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/competition/dto/TeamWithdrawalResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/competition/dto/TeamWithdrawalResult.kt
@@ -1,0 +1,14 @@
+package com.nextup.core.service.competition.dto
+
+/**
+ * 팀 대회 탈퇴 처리 결과
+ */
+data class TeamWithdrawalResult(
+    val competitionId: Long,
+    val teamId: Long,
+    val teamName: String,
+    val withdrawnPlayerCount: Int,
+    val forfeitedGameCount: Int,
+    val updatedBracketEntryCount: Int,
+    val reason: String,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/competition/CompetitionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/competition/CompetitionServiceTest.kt
@@ -3,13 +3,25 @@ package com.nextup.core.service.competition
 import com.nextup.common.exception.CompetitionNotFoundException
 import com.nextup.common.exception.InvalidCompetitionStateException
 import com.nextup.common.exception.LeagueNotFoundException
+import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionPlayer
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.BracketEntryRepositoryPort
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.LeagueRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -25,13 +37,29 @@ import java.time.LocalDate
 class CompetitionServiceTest {
     private lateinit var competitionRepository: CompetitionRepositoryPort
     private lateinit var leagueRepository: LeagueRepositoryPort
+    private lateinit var competitionPlayerRepository: CompetitionPlayerRepositoryPort
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var bracketEntryRepository: BracketEntryRepositoryPort
     private lateinit var competitionService: CompetitionService
 
     @BeforeEach
     fun setUp() {
         competitionRepository = mockk()
         leagueRepository = mockk()
-        competitionService = CompetitionService(competitionRepository, leagueRepository)
+        competitionPlayerRepository = mockk()
+        gameRepository = mockk()
+        teamRepository = mockk()
+        bracketEntryRepository = mockk()
+        competitionService =
+            CompetitionService(
+                competitionRepository,
+                leagueRepository,
+                competitionPlayerRepository,
+                gameRepository,
+                teamRepository,
+                bracketEntryRepository,
+            )
     }
 
     @Nested
@@ -500,6 +528,170 @@ class CompetitionServiceTest {
             idField.set(this, id)
         }
 
+    @Nested
+    @DisplayName("withdrawTeam")
+    inner class WithdrawTeam {
+        @Test
+        fun `should withdraw team from competition successfully`() {
+            // given
+            val competitionId = 1L
+            val teamId = 10L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition =
+                createCompetition(competitionId, league, "2025 춘계대회", 2025, 1).apply { start() }
+            val team = createTeam(teamId, "한강 타이거즈", league)
+            val opponentTeam = createTeam(20L, "잠실 이글스", league)
+            val player1 = createPlayer(100L, "홍길동")
+            val player2 = createPlayer(101L, "김철수")
+
+            val competitionPlayers =
+                listOf(
+                    CompetitionPlayer.register(competition, team, player1),
+                    CompetitionPlayer.register(competition, team, player2),
+                )
+
+            val game =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = team,
+                    awayTeam = opponentTeam,
+                    id = 1L,
+                )
+
+            every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+            every { teamRepository.findByIdOrNull(teamId) } returns team
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndTeamId(competitionId, teamId)
+            } returns competitionPlayers
+            every { competitionPlayerRepository.saveAll(any()) } answers { firstArg() }
+            every { gameRepository.findByCompetitionId(competitionId) } returns listOf(game)
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { bracketEntryRepository.findByCompetitionId(competitionId) } returns emptyList()
+
+            // when
+            val result = competitionService.withdrawTeam(competitionId, teamId, "팀 해산")
+
+            // then
+            assertThat(result.competitionId).isEqualTo(competitionId)
+            assertThat(result.teamId).isEqualTo(teamId)
+            assertThat(result.withdrawnPlayerCount).isEqualTo(2)
+            assertThat(result.forfeitedGameCount).isEqualTo(1)
+            assertThat(result.updatedBracketEntryCount).isEqualTo(0)
+            assertThat(result.reason).isEqualTo("팀 해산")
+
+            // verify players withdrawn
+            competitionPlayers.forEach {
+                assertThat(it.status).isEqualTo(CompetitionPlayerStatus.WITHDRAWN)
+            }
+
+            // verify game forfeited
+            assertThat(game.status).isEqualTo(GameStatus.FORFEITED)
+
+            verify { competitionPlayerRepository.saveAll(any()) }
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when competition is not in progress`() {
+            // given
+            val competitionId = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(competitionId, league, "2025 춘계대회", 2025, 1)
+            every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.withdrawTeam(competitionId, 10L, "사유")
+            }.isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when team not found`() {
+            // given
+            val competitionId = 1L
+            val teamId = 999L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition =
+                createCompetition(competitionId, league, "2025 춘계대회", 2025, 1).apply { start() }
+            every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+            every { teamRepository.findByIdOrNull(teamId) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.withdrawTeam(competitionId, teamId, "사유")
+            }.isInstanceOf(TeamNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when team has no players in competition`() {
+            // given
+            val competitionId = 1L
+            val teamId = 10L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition =
+                createCompetition(competitionId, league, "2025 춘계대회", 2025, 1).apply { start() }
+            val team = createTeam(teamId, "한강 타이거즈", league)
+            every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+            every { teamRepository.findByIdOrNull(teamId) } returns team
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndTeamId(competitionId, teamId)
+            } returns emptyList()
+
+            // when & then
+            assertThatThrownBy {
+                competitionService.withdrawTeam(competitionId, teamId, "사유")
+            }.isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+
+        @Test
+        fun `should not forfeit already completed games`() {
+            // given
+            val competitionId = 1L
+            val teamId = 10L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition =
+                createCompetition(competitionId, league, "2025 춘계대회", 2025, 1).apply { start() }
+            val team = createTeam(teamId, "한강 타이거즈", league)
+            val opponentTeam = createTeam(20L, "잠실 이글스", league)
+            val player = createPlayer(100L, "홍길동")
+
+            val competitionPlayers =
+                listOf(CompetitionPlayer.register(competition, team, player))
+
+            // 이미 종료된 경기
+            val finishedGame =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = team,
+                    awayTeam = opponentTeam,
+                    status = GameStatus.FINISHED,
+                    id = 1L,
+                )
+
+            every { competitionRepository.findByIdOrNull(competitionId) } returns competition
+            every { teamRepository.findByIdOrNull(teamId) } returns team
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndTeamId(competitionId, teamId)
+            } returns competitionPlayers
+            every { competitionPlayerRepository.saveAll(any()) } answers { firstArg() }
+            every { gameRepository.findByCompetitionId(competitionId) } returns listOf(finishedGame)
+            every { bracketEntryRepository.findByCompetitionId(competitionId) } returns emptyList()
+
+            // when
+            val result = competitionService.withdrawTeam(competitionId, teamId, "팀 해산")
+
+            // then
+            assertThat(result.forfeitedGameCount).isEqualTo(0)
+            assertThat(finishedGame.status).isEqualTo(GameStatus.FINISHED)
+            verify(exactly = 0) { gameRepository.save(any()) }
+        }
+    }
+
     private fun createCompetition(
         id: Long,
         league: League,
@@ -519,6 +711,35 @@ class CompetitionServiceTest {
             maxTeams = null,
         ).apply {
             val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createTeam(
+        id: Long,
+        name: String,
+        league: League,
+    ): Team =
+        Team(
+            league = league,
+            name = name,
+            city = "서울",
+            foundedYear = 2020,
+        ).apply {
+            val idField = Team::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createPlayer(
+        id: Long,
+        name: String,
+    ): Player =
+        Player(
+            name = name,
+            primaryPosition = Position.STARTING_PITCHER,
+        ).apply {
+            val idField = Player::class.java.getDeclaredField("id")
             idField.isAccessible = true
             idField.set(this, id)
         }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/competition/CompetitionServiceWithdrawCoverageTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/competition/CompetitionServiceWithdrawCoverageTest.kt
@@ -4,7 +4,6 @@ import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.BracketEntry
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionPlayer
-import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.game.Game
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @DisplayName("CompetitionService.withdrawTeam 커버리지 보완")
 class CompetitionServiceWithdrawCoverageTest {

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/competition/CompetitionServiceWithdrawCoverageTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/competition/CompetitionServiceWithdrawCoverageTest.kt
@@ -1,0 +1,291 @@
+package com.nextup.core.service.competition
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.BracketEntry
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionPlayer
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.BracketEntryRepositoryPort
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.LeagueRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("CompetitionService.withdrawTeam 커버리지 보완")
+class CompetitionServiceWithdrawCoverageTest {
+    private lateinit var competitionRepository: CompetitionRepositoryPort
+    private lateinit var leagueRepository: LeagueRepositoryPort
+    private lateinit var competitionPlayerRepository: CompetitionPlayerRepositoryPort
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var bracketEntryRepository: BracketEntryRepositoryPort
+    private lateinit var competitionService: CompetitionService
+
+    private lateinit var association: Association
+    private lateinit var league: League
+    private lateinit var competition: Competition
+    private lateinit var team: Team
+    private lateinit var opponentTeam: Team
+
+    @BeforeEach
+    fun setUp() {
+        competitionRepository = mockk()
+        leagueRepository = mockk()
+        competitionPlayerRepository = mockk()
+        gameRepository = mockk()
+        teamRepository = mockk()
+        bracketEntryRepository = mockk()
+        competitionService =
+            CompetitionService(
+                competitionRepository,
+                leagueRepository,
+                competitionPlayerRepository,
+                gameRepository,
+                teamRepository,
+                bracketEntryRepository,
+            )
+
+        association = Association(name = "서울시야구협회", region = "서울")
+        league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춨계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.TOURNAMENT,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+            ).apply {
+                val idField = Competition::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
+        team = createTeam(10L, "한강 타이거즈")
+        opponentTeam = createTeam(20L, "잠실 이글스")
+    }
+
+    @Test
+    fun `이미 WITHDRAWN 상태인 선수는 카운트에서 제외된다`() {
+        // given
+        val player1 = createPlayer(100L, "홍길동")
+        val player2 = createPlayer(101L, "김철수")
+        val cp1 = CompetitionPlayer.register(competition, team, player1)
+        val cp2 = CompetitionPlayer.register(competition, team, player2)
+        cp2.withdraw() // 이미 WITHDRAWN
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(10L) } returns team
+        every { competitionPlayerRepository.findByCompetitionIdAndTeamId(1L, 10L) } returns listOf(cp1, cp2)
+        every { competitionPlayerRepository.saveAll(any()) } answers { firstArg() }
+        every { gameRepository.findByCompetitionId(1L) } returns emptyList()
+        every { bracketEntryRepository.findByCompetitionId(1L) } returns emptyList()
+
+        // when
+        val result = competitionService.withdrawTeam(1L, 10L, "탈퇴 사유")
+
+        // then
+        assertThat(result.withdrawnPlayerCount).isEqualTo(1) // cp2는 이미 WITHDRAWN이므로 제외
+    }
+
+    @Test
+    fun `탈퇴 팀이 참여하지 않는 경기는 건너뛴다`() {
+        // given
+        val player = createPlayer(100L, "홍길동")
+        val cp = CompetitionPlayer.register(competition, team, player)
+        val otherTeam = createTeam(30L, "다른팀")
+
+        // 탈퇴 팀(10L)이 참여하지 않는 경기
+        val game =
+            Game.createForTest(
+                competition = competition,
+                homeTeam = opponentTeam,
+                awayTeam = otherTeam,
+                id = 1L,
+            )
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(10L) } returns team
+        every { competitionPlayerRepository.findByCompetitionIdAndTeamId(1L, 10L) } returns listOf(cp)
+        every { competitionPlayerRepository.saveAll(any()) } answers { firstArg() }
+        every { gameRepository.findByCompetitionId(1L) } returns listOf(game)
+        every { bracketEntryRepository.findByCompetitionId(1L) } returns emptyList()
+
+        // when
+        val result = competitionService.withdrawTeam(1L, 10L, "탈퇴")
+
+        // then
+        assertThat(result.forfeitedGameCount).isEqualTo(0)
+        verify(exactly = 0) { gameRepository.save(any()) }
+    }
+
+    @Test
+    fun `POSTPONED 상태 경기도 몰수 처리된다`() {
+        // given
+        val player = createPlayer(100L, "홍길동")
+        val cp = CompetitionPlayer.register(competition, team, player)
+
+        val game =
+            Game.createForTest(
+                competition = competition,
+                homeTeam = team,
+                awayTeam = opponentTeam,
+                status = GameStatus.POSTPONED,
+                id = 1L,
+            )
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(10L) } returns team
+        every { competitionPlayerRepository.findByCompetitionIdAndTeamId(1L, 10L) } returns listOf(cp)
+        every { competitionPlayerRepository.saveAll(any()) } answers { firstArg() }
+        every { gameRepository.findByCompetitionId(1L) } returns listOf(game)
+        every { gameRepository.save(any()) } answers { firstArg() }
+        every { bracketEntryRepository.findByCompetitionId(1L) } returns emptyList()
+
+        // when
+        val result = competitionService.withdrawTeam(1L, 10L, "탈퇴")
+
+        // then
+        assertThat(result.forfeitedGameCount).isEqualTo(1)
+        assertThat(game.status).isEqualTo(GameStatus.FORFEITED)
+    }
+
+    @Test
+    fun `대진표에서 team1이 탈퇴하면 team2가 승자가 된다`() {
+        // given
+        val player = createPlayer(100L, "홍길동")
+        val cp = CompetitionPlayer.register(competition, team, player)
+
+        val entry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = team,
+                team2 = opponentTeam,
+            )
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(10L) } returns team
+        every { competitionPlayerRepository.findByCompetitionIdAndTeamId(1L, 10L) } returns listOf(cp)
+        every { competitionPlayerRepository.saveAll(any()) } answers { firstArg() }
+        every { gameRepository.findByCompetitionId(1L) } returns emptyList()
+        every { bracketEntryRepository.findByCompetitionId(1L) } returns listOf(entry)
+        every { bracketEntryRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result = competitionService.withdrawTeam(1L, 10L, "탈퇴")
+
+        // then
+        assertThat(result.updatedBracketEntryCount).isEqualTo(1)
+        assertThat(entry.winner).isEqualTo(opponentTeam)
+    }
+
+    @Test
+    fun `대진표에서 team2가 탈퇴하면 team1이 승자가 된다`() {
+        // given
+        val player = createPlayer(100L, "홍길동")
+        val cp = CompetitionPlayer.register(competition, team, player)
+
+        val entry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = opponentTeam,
+                team2 = team,
+            )
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(10L) } returns team
+        every { competitionPlayerRepository.findByCompetitionIdAndTeamId(1L, 10L) } returns listOf(cp)
+        every { competitionPlayerRepository.saveAll(any()) } answers { firstArg() }
+        every { gameRepository.findByCompetitionId(1L) } returns emptyList()
+        every { bracketEntryRepository.findByCompetitionId(1L) } returns listOf(entry)
+        every { bracketEntryRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result = competitionService.withdrawTeam(1L, 10L, "탈퇴")
+
+        // then
+        assertThat(result.updatedBracketEntryCount).isEqualTo(1)
+        assertThat(entry.winner).isEqualTo(opponentTeam)
+    }
+
+    @Test
+    fun `이미 완료된 대진표 엔트리는 건너뛴다`() {
+        // given
+        val player = createPlayer(100L, "홍길동")
+        val cp = CompetitionPlayer.register(competition, team, player)
+
+        val entry =
+            BracketEntry(
+                competition = competition,
+                roundNumber = 1,
+                matchNumber = 1,
+                team1 = team,
+                team2 = opponentTeam,
+                winner = opponentTeam, // 이미 승자 결정
+            )
+
+        every { competitionRepository.findByIdOrNull(1L) } returns competition
+        every { teamRepository.findByIdOrNull(10L) } returns team
+        every { competitionPlayerRepository.findByCompetitionIdAndTeamId(1L, 10L) } returns listOf(cp)
+        every { competitionPlayerRepository.saveAll(any()) } answers { firstArg() }
+        every { gameRepository.findByCompetitionId(1L) } returns emptyList()
+        every { bracketEntryRepository.findByCompetitionId(1L) } returns listOf(entry)
+
+        // when
+        val result = competitionService.withdrawTeam(1L, 10L, "탈퇴")
+
+        // then
+        assertThat(result.updatedBracketEntryCount).isEqualTo(0)
+        verify(exactly = 0) { bracketEntryRepository.save(any()) }
+    }
+
+    private fun createTeam(
+        id: Long,
+        name: String,
+    ): Team =
+        Team(
+            league = league,
+            name = name,
+            city = "서울",
+            foundedYear = 2020,
+        ).apply {
+            val idField = Team::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createPlayer(
+        id: Long,
+        name: String,
+    ): Player =
+        Player(
+            name = name,
+            primaryPosition = Position.STARTING_PITCHER,
+        ).apply {
+            val idField = Player::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+}

--- a/nextup-infrastructure/build.gradle.kts
+++ b/nextup-infrastructure/build.gradle.kts
@@ -62,11 +62,11 @@ dependencies {
 
     // PDF Generation (OpenPDF)
     implementation("com.github.librepdf:openpdf:2.0.3")
-    
+
     // QR Code Generation (ZXing)
     implementation("com.google.zxing:core:3.5.3")
     implementation("com.google.zxing:javase:3.5.3")
-    
+
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.assertj:assertj-core:3.27.3")


### PR DESCRIPTION
## Summary

> - Closes #266

대회 진행 중 특정 팀의 전체 탈퇴(withdraw) 시 연쇄 처리 로직 구현

## Tasks

- `CompetitionService.withdrawTeam()`: 3단계 연쇄 처리 (선수 탈퇴 → 경기 몰수 → 대진표 업데이트)
- `TeamWithdrawalResult` DTO: 처리 결과 반환 (탈퇴 선수 수, 몰수 경기 수, 대진표 업데이트 수)
- `WithdrawTeamRequest`: 탈퇴 사유 입력 DTO (@NotBlank 검증)
- `CompetitionAdminController`: `POST /{id}/teams/{teamId}/withdraw` 엔드포인트
- Service/Controller 단위 테스트 추가
- 누락 분기 커버리지 테스트 추가

## To Reviewer

- Rich Domain Model 패턴: `CompetitionPlayer.withdraw()`, `Game.forfeit()`, `BracketEntry.recordWinner()` 등 기존 도메인 메서드 활용
- IN_PROGRESS 상태가 아닌 대회에서는 `InvalidCompetitionStateException` 발생