### PR TITLE
refactor(#278): Cross-Aggregate 트랜잭션 → 도메인 이벤트 기반 전환

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/ElectionCompletedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/ElectionCompletedEvent.kt
@@ -1,0 +1,15 @@
+package com.nextup.core.domain.event
+
+import com.nextup.core.domain.election.ElectionType
+
+/**
+ * 선거 완료 이벤트
+ *
+ * 선거가 완료되었을 때 발행됩니다.
+ * OWNER_ELECTION인 경우, 리스너에서 당선자에게 OWNER 권한을 이양합니다.
+ */
+data class ElectionCompletedEvent(
+    val electionId: Long,
+    val teamId: Long,
+    val electionType: ElectionType,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/election/ElectionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/election/ElectionService.kt
@@ -6,14 +6,13 @@ import com.nextup.common.exception.ElectionNotFoundException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.core.domain.election.Candidate
 import com.nextup.core.domain.election.Election
-import com.nextup.core.domain.election.ElectionType
 import com.nextup.core.domain.election.ElectionVote
-import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.domain.event.ElectionCompletedEvent
 import com.nextup.core.port.repository.CandidateRepositoryPort
 import com.nextup.core.port.repository.ElectionRepositoryPort
 import com.nextup.core.port.repository.ElectionVoteRepositoryPort
-import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.election.dto.*
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -28,7 +27,7 @@ class ElectionService(
     private val electionRepository: ElectionRepositoryPort,
     private val candidateRepository: CandidateRepositoryPort,
     private val electionVoteRepository: ElectionVoteRepositoryPort,
-    private val teamMemberRepository: TeamMemberRepositoryPort,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     /**
      * 선거를 생성합니다.
@@ -59,63 +58,22 @@ class ElectionService(
 
     /**
      * 선거를 완료합니다.
-     * OWNER_ELECTION인 경우, 단독 최다 득표자에게 자동으로 OWNER 권한을 이양합니다.
-     * 동률이거나 투표가 없으면 자동 이양하지 않습니다.
+     * 도메인 이벤트를 발행하여 OWNER_ELECTION의 경우 리스너에서 권한 이양을 처리합니다.
      */
     @Transactional
     fun completeElection(electionId: Long): ElectionResponse {
         val election = findElection(electionId)
         election.complete()
 
-        if (election.electionType == ElectionType.OWNER_ELECTION) {
-            transferOwnershipToWinner(election)
-        }
+        eventPublisher.publishEvent(
+            ElectionCompletedEvent(
+                electionId = election.id,
+                teamId = election.teamId,
+                electionType = election.electionType,
+            ),
+        )
 
         return election.toResponse()
-    }
-
-    /**
-     * OWNER 선거 완료 후 당선자에게 OWNER 권한을 자동 이양합니다.
-     * 동률이거나 투표가 없으면 이양하지 않습니다.
-     */
-    private fun transferOwnershipToWinner(election: Election) {
-        val voteCounts =
-            electionVoteRepository.countByElectionIdGroupByCandidateId(election.id)
-
-        // 투표가 없으면 이양하지 않음
-        if (voteCounts.isEmpty()) return
-
-        // 최다 득표수 확인
-        val maxVotes = voteCounts.values.max()
-        val topCandidates = voteCounts.filter { it.value == maxVotes }
-
-        // 동률이면 이양하지 않음
-        if (topCandidates.size > 1) return
-
-        val winnerCandidateId = topCandidates.keys.first()
-        val winnerCandidate =
-            candidateRepository.findById(winnerCandidateId) ?: return
-
-        val winner =
-            teamMemberRepository.findByIdOrNull(winnerCandidate.memberId) ?: return
-
-        // 당선자가 이미 OWNER이면 이양 불필요
-        if (winner.role == TeamMemberRole.OWNER) return
-
-        // 기존 OWNER를 MEMBER로 강등
-        val teamMembers =
-            teamMemberRepository.findByTeamId(election.teamId)
-        val currentOwner =
-            teamMembers.firstOrNull { it.role == TeamMemberRole.OWNER }
-
-        if (currentOwner != null) {
-            currentOwner.role = TeamMemberRole.MEMBER
-            teamMemberRepository.save(currentOwner)
-        }
-
-        // 당선자를 OWNER로 승격
-        winner.role = TeamMemberRole.OWNER
-        teamMemberRepository.save(winner)
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/election/ElectionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/election/ElectionServiceTest.kt
@@ -5,12 +5,10 @@ import com.nextup.common.exception.DuplicateVoteException
 import com.nextup.common.exception.ElectionNotFoundException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.core.domain.election.*
-import com.nextup.core.domain.team.TeamMember
-import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.domain.event.ElectionCompletedEvent
 import com.nextup.core.port.repository.CandidateRepositoryPort
 import com.nextup.core.port.repository.ElectionRepositoryPort
 import com.nextup.core.port.repository.ElectionVoteRepositoryPort
-import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.election.dto.*
 import io.mockk.every
 import io.mockk.mockk
@@ -21,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -29,7 +28,7 @@ class ElectionServiceTest {
     private lateinit var electionRepository: ElectionRepositoryPort
     private lateinit var candidateRepository: CandidateRepositoryPort
     private lateinit var electionVoteRepository: ElectionVoteRepositoryPort
-    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
+    private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var electionService: ElectionService
 
     @BeforeEach
@@ -37,13 +36,13 @@ class ElectionServiceTest {
         electionRepository = mockk()
         candidateRepository = mockk()
         electionVoteRepository = mockk()
-        teamMemberRepository = mockk()
+        eventPublisher = mockk(relaxed = true)
         electionService =
             ElectionService(
                 electionRepository,
                 candidateRepository,
                 electionVoteRepository,
-                teamMemberRepository,
+                eventPublisher,
             )
     }
 
@@ -198,107 +197,32 @@ class ElectionServiceTest {
     }
 
     @Nested
-    @DisplayName("completeElection - 자동 OWNER 이양")
-    inner class CompleteElectionOwnerTransfer {
+    @DisplayName("completeElection - 도메인 이벤트 발행")
+    inner class CompleteElectionEventPublishing {
         @Test
-        fun `OWNER_ELECTION 완료 시 단독 최다 득표자에게 OWNER 이양`() {
+        fun `OWNER_ELECTION 완료 시 ElectionCompletedEvent를 발행한다`() {
             // given
             val election = createTestOwnerElection(1L, ElectionStatus.IN_PROGRESS)
-            val winnerCandidate = createTestCandidate(10L, 1L, 100L, "김철수")
-            val currentOwner =
-                mockk<TeamMember>(relaxed = true) {
-                    every { id } returns 200L
-                    every { role } returns TeamMemberRole.OWNER
-                }
-            val winner =
-                mockk<TeamMember>(relaxed = true) {
-                    every { id } returns 100L
-                    every { role } returns TeamMemberRole.MEMBER
-                }
-
             every { electionRepository.findById(1L) } returns election
-            every {
-                electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
-            } returns mapOf(10L to 5L, 11L to 3L)
-            every { candidateRepository.findById(10L) } returns winnerCandidate
-            every { teamMemberRepository.findByIdOrNull(100L) } returns winner
-            every { teamMemberRepository.findByTeamId(1L) } returns listOf(currentOwner, winner)
-            every { teamMemberRepository.save(any()) } answers { firstArg() }
 
             // when
             val result = electionService.completeElection(1L)
 
             // then
             assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
-            verify { winner.role = TeamMemberRole.OWNER }
-            verify { currentOwner.role = TeamMemberRole.MEMBER }
-            verify(exactly = 2) { teamMemberRepository.save(any()) }
+            verify {
+                eventPublisher.publishEvent(
+                    ElectionCompletedEvent(
+                        electionId = 1L,
+                        teamId = 1L,
+                        electionType = ElectionType.OWNER_ELECTION,
+                    ),
+                )
+            }
         }
 
         @Test
-        fun `OWNER_ELECTION 동률이면 자동 이양하지 않음`() {
-            // given
-            val election = createTestOwnerElection(1L, ElectionStatus.IN_PROGRESS)
-
-            every { electionRepository.findById(1L) } returns election
-            every {
-                electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
-            } returns mapOf(10L to 5L, 11L to 5L)
-
-            // when
-            val result = electionService.completeElection(1L)
-
-            // then
-            assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
-            verify(exactly = 0) { teamMemberRepository.save(any()) }
-        }
-
-        @Test
-        fun `OWNER_ELECTION 투표가 없으면 자동 이양하지 않음`() {
-            // given
-            val election = createTestOwnerElection(1L, ElectionStatus.IN_PROGRESS)
-
-            every { electionRepository.findById(1L) } returns election
-            every {
-                electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
-            } returns emptyMap()
-
-            // when
-            val result = electionService.completeElection(1L)
-
-            // then
-            assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
-            verify(exactly = 0) { teamMemberRepository.save(any()) }
-        }
-
-        @Test
-        fun `당선자가 이미 OWNER이면 이양하지 않음`() {
-            // given
-            val election = createTestOwnerElection(1L, ElectionStatus.IN_PROGRESS)
-            val winnerCandidate = createTestCandidate(10L, 1L, 100L, "김철수")
-            val winner =
-                mockk<TeamMember>(relaxed = true) {
-                    every { id } returns 100L
-                    every { role } returns TeamMemberRole.OWNER
-                }
-
-            every { electionRepository.findById(1L) } returns election
-            every {
-                electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
-            } returns mapOf(10L to 5L)
-            every { candidateRepository.findById(10L) } returns winnerCandidate
-            every { teamMemberRepository.findByIdOrNull(100L) } returns winner
-
-            // when
-            val result = electionService.completeElection(1L)
-
-            // then
-            assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
-            verify(exactly = 0) { teamMemberRepository.save(any()) }
-        }
-
-        @Test
-        fun `CAPTAIN_ELECTION이면 자동 이양하지 않음`() {
+        fun `CAPTAIN_ELECTION 완료 시에도 ElectionCompletedEvent를 발행한다`() {
             // given
             val election = createTestElection(1L, ElectionStatus.IN_PROGRESS)
             every { electionRepository.findById(1L) } returns election
@@ -308,36 +232,15 @@ class ElectionServiceTest {
 
             // then
             assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
-            verify(exactly = 0) { teamMemberRepository.save(any()) }
-        }
-
-        @Test
-        fun `기존 OWNER가 없어도 당선자에게 OWNER 부여`() {
-            // given
-            val election = createTestOwnerElection(1L, ElectionStatus.IN_PROGRESS)
-            val winnerCandidate = createTestCandidate(10L, 1L, 100L, "김철수")
-            val winner =
-                mockk<TeamMember>(relaxed = true) {
-                    every { id } returns 100L
-                    every { role } returns TeamMemberRole.MEMBER
-                }
-
-            every { electionRepository.findById(1L) } returns election
-            every {
-                electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
-            } returns mapOf(10L to 5L)
-            every { candidateRepository.findById(10L) } returns winnerCandidate
-            every { teamMemberRepository.findByIdOrNull(100L) } returns winner
-            every { teamMemberRepository.findByTeamId(1L) } returns listOf(winner)
-            every { teamMemberRepository.save(any()) } answers { firstArg() }
-
-            // when
-            val result = electionService.completeElection(1L)
-
-            // then
-            assertThat(result.status).isEqualTo(ElectionStatus.COMPLETED)
-            verify { winner.role = TeamMemberRole.OWNER }
-            verify(exactly = 1) { teamMemberRepository.save(any()) }
+            verify {
+                eventPublisher.publishEvent(
+                    ElectionCompletedEvent(
+                        electionId = 1L,
+                        teamId = 1L,
+                        electionType = ElectionType.CAPTAIN_ELECTION,
+                    ),
+                )
+            }
         }
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/ElectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/ElectionEventListener.kt
@@ -1,0 +1,94 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.core.domain.election.ElectionType
+import com.nextup.core.domain.event.ElectionCompletedEvent
+import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.port.repository.CandidateRepositoryPort
+import com.nextup.core.port.repository.ElectionVoteRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * 선거 완료 이벤트 리스너
+ *
+ * OWNER_ELECTION 완료 시 당선자에게 OWNER 권한을 이양합니다.
+ * Election Aggregate와 TeamMember Aggregate의 변경을 분리합니다.
+ */
+@Component
+class ElectionEventListener(
+    private val electionVoteRepository: ElectionVoteRepositoryPort,
+    private val candidateRepository: CandidateRepositoryPort,
+    private val teamMemberRepository: TeamMemberRepositoryPort,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * 선거 완료 이벤트를 수신하여 OWNER 권한을 이양합니다.
+     * 동률이거나 투표가 없으면 이양하지 않습니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional
+    fun onElectionCompleted(event: ElectionCompletedEvent) {
+        if (event.electionType != ElectionType.OWNER_ELECTION) {
+            log.debug("선거 완료 이벤트 무시 (OWNER_ELECTION이 아님): electionId={}", event.electionId)
+            return
+        }
+
+        log.info("OWNER 선거 완료 이벤트 수신: electionId={}, teamId={}", event.electionId, event.teamId)
+        transferOwnershipToWinner(event.electionId, event.teamId)
+    }
+
+    private fun transferOwnershipToWinner(
+        electionId: Long,
+        teamId: Long,
+    ) {
+        val voteCounts =
+            electionVoteRepository.countByElectionIdGroupByCandidateId(electionId)
+
+        // 투표가 없으면 이양하지 않음
+        if (voteCounts.isEmpty()) {
+            log.info("투표가 없어 OWNER 이양 생략: electionId={}", electionId)
+            return
+        }
+
+        // 최다 득표수 확인
+        val maxVotes = voteCounts.values.max()
+        val topCandidates = voteCounts.filter { it.value == maxVotes }
+
+        // 동률이면 이양하지 않음
+        if (topCandidates.size > 1) {
+            log.info("동률로 OWNER 이양 생략: electionId={}, 후보수={}", electionId, topCandidates.size)
+            return
+        }
+
+        val winnerCandidateId = topCandidates.keys.first()
+        val winnerCandidate = candidateRepository.findById(winnerCandidateId) ?: return
+
+        val winner = teamMemberRepository.findByIdOrNull(winnerCandidate.memberId) ?: return
+
+        // 당선자가 이미 OWNER이면 이양 불필요
+        if (winner.role == TeamMemberRole.OWNER) {
+            log.info("당선자가 이미 OWNER: electionId={}, memberId={}", electionId, winnerCandidate.memberId)
+            return
+        }
+
+        // 기존 OWNER를 MEMBER로 강등
+        val teamMembers = teamMemberRepository.findByTeamId(teamId)
+        val currentOwner = teamMembers.firstOrNull { it.role == TeamMemberRole.OWNER }
+
+        if (currentOwner != null) {
+            currentOwner.role = TeamMemberRole.MEMBER
+            teamMemberRepository.save(currentOwner)
+            log.info("기존 OWNER 강등: memberId={}", currentOwner.id)
+        }
+
+        // 당선자를 OWNER로 승격
+        winner.role = TeamMemberRole.OWNER
+        teamMemberRepository.save(winner)
+        log.info("당선자 OWNER 승격: electionId={}, memberId={}", electionId, winnerCandidate.memberId)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamDashboardServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamDashboardServiceImpl.kt
@@ -9,6 +9,7 @@ import com.nextup.core.port.attendance.AttendancePollRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.standings.StandingsService
 import com.nextup.core.service.team.TeamDashboardService
 import com.nextup.core.service.team.TeamMembershipService
 import com.nextup.core.service.team.dto.GameSummaryForDashboardDto
@@ -17,6 +18,7 @@ import com.nextup.core.service.team.dto.StandingEntryDto
 import com.nextup.core.service.team.dto.TeamDashboardDto
 import com.nextup.core.service.team.dto.TeamStatsSummaryDto
 import com.nextup.core.service.team.dto.TeamSummaryDto
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -37,7 +39,9 @@ class TeamDashboardServiceImpl(
     private val gameTeamRepository: GameTeamRepositoryPort,
     private val teamMembershipService: TeamMembershipService,
     private val attendancePollRepository: AttendancePollRepositoryPort,
+    private val standingsService: StandingsService,
 ) : TeamDashboardService {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
         private const val RECENT_RESULTS_LIMIT = 5
@@ -156,6 +160,7 @@ class TeamDashboardServiceImpl(
     /**
      * 팀이 참여 중인 가장 최근 대회에서의 순위 정보를 조회합니다.
      *
+     * StandingsService에 위임하여 순위 계산 로직 중복을 제거합니다.
      * 팀이 여러 대회에 참여 중인 경우 가장 많은 경기를 치른 대회를 기준으로 합니다.
      */
     private fun resolveStanding(
@@ -173,114 +178,29 @@ class TeamDashboardServiceImpl(
         val primaryCompetitionId =
             competitionGameCounts.maxByOrNull { it.value }?.key ?: return null
 
-        // 해당 대회의 모든 GameTeam 조회
-        val competitionGameTeams = gameTeamRepository.findAllByCompetitionId(primaryCompetitionId)
-        val decidedGameTeams =
-            gameTeamRepository.findAllByCompetitionIdWithDecidedResult(primaryCompetitionId)
+        // StandingsService에 위임하여 순위 조회
+        return try {
+            val standings = standingsService.getStandings(primaryCompetitionId)
+            val teamStanding =
+                standings.standings.firstOrNull { it.teamId == teamId }
+                    ?: return null
 
-        if (competitionGameTeams.isEmpty()) return null
-
-        // 대회명 추출
-        val competitionName =
-            competitionGameTeams
-                .firstOrNull()
-                ?.game
-                ?.competition
-                ?.name ?: return null
-
-        // 대회 참여 팀 ID 목록
-        val allTeamIds = competitionGameTeams.map { it.team.id }.distinct()
-
-        // 팀별 성적 계산
-        val teamStatsMap = calculateTeamStatsForStanding(decidedGameTeams, competitionGameTeams)
-
-        // 정렬 (승률 DESC, 득실차 DESC, 득점 DESC)
-        val sortedStats =
-            allTeamIds
-                .mapNotNull { id -> teamStatsMap[id] }
-                .sortedWith(
-                    compareByDescending<TeamStandingStats> { it.winningPercentage }
-                        .thenByDescending { it.runDifferential }
-                        .thenByDescending { it.runsScored },
-                )
-
-        // 해당 팀의 순위 찾기
-        val teamIndex = sortedStats.indexOfFirst { it.teamId == teamId }
-        if (teamIndex < 0) return null
-
-        val teamStats = sortedStats[teamIndex]
-        val leader = sortedStats.firstOrNull()
-
-        val gamesBehind =
-            if (leader == null || leader.teamId == teamId) {
-                BigDecimal.ZERO
-            } else {
-                val winDiff = leader.wins - teamStats.wins
-                val lossDiff = teamStats.losses - leader.losses
-                BigDecimal(winDiff + lossDiff)
-                    .divide(BigDecimal(2), 1, RoundingMode.HALF_UP)
-            }
-
-        return StandingEntryDto(
-            rank = teamIndex + 1,
-            teamId = teamId,
-            teamName = teamStats.teamName,
-            competitionId = primaryCompetitionId,
-            competitionName = competitionName,
-            gamesPlayed = teamStats.gamesPlayed,
-            wins = teamStats.wins,
-            losses = teamStats.losses,
-            draws = teamStats.draws,
-            winningPercentage = teamStats.winningPercentage,
-            gamesBehind = gamesBehind,
-        )
-    }
-
-    /**
-     * 순위 계산용 팀별 통계를 집계합니다.
-     */
-    private fun calculateTeamStatsForStanding(
-        decidedGameTeams: List<com.nextup.core.domain.game.GameTeam>,
-        allGameTeams: List<com.nextup.core.domain.game.GameTeam>,
-    ): Map<Long, TeamStandingStats> {
-        val decidedByTeam = decidedGameTeams.groupBy { it.team.id }
-        val allTeamIds = allGameTeams.map { it.team.id }.distinct()
-
-        return allTeamIds.associateWith { teamId ->
-            val gameTeams = decidedByTeam[teamId] ?: emptyList()
-            val teamName = allGameTeams.first { it.team.id == teamId }.team.name
-            val wins = gameTeams.count { it.result == GameResult.WIN }
-            val losses = gameTeams.count { it.result == GameResult.LOSS }
-            val draws = gameTeams.count { it.result == GameResult.DRAW }
-            val gamesPlayed = wins + losses + draws
-            val runsScored = gameTeams.sumOf { it.totalScore }
-            val runsAllowed =
-                gameTeams.sumOf { gameTeam ->
-                    decidedGameTeams
-                        .filter { it.game.id == gameTeam.game.id && it.team.id != teamId }
-                        .sumOf { it.totalScore }
-                }
-            val runDifferential = runsScored - runsAllowed
-            val winningPercentage =
-                if (gamesPlayed > 0) {
-                    BigDecimal(wins)
-                        .add(BigDecimal(draws).multiply(BigDecimal("0.5")))
-                        .divide(BigDecimal(gamesPlayed), 3, RoundingMode.HALF_UP)
-                } else {
-                    BigDecimal.ZERO
-                }
-
-            TeamStandingStats(
-                teamId = teamId,
-                teamName = teamName,
-                gamesPlayed = gamesPlayed,
-                wins = wins,
-                losses = losses,
-                draws = draws,
-                winningPercentage = winningPercentage,
-                runsScored = runsScored,
-                runDifferential = runDifferential,
+            StandingEntryDto(
+                rank = teamStanding.rank,
+                teamId = teamStanding.teamId,
+                teamName = teamStanding.teamName,
+                competitionId = standings.competitionId,
+                competitionName = standings.competitionName,
+                gamesPlayed = teamStanding.gamesPlayed,
+                wins = teamStanding.wins,
+                losses = teamStanding.losses,
+                draws = teamStanding.draws,
+                winningPercentage = teamStanding.winningPercentage,
+                gamesBehind = teamStanding.gamesBehind,
             )
+        } catch (e: Exception) {
+            log.warn("순위 조회 실패 (competitionId={}): {}", primaryCompetitionId, e.message)
+            null
         }
     }
 
@@ -337,19 +257,4 @@ class TeamDashboardServiceImpl(
             teamEra = BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP),
         )
     }
-
-    /**
-     * 순위 계산용 내부 데이터 클래스
-     */
-    private data class TeamStandingStats(
-        val teamId: Long,
-        val teamName: String,
-        val gamesPlayed: Int,
-        val wins: Int,
-        val losses: Int,
-        val draws: Int,
-        val winningPercentage: BigDecimal,
-        val runsScored: Int,
-        val runDifferential: Int,
-    )
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/ElectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/ElectionEventListenerTest.kt
@@ -1,0 +1,267 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.core.domain.election.Candidate
+import com.nextup.core.domain.election.ElectionType
+import com.nextup.core.domain.event.ElectionCompletedEvent
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.port.repository.CandidateRepositoryPort
+import com.nextup.core.port.repository.ElectionVoteRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import io.mockk.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("ElectionEventListener 테스트")
+class ElectionEventListenerTest {
+    private val electionVoteRepository: ElectionVoteRepositoryPort = mockk()
+    private val candidateRepository: CandidateRepositoryPort = mockk()
+    private val teamMemberRepository: TeamMemberRepositoryPort = mockk()
+
+    private lateinit var listener: ElectionEventListener
+
+    @BeforeEach
+    fun setUp() {
+        listener =
+            ElectionEventListener(
+                electionVoteRepository = electionVoteRepository,
+                candidateRepository = candidateRepository,
+                teamMemberRepository = teamMemberRepository,
+            )
+    }
+
+    @Test
+    fun `OWNER_ELECTION이 아닌 선거 완료 이벤트는 무시한다`() {
+        // given
+        val event =
+            ElectionCompletedEvent(
+                electionId = 1L,
+                teamId = 1L,
+                electionType = ElectionType.CAPTAIN_ELECTION,
+            )
+
+        // when
+        listener.onElectionCompleted(event)
+
+        // then
+        verify(exactly = 0) { electionVoteRepository.countByElectionIdGroupByCandidateId(any()) }
+    }
+
+    @Test
+    fun `투표가 없으면 OWNER 이양을 생략한다`() {
+        // given
+        val event =
+            ElectionCompletedEvent(
+                electionId = 1L,
+                teamId = 1L,
+                electionType = ElectionType.OWNER_ELECTION,
+            )
+        every { electionVoteRepository.countByElectionIdGroupByCandidateId(1L) } returns emptyMap()
+
+        // when
+        listener.onElectionCompleted(event)
+
+        // then
+        verify { electionVoteRepository.countByElectionIdGroupByCandidateId(1L) }
+        verify(exactly = 0) { candidateRepository.findById(any()) }
+    }
+
+    @Test
+    fun `동률이면 OWNER 이양을 생략한다`() {
+        // given
+        val event =
+            ElectionCompletedEvent(
+                electionId = 1L,
+                teamId = 1L,
+                electionType = ElectionType.OWNER_ELECTION,
+            )
+        every {
+            electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+        } returns
+            mapOf(
+                10L to 5L,
+                20L to 5L,
+            )
+
+        // when
+        listener.onElectionCompleted(event)
+
+        // then
+        verify(exactly = 0) { candidateRepository.findById(any()) }
+    }
+
+    @Test
+    fun `당선 후보자를 찾을 수 없으면 이양을 생략한다`() {
+        // given
+        val event =
+            ElectionCompletedEvent(
+                electionId = 1L,
+                teamId = 1L,
+                electionType = ElectionType.OWNER_ELECTION,
+            )
+        every {
+            electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+        } returns
+            mapOf(
+                10L to 5L,
+                20L to 3L,
+            )
+        every { candidateRepository.findById(10L) } returns null
+
+        // when
+        listener.onElectionCompleted(event)
+
+        // then
+        verify { candidateRepository.findById(10L) }
+        verify(exactly = 0) { teamMemberRepository.findByIdOrNull(any()) }
+    }
+
+    @Test
+    fun `당선자의 TeamMember를 찾을 수 없으면 이양을 생략한다`() {
+        // given
+        val event =
+            ElectionCompletedEvent(
+                electionId = 1L,
+                teamId = 1L,
+                electionType = ElectionType.OWNER_ELECTION,
+            )
+        val candidate =
+            Candidate.create(
+                electionId = 1L,
+                memberId = 100L,
+                memberName = "홍길동",
+            )
+        every {
+            electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+        } returns mapOf(10L to 5L)
+        every { candidateRepository.findById(10L) } returns candidate
+        every { teamMemberRepository.findByIdOrNull(100L) } returns null
+
+        // when
+        listener.onElectionCompleted(event)
+
+        // then
+        verify { teamMemberRepository.findByIdOrNull(100L) }
+        verify(exactly = 0) { teamMemberRepository.findByTeamId(any()) }
+    }
+
+    @Test
+    fun `당선자가 이미 OWNER이면 이양을 생략한다`() {
+        // given
+        val event =
+            ElectionCompletedEvent(
+                electionId = 1L,
+                teamId = 1L,
+                electionType = ElectionType.OWNER_ELECTION,
+            )
+        val candidate =
+            Candidate.create(
+                electionId = 1L,
+                memberId = 100L,
+                memberName = "홍길동",
+            )
+        val winner: TeamMember =
+            mockk {
+                every { role } returns TeamMemberRole.OWNER
+            }
+        every {
+            electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+        } returns mapOf(10L to 5L)
+        every { candidateRepository.findById(10L) } returns candidate
+        every { teamMemberRepository.findByIdOrNull(100L) } returns winner
+
+        // when
+        listener.onElectionCompleted(event)
+
+        // then
+        verify(exactly = 0) { teamMemberRepository.findByTeamId(any()) }
+    }
+
+    @Test
+    fun `OWNER 선거 완료 시 기존 OWNER를 강등하고 당선자를 승격한다`() {
+        // given
+        val event =
+            ElectionCompletedEvent(
+                electionId = 1L,
+                teamId = 1L,
+                electionType = ElectionType.OWNER_ELECTION,
+            )
+        val candidate =
+            Candidate.create(
+                electionId = 1L,
+                memberId = 100L,
+                memberName = "홍길동",
+            )
+        val winner: TeamMember =
+            mockk {
+                every { role } returns TeamMemberRole.MEMBER
+                every { role = any() } just Runs
+            }
+        val currentOwner: TeamMember =
+            mockk {
+                every { role } returns TeamMemberRole.OWNER
+                every { role = any() } just Runs
+                every { id } returns 200L
+            }
+        val otherMember: TeamMember =
+            mockk {
+                every { role } returns TeamMemberRole.MEMBER
+            }
+        every {
+            electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+        } returns
+            mapOf(
+                10L to 5L,
+                20L to 3L,
+            )
+        every { candidateRepository.findById(10L) } returns candidate
+        every { teamMemberRepository.findByIdOrNull(100L) } returns winner
+        every { teamMemberRepository.findByTeamId(1L) } returns listOf(currentOwner, winner, otherMember)
+        every { teamMemberRepository.save(any()) } returnsArgument 0
+
+        // when
+        listener.onElectionCompleted(event)
+
+        // then
+        verify { currentOwner.role = TeamMemberRole.MEMBER }
+        verify { winner.role = TeamMemberRole.OWNER }
+        verify(exactly = 2) { teamMemberRepository.save(any()) }
+    }
+
+    @Test
+    fun `기존 OWNER가 없는 경우에도 당선자를 OWNER로 승격한다`() {
+        // given
+        val event =
+            ElectionCompletedEvent(
+                electionId = 1L,
+                teamId = 1L,
+                electionType = ElectionType.OWNER_ELECTION,
+            )
+        val candidate =
+            Candidate.create(
+                electionId = 1L,
+                memberId = 100L,
+                memberName = "홍길동",
+            )
+        val winner: TeamMember =
+            mockk {
+                every { role } returns TeamMemberRole.MEMBER
+                every { role = any() } just Runs
+            }
+        every {
+            electionVoteRepository.countByElectionIdGroupByCandidateId(1L)
+        } returns mapOf(10L to 5L)
+        every { candidateRepository.findById(10L) } returns candidate
+        every { teamMemberRepository.findByIdOrNull(100L) } returns winner
+        every { teamMemberRepository.findByTeamId(1L) } returns listOf(winner)
+        every { teamMemberRepository.save(any()) } returnsArgument 0
+
+        // when
+        listener.onElectionCompleted(event)
+
+        // then
+        verify { winner.role = TeamMemberRole.OWNER }
+        verify(exactly = 1) { teamMemberRepository.save(any()) }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamDashboardServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamDashboardServiceImplTest.kt
@@ -17,6 +17,9 @@ import com.nextup.core.port.attendance.AttendancePollRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.service.standings.StandingsService
+import com.nextup.core.service.standings.dto.StandingsDto
+import com.nextup.core.service.standings.dto.TeamStandingDto
 import com.nextup.core.service.team.TeamMembershipService
 import io.mockk.every
 import io.mockk.mockk
@@ -36,6 +39,7 @@ class TeamDashboardServiceImplTest {
     private lateinit var gameTeamRepository: GameTeamRepositoryPort
     private lateinit var teamMembershipService: TeamMembershipService
     private lateinit var attendancePollRepository: AttendancePollRepositoryPort
+    private lateinit var standingsService: StandingsService
     private lateinit var service: TeamDashboardServiceImpl
 
     private lateinit var association: Association
@@ -50,6 +54,7 @@ class TeamDashboardServiceImplTest {
         gameTeamRepository = mockk()
         teamMembershipService = mockk()
         attendancePollRepository = mockk()
+        standingsService = mockk()
 
         service =
             TeamDashboardServiceImpl(
@@ -58,6 +63,7 @@ class TeamDashboardServiceImplTest {
                 gameTeamRepository,
                 teamMembershipService,
                 attendancePollRepository,
+                standingsService,
             )
 
         association = Association(name = "테스트 협회", id = 1L)
@@ -411,8 +417,6 @@ class TeamDashboardServiceImplTest {
         @DisplayName("팀이 리더가 아닐 때 gamesBehind가 올바르게 계산된다")
         fun `순위에서 리더가 아닌 팀의 gamesBehind가 계산된다`() {
             // given
-            val leaderTeam =
-                Team(league = league, name = "1위팀", city = "서울", foundedYear = 2019, id = 10L)
             val game1 =
                 makeGame(
                     id = 50L,
@@ -426,38 +430,65 @@ class TeamDashboardServiceImplTest {
                     status = GameStatus.FINISHED,
                 )
 
-            // leaderTeam: 2승 0패 / team(id=1): 0승 2패
-            val gt1Home =
-                makeGameTeam(game1, leaderTeam, HomeAway.HOME, score = 5, result = GameResult.WIN)
             val gt1Away =
                 makeGameTeam(game1, team, HomeAway.AWAY, score = 1, result = GameResult.LOSS)
-            val gt2Home =
-                makeGameTeam(game2, leaderTeam, HomeAway.HOME, score = 4, result = GameResult.WIN)
             val gt2Away =
                 makeGameTeam(game2, team, HomeAway.AWAY, score = 2, result = GameResult.LOSS)
 
-            // team(id=1)이 참가한 gameTeams
             every { teamRepository.findByIdWithLeague(1L) } returns team
             every { teamMembershipService.getTeamMemberCount(1L) } returns 10
             every { gameTeamRepository.findAllByTeamId(1L) } returns listOf(gt1Away, gt2Away)
             every { gameRepository.findAllByIds(listOf(50L, 51L)) } returns listOf(game1, game2)
             every {
                 gameTeamRepository.findAllByGameIds(listOf(50L, 51L))
-            } returns listOf(gt1Home, gt1Away, gt2Home, gt2Away)
-            // 대회 전체 gameTeams
-            every { gameTeamRepository.findAllByCompetitionId(100L) } returns
-                listOf(gt1Home, gt1Away, gt2Home, gt2Away)
-            every {
-                gameTeamRepository.findAllByCompetitionIdWithDecidedResult(100L)
-            } returns listOf(gt1Home, gt1Away, gt2Home, gt2Away)
+            } returns listOf(gt1Away, gt2Away)
             every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { standingsService.getStandings(100L) } returns
+                StandingsDto(
+                    competitionId = 100L,
+                    competitionName = "봄리그",
+                    totalGamesPerTeam = 2,
+                    standings =
+                        listOf(
+                            TeamStandingDto(
+                                rank = 1,
+                                teamId = 10L,
+                                teamName = "1위팀",
+                                gamesPlayed = 2,
+                                remainingGames = 0,
+                                wins = 2,
+                                losses = 0,
+                                draws = 0,
+                                winningPercentage = java.math.BigDecimal("1.000"),
+                                gamesBehind = java.math.BigDecimal("0.0"),
+                                runsScored = 9,
+                                runsAllowed = 3,
+                                runDifferential = 6,
+                            ),
+                            TeamStandingDto(
+                                rank = 2,
+                                teamId = 1L,
+                                teamName = "테스트팀",
+                                gamesPlayed = 2,
+                                remainingGames = 0,
+                                wins = 0,
+                                losses = 2,
+                                draws = 0,
+                                winningPercentage = java.math.BigDecimal("0.000"),
+                                gamesBehind = java.math.BigDecimal("2.0"),
+                                runsScored = 3,
+                                runsAllowed = 9,
+                                runDifferential = -6,
+                            ),
+                        ),
+                    lastUpdated = LocalDateTime.now(),
+                )
 
             // when
             val result = service.getTeamDashboard(1L)
 
             // then
             assertThat(result.standing).isNotNull
-            // leaderTeam: 2W 0L, team: 0W 2L → gamesBehind = (2-0 + 2-0)/2 = 2.0
             assertThat(result.standing!!.gamesBehind).isEqualByComparingTo("2.0")
             assertThat(result.standing!!.rank).isEqualTo(2)
         }
@@ -466,10 +497,6 @@ class TeamDashboardServiceImplTest {
         @DisplayName("팀이 대회 순위 목록에 없을 때 standing은 null이다")
         fun `대회 순위에서 팀을 찾을 수 없으면 standing은 null이다`() {
             // given
-            val otherTeam1 =
-                Team(league = league, name = "다른팀A", city = "인천", foundedYear = 2018, id = 20L)
-            val otherTeam2 =
-                Team(league = league, name = "다른팀B", city = "수원", foundedYear = 2019, id = 21L)
             val game =
                 makeGame(
                     id = 60L,
@@ -477,29 +504,45 @@ class TeamDashboardServiceImplTest {
                     status = GameStatus.FINISHED,
                 )
 
-            // team(id=1)은 allGameTeams에는 있지만 competition의 전체 gameTeams에는 없는 상황
             val teamGt = makeGameTeam(game, team, HomeAway.HOME, score = 3, result = GameResult.WIN)
-            val gt1 =
-                makeGameTeam(game, otherTeam1, HomeAway.HOME, score = 5, result = GameResult.WIN)
-            val gt2 =
-                makeGameTeam(game, otherTeam2, HomeAway.AWAY, score = 2, result = GameResult.LOSS)
 
             every { teamRepository.findByIdWithLeague(1L) } returns team
             every { teamMembershipService.getTeamMemberCount(1L) } returns 10
             every { gameTeamRepository.findAllByTeamId(1L) } returns listOf(teamGt)
             every { gameRepository.findAllByIds(listOf(60L)) } returns listOf(game)
-            every { gameTeamRepository.findAllByGameIds(listOf(60L)) } returns listOf(gt1, gt2)
-            // competitionId 100L의 전체 목록에는 team(id=1)이 없음
-            every { gameTeamRepository.findAllByCompetitionId(100L) } returns listOf(gt1, gt2)
-            every {
-                gameTeamRepository.findAllByCompetitionIdWithDecidedResult(100L)
-            } returns listOf(gt1, gt2)
+            every { gameTeamRepository.findAllByGameIds(listOf(60L)) } returns listOf(teamGt)
             every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            // StandingsService 결과에 team(id=1)이 없음
+            every { standingsService.getStandings(100L) } returns
+                StandingsDto(
+                    competitionId = 100L,
+                    competitionName = "봄리그",
+                    totalGamesPerTeam = 1,
+                    standings =
+                        listOf(
+                            TeamStandingDto(
+                                rank = 1,
+                                teamId = 20L,
+                                teamName = "다른팀A",
+                                gamesPlayed = 1,
+                                remainingGames = 0,
+                                wins = 1,
+                                losses = 0,
+                                draws = 0,
+                                winningPercentage = java.math.BigDecimal("1.000"),
+                                gamesBehind = java.math.BigDecimal("0.0"),
+                                runsScored = 5,
+                                runsAllowed = 2,
+                                runDifferential = 3,
+                            ),
+                        ),
+                    lastUpdated = LocalDateTime.now(),
+                )
 
             // when
             val result = service.getTeamDashboard(1L)
 
-            // then — teamIndex < 0 분기 → standing == null
+            // then — team이 순위 목록에 없음 → standing == null
             assertThat(result.standing).isNull()
         }
 
@@ -554,7 +597,6 @@ class TeamDashboardServiceImplTest {
 
             every { teamRepository.findByIdWithLeague(1L) } returns team
             every { teamMembershipService.getTeamMemberCount(1L) } returns 10
-            // team이 참여한 gameTeams: comp100 1경기, comp200 2경기
             every {
                 gameTeamRepository.findAllByTeamId(1L)
             } returns listOf(gt1Home, gt2Home, gt3Home)
@@ -564,13 +606,48 @@ class TeamDashboardServiceImplTest {
             every {
                 gameTeamRepository.findAllByGameIds(listOf(70L, 71L, 72L))
             } returns listOf(gt1Home, gt1Away, gt2Home, gt2Away, gt3Home, gt3Away)
-            // primaryCompetition은 경기 수가 많은 200L
-            every { gameTeamRepository.findAllByCompetitionId(200L) } returns
-                listOf(gt2Home, gt2Away, gt3Home, gt3Away)
-            every {
-                gameTeamRepository.findAllByCompetitionIdWithDecidedResult(200L)
-            } returns listOf(gt2Home, gt2Away, gt3Home, gt3Away)
             every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            // primaryCompetition은 경기 수가 많은 200L → StandingsService에 위임
+            every { standingsService.getStandings(200L) } returns
+                StandingsDto(
+                    competitionId = 200L,
+                    competitionName = "여름리그",
+                    totalGamesPerTeam = 2,
+                    standings =
+                        listOf(
+                            TeamStandingDto(
+                                rank = 1,
+                                teamId = 1L,
+                                teamName = "테스트팀",
+                                gamesPlayed = 2,
+                                remainingGames = 0,
+                                wins = 2,
+                                losses = 0,
+                                draws = 0,
+                                winningPercentage = java.math.BigDecimal("1.000"),
+                                gamesBehind = java.math.BigDecimal("0.0"),
+                                runsScored = 9,
+                                runsAllowed = 2,
+                                runDifferential = 7,
+                            ),
+                            TeamStandingDto(
+                                rank = 2,
+                                teamId = 2L,
+                                teamName = "상대팀",
+                                gamesPlayed = 2,
+                                remainingGames = 0,
+                                wins = 0,
+                                losses = 2,
+                                draws = 0,
+                                winningPercentage = java.math.BigDecimal("0.000"),
+                                gamesBehind = java.math.BigDecimal("2.0"),
+                                runsScored = 2,
+                                runsAllowed = 9,
+                                runDifferential = -7,
+                            ),
+                        ),
+                    lastUpdated = LocalDateTime.now(),
+                )
 
             // when
             val result = service.getTeamDashboard(1L)


### PR DESCRIPTION
## Summary

> - Closes #278

**ElectionService의 Cross-Aggregate 트랜잭션(Election + TeamMember)을 도메인 이벤트 기반으로 분리. `ElectionCompletedEvent` 도메인 이벤트를 통해 OWNER 권한 이양을 처리하고, TeamDashboardServiceImpl의 순위 계산 중복 로직을 StandingsService에 위임합니다.**

## Tasks

- `ElectionCompletedEvent` 도메인 이벤트 생성
- `ElectionService`: `ApplicationEventPublisher`로 이벤트 발행
- `ElectionEventListener`: OWNER_ELECTION 완료 시 `@TransactionalEventListener(AFTER_COMMIT)`로 권한 이양
- `TeamDashboardServiceImpl`: `StandingsService` 위임으로 중복 제거
- `ElectionServiceTest` 이벤트 발행 검증으로 수정
- `TeamDashboardServiceImplTest` StandingsService 목 적용
- `ElectionEventListenerTest` 커버리지 테스트 8개 추가

## To Reviewer

- Cross-Aggregate 경계를 도메인 이벤트로 분리하여 트랜잭션 일관성 확보
- AFTER_COMMIT 전략으로 Election 커밋 후 TeamMember 변경 보장
- 기존 RecordCorrectionServiceImpl, CertificateServiceImpl은 이미 올바른 패턴 사용 중이므로 변경 불필요