### PR TITLE
feat(#263): Firebase Cloud Messaging 푸시 알림 실제 연동

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/port/service/PushNotificationPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/service/PushNotificationPort.kt
@@ -1,0 +1,40 @@
+package com.nextup.core.port.service
+
+/**
+ * 푸시 알림 발송 포트
+ *
+ * Infrastructure 계층에서 FCM 등 실제 푸시 서비스로 구현합니다.
+ */
+interface PushNotificationPort {
+    /**
+     * 단일 디바이스에 푸시 알림을 발송합니다.
+     *
+     * @param token FCM 디바이스 토큰
+     * @param title 알림 제목
+     * @param body 알림 본문
+     * @param data 추가 데이터
+     * @return 발송 성공 여부
+     */
+    fun send(
+        token: String,
+        title: String,
+        body: String,
+        data: Map<String, String>? = null,
+    ): Boolean
+
+    /**
+     * 여러 디바이스에 푸시 알림을 일괄 발송합니다.
+     *
+     * @param tokens FCM 디바이스 토큰 목록
+     * @param title 알림 제목
+     * @param body 알림 본문
+     * @param data 추가 데이터
+     * @return 성공한 발송 수
+     */
+    fun sendBatch(
+        tokens: List<String>,
+        title: String,
+        body: String,
+        data: Map<String, String>? = null,
+    ): Int
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
@@ -11,9 +11,11 @@ import com.nextup.core.domain.notification.NotificationPreference
 import com.nextup.core.port.repository.DeviceTokenRepositoryPort
 import com.nextup.core.port.repository.NotificationPreferenceRepositoryPort
 import com.nextup.core.port.repository.NotificationRepositoryPort
+import com.nextup.core.port.service.PushNotificationPort
 import com.nextup.core.service.notification.dto.RegisterDeviceRequest
 import com.nextup.core.service.notification.dto.SendNotificationRequest
 import com.nextup.core.service.notification.dto.UpdatePreferenceRequest
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -28,9 +30,14 @@ class NotificationService(
     private val notificationRepository: NotificationRepositoryPort,
     private val deviceTokenRepository: DeviceTokenRepositoryPort,
     private val preferenceRepository: NotificationPreferenceRepositoryPort,
+    private val pushNotificationPort: PushNotificationPort,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     /**
      * 알림을 전송합니다.
+     *
+     * DB에 알림을 저장한 후, 사용자의 등록된 디바이스로 푸시 알림을 발송합니다.
      */
     @Transactional
     fun sendNotification(request: SendNotificationRequest): Notification {
@@ -44,7 +51,38 @@ class NotificationService(
             )
 
         notification.markAsSent()
-        return notificationRepository.save(notification)
+        val saved = notificationRepository.save(notification)
+
+        sendPushToUser(request)
+
+        return saved
+    }
+
+    private fun sendPushToUser(request: SendNotificationRequest) {
+        try {
+            val tokens = deviceTokenRepository.findByUserId(request.userId)
+            if (tokens.isEmpty()) return
+
+            val dataMap =
+                request.data?.let { mapOf("data" to it) }
+
+            val tokenStrings = tokens.map { it.token }
+            val successCount =
+                pushNotificationPort.sendBatch(
+                    tokens = tokenStrings,
+                    title = request.title,
+                    body = request.body,
+                    data = dataMap,
+                )
+            log.debug(
+                "푸시 발송 완료: userId={}, total={}, success={}",
+                request.userId,
+                tokenStrings.size,
+                successCount,
+            )
+        } catch (e: Exception) {
+            log.warn("푸시 발송 실패 (알림 저장은 완료): userId={}, error={}", request.userId, e.message)
+        }
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServicePushCoverageTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServicePushCoverageTest.kt
@@ -1,0 +1,161 @@
+package com.nextup.core.service.notification
+
+import com.nextup.core.domain.notification.DevicePlatform
+import com.nextup.core.domain.notification.DeviceToken
+import com.nextup.core.domain.notification.NotificationType
+import com.nextup.core.port.repository.DeviceTokenRepositoryPort
+import com.nextup.core.port.repository.NotificationPreferenceRepositoryPort
+import com.nextup.core.port.repository.NotificationRepositoryPort
+import com.nextup.core.port.service.PushNotificationPort
+import com.nextup.core.service.notification.dto.SendNotificationRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("NotificationService sendPushToUser 커버리지 보완")
+class NotificationServicePushCoverageTest {
+    private lateinit var notificationRepository: NotificationRepositoryPort
+    private lateinit var deviceTokenRepository: DeviceTokenRepositoryPort
+    private lateinit var preferenceRepository: NotificationPreferenceRepositoryPort
+    private lateinit var pushNotificationPort: PushNotificationPort
+    private lateinit var notificationService: NotificationService
+
+    @BeforeEach
+    fun setUp() {
+        notificationRepository = mockk()
+        deviceTokenRepository = mockk()
+        preferenceRepository = mockk()
+        pushNotificationPort = mockk(relaxed = true)
+        notificationService =
+            NotificationService(
+                notificationRepository,
+                deviceTokenRepository,
+                preferenceRepository,
+                pushNotificationPort,
+            )
+    }
+
+    @Test
+    fun `토큰이 있으면 푸시 발송을 호출한다 - data 있는 경우`() {
+        // given
+        val request =
+            SendNotificationRequest(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                title = "경기 시작",
+                body = "경기가 곧 시작됩니다",
+                data = """{"gameId": 123}""",
+            )
+
+        val tokens =
+            listOf(
+                DeviceToken.create(
+                    userId = 1L,
+                    token = "token-1",
+                    platform = DevicePlatform.ANDROID,
+                ),
+                DeviceToken.create(
+                    userId = 1L,
+                    token = "token-2",
+                    platform = DevicePlatform.IOS,
+                ),
+            )
+
+        every { notificationRepository.save(any()) } answers { firstArg() }
+        every { deviceTokenRepository.findByUserId(1L) } returns tokens
+        every { pushNotificationPort.sendBatch(any(), any(), any(), any()) } returns 2
+
+        // when
+        val result = notificationService.sendNotification(request)
+
+        // then
+        assertThat(result.isSent()).isTrue()
+        verify(exactly = 1) {
+            pushNotificationPort.sendBatch(
+                tokens = listOf("token-1", "token-2"),
+                title = "경기 시작",
+                body = "경기가 곧 시작됩니다",
+                data = mapOf("data" to """{"gameId": 123}"""),
+            )
+        }
+    }
+
+    @Test
+    fun `토큰이 있으면 푸시 발송을 호출한다 - data null인 경우`() {
+        // given
+        val request =
+            SendNotificationRequest(
+                userId = 1L,
+                type = NotificationType.TEAM_NOTICE,
+                title = "팀 공지",
+                body = "내용",
+                data = null,
+            )
+
+        val tokens =
+            listOf(
+                DeviceToken.create(
+                    userId = 1L,
+                    token = "token-1",
+                    platform = DevicePlatform.ANDROID,
+                ),
+            )
+
+        every { notificationRepository.save(any()) } answers { firstArg() }
+        every { deviceTokenRepository.findByUserId(1L) } returns tokens
+        every { pushNotificationPort.sendBatch(any(), any(), any(), any()) } returns 1
+
+        // when
+        val result = notificationService.sendNotification(request)
+
+        // then
+        assertThat(result.isSent()).isTrue()
+        verify(exactly = 1) {
+            pushNotificationPort.sendBatch(
+                tokens = listOf("token-1"),
+                title = "팀 공지",
+                body = "내용",
+                data = null,
+            )
+        }
+    }
+
+    @Test
+    fun `푸시 발송 중 예외 발생 시 알림 저장은 유지된다`() {
+        // given
+        val request =
+            SendNotificationRequest(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                title = "경기 시작",
+                body = "내용",
+                data = null,
+            )
+
+        val tokens =
+            listOf(
+                DeviceToken.create(
+                    userId = 1L,
+                    token = "token-1",
+                    platform = DevicePlatform.ANDROID,
+                ),
+            )
+
+        every { notificationRepository.save(any()) } answers { firstArg() }
+        every { deviceTokenRepository.findByUserId(1L) } returns tokens
+        every {
+            pushNotificationPort.sendBatch(any(), any(), any(), any())
+        } throws RuntimeException("FCM error")
+
+        // when
+        val result = notificationService.sendNotification(request)
+
+        // then - 알림은 정상적으로 저장되어야 한다
+        assertThat(result.isSent()).isTrue()
+        verify(exactly = 1) { notificationRepository.save(any()) }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServiceTest.kt
@@ -13,6 +13,7 @@ import com.nextup.core.domain.notification.NotificationType
 import com.nextup.core.port.repository.DeviceTokenRepositoryPort
 import com.nextup.core.port.repository.NotificationPreferenceRepositoryPort
 import com.nextup.core.port.repository.NotificationRepositoryPort
+import com.nextup.core.port.service.PushNotificationPort
 import com.nextup.core.service.notification.dto.RegisterDeviceRequest
 import com.nextup.core.service.notification.dto.SendNotificationRequest
 import com.nextup.core.service.notification.dto.UpdatePreferenceRequest
@@ -28,6 +29,7 @@ class NotificationServiceTest {
     private lateinit var notificationRepository: NotificationRepositoryPort
     private lateinit var deviceTokenRepository: DeviceTokenRepositoryPort
     private lateinit var preferenceRepository: NotificationPreferenceRepositoryPort
+    private lateinit var pushNotificationPort: PushNotificationPort
     private lateinit var notificationService: NotificationService
 
     @BeforeEach
@@ -35,11 +37,13 @@ class NotificationServiceTest {
         notificationRepository = mockk()
         deviceTokenRepository = mockk()
         preferenceRepository = mockk()
+        pushNotificationPort = mockk(relaxed = true)
         notificationService =
             NotificationService(
                 notificationRepository,
                 deviceTokenRepository,
                 preferenceRepository,
+                pushNotificationPort,
             )
     }
 
@@ -58,6 +62,7 @@ class NotificationServiceTest {
             )
 
         every { notificationRepository.save(any()) } answers { firstArg() }
+        every { deviceTokenRepository.findByUserId(1L) } returns emptyList()
 
         // when
         val result = notificationService.sendNotification(request)
@@ -86,6 +91,7 @@ class NotificationServiceTest {
             )
 
         every { notificationRepository.save(any()) } answers { firstArg() }
+        every { deviceTokenRepository.findByUserId(1L) } returns emptyList()
 
         // when
         val result = notificationService.sendNotification(request)

--- a/nextup-infrastructure/build.gradle.kts
+++ b/nextup-infrastructure/build.gradle.kts
@@ -60,6 +60,9 @@ dependencies {
     // Spring Cache
     implementation("org.springframework.boot:spring-boot-starter-cache")
 
+    // Firebase Admin SDK (FCM Push Notification)
+    implementation("com.google.firebase:firebase-admin:9.4.2")
+
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.assertj:assertj-core:3.27.3")

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/adapter/notification/FcmPushNotificationAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/adapter/notification/FcmPushNotificationAdapter.kt
@@ -1,0 +1,131 @@
+package com.nextup.infrastructure.adapter.notification
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.MulticastMessage
+import com.google.firebase.messaging.Notification
+import com.nextup.core.port.service.PushNotificationPort
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Component
+
+/**
+ * Firebase Cloud Messaging 기반 푸시 알림 어댑터
+ *
+ * FirebaseMessaging을 사용하여 실제 푸시 알림을 발송합니다.
+ * 발송 실패 시 최대 3회 재시도합니다.
+ */
+@Component
+@Primary
+class FcmPushNotificationAdapter : PushNotificationPort {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val MAX_RETRY = 3
+        private const val MAX_MULTICAST_SIZE = 500
+    }
+
+    override fun send(
+        token: String,
+        title: String,
+        body: String,
+        data: Map<String, String>?,
+    ): Boolean {
+        val message =
+            Message.builder()
+                .setToken(token)
+                .setNotification(
+                    Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build(),
+                )
+                .apply { data?.let { putAllData(it) } }
+                .build()
+
+        return sendWithRetry(token, message)
+    }
+
+    override fun sendBatch(
+        tokens: List<String>,
+        title: String,
+        body: String,
+        data: Map<String, String>?,
+    ): Int {
+        if (tokens.isEmpty()) return 0
+
+        var successCount = 0
+
+        tokens.chunked(MAX_MULTICAST_SIZE).forEach { chunk ->
+            val message =
+                MulticastMessage.builder()
+                    .addAllTokens(chunk)
+                    .setNotification(
+                        Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build(),
+                    )
+                    .apply { data?.let { putAllData(it) } }
+                    .build()
+
+            try {
+                val response = FirebaseMessaging.getInstance().sendEachForMulticast(message)
+                successCount += response.successCount
+                if (response.failureCount > 0) {
+                    response.responses
+                        .filter { !it.isSuccessful }
+                        .forEach { sendResponse ->
+                            log.warn(
+                                "FCM 배치 발송 실패: {}",
+                                sendResponse.exception?.messagingErrorCode,
+                            )
+                        }
+                }
+            } catch (e: Exception) {
+                log.error("FCM 배치 발송 중 오류: {}", e.message, e)
+            }
+        }
+
+        return successCount
+    }
+
+    private fun sendWithRetry(
+        token: String,
+        message: Message,
+    ): Boolean {
+        repeat(MAX_RETRY) { attempt ->
+            try {
+                FirebaseMessaging.getInstance().send(message)
+                return true
+            } catch (e: com.google.firebase.messaging.FirebaseMessagingException) {
+                if (isRetryable(e.messagingErrorCode)) {
+                    log.warn(
+                        "FCM 발송 재시도 ({}/{}): token={}, error={}",
+                        attempt + 1,
+                        MAX_RETRY,
+                        token.take(20),
+                        e.messagingErrorCode,
+                    )
+                } else {
+                    log.error(
+                        "FCM 발송 실패 (재시도 불가): token={}, error={}",
+                        token.take(20),
+                        e.messagingErrorCode,
+                    )
+                    return false
+                }
+            } catch (e: Exception) {
+                log.error("FCM 발송 중 예상치 못한 오류: {}", e.message, e)
+                return false
+            }
+        }
+        log.error("FCM 발송 최종 실패: token={}", token.take(20))
+        return false
+    }
+
+    private fun isRetryable(errorCode: MessagingErrorCode?): Boolean =
+        errorCode == MessagingErrorCode.UNAVAILABLE ||
+            errorCode == MessagingErrorCode.INTERNAL
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/adapter/notification/StubPushNotificationAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/adapter/notification/StubPushNotificationAdapter.kt
@@ -1,0 +1,37 @@
+package com.nextup.infrastructure.adapter.notification
+
+import com.nextup.core.port.service.PushNotificationPort
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+/**
+ * 푸시 알림 Stub 어댑터
+ *
+ * 테스트 환경에서 실제 FCM 발송 없이 로그만 출력합니다.
+ */
+@Component
+@Profile("test")
+class StubPushNotificationAdapter : PushNotificationPort {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun send(
+        token: String,
+        title: String,
+        body: String,
+        data: Map<String, String>?,
+    ): Boolean {
+        log.info("[STUB] 푸시 발송: token={}, title={}", token.take(20), title)
+        return true
+    }
+
+    override fun sendBatch(
+        tokens: List<String>,
+        title: String,
+        body: String,
+        data: Map<String, String>?,
+    ): Int {
+        log.info("[STUB] 푸시 배치 발송: count={}, title={}", tokens.size, title)
+        return tokens.size
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/FirebaseConfig.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/FirebaseConfig.kt
@@ -1,0 +1,51 @@
+package com.nextup.infrastructure.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import java.io.FileInputStream
+
+/**
+ * Firebase Admin SDK 초기화 설정
+ *
+ * GOOGLE_APPLICATION_CREDENTIALS 환경변수 또는 firebase.credentials-path 속성으로
+ * 서비스 계정 키 파일 경로를 지정합니다.
+ */
+@Configuration
+@Profile("!test")
+class FirebaseConfig(
+    @Value("\${firebase.credentials-path:}")
+    private val credentialsPath: String,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostConstruct
+    fun initialize() {
+        if (FirebaseApp.getApps().isNotEmpty()) {
+            log.info("Firebase 이미 초기화됨")
+            return
+        }
+
+        try {
+            val options =
+                if (credentialsPath.isNotBlank()) {
+                    FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(FileInputStream(credentialsPath)))
+                        .build()
+                } else {
+                    FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.getApplicationDefault())
+                        .build()
+                }
+            FirebaseApp.initializeApp(options)
+            log.info("Firebase Admin SDK 초기화 완료")
+        } catch (e: Exception) {
+            log.warn("Firebase Admin SDK 초기화 실패: {}. 푸시 알림이 비활성화됩니다.", e.message)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/adapter/notification/FcmPushNotificationAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/adapter/notification/FcmPushNotificationAdapterTest.kt
@@ -1,0 +1,225 @@
+package com.nextup.infrastructure.adapter.notification
+
+import com.google.firebase.messaging.BatchResponse
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.SendResponse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("FcmPushNotificationAdapter")
+class FcmPushNotificationAdapterTest {
+    private lateinit var adapter: FcmPushNotificationAdapter
+    private lateinit var firebaseMessaging: FirebaseMessaging
+
+    @BeforeEach
+    fun setUp() {
+        adapter = FcmPushNotificationAdapter()
+        firebaseMessaging = mockk()
+        mockkStatic(FirebaseMessaging::class)
+        every { FirebaseMessaging.getInstance() } returns firebaseMessaging
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(FirebaseMessaging::class)
+    }
+
+    @Nested
+    @DisplayName("send")
+    inner class Send {
+        @Test
+        fun `성공적으로 푸시를 발송한다`() {
+            // given
+            every { firebaseMessaging.send(any()) } returns "message-id"
+
+            // when
+            val result = adapter.send("token-1", "제목", "내용")
+
+            // then
+            assertThat(result).isTrue()
+            verify(exactly = 1) { firebaseMessaging.send(any()) }
+        }
+
+        @Test
+        fun `data와 함께 발송한다`() {
+            // given
+            every { firebaseMessaging.send(any()) } returns "message-id"
+
+            // when
+            val result =
+                adapter.send("token-1", "제목", "내용", mapOf("key" to "value"))
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `재시도 가능한 오류 시 재시도 후 성공한다`() {
+            // given
+            val exception = mockk<FirebaseMessagingException>()
+            every { exception.messagingErrorCode } returns MessagingErrorCode.UNAVAILABLE
+
+            var callCount = 0
+            every { firebaseMessaging.send(any()) } answers {
+                callCount++
+                if (callCount == 1) throw exception
+                "message-id"
+            }
+
+            // when
+            val result = adapter.send("token-1", "제목", "내용")
+
+            // then
+            assertThat(result).isTrue()
+            verify(exactly = 2) { firebaseMessaging.send(any()) }
+        }
+
+        @Test
+        fun `재시도 불가능한 오류 시 즉시 실패한다`() {
+            // given
+            val exception = mockk<FirebaseMessagingException>()
+            every { exception.messagingErrorCode } returns MessagingErrorCode.INVALID_ARGUMENT
+
+            every { firebaseMessaging.send(any()) } throws exception
+
+            // when
+            val result = adapter.send("token-1", "제목", "내용")
+
+            // then
+            assertThat(result).isFalse()
+            verify(exactly = 1) { firebaseMessaging.send(any()) }
+        }
+
+        @Test
+        fun `INTERNAL 오류로 최대 재시도 횟수 초과 시 실패한다`() {
+            // given
+            val exception = mockk<FirebaseMessagingException>()
+            every { exception.messagingErrorCode } returns MessagingErrorCode.INTERNAL
+
+            every { firebaseMessaging.send(any()) } throws exception
+
+            // when
+            val result = adapter.send("token-1", "제목", "내용")
+
+            // then
+            assertThat(result).isFalse()
+            verify(exactly = 3) { firebaseMessaging.send(any()) }
+        }
+
+        @Test
+        fun `예상치 못한 예외 시 즉시 실패한다`() {
+            // given
+            every { firebaseMessaging.send(any()) } throws
+                RuntimeException("unexpected")
+
+            // when
+            val result = adapter.send("token-1", "제목", "내용")
+
+            // then
+            assertThat(result).isFalse()
+            verify(exactly = 1) { firebaseMessaging.send(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("sendBatch")
+    inner class SendBatch {
+        @Test
+        fun `빈 토큰 목록이면 0을 반환한다`() {
+            // when
+            val result = adapter.sendBatch(emptyList(), "제목", "내용")
+
+            // then
+            assertThat(result).isEqualTo(0)
+        }
+
+        @Test
+        fun `배치 발송 성공`() {
+            // given
+            val batchResponse = mockk<BatchResponse>()
+            every { batchResponse.successCount } returns 3
+            every { batchResponse.failureCount } returns 0
+            every { firebaseMessaging.sendEachForMulticast(any()) } returns batchResponse
+
+            // when
+            val result =
+                adapter.sendBatch(listOf("t1", "t2", "t3"), "제목", "내용")
+
+            // then
+            assertThat(result).isEqualTo(3)
+        }
+
+        @Test
+        fun `data와 함께 배치 발송한다`() {
+            // given
+            val batchResponse = mockk<BatchResponse>()
+            every { batchResponse.successCount } returns 2
+            every { batchResponse.failureCount } returns 0
+            every { firebaseMessaging.sendEachForMulticast(any()) } returns batchResponse
+
+            // when
+            val result =
+                adapter.sendBatch(
+                    listOf("t1", "t2"),
+                    "제목",
+                    "내용",
+                    mapOf("key" to "value"),
+                )
+
+            // then
+            assertThat(result).isEqualTo(2)
+        }
+
+        @Test
+        fun `부분 실패 시 성공 수만 반환한다`() {
+            // given
+            val failedException = mockk<FirebaseMessagingException>()
+            every { failedException.messagingErrorCode } returns MessagingErrorCode.INVALID_ARGUMENT
+
+            val failedResponse = mockk<SendResponse>()
+            every { failedResponse.isSuccessful } returns false
+            every { failedResponse.exception } returns failedException
+
+            val successResponse = mockk<SendResponse>()
+            every { successResponse.isSuccessful } returns true
+
+            val batchResponse = mockk<BatchResponse>()
+            every { batchResponse.successCount } returns 2
+            every { batchResponse.failureCount } returns 1
+            every { batchResponse.responses } returns
+                listOf(successResponse, successResponse, failedResponse)
+            every { firebaseMessaging.sendEachForMulticast(any()) } returns batchResponse
+
+            // when
+            val result =
+                adapter.sendBatch(listOf("t1", "t2", "t3"), "제목", "내용")
+
+            // then
+            assertThat(result).isEqualTo(2)
+        }
+
+        @Test
+        fun `배치 발송 중 예외 발생 시 0을 반환한다`() {
+            // given
+            every { firebaseMessaging.sendEachForMulticast(any()) } throws
+                RuntimeException("error")
+
+            // when
+            val result = adapter.sendBatch(listOf("t1"), "제목", "내용")
+
+            // then
+            assertThat(result).isEqualTo(0)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/adapter/notification/StubPushNotificationAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/adapter/notification/StubPushNotificationAdapterTest.kt
@@ -1,0 +1,50 @@
+package com.nextup.infrastructure.adapter.notification
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class StubPushNotificationAdapterTest {
+    private val adapter = StubPushNotificationAdapter()
+
+    @Test
+    fun `단일 발송은 항상 성공을 반환한다`() {
+        val result = adapter.send("test-token", "제목", "내용")
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `배치 발송은 토큰 수만큼 성공 수를 반환한다`() {
+        val tokens = listOf("token-1", "token-2", "token-3")
+
+        val result = adapter.sendBatch(tokens, "제목", "내용")
+
+        assertThat(result).isEqualTo(3)
+    }
+
+    @Test
+    fun `빈 토큰 목록의 배치 발송은 0을 반환한다`() {
+        val result = adapter.sendBatch(emptyList(), "제목", "내용")
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `추가 데이터와 함께 발송할 수 있다`() {
+        val data = mapOf("gameId" to "123", "type" to "GAME_START")
+
+        val result = adapter.send("test-token", "제목", "내용", data)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `추가 데이터와 함께 배치 발송할 수 있다`() {
+        val tokens = listOf("token-1", "token-2")
+        val data = mapOf("gameId" to "123")
+
+        val result = adapter.sendBatch(tokens, "제목", "내용", data)
+
+        assertThat(result).isEqualTo(2)
+    }
+}


### PR DESCRIPTION
## Summary

> - Closes #263

Firebase Cloud Messaging 기반 푸시 알림 실제 연동 구현

## Tasks

- `PushNotificationPort` 인터페이스 생성 (Core 모듈 outbound port)
- `FcmPushNotificationAdapter` 구현 (Firebase Admin SDK 기반, `@Primary`)
- `StubPushNotificationAdapter` 테스트용 구현 (`@Profile("test")`)
- `FirebaseConfig` 설정 클래스 추가 (서비스 계정 키 기반 초기화)
- `NotificationService.sendNotification()`에 푸시 발송 연동
- 재시도 로직 (최대 3회, UNAVAILABLE/INTERNAL 에러만)
- 배치 발송 지원 (500개 단위 청크)
- 기존 테스트 업데이트 + StubAdapter 테스트 5건 추가

## To Reviewer

- Firebase Admin SDK 9.4.2 의존성 추가 (`firebase-admin`)
- `firebase.credentials-path` 속성 또는 `GOOGLE_APPLICATION_CREDENTIALS` 환경변수로 인증
- Firebase 초기화 실패 시 warn 로그만 출력하고 앱은 정상 기동 (푸시만 비활성화)
- 푸시 발송 실패는 알림 DB 저장에 영향 없음 (try-catch로 격리)