### PR TITLE
fix(#279): Stats applyFieldCorrection() 도메인 불변식 검증 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
@@ -257,7 +257,9 @@ class CareerBattingStats(
             "stolenBases" -> stolenBases = maxOf(0, stolenBases + delta)
             "caughtStealing" -> caughtStealing = maxOf(0, caughtStealing + delta)
             "groundedIntoDoublePlays" -> groundedIntoDoublePlays = maxOf(0, groundedIntoDoublePlays + delta)
+            else -> throw IllegalArgumentException("유효하지 않은 커리어 타격 통계 필드입니다: $fieldName")
         }
+        validate()
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
@@ -312,7 +312,9 @@ class CareerPitchingStats(
             "battersFaced" -> battersFaced = maxOf(0, battersFaced + delta)
             "pitchesThrown" -> pitchesThrown = maxOf(0, (pitchesThrown ?: 0) + delta)
             "strikesThrown" -> strikesThrown = maxOf(0, (strikesThrown ?: 0) + delta)
+            else -> throw IllegalArgumentException("유효하지 않은 커리어 투수 통계 필드입니다: $fieldName")
         }
+        validate()
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
@@ -350,7 +350,9 @@ class SeasonBattingStats(
             "stolenBases" -> stolenBases = maxOf(0, stolenBases + delta)
             "caughtStealing" -> caughtStealing = maxOf(0, caughtStealing + delta)
             "groundedIntoDoublePlays" -> groundedIntoDoublePlays = maxOf(0, groundedIntoDoublePlays + delta)
+            else -> throw IllegalArgumentException("유효하지 않은 시즌 타격 통계 필드입니다: $fieldName")
         }
+        validate()
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
@@ -351,7 +351,9 @@ class SeasonPitchingStats(
             "battersFaced" -> battersFaced = maxOf(0, battersFaced + delta)
             "pitchesThrown" -> pitchesThrown = maxOf(0, (pitchesThrown ?: 0) + delta)
             "strikesThrown" -> strikesThrown = maxOf(0, (strikesThrown ?: 0) + delta)
+            else -> throw IllegalArgumentException("유효하지 않은 시즌 투수 통계 필드입니다: $fieldName")
         }
+        validate()
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/BattingStatsApplyFieldCorrectionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/BattingStatsApplyFieldCorrectionTest.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 @DisplayName("타격 통계 applyFieldCorrection 테스트")
 class BattingStatsApplyFieldCorrectionTest {
@@ -67,9 +68,10 @@ class BattingStatsApplyFieldCorrectionTest {
         @Test
         fun `음수 델타 적용 시 0 미만으로 내려가지 않음`() {
             val stats = SeasonBattingStats.create(testPlayer, 2024)
-            stats.applyFieldCorrection("plateAppearances", 2)
-            stats.applyFieldCorrection("atBats", 2)
-            stats.applyFieldCorrection("hits", 2)
+            // 불변식을 만족하는 초기값 설정 (PA ≥ AB ≥ H ≥ 2B+3B+HR)
+            stats.applyFieldCorrection("plateAppearances", 20)
+            stats.applyFieldCorrection("atBats", 15)
+            stats.applyFieldCorrection("hits", 10)
             stats.applyFieldCorrection("doubles", 2)
             stats.applyFieldCorrection("triples", 2)
             stats.applyFieldCorrection("homeRuns", 2)
@@ -85,24 +87,24 @@ class BattingStatsApplyFieldCorrectionTest {
             stats.applyFieldCorrection("caughtStealing", 2)
             stats.applyFieldCorrection("groundedIntoDoublePlays", 2)
 
-            // 모든 필드에 -10 적용 (현재값 2보다 큰 음수)
-            stats.applyFieldCorrection("plateAppearances", -10)
-            stats.applyFieldCorrection("atBats", -10)
-            stats.applyFieldCorrection("hits", -10)
-            stats.applyFieldCorrection("doubles", -10)
-            stats.applyFieldCorrection("triples", -10)
-            stats.applyFieldCorrection("homeRuns", -10)
-            stats.applyFieldCorrection("runs", -10)
-            stats.applyFieldCorrection("runsBattedIn", -10)
-            stats.applyFieldCorrection("walks", -10)
-            stats.applyFieldCorrection("intentionalWalks", -10)
-            stats.applyFieldCorrection("hitByPitch", -10)
-            stats.applyFieldCorrection("strikeouts", -10)
-            stats.applyFieldCorrection("sacrificeBunts", -10)
-            stats.applyFieldCorrection("sacrificeFlies", -10)
-            stats.applyFieldCorrection("stolenBases", -10)
-            stats.applyFieldCorrection("caughtStealing", -10)
-            stats.applyFieldCorrection("groundedIntoDoublePlays", -10)
+            // 역의존 순서로 큰 음수 적용 (2B+3B+HR → H → AB → PA)
+            stats.applyFieldCorrection("doubles", -100)
+            stats.applyFieldCorrection("triples", -100)
+            stats.applyFieldCorrection("homeRuns", -100)
+            stats.applyFieldCorrection("hits", -100)
+            stats.applyFieldCorrection("atBats", -100)
+            stats.applyFieldCorrection("plateAppearances", -100)
+            stats.applyFieldCorrection("runs", -100)
+            stats.applyFieldCorrection("runsBattedIn", -100)
+            stats.applyFieldCorrection("walks", -100)
+            stats.applyFieldCorrection("intentionalWalks", -100)
+            stats.applyFieldCorrection("hitByPitch", -100)
+            stats.applyFieldCorrection("strikeouts", -100)
+            stats.applyFieldCorrection("sacrificeBunts", -100)
+            stats.applyFieldCorrection("sacrificeFlies", -100)
+            stats.applyFieldCorrection("stolenBases", -100)
+            stats.applyFieldCorrection("caughtStealing", -100)
+            stats.applyFieldCorrection("groundedIntoDoublePlays", -100)
 
             assertThat(stats.plateAppearances).isZero()
             assertThat(stats.atBats).isZero()
@@ -124,10 +126,11 @@ class BattingStatsApplyFieldCorrectionTest {
         }
 
         @Test
-        fun `존재하지 않는 필드명은 무시됨`() {
+        fun `존재하지 않는 필드명에 대해 예외가 발생함`() {
             val stats = SeasonBattingStats.create(testPlayer, 2024)
-            stats.applyFieldCorrection("unknownField", 5)
-            assertThat(stats.plateAppearances).isZero()
+            assertThrows<IllegalArgumentException> {
+                stats.applyFieldCorrection("unknownField", 5)
+            }
         }
     }
 
@@ -214,6 +217,14 @@ class BattingStatsApplyFieldCorrectionTest {
             assertThat(stats.stolenBases).isZero()
             assertThat(stats.caughtStealing).isZero()
             assertThat(stats.groundedIntoDoublePlays).isZero()
+        }
+
+        @Test
+        fun `존재하지 않는 필드명에 대해 예외가 발생함`() {
+            val stats = CareerBattingStats.create(testPlayer)
+            assertThrows<IllegalArgumentException> {
+                stats.applyFieldCorrection("unknownField", 5)
+            }
         }
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/PitchingStatsApplyFieldCorrectionTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/PitchingStatsApplyFieldCorrectionTest.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 @DisplayName("투수 통계 applyFieldCorrection 테스트")
 class PitchingStatsApplyFieldCorrectionTest {
@@ -28,8 +29,8 @@ class PitchingStatsApplyFieldCorrectionTest {
             val stats = SeasonPitchingStats.create(testPlayer, 2024)
 
             stats.applyFieldCorrection("inningsPitchedOuts", 18)
-            stats.applyFieldCorrection("earnedRuns", 3)
             stats.applyFieldCorrection("runsAllowed", 4)
+            stats.applyFieldCorrection("earnedRuns", 3)
             stats.applyFieldCorrection("hitsAllowed", 6)
             stats.applyFieldCorrection("walksAllowed", 2)
             stats.applyFieldCorrection("strikeouts", 7)
@@ -59,9 +60,10 @@ class PitchingStatsApplyFieldCorrectionTest {
         @Test
         fun `음수 델타 적용 시 0 미만으로 내려가지 않음`() {
             val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            // 불변식을 만족하는 순서로 설정 (RA ≥ ER, PT ≥ ST)
             stats.applyFieldCorrection("inningsPitchedOuts", 3)
-            stats.applyFieldCorrection("earnedRuns", 3)
             stats.applyFieldCorrection("runsAllowed", 3)
+            stats.applyFieldCorrection("earnedRuns", 3)
             stats.applyFieldCorrection("hitsAllowed", 3)
             stats.applyFieldCorrection("walksAllowed", 3)
             stats.applyFieldCorrection("strikeouts", 3)
@@ -73,6 +75,7 @@ class PitchingStatsApplyFieldCorrectionTest {
             stats.applyFieldCorrection("pitchesThrown", 3)
             stats.applyFieldCorrection("strikesThrown", 3)
 
+            // 역의존 순서로 감소 (ER → RA, ST → PT)
             stats.applyFieldCorrection("inningsPitchedOuts", -10)
             stats.applyFieldCorrection("earnedRuns", -10)
             stats.applyFieldCorrection("runsAllowed", -10)
@@ -84,8 +87,8 @@ class PitchingStatsApplyFieldCorrectionTest {
             stats.applyFieldCorrection("wildPitches", -10)
             stats.applyFieldCorrection("balks", -10)
             stats.applyFieldCorrection("battersFaced", -10)
-            stats.applyFieldCorrection("pitchesThrown", -10)
             stats.applyFieldCorrection("strikesThrown", -10)
+            stats.applyFieldCorrection("pitchesThrown", -10)
 
             assertThat(stats.inningsPitchedOuts).isZero()
             assertThat(stats.earnedRuns).isZero()
@@ -103,10 +106,11 @@ class PitchingStatsApplyFieldCorrectionTest {
         }
 
         @Test
-        fun `존재하지 않는 필드명은 무시됨`() {
+        fun `존재하지 않는 필드명에 대해 예외가 발생함`() {
             val stats = SeasonPitchingStats.create(testPlayer, 2024)
-            stats.applyFieldCorrection("unknownField", 5)
-            assertThat(stats.inningsPitchedOuts).isZero()
+            assertThrows<IllegalArgumentException> {
+                stats.applyFieldCorrection("unknownField", 5)
+            }
         }
     }
 
@@ -118,8 +122,8 @@ class PitchingStatsApplyFieldCorrectionTest {
             val stats = CareerPitchingStats.create(testPlayer)
 
             stats.applyFieldCorrection("inningsPitchedOuts", 18)
-            stats.applyFieldCorrection("earnedRuns", 3)
             stats.applyFieldCorrection("runsAllowed", 4)
+            stats.applyFieldCorrection("earnedRuns", 3)
             stats.applyFieldCorrection("hitsAllowed", 6)
             stats.applyFieldCorrection("walksAllowed", 2)
             stats.applyFieldCorrection("strikeouts", 7)
@@ -177,6 +181,14 @@ class PitchingStatsApplyFieldCorrectionTest {
             assertThat(stats.battersFaced).isZero()
             assertThat(stats.pitchesThrown).isZero()
             assertThat(stats.strikesThrown).isZero()
+        }
+
+        @Test
+        fun `존재하지 않는 필드명에 대해 예외가 발생함`() {
+            val stats = CareerPitchingStats.create(testPlayer)
+            assertThrows<IllegalArgumentException> {
+                stats.applyFieldCorrection("unknownField", 5)
+            }
         }
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
@@ -70,8 +70,12 @@ class RecordCorrectionEventListenerTest {
             // given
             val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
             val careerStats = CareerBattingStats.create(testPlayer)
-            // 기존 값 설정: hits = 10 (addGameRecord 대신 applyFieldCorrection으로 세팅)
+            // 기존 값 설정 (불변식을 만족하는 순서: PA ≥ AB ≥ H)
+            seasonStats.applyFieldCorrection("plateAppearances", 15)
+            seasonStats.applyFieldCorrection("atBats", 12)
             seasonStats.applyFieldCorrection("hits", 10)
+            careerStats.applyFieldCorrection("plateAppearances", 15)
+            careerStats.applyFieldCorrection("atBats", 12)
             careerStats.applyFieldCorrection("hits", 10)
 
             every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
@@ -103,6 +107,10 @@ class RecordCorrectionEventListenerTest {
         fun `음수 델타 적용 시 통계가 감소됨`() {
             // given
             val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            // 불변식을 만족하는 순서: PA ≥ AB ≥ H ≥ 2B+3B+HR
+            seasonStats.applyFieldCorrection("plateAppearances", 10)
+            seasonStats.applyFieldCorrection("atBats", 8)
+            seasonStats.applyFieldCorrection("hits", 5)
             seasonStats.applyFieldCorrection("homeRuns", 5)
 
             every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
@@ -263,6 +271,8 @@ class RecordCorrectionEventListenerTest {
         fun `자책점 감소 정정이 올바르게 반영됨`() {
             // given
             val seasonStats = SeasonPitchingStats.create(testPlayer, 2024)
+            // 불변식을 만족하는 순서: RA ≥ ER
+            seasonStats.applyFieldCorrection("runsAllowed", 12)
             seasonStats.applyFieldCorrection("earnedRuns", 10)
 
             every { seasonPitchingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats


### PR DESCRIPTION
## Summary

> - Closes #279

Stats 엔티티의 `applyFieldCorrection()` 메서드에 도메인 불변식 검증 로직을 추가합니다. 기존에는 알 수 없는 필드명이 무시되고, 필드 수정 후 교차 필드 불변식이 검증되지 않았습니다.

## Tasks

- `SeasonBattingStats`, `CareerBattingStats`, `SeasonPitchingStats`, `CareerPitchingStats`의 `applyFieldCorrection()`에 `validate()` 호출 추가
- 알 수 없는 필드명에 대해 `IllegalArgumentException` 발생하도록 `else` 분기 추가
- 테스트 데이터를 불변식(PA>=AB>=H>=2B+3B+HR, RA>=ER, PT>=ST)에 맞게 수정
- 존재하지 않는 필드명 테스트를 예외 발생 검증으로 변경

## To Reviewer

`correctField()`(Record 엔티티)는 이미 `validate()`를 호출하고 있었으나, `applyFieldCorrection()`(Stats 엔티티)에는 누락되어 있었습니다. 이번 변경으로 두 메서드 모두 일관되게 불변식을 검증합니다.