### PR TITLE
feat(#264): ZXing 기반 QR 코드 생성 실제 구현

### DIFF
--- a/nextup-infrastructure/build.gradle.kts
+++ b/nextup-infrastructure/build.gradle.kts
@@ -60,6 +60,10 @@ dependencies {
     // Spring Cache
     implementation("org.springframework.boot:spring-boot-starter-cache")
 
+    // QR Code Generation (ZXing)
+    implementation("com.google.zxing:core:3.5.3")
+    implementation("com.google.zxing:javase:3.5.3")
+
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.assertj:assertj-core:3.27.3")

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/StubQrCodeGenerator.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/StubQrCodeGenerator.kt
@@ -5,12 +5,13 @@ import org.springframework.stereotype.Component
 import java.util.*
 
 /**
- * QR 코드 생성기 스텁 구현
+ * QR 코드 생성기 스텁 구현 (테스트 전용)
  *
- * 실제 QR 코드 생성 라이브러리는 추가하지 않고,
- * Base64로 인코딩된 더미 데이터를 반환합니다.
+ * 테스트 환경에서 외부 라이브러리 의존 없이 더미 데이터를 반환합니다.
+ * 프로덕션에서는 ZxingQrCodeGenerator가 @Primary로 우선 사용됩니다.
  */
 @Component
+@org.springframework.context.annotation.Profile("test")
 class StubQrCodeGenerator : QrCodeGeneratorPort {
     override fun generate(
         content: String,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/ZxingQrCodeGenerator.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/certificate/ZxingQrCodeGenerator.kt
@@ -1,0 +1,45 @@
+package com.nextup.infrastructure.service.certificate
+
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.client.j2se.MatrixToImageWriter
+import com.google.zxing.qrcode.QRCodeWriter
+import com.nextup.core.port.service.QrCodeGeneratorPort
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Component
+import java.io.ByteArrayOutputStream
+import java.util.Base64
+
+/**
+ * ZXing 기반 QR 코드 생성기
+ *
+ * QR 코드를 실제 PNG 이미지로 생성하여 Base64로 인코딩합니다.
+ */
+@Component
+@Primary
+class ZxingQrCodeGenerator : QrCodeGeneratorPort {
+    override fun generate(
+        content: String,
+        size: Int,
+    ): String {
+        val hints =
+            mapOf(
+                EncodeHintType.CHARACTER_SET to "UTF-8",
+                EncodeHintType.MARGIN to 1,
+            )
+
+        val bitMatrix =
+            QRCodeWriter().encode(
+                content,
+                BarcodeFormat.QR_CODE,
+                size,
+                size,
+                hints,
+            )
+
+        val outputStream = ByteArrayOutputStream()
+        MatrixToImageWriter.writeToStream(bitMatrix, "PNG", outputStream)
+
+        return Base64.getEncoder().encodeToString(outputStream.toByteArray())
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/certificate/ZxingQrCodeGeneratorTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/certificate/ZxingQrCodeGeneratorTest.kt
@@ -1,0 +1,74 @@
+package com.nextup.infrastructure.service.certificate
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.Base64
+import javax.imageio.ImageIO
+
+@DisplayName("ZxingQrCodeGenerator")
+class ZxingQrCodeGeneratorTest {
+    private val generator = ZxingQrCodeGenerator()
+
+    @Test
+    fun `QR 코드를 Base64 인코딩된 PNG 이미지로 생성한다`() {
+        // when
+        val result = generator.generate("https://nextup.kr/verify/ABC-123")
+
+        // then
+        assertThat(result).isNotBlank()
+        val decoded = Base64.getDecoder().decode(result)
+        assertThat(decoded).isNotEmpty()
+
+        // PNG 헤더 확인 (0x89504E47)
+        assertThat(decoded[0]).isEqualTo(0x89.toByte())
+        assertThat(decoded[1]).isEqualTo(0x50.toByte()) // 'P'
+        assertThat(decoded[2]).isEqualTo(0x4E.toByte()) // 'N'
+        assertThat(decoded[3]).isEqualTo(0x47.toByte()) // 'G'
+    }
+
+    @Test
+    fun `지정된 크기로 QR 코드를 생성한다`() {
+        // when
+        val result = generator.generate("test-content", size = 200)
+
+        // then
+        val decoded = Base64.getDecoder().decode(result)
+        val image = ImageIO.read(decoded.inputStream())
+        assertThat(image.width).isEqualTo(200)
+        assertThat(image.height).isEqualTo(200)
+    }
+
+    @Test
+    fun `기본 크기 300px로 QR 코드를 생성한다`() {
+        // when
+        val result = generator.generate("default-size-test")
+
+        // then
+        val decoded = Base64.getDecoder().decode(result)
+        val image = ImageIO.read(decoded.inputStream())
+        assertThat(image.width).isEqualTo(300)
+        assertThat(image.height).isEqualTo(300)
+    }
+
+    @Test
+    fun `한글 콘텐츠로 QR 코드를 생성할 수 있다`() {
+        // when
+        val result = generator.generate("증명서 검증: 홍길동")
+
+        // then
+        assertThat(result).isNotBlank()
+        val decoded = Base64.getDecoder().decode(result)
+        assertThat(decoded).isNotEmpty()
+    }
+
+    @Test
+    fun `빈 문자열이 아닌 콘텐츠는 서로 다른 QR 코드를 생성한다`() {
+        // when
+        val result1 = generator.generate("content-A")
+        val result2 = generator.generate("content-B")
+
+        // then
+        assertThat(result1).isNotEqualTo(result2)
+    }
+}


### PR DESCRIPTION
## Summary
- ZXing 라이브러리(core 3.5.3 + javase 3.5.3) 의존성 추가
- `ZxingQrCodeGenerator` 구현: 실제 PNG QR 코드를 Base64로 인코딩하여 반환
- `@Primary`로 프로덕션 환경에서 우선 사용, `StubQrCodeGenerator`는 `@Profile("test")`로 전환
- UTF-8 인코딩으로 한글 콘텐츠 지원

## Tasks
Closes #264

- [x] ZXing 라이브러리 의존성 추가
- [x] QrCodeGeneratorPort 실제 구현체(ZxingQrCodeGenerator) 작성
- [x] StubQrCodeGenerator를 테스트 전용으로 전환
- [x] 단위 테스트 5개 작성 (PNG 헤더, 크기, 한글, 고유성)
- [x] 전체 빌드 및 테스트 통과

## To Reviewer
- ZXing은 Apache 2.0 라이선스로 상용 사용에 문제 없음
- 증명서 검증 URL을 QR 코드로 인코딩하여 CertificateService에서 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)