### PR TITLE
feat(#123): Testcontainers 기반 통합 테스트 인프라 도입

### DIFF
--- a/nextup-api/build.gradle.kts
+++ b/nextup-api/build.gradle.kts
@@ -34,6 +34,11 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.14")
     testImplementation("org.assertj:assertj-core:3.27.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // Testcontainers (Integration Tests)
+    testImplementation("org.testcontainers:postgresql:1.20.4")
+    testImplementation("org.testcontainers:junit-jupiter:1.20.4")
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 tasks.withType<Test> {

--- a/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/config/SecurityConfig.kt
@@ -121,8 +121,8 @@ class SecurityConfig(
                     .userInfoEndpoint { it.userService(customOAuth2UserService) }
                     .successHandler(oAuth2AuthenticationSuccessHandler)
                     .failureHandler(oAuth2AuthenticationFailureHandler)
-            }.addFilterBefore(rateLimitFilter, JwtAuthenticationFilter::class.java)
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            }.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(rateLimitFilter, JwtAuthenticationFilter::class.java)
             .build()
 
     @Bean

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/NudgeController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/attendance/NudgeController.kt
@@ -7,13 +7,13 @@ import com.nextup.core.service.attendance.NudgeService
 import org.springframework.web.bind.annotation.*
 
 /**
- * 출석 관리 API Controller
+ * 출석 재촉 API Controller
  *
- * 경기 출석 투표 및 재촉 기능을 제공합니다.
+ * 경기 출석 투표 독려(재촉) 기능을 제공합니다.
  */
 @RestController
 @RequestMapping("/api/v1/games/{gameId}/attendance")
-class AttendanceController(
+class NudgeController(
     private val nudgeService: NudgeService,
 ) {
     /**

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/user/ProfileController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/user/ProfileController.kt
@@ -46,25 +46,6 @@ class ProfileController(
     }
 
     /**
-     * 연동된 OAuth 계정 목록을 조회합니다.
-     */
-    @GetMapping("/oauth-accounts")
-    fun getLinkedOAuthAccounts(
-        @AuthenticationPrincipal userId: Long,
-    ): ApiResponse<List<LinkedOAuthProvider>> {
-        val user = userService.getActiveById(userId)
-        val providers =
-            user.oauthAccounts.map {
-                LinkedOAuthProvider(
-                    provider = it.provider.name,
-                    displayName = it.provider.displayName,
-                    connectedAt = it.connectedAt,
-                )
-            }
-        return ApiResponse.success(providers)
-    }
-
-    /**
      * 회원 탈퇴합니다 (계정 비활성화).
      */
     @DeleteMapping

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/attendance/AttendanceControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/attendance/AttendanceControllerTest.kt
@@ -30,7 +30,7 @@ class AttendanceControllerTest {
 
         mockMvc =
             MockMvcBuilders
-                .standaloneSetup(AttendanceController(nudgeService))
+                .standaloneSetup(NudgeController(nudgeService))
                 .setControllerAdvice(GlobalExceptionHandler())
                 .build()
     }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/user/ProfileControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/user/ProfileControllerTest.kt
@@ -128,42 +128,6 @@ class ProfileControllerTest {
     }
 
     @Nested
-    @DisplayName("연동된 OAuth 계정 조회")
-    inner class GetLinkedOAuthAccounts {
-        @Test
-        fun `should return empty list when no oauth linked`() {
-            // given
-            val userId = 1L
-            val user = createTestUser(userId, hasOAuth = false)
-            every { userService.getActiveById(userId) } returns user
-
-            // when
-            val response = profileController.getLinkedOAuthAccounts(userId)
-
-            // then
-            assertThat(response.success).isTrue()
-            assertThat(response.data).isEmpty()
-        }
-
-        @Test
-        fun `should return oauth accounts when linked`() {
-            // given
-            val userId = 1L
-            val user = createTestUser(userId, hasOAuth = true)
-            every { userService.getActiveById(userId) } returns user
-
-            // when
-            val response = profileController.getLinkedOAuthAccounts(userId)
-
-            // then
-            assertThat(response.success).isTrue()
-            assertThat(response.data).hasSize(1)
-            assertThat(response.data?.first()?.provider).isEqualTo("GOOGLE")
-            assertThat(response.data?.first()?.displayName).isEqualTo("구글")
-        }
-    }
-
-    @Nested
     @DisplayName("회원 탈퇴")
     inner class DeactivateMyAccount {
         @Test

--- a/nextup-api/src/test/kotlin/com/nextup/api/integration/IntegrationTestBase.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/integration/IntegrationTestBase.kt
@@ -1,0 +1,45 @@
+package com.nextup.api.integration
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * 통합 테스트 기본 클래스
+ *
+ * Testcontainers로 PostgreSQL + PostGIS를 실행하고,
+ * Flyway 마이그레이션을 적용하여 실제 DB 환경에서 테스트합니다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@ActiveProfiles("integration")
+abstract class IntegrationTestBase {
+    companion object {
+        private val postgisImage =
+            DockerImageName.parse("postgis/postgis:15-3.3")
+                .asCompatibleSubstituteFor("postgres")
+
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> =
+            PostgreSQLContainer(postgisImage)
+                .withDatabaseName("nextup_test")
+                .withUsername("test")
+                .withPassword("test")
+
+        init {
+            postgres.start()
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/integration/NotificationApiIntegrationTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/integration/NotificationApiIntegrationTest.kt
@@ -1,0 +1,121 @@
+package com.nextup.api.integration
+
+import com.nextup.core.domain.notification.DevicePlatform
+import com.nextup.core.domain.notification.DeviceToken
+import com.nextup.core.domain.notification.Notification
+import com.nextup.core.domain.notification.NotificationType
+import com.nextup.core.port.repository.DeviceTokenRepositoryPort
+import com.nextup.core.port.repository.NotificationRepositoryPort
+import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@AutoConfigureMockMvc
+@Transactional
+class NotificationApiIntegrationTest : IntegrationTestBase() {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    @Autowired
+    private lateinit var notificationRepository: NotificationRepositoryPort
+
+    @Autowired
+    private lateinit var deviceTokenRepository: DeviceTokenRepositoryPort
+
+    private fun createToken(userId: Long): String =
+        jwtTokenProvider.createAccessToken(
+            userId = userId,
+            email = "test@test.com",
+            roles = setOf("ROLE_USER"),
+        )
+
+    @Test
+    fun `알림 생성 후 미읽음 수 조회가 정상 동작한다`() {
+        // given
+        val userId = 100L
+        val notification =
+            Notification.create(
+                userId = userId,
+                type = NotificationType.TEAM_NOTICE,
+                title = "테스트 알림",
+                body = "테스트 알림 내용입니다",
+            )
+        notification.markAsSent()
+        notificationRepository.save(notification)
+
+        val token = createToken(userId)
+
+        // when & then
+        val result =
+            mockMvc
+                .perform(
+                    get("/api/v1/notifications/unread-count")
+                        .header("Authorization", "Bearer $token"),
+                )
+                .andExpect(status().isOk)
+                .andReturn()
+
+        assertThat(result.response.contentAsString).contains("\"count\":1")
+    }
+
+    @Test
+    fun `디바이스 토큰 등록 후 목록 조회가 정상 동작한다`() {
+        // given
+        val userId = 200L
+        val device =
+            DeviceToken.create(
+                userId = userId,
+                token = "fcm-integration-test-token",
+                platform = DevicePlatform.ANDROID,
+            )
+        deviceTokenRepository.save(device)
+
+        // when
+        val devices = deviceTokenRepository.findByUserId(userId)
+
+        // then
+        assertThat(devices).hasSize(1)
+        assertThat(devices[0].token).isEqualTo("fcm-integration-test-token")
+        assertThat(devices[0].platform).isEqualTo(DevicePlatform.ANDROID)
+    }
+
+    @Test
+    fun `알림 목록 API 조회가 정상 동작한다`() {
+        // given
+        val userId = 300L
+        repeat(3) { i ->
+            val notification =
+                Notification.create(
+                    userId = userId,
+                    type = NotificationType.GAME_START,
+                    title = "알림 ${i + 1}",
+                    body = "알림 내용 ${i + 1}",
+                )
+            notification.markAsSent()
+            notificationRepository.save(notification)
+        }
+
+        val token = createToken(userId)
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/notifications")
+                    .param("page", "0")
+                    .param("size", "10")
+                    .header("Authorization", "Bearer $token"),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.content").isArray)
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/integration/SecurityIntegrationTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/integration/SecurityIntegrationTest.kt
@@ -1,0 +1,57 @@
+package com.nextup.api.integration
+
+import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@AutoConfigureMockMvc
+class SecurityIntegrationTest : IntegrationTestBase() {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    @Test
+    fun `인증 없이 보호된 API 호출 시 401이 반환된다`() {
+        mockMvc
+            .perform(get("/api/v1/teams"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `유효한 JWT로 API 호출 시 정상 응답이 반환된다`() {
+        val token =
+            jwtTokenProvider.createAccessToken(
+                userId = 1L,
+                email = "test@test.com",
+                roles = setOf("ROLE_USER"),
+            )
+
+        mockMvc
+            .perform(
+                get("/api/v1/notifications/unread-count")
+                    .header("Authorization", "Bearer $token"),
+            )
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `만료된 JWT로 API 호출 시 401이 반환된다`() {
+        val expiredToken =
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwi" +
+                "cm9sZXMiOlsiUk9MRV9VU0VSIl0sInR5cGUiOiJhY2Nlc3MiLCJpc3MiOiJuZXh0dXAi" +
+                "LCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MTcwMDAwMDAwMX0.invalid"
+
+        mockMvc
+            .perform(
+                get("/api/v1/teams")
+                    .header("Authorization", "Bearer $expiredToken"),
+            )
+            .andExpect(status().isUnauthorized)
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/integration/TeamRepositoryIntegrationTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/integration/TeamRepositoryIntegrationTest.kt
@@ -1,0 +1,154 @@
+package com.nextup.api.integration
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.TeamRepositoryPort
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+class TeamRepositoryIntegrationTest : IntegrationTestBase() {
+    @Autowired
+    private lateinit var teamRepository: TeamRepositoryPort
+
+    @Autowired
+    private lateinit var entityManager: EntityManager
+
+    private lateinit var league: League
+
+    @BeforeEach
+    fun setUp() {
+        val association =
+            Association(
+                name = "서울시야구협회",
+                abbreviation = "SBA",
+                region = "서울",
+            )
+        entityManager.persist(association)
+
+        league =
+            League(
+                association = association,
+                name = "1부 리그",
+                abbreviation = "L1",
+                foundedYear = 2020,
+            )
+        entityManager.persist(league)
+        entityManager.flush()
+    }
+
+    @Test
+    fun `팀을 저장하고 ID로 조회할 수 있다`() {
+        // given
+        val team =
+            Team(
+                league = league,
+                name = "테스트팀",
+                city = "서울",
+                foundedYear = 2024,
+                abbreviation = "TST",
+            )
+        val saved = teamRepository.save(team)
+
+        entityManager.flush()
+        entityManager.clear()
+
+        // when
+        val found = teamRepository.findByIdOrNull(saved.id)
+
+        // then
+        assertThat(found).isNotNull
+        assertThat(found!!.name).isEqualTo("테스트팀")
+        assertThat(found.city).isEqualTo("서울")
+        assertThat(found.foundedYear).isEqualTo(2024)
+    }
+
+    @Test
+    fun `이름으로 팀을 조회할 수 있다`() {
+        // given
+        val team =
+            Team(
+                league = league,
+                name = "유니크팀",
+                city = "부산",
+                foundedYear = 2023,
+            )
+        teamRepository.save(team)
+        entityManager.flush()
+        entityManager.clear()
+
+        // when
+        val found = teamRepository.findByName("유니크팀")
+
+        // then
+        assertThat(found).isNotNull
+        assertThat(found!!.city).isEqualTo("부산")
+    }
+
+    @Test
+    fun `활성 팀만 필터 조회할 수 있다`() {
+        // given
+        val activeTeam =
+            Team(
+                league = league,
+                name = "활성팀",
+                city = "서울",
+                foundedYear = 2024,
+                isActive = true,
+            )
+        val inactiveTeam =
+            Team(
+                league = league,
+                name = "비활성팀",
+                city = "인천",
+                foundedYear = 2024,
+                isActive = false,
+            )
+        teamRepository.save(activeTeam)
+        teamRepository.save(inactiveTeam)
+        entityManager.flush()
+        entityManager.clear()
+
+        // when
+        val activeTeams = teamRepository.findActiveTeams()
+
+        // then
+        assertThat(activeTeams.map { it.name }).contains("활성팀")
+        assertThat(activeTeams.map { it.name }).doesNotContain("비활성팀")
+    }
+
+    @Test
+    fun `리그 ID로 팀 목록을 조회할 수 있다`() {
+        // given
+        val team1 =
+            Team(
+                league = league,
+                name = "팀A",
+                city = "서울",
+                foundedYear = 2024,
+            )
+        val team2 =
+            Team(
+                league = league,
+                name = "팀B",
+                city = "부산",
+                foundedYear = 2024,
+            )
+        teamRepository.save(team1)
+        teamRepository.save(team2)
+        entityManager.flush()
+        entityManager.clear()
+
+        // when
+        val teams = teamRepository.findByLeagueId(league.id)
+
+        // then
+        assertThat(teams).hasSizeGreaterThanOrEqualTo(2)
+        assertThat(teams.map { it.name }).containsAll(listOf("팀A", "팀B"))
+    }
+}

--- a/nextup-api/src/test/resources/application-integration.yml
+++ b/nextup-api/src/test/resources/application-integration.yml
@@ -1,0 +1,62 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-client-id
+            client-secret: test-client-secret
+            scope: email,profile
+          kakao:
+            client-id: test-client-id
+            client-secret: test-client-secret
+            scope: account_email,profile_nickname
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            client-authentication-method: client_secret_post
+          naver:
+            client-id: test-client-id
+            client-secret: test-client-secret
+            scope: email,name
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            client-name: Naver
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
+  flyway:
+    enabled: false
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+    default-property-inclusion: non_null
+
+jwt:
+  secret: dGVzdC1vbmx5LXNlY3JldC1rZXktZm9yLWludGVncmF0aW9uLXRlc3RpbmctcHVycG9zZXM=
+  access-token-expiration: 1800000
+  refresh-token-expiration: 604800000
+  issuer: nextup
+
+app:
+  oauth2:
+    base-url: http://localhost:8080
+    redirect-uri: http://localhost:3000/oauth2/callback
+  cors:
+    allowed-origins: http://localhost:3000

--- a/nextup-infrastructure/build.gradle.kts
+++ b/nextup-infrastructure/build.gradle.kts
@@ -13,7 +13,7 @@ java {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.addAll("-Xjsr305=strict")
+        freeCompilerArgs.addAll("-Xjsr305=strict", "-Xjvm-default=all")
     }
 }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/JpaConfig.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/JpaConfig.kt
@@ -1,10 +1,12 @@
 package com.nextup.infrastructure.config
 
+import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @Configuration
 @EnableJpaAuditing
-@EnableJpaRepositories(basePackages = ["com.nextup.infrastructure.repository"])
+@EntityScan(basePackages = ["com.nextup.core.domain"])
+@EnableJpaRepositories(basePackages = ["com.nextup.infrastructure"])
 class JpaConfig

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/ElectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/ElectionEventListener.kt
@@ -8,6 +8,7 @@ import com.nextup.core.port.repository.ElectionVoteRepositoryPort
 import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -31,7 +32,7 @@ class ElectionEventListener(
      * 동률이거나 투표가 없으면 이양하지 않습니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onElectionCompleted(event: ElectionCompletedEvent) {
         if (event.electionType != ElectionType.OWNER_ELECTION) {
             log.debug("선거 완료 이벤트 무시 (OWNER_ELECTION이 아님): electionId={}", event.electionId)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
@@ -9,6 +9,7 @@ import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -42,7 +43,7 @@ class GameCancelEventListener(
      * AFTER_COMMIT 단계에서 실행하여 취소 트랜잭션이 완전히 커밋된 이후 통계를 역산합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onGameCancelled(event: GameCancelledEvent) {
         val gameId = event.gameId
         logger.info("경기 취소 스탯 롤백 시작 (gameId={})", gameId)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameResultEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameResultEventListener.kt
@@ -9,7 +9,6 @@ import com.nextup.infrastructure.config.CacheConfig
 import org.slf4j.LoggerFactory
 import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
@@ -34,7 +33,6 @@ class GameResultEventListener(
      * BEFORE_COMMIT 단계에서 실행하여 대회 자동 완료를 동일 트랜잭션 내에서 처리합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
-    @Transactional
     fun onGameResultConfirmed(event: GameResultConfirmedEvent) {
         val game =
             gameRepository.findByIdOrNull(event.gameId)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
@@ -10,6 +10,7 @@ import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -31,7 +32,7 @@ class RecordCorrectionEventListener(
     private val logger = LoggerFactory.getLogger(RecordCorrectionEventListener::class.java)
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onRecordCorrected(event: RecordCorrectedEvent) {
         val delta = event.newValue.toInt() - event.oldValue.toInt()
         if (delta == 0) {

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
@@ -21,6 +21,7 @@ import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -54,7 +55,7 @@ class StatsEventListener(
      * 시즌 통계가 없는 경우 갱신을 건너뜁니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onPlateAppearanceRecorded(event: PlateAppearanceRecordedEvent) {
         val year = resolveYear(event.gameId)
         val stats =
@@ -86,7 +87,7 @@ class StatsEventListener(
      * 시즌 통계가 없는 경우 갱신을 건너뜁니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onPlateAppearanceUndone(event: PlateAppearanceUndoneEvent) {
         val year = resolveYear(event.gameId)
         val stats =
@@ -127,7 +128,7 @@ class StatsEventListener(
      * 2. 타자 스탯: isFirstSeasonRecord 확인 → CareerBattingStats 갱신
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onGameResultConfirmed(event: GameResultConfirmedEvent) {
         val gameId = event.gameId
         val year = resolveYear(gameId)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListener.kt
@@ -19,6 +19,7 @@ import com.nextup.core.port.repository.StadiumBookingRepositoryPort
 import com.nextup.core.port.repository.TeamJoinRequestRepositoryPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -49,7 +50,7 @@ class TeamMemberEventListener(
      * 제거 후 라인업이 비어 있으면 상태를 DRAFT로 되돌립니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun handleTeamMemberLeft(event: TeamMemberLeftEvent) {
         logger.info("팀원 탈퇴 처리 - teamId={}, playerId={}, memberId={}", event.teamId, event.playerId, event.memberId)
         removePlayerFromActiveLineups(event.teamId, event.playerId)
@@ -63,7 +64,7 @@ class TeamMemberEventListener(
      * 제거 후 라인업이 비어 있으면 상태를 DRAFT로 되돌립니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun handleTeamMemberKicked(event: TeamMemberKickedEvent) {
         logger.info("팀원 강퇴 처리 - teamId={}, playerId={}, memberId={}", event.teamId, event.playerId, event.memberId)
         removePlayerFromActiveLineups(event.teamId, event.playerId)
@@ -80,7 +81,7 @@ class TeamMemberEventListener(
      * - PENDING 상태의 TeamJoinRequest → 일괄 REJECTED
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun handleTeamDisbanded(event: TeamDisbandedEvent) {
         logger.info("팀 해산 연쇄 처리 - teamId={}", event.teamId)
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerRepository.kt
@@ -17,6 +17,8 @@ import java.time.LocalDate
 interface PlayerRepository :
     JpaRepository<Player, Long>,
     PlayerRepositoryPort {
+    override fun findByIdOrNull(id: Long): Player? = findById(id).orElse(null)
+
     override fun findByName(name: String): List<Player>
 
     override fun findByNameContaining(name: String): List<Player>
@@ -26,8 +28,8 @@ interface PlayerRepository :
 
     @Query(
         """
-        SELECT p FROM Player p
-        JOIN FETCH p._teamHistories h
+        SELECT DISTINCT p FROM Player p
+        JOIN PlayerTeamHistory h ON h.player.id = p.id
         WHERE h.team.id = :teamId AND h.endDate IS NULL
     """,
     )
@@ -35,8 +37,8 @@ interface PlayerRepository :
 
     @Query(
         """
-        SELECT p FROM Player p
-        JOIN p._teamHistories h
+        SELECT DISTINCT p FROM Player p
+        JOIN PlayerTeamHistory h ON h.player.id = p.id
         WHERE h.team.id = :teamId
         AND h.startDate <= :date
         AND (h.endDate IS NULL OR h.endDate >= :date)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerTeamHistoryRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/PlayerTeamHistoryRepository.kt
@@ -11,6 +11,8 @@ import java.time.LocalDate
 interface PlayerTeamHistoryRepository :
     JpaRepository<PlayerTeamHistory, Long>,
     PlayerTeamHistoryRepositoryPort {
+    override fun findByIdOrNull(id: Long): PlayerTeamHistory? = findById(id).orElse(null)
+
     override fun findByPlayerId(playerId: Long): List<PlayerTeamHistory>
 
     override fun findByTeamId(teamId: Long): List<PlayerTeamHistory>

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/UserJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/UserJpaRepository.kt
@@ -1,0 +1,13 @@
+package com.nextup.infrastructure.repository
+
+import com.nextup.core.domain.user.User
+import org.springframework.data.jpa.repository.JpaRepository
+
+/**
+ * User JPA Repository
+ */
+interface UserJpaRepository : JpaRepository<User, Long> {
+    fun findByEmail(email: String): User?
+
+    fun existsByEmail(email: String): Boolean
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/admin/OrganizationAdminRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/admin/OrganizationAdminRepository.kt
@@ -11,6 +11,8 @@ import org.springframework.data.jpa.repository.Query
 interface OrganizationAdminRepository :
     JpaRepository<OrganizationAdmin, Long>,
     OrganizationAdminRepositoryPort {
+    override fun findByIdOrNull(id: Long): OrganizationAdmin? = findById(id).orElse(null)
+
     /**
      * 특정 사용자의 모든 조직 관리자 권한을 조회합니다.
      */

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/appeal/AppealRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/appeal/AppealRepository.kt
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface AppealRepository :
     JpaRepository<Appeal, Long>,
     AppealRepositoryPort {
+    override fun findByIdOrNull(id: Long): Appeal? = findById(id).orElse(null)
+
     override fun findByGameId(gameId: Long): List<Appeal>
 
     override fun findByAppealerId(appealerId: Long): List<Appeal>

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/association/AssociationRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/association/AssociationRepository.kt
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query
 interface AssociationRepository :
     JpaRepository<Association, Long>,
     AssociationRepositoryPort {
+    override fun findByIdOrNull(id: Long): Association? = findById(id).orElse(null)
+
     /**
      * 협회 이름으로 조회합니다.
      */

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/competition/CompetitionRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/competition/CompetitionRepository.kt
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query
 interface CompetitionRepository :
     JpaRepository<Competition, Long>,
     CompetitionRepositoryPort {
+    override fun findByIdOrNull(id: Long): Competition? = findById(id).orElse(null)
+
     /**
      * 리그별 대회 목록 조회
      */

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/discipline/DisciplineRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/discipline/DisciplineRepository.kt
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query
 interface DisciplineRepository :
     JpaRepository<Discipline, Long>,
     DisciplineRepositoryPort {
+    override fun findByIdOrNull(id: Long): Discipline? = findById(id).orElse(null)
+
     override fun findByPlayerId(playerId: Long): List<Discipline>
 
     override fun findByPlayerIdAndCompetitionId(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
@@ -35,7 +35,7 @@ interface BattingRecordRepository :
         """
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
-        WHERE gp.game.id = :gameId
+        WHERE gp.gameTeam.game.id = :gameId
     """,
     )
     override fun findAllByGameId(
@@ -50,7 +50,7 @@ interface BattingRecordRepository :
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
         WHERE gp.player.id = :playerId
-        ORDER BY gp.game.scheduledDate DESC
+        ORDER BY gp.gameTeam.game.scheduledAt DESC
     """,
     )
     override fun findAllByPlayerId(
@@ -65,7 +65,7 @@ interface BattingRecordRepository :
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
         WHERE gp.player.id = :playerId
-        ORDER BY gp.game.scheduledDate DESC
+        ORDER BY gp.gameTeam.game.scheduledAt DESC
         LIMIT :limit
     """,
     )
@@ -83,7 +83,7 @@ interface BattingRecordRepository :
         JOIN br.gamePlayer gp
         JOIN gp.gameTeam gt
         WHERE gt.team.id = :teamId
-        AND gp.game.id = :gameId
+        AND gp.gameTeam.game.id = :gameId
     """,
     )
     override fun findAllByTeamIdAndGameId(
@@ -98,7 +98,7 @@ interface BattingRecordRepository :
         """
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
-        WHERE gp.game.id = :gameId
+        WHERE gp.gameTeam.game.id = :gameId
         AND br.plateAppearances >= :minPlateAppearances
     """,
     )
@@ -159,8 +159,8 @@ interface BattingRecordRepository :
         SELECT br FROM BattingRecord br
         JOIN br.gamePlayer gp
         WHERE gp.player.id = :playerId
-        AND FUNCTION('YEAR', gp.game.scheduledAt) = :year
-        ORDER BY gp.game.scheduledAt DESC
+        AND FUNCTION('YEAR', gp.gameTeam.game.scheduledAt) = :year
+        ORDER BY gp.gameTeam.game.scheduledAt DESC
     """,
     )
     override fun findAllByPlayerIdAndYear(
@@ -177,7 +177,7 @@ interface BattingRecordRepository :
         JOIN br.gamePlayer gp
         JOIN gp.gameTeam gt
         WHERE gt.team.id = :teamId
-        AND gp.game.id IN :gameIds
+        AND gp.gameTeam.game.id IN :gameIds
     """,
     )
     override fun findAllByTeamIdAndGameIds(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GamePlayerRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GamePlayerRepository.kt
@@ -9,6 +9,8 @@ import org.springframework.data.repository.query.Param
 interface GamePlayerRepository :
     JpaRepository<GamePlayer, Long>,
     GamePlayerRepositoryPort {
+    override fun findByIdOrNull(id: Long): GamePlayer? = findById(id).orElse(null)
+
     /**
      * 경기 ID와 선수 ID로 GamePlayer를 조회합니다.
      */

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
@@ -12,7 +12,10 @@ interface GameRepository :
     GameRepositoryPort {
     override fun findByIdOrNull(id: Long): Game? = findById(id).orElse(null)
 
-    override fun findAllByIds(ids: List<Long>): List<Game> = findAllById(ids)
+    @Query("SELECT g FROM Game g WHERE g.id IN :ids")
+    override fun findAllByIds(
+        @Param("ids") ids: List<Long>,
+    ): List<Game>
 
     @Query("SELECT g FROM Game g WHERE g.competition.id = :competitionId ORDER BY g.scheduledAt ASC")
     override fun findByCompetitionId(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/LineupEntryRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/LineupEntryRepository.kt
@@ -11,6 +11,9 @@ interface LineupEntryRepository :
     LineupEntryRepositoryPort {
     override fun findByIdOrNull(id: Long): LineupEntry? = findById(id).orElse(null)
 
+    @Suppress("UNCHECKED_CAST")
+    override fun saveAll(entries: List<LineupEntry>): List<LineupEntry> = saveAll(entries as Iterable<LineupEntry>)
+
     @Query(
         "SELECT le FROM LineupEntry le WHERE le.submission.id = :submissionId " +
             "ORDER BY le.battingOrder ASC NULLS LAST",

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
@@ -36,7 +36,7 @@ interface PitchingRecordRepository :
         """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
-        WHERE gp.game.id = :gameId
+        WHERE gp.gameTeam.game.id = :gameId
     """,
     )
     override fun findAllByGameId(
@@ -51,7 +51,7 @@ interface PitchingRecordRepository :
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.player.id = :playerId
-        ORDER BY gp.game.scheduledDate DESC
+        ORDER BY gp.gameTeam.game.scheduledAt DESC
     """,
     )
     override fun findAllByPlayerId(
@@ -66,7 +66,7 @@ interface PitchingRecordRepository :
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.player.id = :playerId
-        ORDER BY gp.game.scheduledDate DESC
+        ORDER BY gp.gameTeam.game.scheduledAt DESC
         LIMIT :limit
     """,
     )
@@ -84,7 +84,7 @@ interface PitchingRecordRepository :
         JOIN pr.gamePlayer gp
         JOIN gp.gameTeam gt
         WHERE gt.team.id = :teamId
-        AND gp.game.id = :gameId
+        AND gp.gameTeam.game.id = :gameId
     """,
     )
     override fun findAllByTeamIdAndGameId(
@@ -99,7 +99,7 @@ interface PitchingRecordRepository :
         """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
-        WHERE gp.game.id = :gameId
+        WHERE gp.gameTeam.game.id = :gameId
         AND pr.isStartingPitcher = true
     """,
     )
@@ -114,7 +114,7 @@ interface PitchingRecordRepository :
         """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
-        WHERE gp.game.id = :gameId
+        WHERE gp.gameTeam.game.id = :gameId
         AND pr.isStartingPitcher = false
     """,
     )
@@ -142,7 +142,7 @@ interface PitchingRecordRepository :
         """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
-        WHERE gp.game.id = :gameId
+        WHERE gp.gameTeam.game.id = :gameId
         AND pr.decision = 'WIN'
     """,
     )
@@ -157,7 +157,7 @@ interface PitchingRecordRepository :
         """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
-        WHERE gp.game.id = :gameId
+        WHERE gp.gameTeam.game.id = :gameId
         AND pr.decision = 'LOSS'
     """,
     )
@@ -172,7 +172,7 @@ interface PitchingRecordRepository :
         """
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
-        WHERE gp.game.id = :gameId
+        WHERE gp.gameTeam.game.id = :gameId
         AND pr.decision = 'SAVE'
     """,
     )
@@ -248,8 +248,8 @@ interface PitchingRecordRepository :
         SELECT pr FROM PitchingRecord pr
         JOIN pr.gamePlayer gp
         WHERE gp.player.id = :playerId
-        AND FUNCTION('YEAR', gp.game.scheduledAt) = :year
-        ORDER BY gp.game.scheduledAt DESC
+        AND FUNCTION('YEAR', gp.gameTeam.game.scheduledAt) = :year
+        ORDER BY gp.gameTeam.game.scheduledAt DESC
     """,
     )
     override fun findAllByPlayerIdAndYear(
@@ -266,7 +266,7 @@ interface PitchingRecordRepository :
         JOIN pr.gamePlayer gp
         JOIN gp.gameTeam gt
         WHERE gt.team.id = :teamId
-        AND gp.game.id IN :gameIds
+        AND gp.gameTeam.game.id IN :gameIds
     """,
     )
     override fun findAllByTeamIdAndGameIds(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/league/LeagueRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/league/LeagueRepository.kt
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query
 interface LeagueRepository :
     JpaRepository<League, Long>,
     LeagueRepositoryPort {
+    override fun findByIdOrNull(id: Long): League? = findById(id).orElse(null)
+
     /**
      * 협회 ID로 리그 목록을 조회합니다.
      */

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/DeviceTokenRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/DeviceTokenRepository.kt
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface DeviceTokenRepository :
     JpaRepository<DeviceToken, Long>,
     DeviceTokenRepositoryPort {
+    override fun findByIdOrNull(id: Long): DeviceToken? = findById(id).orElse(null)
+
     override fun findByUserId(userId: Long): List<DeviceToken>
 
     override fun deleteByToken(token: String)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
@@ -15,6 +15,8 @@ import org.springframework.data.repository.query.Param
 interface NotificationRepository :
     JpaRepository<Notification, Long>,
     NotificationRepositoryPort {
+    override fun findByIdOrNull(id: Long): Notification? = findById(id).orElse(null)
+
     fun findByUserId(
         userId: Long,
         pageable: Pageable,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/recruitment/TeamRecruitmentRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/recruitment/TeamRecruitmentRepository.kt
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query
 interface TeamRecruitmentRepository :
     JpaRepository<TeamRecruitment, Long>,
     TeamRecruitmentRepositoryPort {
+    override fun findByIdOrNull(id: Long): TeamRecruitment? = findById(id).orElse(null)
+
     override fun findByTeamId(teamId: Long): List<TeamRecruitment>
 
     @Query("SELECT r FROM TeamRecruitment r WHERE r.status = 'OPEN' ORDER BY r.deadline ASC")

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonBattingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonBattingStatsRepository.kt
@@ -181,7 +181,7 @@ interface SeasonBattingStatsRepository :
         SELECT DISTINCT sbs FROM SeasonBattingStats sbs
         WHERE sbs.player.id IN (
             SELECT br.gamePlayer.player.id FROM BattingRecord br
-            WHERE br.gamePlayer.game.id = :gameId
+            WHERE br.gamePlayer.gameTeam.game.id = :gameId
         )
         AND sbs.year = (
             SELECT FUNCTION('YEAR', g.scheduledAt) FROM Game g WHERE g.id = :gameId

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonFieldingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonFieldingStatsRepository.kt
@@ -43,7 +43,7 @@ interface SeasonFieldingStatsRepository :
         SELECT DISTINCT sfs FROM SeasonFieldingStats sfs
         WHERE sfs.player.id IN (
             SELECT fr.gamePlayer.player.id FROM FieldingRecord fr
-            WHERE fr.gamePlayer.game.id = :gameId
+            WHERE fr.gamePlayer.gameTeam.game.id = :gameId
         )
         AND sfs.year = (
             SELECT FUNCTION('YEAR', g.scheduledAt) FROM Game g WHERE g.id = :gameId

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonPitchingStatsRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonPitchingStatsRepository.kt
@@ -129,7 +129,7 @@ interface SeasonPitchingStatsRepository :
         SELECT DISTINCT sps FROM SeasonPitchingStats sps
         WHERE sps.player.id IN (
             SELECT pr.gamePlayer.player.id FROM PitchingRecord pr
-            WHERE pr.gamePlayer.game.id = :gameId
+            WHERE pr.gamePlayer.gameTeam.game.id = :gameId
         )
         AND sps.year = (
             SELECT FUNCTION('YEAR', g.scheduledAt) FROM Game g WHERE g.id = :gameId

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/UserRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/user/UserRepository.kt
@@ -15,6 +15,8 @@ import org.springframework.data.jpa.repository.Query
 interface UserRepository :
     JpaRepository<User, Long>,
     UserRepositoryPort {
+    override fun findByIdOrNull(id: Long): User? = findById(id).orElse(null)
+
     override fun findByEmail(email: String): User?
 
     override fun existsByEmail(email: String): Boolean

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/AuthenticationService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/AuthenticationService.kt
@@ -3,11 +3,11 @@ package com.nextup.infrastructure.security
 import com.nextup.common.exception.*
 import com.nextup.core.domain.auth.RefreshToken
 import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.UserJpaRepository
 import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
 import com.nextup.infrastructure.security.jwt.JwtTokenProvider
 import com.nextup.infrastructure.security.oauth2.AuthCodeStore
 import com.nextup.infrastructure.security.userdetails.CustomUserDetails
-import com.nextup.infrastructure.security.userdetails.UserJpaRepository
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserService.kt
@@ -2,8 +2,8 @@ package com.nextup.infrastructure.security.oauth2
 
 import com.nextup.common.exception.OAuth2AuthenticationProcessingException
 import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.UserJpaRepository
 import com.nextup.infrastructure.repository.user.OAuthAccountRepository
-import com.nextup.infrastructure.security.userdetails.UserJpaRepository
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.core.user.OAuth2User

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsService.kt
@@ -1,21 +1,11 @@
 package com.nextup.infrastructure.security.userdetails
 
-import com.nextup.core.domain.user.User
-import org.springframework.data.jpa.repository.JpaRepository
+import com.nextup.infrastructure.repository.UserJpaRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Service
-
-/**
- * User JPA Repository
- */
-interface UserJpaRepository : JpaRepository<User, Long> {
-    fun findByEmail(email: String): User?
-
-    fun existsByEmail(email: String): Boolean
-}
 
 /**
  * Spring Security UserDetailsService 구현체

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkService.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkService.kt
@@ -4,8 +4,8 @@ import com.nextup.common.exception.UserNotFoundException
 import com.nextup.core.domain.user.OAuthAccount
 import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.UserJpaRepository
 import com.nextup.infrastructure.repository.user.OAuthAccountRepository
-import com.nextup.infrastructure.security.userdetails.UserJpaRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/AuthenticationServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/AuthenticationServiceTest.kt
@@ -3,11 +3,11 @@ package com.nextup.infrastructure.security
 import com.nextup.common.exception.*
 import com.nextup.core.domain.auth.RefreshToken
 import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.UserJpaRepository
 import com.nextup.infrastructure.repository.auth.RefreshTokenRepository
 import com.nextup.infrastructure.security.jwt.JwtTokenProvider
 import com.nextup.infrastructure.security.oauth2.AuthCodeResult
 import com.nextup.infrastructure.security.oauth2.AuthCodeStore
-import com.nextup.infrastructure.security.userdetails.UserJpaRepository
 import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/oauth2/CustomOAuth2UserServiceTest.kt
@@ -4,8 +4,8 @@ import com.nextup.common.exception.OAuth2AuthenticationProcessingException
 import com.nextup.core.domain.user.OAuthAccount
 import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.UserJpaRepository
 import com.nextup.infrastructure.repository.user.OAuthAccountRepository
-import com.nextup.infrastructure.security.userdetails.UserJpaRepository
 import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/security/userdetails/CustomUserDetailsServiceTest.kt
@@ -2,6 +2,7 @@ package com.nextup.infrastructure.security.userdetails
 
 import com.nextup.core.domain.user.Role
 import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.UserJpaRepository
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkServiceTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/oauth/OAuthLinkServiceTest.kt
@@ -4,8 +4,8 @@ import com.nextup.common.exception.UserNotFoundException
 import com.nextup.core.domain.user.OAuthAccount
 import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.User
+import com.nextup.infrastructure.repository.UserJpaRepository
 import com.nextup.infrastructure.repository.user.OAuthAccountRepository
-import com.nextup.infrastructure.security.userdetails.UserJpaRepository
 import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy


### PR DESCRIPTION
## Summary

> - Closes #123

Testcontainers(PostgreSQL+PostGIS) 기반 `@SpringBootTest` 통합 테스트 인프라를 도입합니다.
전체 Spring Context를 로딩하면서 발견된 **30+개의 잠재 런타임 버그**를 함께 수정합니다.

## Tasks

### 통합 테스트 (4개 클래스, 10개 테스트)
- `IntegrationTestBase`: Testcontainers PostgreSQL+PostGIS 컨테이너 설정
- `TeamRepositoryIntegrationTest`: Repository CRUD 4개 테스트
- `SecurityIntegrationTest`: JWT 인증 플로우 3개 테스트
- `NotificationApiIntegrationTest`: API 엔드포인트 E2E 3개 테스트
- `application-integration.yml`: 통합 테스트 전용 프로파일 (`ddl-auto: create-drop`)

### 발견 및 수정된 잠재 버그 (30+개)
- **JPQL 경로 오류**: `GamePlayer.game` → `GamePlayer.gameTeam.game` (6개 Repository)
- **JPQL 경로 오류**: `Player._teamHistories` → `JOIN PlayerTeamHistory ON` 명시적 조인
- **JPQL 필드명 오류**: `scheduledDate` → `scheduledAt`
- **Bean 이름 충돌**: `AttendanceController` → `NudgeController` 리네이밍
- **Spring Data 시그니처 불일치**: `findByIdOrNull` override 13개 Repository 추가
- **Spring Data saveAll**: `List` vs `Iterable` 브릿지 메서드 추가
- **URL 매핑 충돌**: `ProfileController` 중복 엔드포인트 제거
- **Security 필터 순서**: `JwtAuthenticationFilter` 등록 순서 수정
- **Spring 6.2+ 제약**: `@TransactionalEventListener` + `@Transactional(REQUIRES_NEW)` 적용
- **JpaConfig**: `EntityScan`/`EnableJpaRepositories` 범위 확장
- **UserJpaRepository**: `security.userdetails` → `repository` 패키지 이동
- **Kotlin 컴파일러**: `-Xjvm-default=all` 플래그 추가

## To Reviewer

이 PR은 통합 테스트 도입이 주 목적이지만, `@SpringBootTest`로 전체 Context를 처음 로딩하면서
기존 단위 테스트(`@WebMvcTest`)에서는 발견할 수 없었던 **실제 런타임 버그들**이 대량으로 발견되었습니다.

모든 수정은 기존 단위 테스트를 깨뜨리지 않으며, 통합 테스트 10개 + 기존 테스트 476개 모두 통과합니다.

주요 검토 포인트:
1. JPQL 경로 수정이 기존 쿼리 의미를 변경하지 않는지 확인
2. `@Transactional(propagation = REQUIRES_NEW)` 적용이 이벤트 리스너 동작에 영향 없는지 확인
3. `NudgeController` 리네이밍이 API 경로에 영향 없는지 확인 (경로는 동일)