### PR TITLE
fix(#265): 기록 정정 시 순위 캐시 무효화 누락 수정

### DIFF
--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
@@ -8,7 +8,9 @@ import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import com.nextup.infrastructure.config.CacheConfig
 import org.slf4j.LoggerFactory
+import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
@@ -27,6 +29,7 @@ class RecordCorrectionEventListener(
     private val careerBattingStatsRepository: CareerBattingStatsRepositoryPort,
     private val careerPitchingStatsRepository: CareerPitchingStatsRepositoryPort,
     private val gameRepository: GameRepositoryPort,
+    private val cacheManager: CacheManager,
 ) {
     private val logger = LoggerFactory.getLogger(RecordCorrectionEventListener::class.java)
 
@@ -66,6 +69,9 @@ class RecordCorrectionEventListener(
             event.fieldName,
             delta,
         )
+
+        // 기록 정정으로 순위가 변경될 수 있으므로 순위 캐시 무효화
+        evictStandingsCache(event.gameId)
     }
 
     private fun applyBattingCorrection(
@@ -120,6 +126,17 @@ class RecordCorrectionEventListener(
         } else {
             logger.debug("커리어 투수 통계 없음 - 정정 건너뜀 (playerId={})", playerId)
         }
+    }
+
+    private fun evictStandingsCache(gameId: Long) {
+        val game = gameRepository.findByIdOrNull(gameId) ?: return
+        val competitionId = game.competition.id
+        cacheManager.getCache(CacheConfig.STANDINGS_CACHE)?.evict(competitionId)
+        logger.debug(
+            "기록 정정으로 순위 캐시 무효화 (competitionId={}, gameId={})",
+            competitionId,
+            gameId,
+        )
     }
 
     private fun resolveYear(gameId: Long): Int {

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerCoverageTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerCoverageTest.kt
@@ -63,6 +63,8 @@ class RecordCorrectionEventListenerCoverageTest {
         every { gameRepository.findByIdOrNull(10L) } returnsMany listOf(mockGame, null)
 
         val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+        seasonStats.applyFieldCorrection("plateAppearances", 10)
+        seasonStats.applyFieldCorrection("atBats", 5)
         every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
         every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
         every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
@@ -96,6 +98,8 @@ class RecordCorrectionEventListenerCoverageTest {
         every { cacheManager.getCache(any()) } returns null
 
         val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+        seasonStats.applyFieldCorrection("plateAppearances", 10)
+        seasonStats.applyFieldCorrection("atBats", 5)
         every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
         every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
         every { careerBattingStatsRepository.findByPlayerId(1L) } returns null

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerCoverageTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerCoverageTest.kt
@@ -1,0 +1,119 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.event.RecordCorrectedEvent
+import com.nextup.core.domain.game.CorrectionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.cache.CacheManager
+import java.time.LocalDateTime
+
+@DisplayName("RecordCorrectionEventListener 캐시 커버리지 테스트")
+class RecordCorrectionEventListenerCoverageTest {
+    private val seasonBattingStatsRepository = mockk<SeasonBattingStatsRepositoryPort>()
+    private val seasonPitchingStatsRepository = mockk<SeasonPitchingStatsRepositoryPort>()
+    private val careerBattingStatsRepository = mockk<CareerBattingStatsRepositoryPort>()
+    private val careerPitchingStatsRepository = mockk<CareerPitchingStatsRepositoryPort>()
+    private val gameRepository = mockk<GameRepositoryPort>()
+    private val cacheManager = mockk<CacheManager>()
+
+    private val listener =
+        RecordCorrectionEventListener(
+            seasonBattingStatsRepository = seasonBattingStatsRepository,
+            seasonPitchingStatsRepository = seasonPitchingStatsRepository,
+            careerBattingStatsRepository = careerBattingStatsRepository,
+            careerPitchingStatsRepository = careerPitchingStatsRepository,
+            gameRepository = gameRepository,
+            cacheManager = cacheManager,
+        )
+
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
+
+    @Test
+    fun `evictStandingsCache에서 게임을 찾을 수 없으면 캐시 무효화를 건너뜄다`() {
+        // given
+        val mockGame = mockk<Game>()
+        val mockCompetition = mockk<Competition>()
+        every { mockGame.scheduledAt } returns LocalDateTime.of(2024, 5, 15, 18, 0)
+        every { mockGame.competition } returns mockCompetition
+        every { mockCompetition.id } returns 100L
+
+        // resolveYear에서는 찾지만, evictStandingsCache에서는 못 찾음
+        every { gameRepository.findByIdOrNull(10L) } returnsMany listOf(mockGame, null)
+
+        val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+        every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+        every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
+        every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+        val event =
+            RecordCorrectedEvent(
+                gameId = 10L,
+                correctionType = CorrectionType.BATTING,
+                playerId = 1L,
+                fieldName = "hits",
+                oldValue = "2",
+                newValue = "3",
+            )
+
+        // when
+        listener.onRecordCorrected(event)
+
+        // then
+        verify(exactly = 0) { cacheManager.getCache(any()) }
+    }
+
+    @Test
+    fun `cacheManager에서 캐시를 찾을 수 없으면 evict를 호출하지 않는다`() {
+        // given
+        val mockGame = mockk<Game>()
+        val mockCompetition = mockk<Competition>()
+        every { mockGame.scheduledAt } returns LocalDateTime.of(2024, 5, 15, 18, 0)
+        every { mockGame.competition } returns mockCompetition
+        every { mockCompetition.id } returns 100L
+        every { gameRepository.findByIdOrNull(any()) } returns mockGame
+        every { cacheManager.getCache(any()) } returns null
+
+        val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+        every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+        every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
+        every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+        val event =
+            RecordCorrectedEvent(
+                gameId = 10L,
+                correctionType = CorrectionType.BATTING,
+                playerId = 1L,
+                fieldName = "hits",
+                oldValue = "2",
+                newValue = "3",
+            )
+
+        // when
+        listener.onRecordCorrected(event)
+
+        // then
+        verify(exactly = 1) { cacheManager.getCache(any()) }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
@@ -1,6 +1,7 @@
 package com.nextup.infrastructure.listener
 
 import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.event.RecordCorrectedEvent
 import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.domain.game.Game
@@ -26,6 +27,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
 import java.time.LocalDateTime
 
 @DisplayName("RecordCorrectionEventListener 테스트")
@@ -35,6 +38,8 @@ class RecordCorrectionEventListenerTest {
     private val careerBattingStatsRepository = mockk<CareerBattingStatsRepositoryPort>()
     private val careerPitchingStatsRepository = mockk<CareerPitchingStatsRepositoryPort>()
     private val gameRepository = mockk<GameRepositoryPort>()
+    private val cacheManager = mockk<CacheManager>()
+    private val mockCache = mockk<Cache>(relaxed = true)
 
     private val listener =
         RecordCorrectionEventListener(
@@ -43,6 +48,7 @@ class RecordCorrectionEventListenerTest {
             careerBattingStatsRepository = careerBattingStatsRepository,
             careerPitchingStatsRepository = careerPitchingStatsRepository,
             gameRepository = gameRepository,
+            cacheManager = cacheManager,
         )
 
     private val testPlayer =
@@ -55,11 +61,15 @@ class RecordCorrectionEventListenerTest {
         )
 
     private val mockGame = mockk<Game>()
+    private val mockCompetition = mockk<Competition>()
 
     @BeforeEach
     fun setUp() {
         every { mockGame.scheduledAt } returns LocalDateTime.of(2024, 5, 15, 18, 0)
+        every { mockGame.competition } returns mockCompetition
+        every { mockCompetition.id } returns 100L
         every { gameRepository.findByIdOrNull(any()) } returns mockGame
+        every { cacheManager.getCache(any()) } returns mockCache
     }
 
     @Nested
@@ -284,6 +294,58 @@ class RecordCorrectionEventListenerTest {
 
             // then: delta = 1 - 3 = -2, earnedRuns = 10 - 2 = 8
             assertThat(seasonStats.earnedRuns).isEqualTo(8)
+        }
+    }
+
+    @Nested
+    @DisplayName("순위 캐시 무효화")
+    inner class StandingsCacheEviction {
+        @Test
+        fun `기록 정정 시 해당 대회의 순위 캐시가 무효화됨`() {
+            // given
+            val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("hits", 10)
+
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "2",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then
+            verify(exactly = 1) { cacheManager.getCache("standings") }
+            verify(exactly = 1) { mockCache.evict(100L) }
+        }
+
+        @Test
+        fun `델타가 0이면 캐시 무효화도 건너뜀`() {
+            // given
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "3",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then
+            verify(exactly = 0) { cacheManager.getCache(any()) }
         }
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
@@ -314,6 +314,8 @@ class RecordCorrectionEventListenerTest {
         fun `기록 정정 시 해당 대회의 순위 캐시가 무효화됨`() {
             // given
             val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("plateAppearances", 15)
+            seasonStats.applyFieldCorrection("atBats", 12)
             seasonStats.applyFieldCorrection("hits", 10)
 
             every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats


### PR DESCRIPTION
## Summary

> - Closes #265

**`RecordCorrectionEventListener`에서 기록 정정 완료 후 해당 대회의 순위(standings) 캐시를 무효화하도록 수정. 기존에는 `GameResultConfirmedEvent`에서만 캐시를 무효화했으나, 기록 정정으로 승패가 변경되어도 순위가 즉시 반영되지 않는 문제를 해결합니다.**

## Tasks

- `RecordCorrectionEventListener`에 `CacheManager` 의존성 추가
- 기록 정정 완료 후 `competitionId` 기준 standings 캐시 무효화 호출
- 델타 0일 경우 캐시 무효화도 건너뛰는 최적화
- 캐시 무효화 검증 테스트 추가

## To Reviewer

- `GameResultEventListener.evictStandingsCache()`와 동일한 패턴으로 구현
- `gameRepository.findByIdOrNull()` → `game.competition.id` → `cacheManager.evict()` 흐름