### PR TITLE
feat(#269): PlateAppearanceResult에 INFIELD_FLY 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
@@ -231,6 +231,7 @@ class BattingRecord(
             }
             PlateAppearanceResult.GROUND_OUT,
             PlateAppearanceResult.FLY_OUT,
+            PlateAppearanceResult.INFIELD_FLY,
             PlateAppearanceResult.LINE_OUT,
             PlateAppearanceResult.FIELDERS_CHOICE,
             PlateAppearanceResult.ERROR,
@@ -344,6 +345,7 @@ class BattingRecord(
             }
             PlateAppearanceResult.GROUND_OUT,
             PlateAppearanceResult.FLY_OUT,
+            PlateAppearanceResult.INFIELD_FLY,
             PlateAppearanceResult.LINE_OUT,
             PlateAppearanceResult.FIELDERS_CHOICE,
             PlateAppearanceResult.ERROR,

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PlateAppearanceResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PlateAppearanceResult.kt
@@ -22,6 +22,7 @@ enum class PlateAppearanceResult(
     STRIKEOUT("삼진", "3스트라이크 아웃", true, false),
     GROUND_OUT("땅볼 아웃", "땅볼로 아웃", true, false),
     FLY_OUT("플라이 아웃", "뜬공으로 아웃", true, false),
+    INFIELD_FLY("인필드플라이", "내야 뜬공으로 아웃 (인필드플라이 룰 적용)", true, false),
     LINE_OUT("라인 드라이브 아웃", "직선타로 아웃", true, false),
     FIELDERS_CHOICE("야수 선택", "야수 선택으로 출루", true, false),
     ERROR("실책", "수비 실책으로 출루", true, false),


### PR DESCRIPTION
## Summary

> - Closes #269

`PlateAppearanceResult` enum에 `INFIELD_FLY`(인필드플라이)를 별도 타입으로 추가하여 `FLY_OUT`과 구분 가능하도록 했습니다.

## Tasks

- `PlateAppearanceResult`에 `INFIELD_FLY` enum 값 추가 (isAtBat=true, isHit=false)
- `BattingRecord.applyPlateAppearanceResult()`에 `INFIELD_FLY` 분기 추가 (FLY_OUT과 동일하게 atBats++)
- `BattingRecord.revertPlateAppearanceResult()`에 `INFIELD_FLY` 분기 추가
- `FIELDERS_CHOICE`는 이미 존재하므로, FC 세부 구분(주자 아웃 vs 전원 세이프)은 GameEvent 레벨에서 처리하는 것이 적절

## To Reviewer

- `PitchingRecord`와 `SeasonBattingStats`는 property-based 분기(`isAtBat`, `isHit`) 또는 `else` 브랜치를 사용하므로 코드 변경 없이 `INFIELD_FLY`를 자동 처리합니다.
- 기존 데이터와 하위 호환성이 유지됩니다 (기존 `FLY_OUT` 기록은 그대로 유효).