### PR TITLE
feat(#262): 매칭 요청 만료 자동 처리 스케줄러 구현

### DIFF
--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/SchedulingConfig.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/SchedulingConfig.kt
@@ -1,0 +1,8 @@
+package com.nextup.infrastructure.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+class SchedulingConfig

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/scheduler/MatchRequestExpiryScheduler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/scheduler/MatchRequestExpiryScheduler.kt
@@ -1,0 +1,62 @@
+package com.nextup.infrastructure.scheduler
+
+import com.nextup.core.domain.match.MatchResponseStatus
+import com.nextup.core.port.repository.MatchRequestRepositoryPort
+import com.nextup.core.port.repository.MatchResponseRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 매칭 요청 만료 자동 처리 스케줄러
+ *
+ * 매일 새벽 3시에 실행되어 30일이 경과한 OPEN 상태의
+ * 매칭 요청을 EXPIRED로 전환하고, 관련 PENDING 응답을 REJECTED로 처리합니다.
+ */
+@Component
+class MatchRequestExpiryScheduler(
+    private val matchRequestRepository: MatchRequestRepositoryPort,
+    private val matchResponseRepository: MatchResponseRepositoryPort,
+) {
+    private val logger = LoggerFactory.getLogger(MatchRequestExpiryScheduler::class.java)
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    fun expireMatchRequests() {
+        val openRequests = matchRequestRepository.findAllOpen()
+        val expiredRequests = openRequests.filter { it.isExpired() }
+
+        if (expiredRequests.isEmpty()) {
+            logger.debug("만료 대상 매칭 요청 없음")
+            return
+        }
+
+        logger.info("매칭 요청 만료 처리 시작 (대상: {}건)", expiredRequests.size)
+
+        var expiredCount = 0
+        var rejectedResponseCount = 0
+
+        for (request in expiredRequests) {
+            request.expire()
+            matchRequestRepository.save(request)
+            expiredCount++
+
+            val pendingResponses =
+                matchResponseRepository.findByMatchRequestId(request.id)
+                    .filter { it.status == MatchResponseStatus.PENDING }
+
+            for (response in pendingResponses) {
+                response.reject()
+                matchResponseRepository.save(response)
+                rejectedResponseCount++
+            }
+        }
+
+        logger.info(
+            "매칭 요청 만료 처리 완료 (만료 요청: {}건, 거절 응답: {}건)",
+            expiredCount,
+            rejectedResponseCount,
+        )
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/scheduler/MatchRequestExpirySchedulerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/scheduler/MatchRequestExpirySchedulerTest.kt
@@ -1,0 +1,165 @@
+package com.nextup.infrastructure.scheduler
+
+import com.nextup.core.domain.match.MatchRequest
+import com.nextup.core.domain.match.MatchResponse
+import com.nextup.core.domain.match.MatchResponseStatus
+import com.nextup.core.port.repository.MatchRequestRepositoryPort
+import com.nextup.core.port.repository.MatchResponseRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("MatchRequestExpiryScheduler 테스트")
+class MatchRequestExpirySchedulerTest {
+    private val matchRequestRepository = mockk<MatchRequestRepositoryPort>()
+    private val matchResponseRepository = mockk<MatchResponseRepositoryPort>()
+
+    private val scheduler =
+        MatchRequestExpiryScheduler(
+            matchRequestRepository = matchRequestRepository,
+            matchResponseRepository = matchResponseRepository,
+        )
+
+    @Nested
+    @DisplayName("만료 처리")
+    inner class ExpireMatchRequests {
+        @Test
+        fun `만료된 OPEN 요청이 EXPIRED로 전환된다`() {
+            // given
+            val expiredRequest = mockk<MatchRequest>(relaxed = true)
+            every { expiredRequest.isExpired() } returns true
+            every { expiredRequest.id } returns 1L
+            every { matchRequestRepository.findAllOpen() } returns listOf(expiredRequest)
+            every { matchRequestRepository.save(any()) } answers { firstArg() }
+            every { matchResponseRepository.findByMatchRequestId(1L) } returns emptyList()
+
+            // when
+            scheduler.expireMatchRequests()
+
+            // then
+            verify(exactly = 1) { expiredRequest.expire() }
+            verify(exactly = 1) { matchRequestRepository.save(expiredRequest) }
+        }
+
+        @Test
+        fun `만료되지 않은 요청은 건너뛴다`() {
+            // given
+            val activeRequest = mockk<MatchRequest>(relaxed = true)
+            every { activeRequest.isExpired() } returns false
+            every { matchRequestRepository.findAllOpen() } returns listOf(activeRequest)
+
+            // when
+            scheduler.expireMatchRequests()
+
+            // then
+            verify(exactly = 0) { activeRequest.expire() }
+            verify(exactly = 0) { matchRequestRepository.save(any()) }
+        }
+
+        @Test
+        fun `OPEN 요청이 없으면 아무 작업도 하지 않는다`() {
+            // given
+            every { matchRequestRepository.findAllOpen() } returns emptyList()
+
+            // when
+            scheduler.expireMatchRequests()
+
+            // then
+            verify(exactly = 0) { matchRequestRepository.save(any()) }
+            verify(exactly = 0) { matchResponseRepository.findByMatchRequestId(any()) }
+        }
+
+        @Test
+        fun `만료 시 관련 PENDING 응답이 REJECTED로 전환된다`() {
+            // given
+            val expiredRequest = mockk<MatchRequest>(relaxed = true)
+            every { expiredRequest.isExpired() } returns true
+            every { expiredRequest.id } returns 1L
+            every { matchRequestRepository.findAllOpen() } returns listOf(expiredRequest)
+            every { matchRequestRepository.save(any()) } answers { firstArg() }
+
+            val pendingResponse = mockk<MatchResponse>(relaxed = true)
+            every { pendingResponse.status } returns MatchResponseStatus.PENDING
+            every { matchResponseRepository.findByMatchRequestId(1L) } returns listOf(pendingResponse)
+            every { matchResponseRepository.save(any()) } answers { firstArg() }
+
+            // when
+            scheduler.expireMatchRequests()
+
+            // then
+            verify(exactly = 1) { pendingResponse.reject() }
+            verify(exactly = 1) { matchResponseRepository.save(pendingResponse) }
+        }
+
+        @Test
+        fun `만료 시 이미 ACCEPTED 또는 REJECTED 상태의 응답은 건너뛴다`() {
+            // given
+            val expiredRequest = mockk<MatchRequest>(relaxed = true)
+            every { expiredRequest.isExpired() } returns true
+            every { expiredRequest.id } returns 1L
+            every { matchRequestRepository.findAllOpen() } returns listOf(expiredRequest)
+            every { matchRequestRepository.save(any()) } answers { firstArg() }
+
+            val acceptedResponse = mockk<MatchResponse>(relaxed = true)
+            every { acceptedResponse.status } returns MatchResponseStatus.ACCEPTED
+            val rejectedResponse = mockk<MatchResponse>(relaxed = true)
+            every { rejectedResponse.status } returns MatchResponseStatus.REJECTED
+
+            every {
+                matchResponseRepository.findByMatchRequestId(1L)
+            } returns listOf(acceptedResponse, rejectedResponse)
+
+            // when
+            scheduler.expireMatchRequests()
+
+            // then
+            verify(exactly = 0) { acceptedResponse.reject() }
+            verify(exactly = 0) { rejectedResponse.reject() }
+            verify(exactly = 0) { matchResponseRepository.save(any()) }
+        }
+
+        @Test
+        fun `여러 만료 요청과 응답이 모두 처리된다`() {
+            // given
+            val request1 = mockk<MatchRequest>(relaxed = true)
+            every { request1.isExpired() } returns true
+            every { request1.id } returns 1L
+
+            val request2 = mockk<MatchRequest>(relaxed = true)
+            every { request2.isExpired() } returns true
+            every { request2.id } returns 2L
+
+            val activeRequest = mockk<MatchRequest>(relaxed = true)
+            every { activeRequest.isExpired() } returns false
+
+            every {
+                matchRequestRepository.findAllOpen()
+            } returns listOf(request1, request2, activeRequest)
+            every { matchRequestRepository.save(any()) } answers { firstArg() }
+
+            val response1 = mockk<MatchResponse>(relaxed = true)
+            every { response1.status } returns MatchResponseStatus.PENDING
+            val response2 = mockk<MatchResponse>(relaxed = true)
+            every { response2.status } returns MatchResponseStatus.PENDING
+
+            every { matchResponseRepository.findByMatchRequestId(1L) } returns listOf(response1)
+            every { matchResponseRepository.findByMatchRequestId(2L) } returns listOf(response2)
+            every { matchResponseRepository.save(any()) } answers { firstArg() }
+
+            // when
+            scheduler.expireMatchRequests()
+
+            // then
+            verify(exactly = 1) { request1.expire() }
+            verify(exactly = 1) { request2.expire() }
+            verify(exactly = 0) { activeRequest.expire() }
+            verify(exactly = 2) { matchRequestRepository.save(any()) }
+            verify(exactly = 1) { response1.reject() }
+            verify(exactly = 1) { response2.reject() }
+            verify(exactly = 2) { matchResponseRepository.save(any()) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

> - Closes #262

매일 새벽 3시에 30일 경과한 OPEN 매칭 요청을 EXPIRED로 자동 전환하는 스케줄러 추가. 만료된 요청에 연결된 PENDING 응답을 REJECTED로 자동 처리. `@EnableScheduling` 설정 및 단위 테스트 6건 포함.

## Tasks

- `MatchRequestExpirationScheduler` 스케줄러 구현 (매일 새벽 3시 cron)
- 30일 경과 OPEN 매칭 요청 EXPIRED 자동 전환
- PENDING 응답 REJECTED 자동 처리
- `@EnableScheduling` 설정 추가 (SchedulingConfig)
- 단위 테스트 6건 추가

## To Reviewer

- 기존 도메인 메서드(`MatchRequest.expire()`, `MatchResponse.reject()`)를 활용하여 상태 전환
- `MatchRequestRepositoryPort.findAllOpen()`으로 OPEN 요청 조회 후 `isExpired()` 필터링
- 스케줄러는 infrastructure 모듈에 위치 (Hexagonal Architecture 준수)