### PR TITLE
fix(#330): SeasonBattingStats findOrCreate 패턴 적용으로 자동 생성

### DIFF
--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
@@ -1,12 +1,14 @@
 package com.nextup.infrastructure.listener
 
 import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.PlayerNotFoundException
 import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlateAppearanceUndoneEvent
 import com.nextup.core.domain.stats.CareerBattingStats
 import com.nextup.core.domain.stats.CareerFieldingStats
 import com.nextup.core.domain.stats.CareerPitchingStats
+import com.nextup.core.domain.stats.SeasonBattingStats
 import com.nextup.core.domain.stats.SeasonFieldingStats
 import com.nextup.core.domain.stats.SeasonPitchingStats
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
@@ -16,6 +18,7 @@ import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
 import com.nextup.core.port.repository.FieldingRecordRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
@@ -45,6 +48,7 @@ class StatsEventListener(
     private val pitchingRecordRepository: PitchingRecordRepositoryPort,
     private val fieldingRecordRepository: FieldingRecordRepositoryPort,
     private val gameRepository: GameRepositoryPort,
+    private val playerRepository: PlayerRepositoryPort,
 ) {
     private val logger = LoggerFactory.getLogger(StatsEventListener::class.java)
 
@@ -52,22 +56,13 @@ class StatsEventListener(
      * 타석 결과 기록 이벤트를 처리합니다.
      *
      * 해당 선수의 시즌 타격 통계를 찾아 실시간으로 갱신합니다.
-     * 시즌 통계가 없는 경우 갱신을 건너뜁니다.
+     * 시즌 통계가 없는 경우 자동으로 생성합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onPlateAppearanceRecorded(event: PlateAppearanceRecordedEvent) {
         val year = resolveYear(event.gameId)
-        val stats =
-            seasonBattingStatsRepository.findByPlayerIdAndYear(event.playerId, year)
-                ?: run {
-                    logger.debug(
-                        "시즌 타격 통계 없음 - 갱신 건너뜀 (playerId={}, year={})",
-                        event.playerId,
-                        year,
-                    )
-                    return
-                }
+        val stats = findOrCreateSeasonBattingStats(event.playerId, year)
 
         stats.applyLiveUpdate(event.result)
         seasonBattingStatsRepository.save(stats)
@@ -84,22 +79,13 @@ class StatsEventListener(
      * 타석 결과 취소 이벤트를 처리합니다.
      *
      * 해당 선수의 시즌 타격 통계를 찾아 이전 타석 결과를 역산합니다.
-     * 시즌 통계가 없는 경우 갱신을 건너뜁니다.
+     * 시즌 통계가 없는 경우 자동으로 생성한 뒤 역산합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onPlateAppearanceUndone(event: PlateAppearanceUndoneEvent) {
         val year = resolveYear(event.gameId)
-        val stats =
-            seasonBattingStatsRepository.findByPlayerIdAndYear(event.playerId, year)
-                ?: run {
-                    logger.debug(
-                        "시즌 타격 통계 없음 - Undo 건너뜀 (playerId={}, year={})",
-                        event.playerId,
-                        year,
-                    )
-                    return
-                }
+        val stats = findOrCreateSeasonBattingStats(event.playerId, year)
 
         stats.revertLiveUpdate(event.result)
         seasonBattingStatsRepository.save(stats)
@@ -241,6 +227,31 @@ class StatsEventListener(
             pitchingRecords.size,
             fieldingRecords.size,
         )
+    }
+
+    /**
+     * 선수의 시즌 타격 통계를 조회하거나, 없으면 자동 생성합니다.
+     *
+     * 첫 시즌 선수의 실시간 타격 통계가 누락되는 문제를 방지합니다.
+     * DB unique constraint (player_id, year)에 의해 동시성 중복 생성이 방어됩니다.
+     */
+    private fun findOrCreateSeasonBattingStats(
+        playerId: Long,
+        year: Int,
+    ): SeasonBattingStats {
+        return seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year)
+            ?: run {
+                val player =
+                    playerRepository.findByIdOrNull(playerId)
+                        ?: throw PlayerNotFoundException(playerId)
+                logger.info(
+                    "시즌 타격 통계 자동 생성 (playerId={}, year={})",
+                    playerId,
+                    year,
+                )
+                val newStats = SeasonBattingStats.create(player = player, year = year)
+                seasonBattingStatsRepository.save(newStats)
+            }
     }
 
     private fun resolveYear(gameId: Long): Int {

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
@@ -1,6 +1,7 @@
 package com.nextup.infrastructure.listener
 
 import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.PlayerNotFoundException
 import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlateAppearanceUndoneEvent
@@ -27,6 +28,7 @@ import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
 import com.nextup.core.port.repository.FieldingRecordRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
@@ -53,6 +55,7 @@ class StatsEventListenerTest {
     private val pitchingRecordRepository = mockk<PitchingRecordRepositoryPort>()
     private val fieldingRecordRepository = mockk<FieldingRecordRepositoryPort>()
     private val gameRepository = mockk<GameRepositoryPort>()
+    private val playerRepository = mockk<PlayerRepositoryPort>()
 
     private val listener =
         StatsEventListener(
@@ -66,6 +69,7 @@ class StatsEventListenerTest {
             pitchingRecordRepository = pitchingRecordRepository,
             fieldingRecordRepository = fieldingRecordRepository,
             gameRepository = gameRepository,
+            playerRepository = playerRepository,
         )
 
     private val testPlayer =
@@ -173,11 +177,13 @@ class StatsEventListenerTest {
         }
 
         @Test
-        fun `시즌 통계가 없는 경우 저장 없이 건너뜀`() {
+        fun `시즌 통계가 없는 경우 자동 생성 후 타석 결과 반영`() {
             // given
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
             } returns null
+            every { playerRepository.findByIdOrNull(testPlayer.id) } returns testPlayer
+            every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
 
             val event =
                 PlateAppearanceRecordedEvent(
@@ -189,8 +195,60 @@ class StatsEventListenerTest {
             // when
             listener.onPlateAppearanceRecorded(event)
 
-            // then
-            verify(exactly = 0) { seasonBattingStatsRepository.save(any()) }
+            // then: 자동 생성 후 저장 (생성 1회 + 갱신 1회 = save 2회)
+            verify(exactly = 2) { seasonBattingStatsRepository.save(any()) }
+            verify { playerRepository.findByIdOrNull(testPlayer.id) }
+        }
+
+        @Test
+        fun `시즌 통계가 없는 신규 선수의 첫 타석 기록 시 통계가 올바르게 반영됨`() {
+            // given
+            val savedStats = mutableListOf<SeasonBattingStats>()
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns null
+            every { playerRepository.findByIdOrNull(testPlayer.id) } returns testPlayer
+            every { seasonBattingStatsRepository.save(capture(savedStats)) } answers { firstArg() }
+
+            val event =
+                PlateAppearanceRecordedEvent(
+                    gameId = 10L,
+                    playerId = testPlayer.id,
+                    result = PlateAppearanceResult.HOME_RUN,
+                )
+
+            // when
+            listener.onPlateAppearanceRecorded(event)
+
+            // then: 마지막 저장된 stats에 홈런이 반영되어 있어야 함
+            val finalStats = savedStats.last()
+            assertThat(finalStats.plateAppearances).isEqualTo(1)
+            assertThat(finalStats.atBats).isEqualTo(1)
+            assertThat(finalStats.hits).isEqualTo(1)
+            assertThat(finalStats.homeRuns).isEqualTo(1)
+            assertThat(finalStats.year).isEqualTo(2024)
+            assertThat(finalStats.player).isEqualTo(testPlayer)
+        }
+
+        @Test
+        fun `선수를 찾을 수 없는 경우 PlayerNotFoundException 발생`() {
+            // given
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(999L, 2024)
+            } returns null
+            every { playerRepository.findByIdOrNull(999L) } returns null
+
+            val event =
+                PlateAppearanceRecordedEvent(
+                    gameId = 10L,
+                    playerId = 999L,
+                    result = PlateAppearanceResult.SINGLE,
+                )
+
+            // when & then
+            assertThrows<PlayerNotFoundException> {
+                listener.onPlateAppearanceRecorded(event)
+            }
         }
 
         @Test
@@ -295,11 +353,13 @@ class StatsEventListenerTest {
         }
 
         @Test
-        fun `시즌 통계가 없는 경우 저장 없이 건너뜀`() {
+        fun `시즌 통계가 없는 경우 자동 생성 후 역산 처리`() {
             // given
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
             } returns null
+            every { playerRepository.findByIdOrNull(testPlayer.id) } returns testPlayer
+            every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
 
             val event =
                 PlateAppearanceUndoneEvent(
@@ -311,8 +371,9 @@ class StatsEventListenerTest {
             // when
             listener.onPlateAppearanceUndone(event)
 
-            // then
-            verify(exactly = 0) { seasonBattingStatsRepository.save(any()) }
+            // then: 자동 생성 후 저장 (생성 1회 + 갱신 1회 = save 2회)
+            verify(exactly = 2) { seasonBattingStatsRepository.save(any()) }
+            verify { playerRepository.findByIdOrNull(testPlayer.id) }
         }
 
         @Test


### PR DESCRIPTION
## Summary

>- close #330

시즌 타격 통계가 없는 신규 선수의 첫 타석 기록 시 `SeasonBattingStats`가 자동 생성되도록 findOrCreate 패턴을 적용합니다. 기존에는 silent return으로 통계가 누적되지 않았습니다.

## Tasks

- [x] StatsEventListener의 `onPlateAppearanceRecorded()`에 findOrCreate 패턴 적용
- [x] `onPlateAppearanceUndone()`에도 동일 패턴 적용
- [x] `PlayerRepositoryPort` 의존성 추가 (Player 엔티티 조회용)
- [x] 동시성 방어 (DB unique constraint `uk_season_batting_stats_player_year` 기반)
- [x] 신규 선수 첫 타석 시나리오 테스트 작성 (3개 추가)
- [x] 기존 테스트 동작 유지 확인

## To Reviewer

감사 보고서 H-3 항목입니다. 첫 시즌 선수의 실시간 타격 통계가 누적되지 않는 문제를 수정합니다.

### 변경 요약

**StatsEventListener.kt**
- `findOrCreateSeasonBattingStats()` private 메서드 추가: 시즌 통계 조회 후 없으면 Player를 조회하여 자동 생성
- `onPlateAppearanceRecorded()`: silent return → findOrCreate 패턴
- `onPlateAppearanceUndone()`: silent return → findOrCreate 패턴
- `PlayerRepositoryPort` 생성자 의존성 추가

**StatsEventListenerTest.kt**
- 기존 '건너뜀' 테스트 → '자동 생성' 테스트로 변경 (2개)
- 신규 테스트 추가: 첫 타석 홈런 시 통계 값 검증, PlayerNotFoundException 발생 검증