### PR TITLE
feat(#329): 홈 화면 API - 내 소속 팀 목록 및 upcoming 경기 통합 조회

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/user/ProfileController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/user/ProfileController.kt
@@ -1,7 +1,10 @@
 package com.nextup.api.controller.user
 
+import com.nextup.api.dto.game.GameSummaryResponse
 import com.nextup.api.dto.user.*
 import com.nextup.common.dto.ApiResponse
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import com.nextup.core.service.game.GameScheduleService
 import com.nextup.core.service.user.UserService
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -16,6 +19,8 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/v1/me")
 class ProfileController(
     private val userService: UserService,
+    private val teamMemberRepository: TeamMemberRepositoryPort,
+    private val gameScheduleService: GameScheduleService,
 ) {
     /**
      * 내 프로필을 조회합니다.
@@ -26,6 +31,31 @@ class ProfileController(
     ): ApiResponse<ProfileResponse> {
         val user = userService.getActiveById(userId)
         return ApiResponse.success(ProfileResponse.from(user))
+    }
+
+    /**
+     * 내 소속 팀 목록을 조회합니다.
+     */
+    @GetMapping("/teams")
+    fun getMyTeams(
+        @AuthenticationPrincipal userId: Long,
+    ): ApiResponse<List<MyTeamResponse>> {
+        val activeMembers = teamMemberRepository.findAllActiveByUserId(userId)
+        return ApiResponse.success(activeMembers.map { MyTeamResponse.from(it) })
+    }
+
+    /**
+     * 내 소속 팀들의 다가오는 경기를 통합 조회합니다.
+     */
+    @GetMapping("/upcoming-games")
+    fun getMyUpcomingGames(
+        @AuthenticationPrincipal userId: Long,
+        @RequestParam(defaultValue = "10") limit: Int,
+    ): ApiResponse<List<GameSummaryResponse>> {
+        val activeMembers = teamMemberRepository.findAllActiveByUserId(userId)
+        val teamIds = activeMembers.map { it.team.id }
+        val games = gameScheduleService.getUpcomingGamesByTeamIds(teamIds, limit)
+        return ApiResponse.success(games.map { GameSummaryResponse.from(it) })
     }
 
     /**

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/user/MyTeamResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/user/MyTeamResponse.kt
@@ -1,0 +1,33 @@
+package com.nextup.api.dto.user
+
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberRole
+import java.time.LocalDateTime
+
+/**
+ * 내 소속 팀 응답 DTO
+ *
+ * 로그인한 사용자의 활성 상태 팀 멤버십 정보를 표현합니다.
+ */
+data class MyTeamResponse(
+    val teamId: Long,
+    val teamName: String,
+    val teamLogoUrl: String?,
+    val role: TeamMemberRole,
+    val roleDisplayName: String,
+    val uniformNumber: Int,
+    val joinedAt: LocalDateTime,
+) {
+    companion object {
+        fun from(teamMember: TeamMember): MyTeamResponse =
+            MyTeamResponse(
+                teamId = teamMember.team.id,
+                teamName = teamMember.team.name,
+                teamLogoUrl = teamMember.team.logoUrl,
+                role = teamMember.role,
+                roleDisplayName = teamMember.role.displayName,
+                uniformNumber = teamMember.uniformNumber,
+                joinedAt = teamMember.joinedAt,
+            )
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/user/ProfileControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/user/ProfileControllerTest.kt
@@ -1,8 +1,15 @@
 package com.nextup.api.controller.user
 
 import com.nextup.api.dto.user.UpdateProfileRequest
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberRole
 import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.User
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import com.nextup.core.service.game.GameScheduleService
+import com.nextup.core.service.game.dto.GameSummaryDto
 import com.nextup.core.service.user.UserService
 import io.mockk.every
 import io.mockk.mockk
@@ -12,16 +19,26 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 
 @DisplayName("ProfileController 테스트")
 class ProfileControllerTest {
     private lateinit var userService: UserService
+    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
+    private lateinit var gameScheduleService: GameScheduleService
     private lateinit var profileController: ProfileController
 
     @BeforeEach
     fun setUp() {
         userService = mockk()
-        profileController = ProfileController(userService)
+        teamMemberRepository = mockk()
+        gameScheduleService = mockk()
+        profileController =
+            ProfileController(
+                userService,
+                teamMemberRepository,
+                gameScheduleService,
+            )
     }
 
     private fun createTestUser(
@@ -44,6 +61,36 @@ class ProfileControllerTest {
         }
 
         return user
+    }
+
+    private fun createMockTeam(
+        teamId: Long,
+        teamName: String,
+        logoUrl: String? = null,
+    ): Team {
+        val team =
+            mockk<Team> {
+                every { id } returns teamId
+                every { name } returns teamName
+                every { this@mockk.logoUrl } returns logoUrl
+            }
+        return team
+    }
+
+    private fun createMockTeamMember(
+        team: Team,
+        role: TeamMemberRole = TeamMemberRole.MEMBER,
+        uniformNumber: Int = 1,
+        joinedAt: LocalDateTime = LocalDateTime.of(2026, 1, 1, 0, 0),
+    ): TeamMember {
+        val member =
+            mockk<TeamMember> {
+                every { this@mockk.team } returns team
+                every { this@mockk.role } returns role
+                every { this@mockk.uniformNumber } returns uniformNumber
+                every { this@mockk.joinedAt } returns joinedAt
+            }
+        return member
     }
 
     @Nested
@@ -86,6 +133,172 @@ class ProfileControllerTest {
                     ?.first()
                     ?.provider,
             ).isEqualTo("GOOGLE")
+        }
+    }
+
+    @Nested
+    @DisplayName("내 소속 팀 목록 조회")
+    inner class GetMyTeams {
+        @Test
+        fun `should return my teams successfully`() {
+            // given
+            val userId = 1L
+            val team1 = createMockTeam(10L, "팀A", "https://logo.com/a.png")
+            val team2 = createMockTeam(20L, "팀B", null)
+            val member1 =
+                createMockTeamMember(
+                    team = team1,
+                    role = TeamMemberRole.OWNER,
+                    uniformNumber = 7,
+                    joinedAt = LocalDateTime.of(2026, 1, 15, 0, 0),
+                )
+            val member2 =
+                createMockTeamMember(
+                    team = team2,
+                    role = TeamMemberRole.MEMBER,
+                    uniformNumber = 3,
+                    joinedAt = LocalDateTime.of(2026, 3, 1, 0, 0),
+                )
+
+            every { teamMemberRepository.findAllActiveByUserId(userId) } returns listOf(member1, member2)
+
+            // when
+            val response = profileController.getMyTeams(userId)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data).hasSize(2)
+
+            val first = response.data!![0]
+            assertThat(first.teamId).isEqualTo(10L)
+            assertThat(first.teamName).isEqualTo("팀A")
+            assertThat(first.teamLogoUrl).isEqualTo("https://logo.com/a.png")
+            assertThat(first.role).isEqualTo(TeamMemberRole.OWNER)
+            assertThat(first.roleDisplayName).isEqualTo("감독")
+            assertThat(first.uniformNumber).isEqualTo(7)
+
+            val second = response.data!![1]
+            assertThat(second.teamId).isEqualTo(20L)
+            assertThat(second.teamName).isEqualTo("팀B")
+            assertThat(second.teamLogoUrl).isNull()
+            assertThat(second.role).isEqualTo(TeamMemberRole.MEMBER)
+            assertThat(second.uniformNumber).isEqualTo(3)
+
+            verify { teamMemberRepository.findAllActiveByUserId(userId) }
+        }
+
+        @Test
+        fun `should return empty list when user has no teams`() {
+            // given
+            val userId = 1L
+            every { teamMemberRepository.findAllActiveByUserId(userId) } returns emptyList()
+
+            // when
+            val response = profileController.getMyTeams(userId)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data).isEmpty()
+            verify { teamMemberRepository.findAllActiveByUserId(userId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("내 upcoming 경기 통합 조회")
+    inner class GetMyUpcomingGames {
+        @Test
+        fun `should return upcoming games for all my teams`() {
+            // given
+            val userId = 1L
+            val team1 = createMockTeam(10L, "팀A")
+            val team2 = createMockTeam(20L, "팀B")
+            val member1 = createMockTeamMember(team = team1)
+            val member2 = createMockTeamMember(team = team2)
+
+            every { teamMemberRepository.findAllActiveByUserId(userId) } returns listOf(member1, member2)
+
+            val gameSummaries =
+                listOf(
+                    GameSummaryDto(
+                        gameId = 100L,
+                        competitionId = 1L,
+                        competitionName = "리그A",
+                        homeTeamId = 10L,
+                        homeTeamName = "팀A",
+                        awayTeamId = 30L,
+                        awayTeamName = "팀C",
+                        scheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0),
+                        status = GameStatus.SCHEDULED,
+                        homeScore = 0,
+                        awayScore = 0,
+                        location = "서울 잠실",
+                        fieldName = "잠실구장",
+                    ),
+                    GameSummaryDto(
+                        gameId = 200L,
+                        competitionId = 2L,
+                        competitionName = "리그B",
+                        homeTeamId = 40L,
+                        homeTeamName = "팀D",
+                        awayTeamId = 20L,
+                        awayTeamName = "팀B",
+                        scheduledAt = LocalDateTime.of(2026, 4, 5, 10, 0),
+                        status = GameStatus.SCHEDULED,
+                        homeScore = 0,
+                        awayScore = 0,
+                        location = "부산 사직",
+                        fieldName = "사직구장",
+                    ),
+                )
+
+            every {
+                gameScheduleService.getUpcomingGamesByTeamIds(listOf(10L, 20L), 10)
+            } returns gameSummaries
+
+            // when
+            val response = profileController.getMyUpcomingGames(userId, 10)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data).hasSize(2)
+            assertThat(response.data!![0].gameId).isEqualTo(100L)
+            assertThat(response.data!![1].gameId).isEqualTo(200L)
+
+            verify { teamMemberRepository.findAllActiveByUserId(userId) }
+            verify { gameScheduleService.getUpcomingGamesByTeamIds(listOf(10L, 20L), 10) }
+        }
+
+        @Test
+        fun `should return empty list when user has no teams`() {
+            // given
+            val userId = 1L
+            every { teamMemberRepository.findAllActiveByUserId(userId) } returns emptyList()
+            every { gameScheduleService.getUpcomingGamesByTeamIds(emptyList(), 10) } returns emptyList()
+
+            // when
+            val response = profileController.getMyUpcomingGames(userId, 10)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data).isEmpty()
+        }
+
+        @Test
+        fun `should respect limit parameter`() {
+            // given
+            val userId = 1L
+            val team1 = createMockTeam(10L, "팀A")
+            val member1 = createMockTeamMember(team = team1)
+
+            every { teamMemberRepository.findAllActiveByUserId(userId) } returns listOf(member1)
+            every { gameScheduleService.getUpcomingGamesByTeamIds(listOf(10L), 5) } returns emptyList()
+
+            // when
+            val response = profileController.getMyUpcomingGames(userId, 5)
+
+            // then
+            assertThat(response.success).isTrue()
+            verify { gameScheduleService.getUpcomingGamesByTeamIds(listOf(10L), 5) }
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamMemberRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamMemberRepositoryPort.kt
@@ -35,6 +35,8 @@ interface TeamMemberRepositoryPort {
 
     fun findActiveByUserId(userId: Long): TeamMember?
 
+    fun findAllActiveByUserId(userId: Long): List<TeamMember>
+
     fun findByTeamIdWithUserAndPlayer(
         teamId: Long,
         pageCommand: PageCommand,

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScheduleService.kt
@@ -38,6 +38,14 @@ interface GameScheduleService {
     ): List<GameSummaryDto>
 
     /**
+     * 여러 팀의 다가오는 경기를 통합 조회합니다.
+     */
+    fun getUpcomingGamesByTeamIds(
+        teamIds: List<Long>,
+        limit: Int = 10,
+    ): List<GameSummaryDto>
+
+    /**
      * 특정 연월에 경기가 있는 날짜(일) 목록을 반환합니다. (캘린더 뷰용)
      */
     fun getGameDaysInMonth(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepository.kt
@@ -39,6 +39,9 @@ interface TeamMemberRepository : JpaRepository<TeamMember, Long> {
     @Query("SELECT tm FROM TeamMember tm WHERE tm.user.id = :userId AND tm.status = 'ACTIVE'")
     fun findActiveByUserId(userId: Long): TeamMember?
 
+    @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.user.id = :userId AND tm.status = 'ACTIVE'")
+    fun findAllActiveByUserId(userId: Long): List<TeamMember>
+
     @Query(
         """
         SELECT tm FROM TeamMember tm

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapter.kt
@@ -43,6 +43,8 @@ class TeamMemberRepositoryAdapter(
 
     override fun findActiveByUserId(userId: Long): TeamMember? = jpaRepository.findActiveByUserId(userId)
 
+    override fun findAllActiveByUserId(userId: Long): List<TeamMember> = jpaRepository.findAllActiveByUserId(userId)
+
     override fun findByTeamIdWithUserAndPlayer(
         teamId: Long,
         pageCommand: PageCommand,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImpl.kt
@@ -120,6 +120,25 @@ class GameScheduleServiceImpl(
         return toSummaryDtos(games)
     }
 
+    override fun getUpcomingGamesByTeamIds(
+        teamIds: List<Long>,
+        limit: Int,
+    ): List<GameSummaryDto> {
+        if (teamIds.isEmpty()) return emptyList()
+
+        val now = LocalDateTime.now()
+        val gameTeams =
+            teamIds.flatMap { gameTeamRepository.findAllByTeamId(it) }
+        val gameIds = gameTeams.map { it.game.id }.distinct()
+        val games =
+            gameRepository.findAllByIds(gameIds)
+                .filter { it.scheduledAt.isAfter(now) && it.status == GameStatus.SCHEDULED }
+                .sortedBy { it.scheduledAt }
+                .take(limit)
+
+        return toSummaryDtos(games)
+    }
+
     override fun getGameDaysInMonth(
         year: Int,
         month: Int,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/repository/TeamMemberRepositoryAdapterTest.kt
@@ -164,6 +164,22 @@ class TeamMemberRepositoryAdapterTest {
     }
 
     @Test
+    @DisplayName("findAllActiveByUserId - 활성 상태 멤버 전체 조회 시 JPA repository에 위임한다")
+    fun `should delegate findAllActiveByUserId to jpa repository`() {
+        // given
+        val members = listOf(mockk<TeamMember>(), mockk<TeamMember>())
+        every { jpaRepository.findAllActiveByUserId(10L) } returns members
+
+        // when
+        val result = adapter.findAllActiveByUserId(10L)
+
+        // then
+        assertThat(result).hasSize(2)
+        assertThat(result).isEqualTo(members)
+        verify(exactly = 1) { jpaRepository.findAllActiveByUserId(10L) }
+    }
+
+    @Test
     @DisplayName("findByTeamIdWithUserAndPlayer - 페이지 조회 시 JPA repository에 위임한다")
     fun `should delegate findByTeamIdWithUserAndPlayer to jpa repository`() {
         // given

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImplTest.kt
@@ -286,6 +286,94 @@ class GameScheduleServiceImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("getUpcomingGamesByTeamIds")
+    inner class GetUpcomingGamesByTeamIdsTest {
+        @Test
+        @DisplayName("여러 팀의 다가오는 경기를 통합 조회한다")
+        fun getUpcomingGamesByTeamIdsReturnsGamesFromMultipleTeams() {
+            // given
+            val teamIds = listOf(1L, 2L)
+            val now = LocalDateTime.now()
+            val game1 = createGame(10L, scheduledAt = now.plusDays(1), status = GameStatus.SCHEDULED)
+            val game2 = createGame(20L, scheduledAt = now.plusDays(3), status = GameStatus.SCHEDULED)
+
+            val gameTeam1 = createGameTeam(10L, teamId = 1L)
+            val gameTeam2 = createGameTeam(20L, teamId = 2L)
+
+            every { gameTeamRepository.findAllByTeamId(1L) } returns listOf(gameTeam1)
+            every { gameTeamRepository.findAllByTeamId(2L) } returns listOf(gameTeam2)
+            every { gameRepository.findAllByIds(listOf(10L, 20L)) } returns listOf(game1, game2)
+            every { gameTeamRepository.findAllByGameIds(listOf(10L, 20L)) } returns listOf(gameTeam1, gameTeam2)
+
+            // when
+            val result = service.getUpcomingGamesByTeamIds(teamIds, limit = 10)
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result[0].gameId).isEqualTo(10L)
+            assertThat(result[1].gameId).isEqualTo(20L)
+        }
+
+        @Test
+        @DisplayName("빈 팀 목록이면 빈 리스트를 반환한다")
+        fun getUpcomingGamesByTeamIdsReturnsEmptyForEmptyTeamIds() {
+            // given & when
+            val result = service.getUpcomingGamesByTeamIds(emptyList(), limit = 10)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        @DisplayName("중복 경기를 제거한다")
+        fun getUpcomingGamesByTeamIdsDeduplicatesGames() {
+            // given
+            val teamIds = listOf(1L, 2L)
+            val now = LocalDateTime.now()
+            // 같은 경기에 두 팀이 모두 참여하는 경우
+            val game = createGame(10L, scheduledAt = now.plusDays(1), status = GameStatus.SCHEDULED)
+
+            val gameTeam1 = createGameTeam(10L, teamId = 1L, homeAway = HomeAway.HOME)
+            val gameTeam2 = createGameTeam(10L, teamId = 2L, homeAway = HomeAway.AWAY)
+
+            every { gameTeamRepository.findAllByTeamId(1L) } returns listOf(gameTeam1)
+            every { gameTeamRepository.findAllByTeamId(2L) } returns listOf(gameTeam2)
+            every { gameRepository.findAllByIds(listOf(10L)) } returns listOf(game)
+            every { gameTeamRepository.findAllByGameIds(listOf(10L)) } returns listOf(gameTeam1, gameTeam2)
+
+            // when
+            val result = service.getUpcomingGamesByTeamIds(teamIds, limit = 10)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].gameId).isEqualTo(10L)
+        }
+
+        @Test
+        @DisplayName("limit을 적용한다")
+        fun getUpcomingGamesByTeamIdsRespectsLimit() {
+            // given
+            val teamIds = listOf(1L)
+            val now = LocalDateTime.now()
+            val games =
+                (1L..5L).map {
+                    createGame(it, scheduledAt = now.plusDays(it), status = GameStatus.SCHEDULED)
+                }
+            val gameTeams = (1L..5L).map { createGameTeam(it, teamId = 1L) }
+
+            every { gameTeamRepository.findAllByTeamId(1L) } returns gameTeams
+            every { gameRepository.findAllByIds(any()) } returns games
+            every { gameTeamRepository.findAllByGameIds(listOf(1L, 2L)) } returns gameTeams.take(2)
+
+            // when
+            val result = service.getUpcomingGamesByTeamIds(teamIds, limit = 2)
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+    }
+
     // Helper methods
     private fun createGame(
         id: Long,


### PR DESCRIPTION
## Summary

>- close #329

홈 화면 구현의 전제 조건인 두 가지 API를 추가합니다:
- `GET /api/v1/me/teams`: 내 소속 팀 목록 조회
- `GET /api/v1/me/upcoming-games`: 사용자별 upcoming 경기 통합 조회

## Tasks

- [x] MyTeamResponse DTO 생성 (teamId, teamName, teamLogoUrl, role, roleDisplayName, uniformNumber, joinedAt)
- [x] `findAllActiveByUserId` 메서드 추가 (TeamMemberRepositoryPort → Repository → Adapter)
- [x] `getUpcomingGamesByTeamIds` 메서드 추가 (GameScheduleService → ServiceImpl)
- [x] GET /api/v1/me/teams 엔드포인트 추가
- [x] GET /api/v1/me/upcoming-games 엔드포인트 추가 (복수 팀 통합, 중복 경기 제거)
- [x] ApiResponse 래핑, Zero Entity Leak 준수
- [x] ProfileControllerTest - 소속 팀 목록, upcoming 경기 통합 테스트
- [x] GameScheduleServiceImplTest - 다중 팀 upcoming 경기, 중복 제거, limit 테스트
- [x] TeamMemberRepositoryAdapterTest - findAllActiveByUserId 위임 테스트

## To Reviewer

감사 보고서 C-5 (CRITICAL) + H-17 통합 구현입니다. 프런트엔드 홈 화면 구현의 전제 조건입니다.

### 변경 레이어
- **Core**: `TeamMemberRepositoryPort`, `GameScheduleService` 인터페이스에 메서드 추가
- **Infrastructure**: JPA 쿼리, Adapter 위임, ServiceImpl 구현
- **API**: `ProfileController` 엔드포인트 2개 추가, `MyTeamResponse` DTO 생성