### PR TITLE
feat(#267): 시즌 종료 → 다음 시즌 준비 워크플로우

### DIFF
--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminController.kt
@@ -2,10 +2,14 @@ package com.nextup.backoffice.controller.competition
 
 import com.nextup.backoffice.dto.competition.CompetitionAdminResponse
 import com.nextup.backoffice.dto.competition.CreateCompetitionRequest
+import com.nextup.backoffice.dto.competition.PrepareNextSeasonRequest
 import com.nextup.backoffice.dto.competition.UpdateCompetitionRequest
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.service.competition.CompetitionService
+import com.nextup.core.service.competition.SeasonTransitionService
+import com.nextup.core.service.competition.dto.NextSeasonPreparationResult
+import com.nextup.core.service.competition.dto.SeasonSummaryDto
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -29,6 +33,7 @@ import java.time.LocalDate
 @RequestMapping("/api/backoffice/competitions")
 class CompetitionAdminController(
     private val competitionService: CompetitionService,
+    private val seasonTransitionService: SeasonTransitionService,
 ) {
     /**
      * 모든 대회 목록을 조회합니다.
@@ -155,5 +160,41 @@ class CompetitionAdminController(
     ): ApiResponse<CompetitionAdminResponse> {
         val competition = competitionService.postpone(id)
         return ApiResponse.success(CompetitionAdminResponse.from(competition))
+    }
+
+    /**
+     * 완료된 대회의 시즌 요약을 조회합니다.
+     *
+     * 최종 순위, 참가 팀/선수 통계를 반환합니다.
+     */
+    @GetMapping("/{id}/season-summary")
+    fun getSeasonSummary(
+        @PathVariable id: Long,
+    ): ApiResponse<SeasonSummaryDto> {
+        val summary = seasonTransitionService.getSeasonSummary(id)
+        return ApiResponse.success(summary)
+    }
+
+    /**
+     * 완료된 대회를 기반으로 다음 시즌 대회를 준비합니다.
+     *
+     * 이전 시즌 활성 선수를 자동 등록합니다.
+     */
+    @PostMapping("/{id}/prepare-next-season")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun prepareNextSeason(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: PrepareNextSeasonRequest,
+    ): ApiResponse<NextSeasonPreparationResult> {
+        val result =
+            seasonTransitionService.prepareNextSeason(
+                previousCompetitionId = id,
+                name = request.name,
+                startDate = request.startDate,
+                endDate = request.endDate,
+                description = request.description,
+                maxTeams = request.maxTeams,
+            )
+        return ApiResponse.success(result)
     }
 }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/PrepareNextSeasonRequest.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/competition/PrepareNextSeasonRequest.kt
@@ -1,0 +1,18 @@
+package com.nextup.backoffice.dto.competition
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+/**
+ * 다음 시즌 준비 요청 DTO
+ */
+data class PrepareNextSeasonRequest(
+    @field:NotBlank(message = "대회 이름은 필수입니다")
+    val name: String,
+    @field:NotNull(message = "시작일은 필수입니다")
+    val startDate: LocalDate,
+    val endDate: LocalDate? = null,
+    val description: String? = null,
+    val maxTeams: Int? = null,
+)

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminControllerTest.kt
@@ -3,6 +3,7 @@ package com.nextup.backoffice.controller.competition
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.nextup.backoffice.dto.competition.CreateCompetitionRequest
+import com.nextup.backoffice.dto.competition.PrepareNextSeasonRequest
 import com.nextup.backoffice.dto.competition.UpdateCompetitionRequest
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
@@ -10,6 +11,10 @@ import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
 import com.nextup.core.service.competition.CompetitionService
+import com.nextup.core.service.competition.SeasonTransitionService
+import com.nextup.core.service.competition.dto.NextSeasonPreparationResult
+import com.nextup.core.service.competition.dto.SeasonSummaryDto
+import com.nextup.core.service.standings.dto.TeamStandingDto
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -25,19 +30,22 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
 import java.time.LocalDate
 
 @DisplayName("CompetitionAdminController")
 class CompetitionAdminControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var competitionService: CompetitionService
+    private lateinit var seasonTransitionService: SeasonTransitionService
     private lateinit var controller: CompetitionAdminController
     private lateinit var objectMapper: ObjectMapper
 
     @BeforeEach
     fun setUp() {
         competitionService = mockk()
-        controller = CompetitionAdminController(competitionService)
+        seasonTransitionService = mockk()
+        controller = CompetitionAdminController(competitionService, seasonTransitionService)
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
         objectMapper = ObjectMapper().registerModule(JavaTimeModule())
     }
@@ -254,6 +262,124 @@ class CompetitionAdminControllerTest {
                 .andExpect(jsonPath("$.data.status").value("COMPLETED"))
 
             verify(exactly = 1) { competitionService.complete(1L, any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/backoffice/competitions/{id}/season-summary")
+    inner class GetSeasonSummary {
+        @Test
+        fun `should return season summary for completed competition`() {
+            // given
+            val summary =
+                SeasonSummaryDto(
+                    competitionId = 1L,
+                    competitionName = "2025 춘계대회",
+                    year = 2025,
+                    season = 1,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    endDate = LocalDate.of(2025, 6, 30),
+                    totalTeams = 2,
+                    totalPlayers = 30,
+                    finalStandings =
+                        listOf(
+                            TeamStandingDto(
+                                rank = 1,
+                                teamId = 1L,
+                                teamName = "한강 타이거즈",
+                                gamesPlayed = 10,
+                                remainingGames = 0,
+                                wins = 8,
+                                losses = 2,
+                                draws = 0,
+                                winningPercentage = BigDecimal("0.800"),
+                                gamesBehind = BigDecimal.ZERO,
+                                runsScored = 50,
+                                runsAllowed = 30,
+                                runDifferential = 20,
+                            ),
+                        ),
+                )
+
+            every { seasonTransitionService.getSeasonSummary(1L) } returns summary
+
+            // when & then
+            mockMvc
+                .perform(get("/api/backoffice/competitions/1/season-summary"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.competitionId").value(1))
+                .andExpect(jsonPath("$.data.competitionName").value("2025 춘계대회"))
+                .andExpect(jsonPath("$.data.totalTeams").value(2))
+                .andExpect(jsonPath("$.data.totalPlayers").value(30))
+                .andExpect(jsonPath("$.data.finalStandings[0].rank").value(1))
+
+            verify(exactly = 1) { seasonTransitionService.getSeasonSummary(1L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/backoffice/competitions/{id}/prepare-next-season")
+    inner class PrepareNextSeason {
+        @Test
+        fun `should prepare next season successfully`() {
+            // given
+            val request =
+                PrepareNextSeasonRequest(
+                    name = "2025 추계대회",
+                    startDate = LocalDate.of(2025, 9, 1),
+                    endDate = LocalDate.of(2025, 11, 30),
+                    description = "2025년 추계 시즌",
+                )
+            val result =
+                NextSeasonPreparationResult(
+                    newCompetitionId = 2L,
+                    newCompetitionName = "2025 추계대회",
+                    year = 2025,
+                    season = 2,
+                    previousCompetitionId = 1L,
+                    registeredTeamCount = 4,
+                    registeredPlayerCount = 60,
+                    skippedPlayerCount = 5,
+                )
+
+            every {
+                seasonTransitionService.prepareNextSeason(
+                    previousCompetitionId = 1L,
+                    name = "2025 추계대회",
+                    startDate = LocalDate.of(2025, 9, 1),
+                    endDate = LocalDate.of(2025, 11, 30),
+                    description = "2025년 추계 시즌",
+                    maxTeams = null,
+                )
+            } returns result
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/backoffice/competitions/1/prepare-next-season")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.newCompetitionId").value(2))
+                .andExpect(jsonPath("$.data.newCompetitionName").value("2025 추계대회"))
+                .andExpect(jsonPath("$.data.year").value(2025))
+                .andExpect(jsonPath("$.data.season").value(2))
+                .andExpect(jsonPath("$.data.registeredTeamCount").value(4))
+                .andExpect(jsonPath("$.data.registeredPlayerCount").value(60))
+                .andExpect(jsonPath("$.data.skippedPlayerCount").value(5))
+
+            verify(exactly = 1) {
+                seasonTransitionService.prepareNextSeason(
+                    previousCompetitionId = 1L,
+                    name = "2025 추계대회",
+                    startDate = LocalDate.of(2025, 9, 1),
+                    endDate = LocalDate.of(2025, 11, 30),
+                    description = "2025년 추계 시즌",
+                    maxTeams = null,
+                )
+            }
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/competition/SeasonTransitionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/competition/SeasonTransitionService.kt
@@ -1,0 +1,148 @@
+package com.nextup.core.service.competition
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidCompetitionStateException
+import com.nextup.core.domain.competition.CompetitionPlayer
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.service.competition.dto.NextSeasonPreparationResult
+import com.nextup.core.service.competition.dto.SeasonSummaryDto
+import com.nextup.core.service.standings.StandingsService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+/**
+ * 시즌 전환 서비스
+ *
+ * 시즌 종료 후 요약 조회, 다음 시즌 대회 생성 및 선수 재등록을 처리합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class SeasonTransitionService(
+    private val competitionRepository: CompetitionRepositoryPort,
+    private val competitionPlayerRepository: CompetitionPlayerRepositoryPort,
+    private val standingsService: StandingsService,
+    private val competitionService: CompetitionService,
+) {
+    /**
+     * 완료된 대회의 시즌 요약을 조회합니다.
+     *
+     * 최종 순위, 참가 팀/선수 통계를 반환합니다.
+     */
+    fun getSeasonSummary(competitionId: Long): SeasonSummaryDto {
+        val competition =
+            competitionRepository.findByIdWithLeague(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        if (competition.status != CompetitionStatus.COMPLETED) {
+            throw InvalidCompetitionStateException(
+                "Season summary is only available for completed competitions",
+            )
+        }
+
+        val standings = standingsService.getStandings(competitionId)
+        val players = competitionPlayerRepository.findByCompetitionId(competitionId)
+        val teamIds = players.map { it.team.id }.distinct()
+
+        return SeasonSummaryDto(
+            competitionId = competition.id,
+            competitionName = competition.name,
+            year = competition.year,
+            season = competition.season,
+            startDate = competition.startDate,
+            endDate = competition.endDate,
+            totalTeams = teamIds.size,
+            totalPlayers = players.size,
+            finalStandings = standings.standings,
+        )
+    }
+
+    /**
+     * 다음 시즌 대회를 준비합니다.
+     *
+     * 이전 시즌의 참가 팀/선수를 기반으로 새 대회를 생성하고,
+     * 이전 시즌 활성(ACTIVE) 선수를 자동 등록합니다.
+     * 탈퇴(WITHDRAWN)/정지(SUSPENDED) 선수는 제외됩니다.
+     */
+    @Transactional
+    fun prepareNextSeason(
+        previousCompetitionId: Long,
+        name: String,
+        startDate: LocalDate,
+        endDate: LocalDate? = null,
+        description: String? = null,
+        maxTeams: Int? = null,
+    ): NextSeasonPreparationResult {
+        val previousCompetition =
+            competitionRepository.findByIdWithLeague(previousCompetitionId)
+                ?: throw CompetitionNotFoundException(previousCompetitionId)
+
+        if (previousCompetition.status != CompetitionStatus.COMPLETED) {
+            throw InvalidCompetitionStateException(
+                "Next season can only be prepared from a completed competition",
+            )
+        }
+
+        // 다음 시즌 번호 결정 (같은 연도 내 시즌 증가 또는 다음 해 시즌 1)
+        val nextYear = if (startDate.year > previousCompetition.year) startDate.year else previousCompetition.year
+        val nextSeason =
+            if (nextYear > previousCompetition.year) {
+                1
+            } else {
+                previousCompetition.season + 1
+            }
+
+        // 새 대회 생성
+        val newCompetition =
+            competitionService.create(
+                leagueId = previousCompetition.league.id,
+                name = name,
+                year = nextYear,
+                season = nextSeason,
+                type = previousCompetition.type,
+                startDate = startDate,
+                endDate = endDate,
+                description = description,
+                maxTeams = maxTeams ?: previousCompetition.maxTeams,
+            )
+
+        // 이전 시즌 활성 선수 조회
+        val activePlayers =
+            competitionPlayerRepository.findByCompetitionIdAndStatus(
+                previousCompetitionId,
+                CompetitionPlayerStatus.ACTIVE,
+            )
+
+        // 이전 시즌의 전체 선수 수 (스킵된 선수 수 계산용)
+        val allPreviousPlayers =
+            competitionPlayerRepository.findByCompetitionId(previousCompetitionId)
+        val skippedCount = allPreviousPlayers.size - activePlayers.size
+
+        // 활성 선수를 새 대회에 등록
+        val newRegistrations =
+            activePlayers.map { previousPlayer ->
+                CompetitionPlayer.register(
+                    competition = newCompetition,
+                    team = previousPlayer.team,
+                    player = previousPlayer.player,
+                )
+            }
+        competitionPlayerRepository.saveAll(newRegistrations)
+
+        val registeredTeamIds = newRegistrations.map { it.team.id }.distinct()
+
+        return NextSeasonPreparationResult(
+            newCompetitionId = newCompetition.id,
+            newCompetitionName = newCompetition.name,
+            year = nextYear,
+            season = nextSeason,
+            previousCompetitionId = previousCompetitionId,
+            registeredTeamCount = registeredTeamIds.size,
+            registeredPlayerCount = newRegistrations.size,
+            skippedPlayerCount = skippedCount,
+        )
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/competition/dto/NextSeasonPreparationResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/competition/dto/NextSeasonPreparationResult.kt
@@ -1,0 +1,15 @@
+package com.nextup.core.service.competition.dto
+
+/**
+ * 다음 시즌 준비 결과 DTO
+ */
+data class NextSeasonPreparationResult(
+    val newCompetitionId: Long,
+    val newCompetitionName: String,
+    val year: Int,
+    val season: Int,
+    val previousCompetitionId: Long,
+    val registeredTeamCount: Int,
+    val registeredPlayerCount: Int,
+    val skippedPlayerCount: Int,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/competition/dto/SeasonSummaryDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/competition/dto/SeasonSummaryDto.kt
@@ -1,0 +1,21 @@
+package com.nextup.core.service.competition.dto
+
+import com.nextup.core.service.standings.dto.TeamStandingDto
+import java.time.LocalDate
+
+/**
+ * 시즌 종료 요약 DTO
+ *
+ * 완료된 대회의 최종 순위, 참가 팀/선수 수 등을 포함합니다.
+ */
+data class SeasonSummaryDto(
+    val competitionId: Long,
+    val competitionName: String,
+    val year: Int,
+    val season: Int,
+    val startDate: LocalDate,
+    val endDate: LocalDate?,
+    val totalTeams: Int,
+    val totalPlayers: Int,
+    val finalStandings: List<TeamStandingDto>,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/competition/SeasonTransitionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/competition/SeasonTransitionServiceTest.kt
@@ -1,0 +1,395 @@
+package com.nextup.core.service.competition
+
+import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.common.exception.InvalidCompetitionStateException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionPlayer
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
+import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.service.standings.StandingsService
+import com.nextup.core.service.standings.dto.StandingsDto
+import com.nextup.core.service.standings.dto.TeamStandingDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("SeasonTransitionService")
+class SeasonTransitionServiceTest {
+    private lateinit var competitionRepository: CompetitionRepositoryPort
+    private lateinit var competitionPlayerRepository: CompetitionPlayerRepositoryPort
+    private lateinit var standingsService: StandingsService
+    private lateinit var competitionService: CompetitionService
+    private lateinit var seasonTransitionService: SeasonTransitionService
+
+    @BeforeEach
+    fun setUp() {
+        competitionRepository = mockk()
+        competitionPlayerRepository = mockk()
+        standingsService = mockk()
+        competitionService = mockk()
+        seasonTransitionService =
+            SeasonTransitionService(
+                competitionRepository,
+                competitionPlayerRepository,
+                standingsService,
+                competitionService,
+            )
+    }
+
+    @Nested
+    @DisplayName("getSeasonSummary")
+    inner class GetSeasonSummary {
+        @Test
+        fun `should return season summary for completed competition`() {
+            // given
+            val competition = createCompletedCompetition(1L)
+            val standings = createStandings(1L)
+            val players = createCompetitionPlayers(competition, 3)
+
+            every { competitionRepository.findByIdWithLeague(1L) } returns competition
+            every { standingsService.getStandings(1L) } returns standings
+            every { competitionPlayerRepository.findByCompetitionId(1L) } returns players
+
+            // when
+            val result = seasonTransitionService.getSeasonSummary(1L)
+
+            // then
+            assertThat(result.competitionId).isEqualTo(1L)
+            assertThat(result.competitionName).isEqualTo("2025 춘계대회")
+            assertThat(result.year).isEqualTo(2025)
+            assertThat(result.season).isEqualTo(1)
+            assertThat(result.totalPlayers).isEqualTo(3)
+            assertThat(result.finalStandings).hasSize(2)
+        }
+
+        @Test
+        fun `should throw exception when competition not found`() {
+            // given
+            every { competitionRepository.findByIdWithLeague(999L) } returns null
+
+            // when & then
+            assertThatThrownBy { seasonTransitionService.getSeasonSummary(999L) }
+                .isInstanceOf(CompetitionNotFoundException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when competition is not completed`() {
+            // given
+            val competition = createInProgressCompetition(1L)
+            every { competitionRepository.findByIdWithLeague(1L) } returns competition
+
+            // when & then
+            assertThatThrownBy { seasonTransitionService.getSeasonSummary(1L) }
+                .isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("prepareNextSeason")
+    inner class PrepareNextSeason {
+        @Test
+        fun `should prepare next season with active players from previous season`() {
+            // given
+            val previousCompetition = createCompletedCompetition(1L)
+            val activePlayers = createCompetitionPlayers(previousCompetition, 5)
+            val withdrawnPlayer =
+                createCompetitionPlayer(previousCompetition, 6L, "탈퇴선수").apply {
+                    withdraw()
+                }
+            val allPlayers = activePlayers + withdrawnPlayer
+
+            val newCompetition = createScheduledCompetition(2L, "2025 추계대회", 2025, 2)
+
+            every { competitionRepository.findByIdWithLeague(1L) } returns previousCompetition
+            every {
+                competitionService.create(
+                    leagueId = any(),
+                    name = "2025 추계대회",
+                    year = 2025,
+                    season = 2,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 9, 1),
+                    endDate = null,
+                    description = null,
+                    maxTeams = any(),
+                )
+            } returns newCompetition
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndStatus(
+                    1L,
+                    CompetitionPlayerStatus.ACTIVE,
+                )
+            } returns activePlayers
+            every { competitionPlayerRepository.findByCompetitionId(1L) } returns allPlayers
+            every { competitionPlayerRepository.saveAll(any()) } answers { firstArg() }
+
+            // when
+            val result =
+                seasonTransitionService.prepareNextSeason(
+                    previousCompetitionId = 1L,
+                    name = "2025 추계대회",
+                    startDate = LocalDate.of(2025, 9, 1),
+                )
+
+            // then
+            assertThat(result.newCompetitionId).isEqualTo(2L)
+            assertThat(result.newCompetitionName).isEqualTo("2025 추계대회")
+            assertThat(result.year).isEqualTo(2025)
+            assertThat(result.season).isEqualTo(2)
+            assertThat(result.registeredPlayerCount).isEqualTo(5)
+            assertThat(result.skippedPlayerCount).isEqualTo(1)
+
+            verify(exactly = 1) { competitionPlayerRepository.saveAll(any()) }
+        }
+
+        @Test
+        fun `should prepare next year season when start date is next year`() {
+            // given
+            val previousCompetition = createCompletedCompetition(1L)
+            val newCompetition = createScheduledCompetition(2L, "2026 춘계대회", 2026, 1)
+
+            every { competitionRepository.findByIdWithLeague(1L) } returns previousCompetition
+            every {
+                competitionService.create(
+                    leagueId = any(),
+                    name = "2026 춘계대회",
+                    year = 2026,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2026, 3, 1),
+                    endDate = null,
+                    description = null,
+                    maxTeams = any(),
+                )
+            } returns newCompetition
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+            every { competitionPlayerRepository.findByCompetitionId(1L) } returns emptyList()
+            every { competitionPlayerRepository.saveAll(any()) } answers { firstArg() }
+
+            // when
+            val result =
+                seasonTransitionService.prepareNextSeason(
+                    previousCompetitionId = 1L,
+                    name = "2026 춘계대회",
+                    startDate = LocalDate.of(2026, 3, 1),
+                )
+
+            // then
+            assertThat(result.year).isEqualTo(2026)
+            assertThat(result.season).isEqualTo(1)
+            assertThat(result.registeredPlayerCount).isEqualTo(0)
+            assertThat(result.skippedPlayerCount).isEqualTo(0)
+        }
+
+        @Test
+        fun `should throw exception when previous competition is not completed`() {
+            // given
+            val competition = createInProgressCompetition(1L)
+            every { competitionRepository.findByIdWithLeague(1L) } returns competition
+
+            // when & then
+            assertThatThrownBy {
+                seasonTransitionService.prepareNextSeason(
+                    previousCompetitionId = 1L,
+                    name = "다음 시즌",
+                    startDate = LocalDate.of(2025, 9, 1),
+                )
+            }.isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when previous competition not found`() {
+            // given
+            every { competitionRepository.findByIdWithLeague(999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                seasonTransitionService.prepareNextSeason(
+                    previousCompetitionId = 999L,
+                    name = "다음 시즌",
+                    startDate = LocalDate.of(2025, 9, 1),
+                )
+            }.isInstanceOf(CompetitionNotFoundException::class.java)
+        }
+    }
+
+    // --- Helper methods ---
+
+    private fun createCompletedCompetition(id: Long): Competition {
+        val league = createLeague()
+        return Competition(
+            league = league,
+            name = "2025 춘계대회",
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            endDate = LocalDate.of(2025, 6, 30),
+            status = CompetitionStatus.COMPLETED,
+        ).apply {
+            setId(this, id)
+        }
+    }
+
+    private fun createInProgressCompetition(id: Long): Competition =
+        Competition(
+            league = createLeague(),
+            name = "2025 춘계대회",
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            status = CompetitionStatus.IN_PROGRESS,
+        ).apply {
+            setId(this, id)
+        }
+
+    private fun createScheduledCompetition(
+        id: Long,
+        name: String,
+        year: Int,
+        season: Int,
+    ): Competition =
+        Competition(
+            league = createLeague(),
+            name = name,
+            year = year,
+            season = season,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(year, 3, 1),
+        ).apply {
+            setId(this, id)
+        }
+
+    private fun createLeague(): League {
+        val association =
+            Association(
+                name = "서울시야구협회",
+                abbreviation = null,
+                region = "서울",
+                description = null,
+                logoUrl = null,
+                websiteUrl = null,
+            ).apply { setId(this, 1L) }
+        return League(
+            association = association,
+            name = "1부 리그",
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null,
+        ).apply { setId(this, 1L) }
+    }
+
+    private fun createCompetitionPlayers(
+        competition: Competition,
+        count: Int,
+    ): List<CompetitionPlayer> {
+        val team = createTeam(1L, "한강 타이거즈")
+        return (1..count).map { i ->
+            createCompetitionPlayer(competition, i.toLong(), "선수$i", team)
+        }
+    }
+
+    private fun createCompetitionPlayer(
+        competition: Competition,
+        playerId: Long,
+        playerName: String,
+        team: Team = createTeam(1L, "한강 타이거즈"),
+    ): CompetitionPlayer {
+        val player = createPlayer(playerId, playerName)
+        return CompetitionPlayer.register(competition, team, player).apply {
+            setId(this, playerId)
+        }
+    }
+
+    private fun createTeam(
+        id: Long,
+        name: String,
+    ): Team =
+        Team(
+            league = createLeague(),
+            name = name,
+            city = "서울",
+            foundedYear = 2020,
+        ).apply { setId(this, id) }
+
+    private fun createPlayer(
+        id: Long,
+        name: String,
+    ): Player =
+        Player(
+            name = name,
+            primaryPosition = Position.STARTING_PITCHER,
+        ).apply { setId(this, id) }
+
+    private fun createStandings(competitionId: Long): StandingsDto =
+        StandingsDto(
+            competitionId = competitionId,
+            competitionName = "2025 춘계대회",
+            totalGamesPerTeam = 10,
+            standings =
+                listOf(
+                    TeamStandingDto(
+                        rank = 1,
+                        teamId = 1L,
+                        teamName = "한강 타이거즈",
+                        gamesPlayed = 10,
+                        remainingGames = 0,
+                        wins = 8,
+                        losses = 2,
+                        draws = 0,
+                        winningPercentage = BigDecimal("0.800"),
+                        gamesBehind = BigDecimal.ZERO,
+                        runsScored = 50,
+                        runsAllowed = 30,
+                        runDifferential = 20,
+                    ),
+                    TeamStandingDto(
+                        rank = 2,
+                        teamId = 2L,
+                        teamName = "잠실 베어스",
+                        gamesPlayed = 10,
+                        remainingGames = 0,
+                        wins = 5,
+                        losses = 5,
+                        draws = 0,
+                        winningPercentage = BigDecimal("0.500"),
+                        gamesBehind = BigDecimal("3.0"),
+                        runsScored = 40,
+                        runsAllowed = 40,
+                        runDifferential = 0,
+                    ),
+                ),
+            lastUpdated = LocalDateTime.now(),
+        )
+
+    private fun setId(
+        entity: Any,
+        id: Long,
+    ) {
+        val idField = entity::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(entity, id)
+    }
+}


### PR DESCRIPTION
## Summary

> - Closes #267

**시즌 종료 후 다음 시즌을 준비하는 워크플로우 구현. 완료된 대회의 최종 순위/통계 요약 조회 및 이전 시즌 기반 다음 시즌 대회 자동 생성과 선수 재등록 기능을 제공합니다.**

## Tasks

- `SeasonTransitionService` 신규 생성 (Core): `getSeasonSummary()`, `prepareNextSeason()`
- `SeasonSummaryDto`, `NextSeasonPreparationResult` DTO 생성
- `PrepareNextSeasonRequest` Backoffice 요청 DTO 생성
- `CompetitionAdminController`에 엔드포인트 2개 추가 (`GET /{id}/season-summary`, `POST /{id}/prepare-next-season`)
- Service 테스트 6개, Controller 테스트 2개 추가

## To Reviewer

- WITHDRAWN/SUSPENDED 선수는 다음 시즌에 자동 등록되지 않음 (시즌 간 이적/탈퇴 반영)
- 시즌 스탯은 year 기반으로 별도 관리되므로 새 시즌 스탯은 자동으로 0부터 시작
- 다음 시즌 번호는 startDate 기준으로 자동 결정 (같은 해: season+1, 다음 해: season 1)