### PR TITLE
fix(#327): 경기 종료 시 GameTeam.result WIN/LOSS/DRAW 설정

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -163,11 +163,16 @@ class Game private constructor(
 
     /**
      * 경기를 정상 종료합니다.
+     *
+     * 양 팀의 점수를 비교하여 WIN/LOSS/DRAW 결과를 자동으로 설정합니다.
+     *
+     * @param gameTeams 해당 경기에 참여하는 GameTeam 목록 (정확히 2개)
      */
-    fun finish() {
+    fun finish(gameTeams: List<GameTeam>) {
         require(status.isOngoing()) { "진행 중인 경기만 종료할 수 있습니다." }
         status = GameStatus.FINISHED
         endedAt = LocalDateTime.now()
+        determineResults(gameTeams)
     }
 
     /**
@@ -178,14 +183,18 @@ class Game private constructor(
      * - 예외: [minimumInning]회 초(top)까지 완료되고 홈팀이 리드 중이면
      *         [minimumInning - 1].5이닝에서도 선언 가능 (홈팀 승리 확정)
      *
+     * 양 팀의 점수를 비교하여 WIN/LOSS/DRAW 결과를 자동으로 설정합니다.
+     *
      * @param minimumInning 콜드게임 최소 요건 이닝 (기본값: 5이닝)
      * @param isHomeTeamLeading 홈팀이 리드 중인지 여부 (기본값: false)
      * @param reason 콜드게임 사유 (선택)
+     * @param gameTeams 해당 경기에 참여하는 GameTeam 목록 (정확히 2개)
      */
     fun callGame(
         minimumInning: Int = DEFAULT_COLD_GAME_MINIMUM_INNING,
         isHomeTeamLeading: Boolean = false,
         reason: String? = null,
+        gameTeams: List<GameTeam> = emptyList(),
     ) {
         require(status.isOngoing()) { "진행 중인 경기만 콜드게임 처리할 수 있습니다." }
         require(minimumInning >= 1) { "최소 이닝은 1 이상이어야 합니다." }
@@ -204,6 +213,9 @@ class Game private constructor(
         endedAt = LocalDateTime.now()
         if (reason != null) {
             note = (note?.let { "$it\n" } ?: "") + "콜드게임 사유: $reason"
+        }
+        if (gameTeams.isNotEmpty()) {
+            determineResults(gameTeams)
         }
     }
 
@@ -331,6 +343,38 @@ class Game private constructor(
             } else {
                 gameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
                 gameTeam.updateResult(GameResult.LOSS)
+            }
+        }
+    }
+
+    /**
+     * 양 팀의 점수를 비교하여 GameTeam의 result를 설정합니다.
+     *
+     * - 점수가 높은 팀: WIN, 낮은 팀: LOSS
+     * - 동점: 양 팀 모두 DRAW
+     *
+     * @param gameTeams 해당 경기에 참여하는 GameTeam 목록 (정확히 2개)
+     */
+    private fun determineResults(gameTeams: List<GameTeam>) {
+        require(gameTeams.size == 2) {
+            "결과 판정을 위해서는 정확히 2개의 GameTeam이 필요합니다."
+        }
+
+        val team1 = gameTeams[0]
+        val team2 = gameTeams[1]
+
+        when {
+            team1.totalScore > team2.totalScore -> {
+                team1.updateResult(GameResult.WIN)
+                team2.updateResult(GameResult.LOSS)
+            }
+            team1.totalScore < team2.totalScore -> {
+                team1.updateResult(GameResult.LOSS)
+                team2.updateResult(GameResult.WIN)
+            }
+            else -> {
+                team1.updateResult(GameResult.DRAW)
+                team2.updateResult(GameResult.DRAW)
             }
         }
     }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -147,9 +147,10 @@ class GameTest {
         fun `진행 중인 경기를 종료할 수 있다`() {
             // given
             val game = createGame(status = GameStatus.IN_PROGRESS)
+            val gameTeams = game.gameTeams
 
             // when
-            game.finish()
+            game.finish(gameTeams)
 
             // then
             assertThat(game.status).isEqualTo(GameStatus.FINISHED)
@@ -160,10 +161,65 @@ class GameTest {
         fun `예정된 경기는 종료할 수 없다`() {
             // given
             val game = createGame(status = GameStatus.SCHEDULED)
+            val gameTeams = game.gameTeams
 
             // when & then
-            assertThatThrownBy { game.finish() }
+            assertThatThrownBy { game.finish(gameTeams) }
                 .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `정상 종료 시 홈팀 점수가 높으면 홈팀 WIN, 원정팀 LOSS`() {
+            // given
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            val gameTeams = game.gameTeams
+            val homeTeam = gameTeams.first { it.homeAway == HomeAway.HOME }
+            val awayTeam = gameTeams.first { it.homeAway == HomeAway.AWAY }
+            homeTeam.addScore(5)
+            awayTeam.addScore(3)
+
+            // when
+            game.finish(gameTeams)
+
+            // then
+            assertThat(homeTeam.result).isEqualTo(GameResult.WIN)
+            assertThat(awayTeam.result).isEqualTo(GameResult.LOSS)
+        }
+
+        @Test
+        fun `정상 종료 시 원정팀 점수가 높으면 원정팀 WIN, 홈팀 LOSS`() {
+            // given
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            val gameTeams = game.gameTeams
+            val homeTeam = gameTeams.first { it.homeAway == HomeAway.HOME }
+            val awayTeam = gameTeams.first { it.homeAway == HomeAway.AWAY }
+            homeTeam.addScore(2)
+            awayTeam.addScore(7)
+
+            // when
+            game.finish(gameTeams)
+
+            // then
+            assertThat(homeTeam.result).isEqualTo(GameResult.LOSS)
+            assertThat(awayTeam.result).isEqualTo(GameResult.WIN)
+        }
+
+        @Test
+        fun `정상 종료 시 동점이면 양 팀 모두 DRAW`() {
+            // given
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            val gameTeams = game.gameTeams
+            val homeTeam = gameTeams.first { it.homeAway == HomeAway.HOME }
+            val awayTeam = gameTeams.first { it.homeAway == HomeAway.AWAY }
+            homeTeam.addScore(4)
+            awayTeam.addScore(4)
+
+            // when
+            game.finish(gameTeams)
+
+            // then
+            assertThat(homeTeam.result).isEqualTo(GameResult.DRAW)
+            assertThat(awayTeam.result).isEqualTo(GameResult.DRAW)
         }
     }
 
@@ -373,6 +429,89 @@ class GameTest {
             assertThatThrownBy { game.callGame(isHomeTeamLeading = true) }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("최소 5이닝")
+        }
+
+        @Test
+        fun `콜드게임 종료 시 홈팀 점수가 높으면 홈팀 WIN, 원정팀 LOSS`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                }
+            val gameTeams = game.gameTeams
+            val homeTeam = gameTeams.first { it.homeAway == HomeAway.HOME }
+            val awayTeam = gameTeams.first { it.homeAway == HomeAway.AWAY }
+            homeTeam.addScore(10)
+            awayTeam.addScore(0)
+
+            // when
+            game.callGame(reason = "점수차", gameTeams = gameTeams)
+
+            // then
+            assertThat(homeTeam.result).isEqualTo(GameResult.WIN)
+            assertThat(awayTeam.result).isEqualTo(GameResult.LOSS)
+        }
+
+        @Test
+        fun `콜드게임 종료 시 원정팀 점수가 높으면 원정팀 WIN, 홈팀 LOSS`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 6
+                    isTopInning = false
+                }
+            val gameTeams = game.gameTeams
+            val homeTeam = gameTeams.first { it.homeAway == HomeAway.HOME }
+            val awayTeam = gameTeams.first { it.homeAway == HomeAway.AWAY }
+            homeTeam.addScore(1)
+            awayTeam.addScore(11)
+
+            // when
+            game.callGame(gameTeams = gameTeams)
+
+            // then
+            assertThat(homeTeam.result).isEqualTo(GameResult.LOSS)
+            assertThat(awayTeam.result).isEqualTo(GameResult.WIN)
+        }
+
+        @Test
+        fun `콜드게임 종료 시 동점이면 양 팀 모두 DRAW`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 7
+                    isTopInning = false
+                }
+            val gameTeams = game.gameTeams
+            val homeTeam = gameTeams.first { it.homeAway == HomeAway.HOME }
+            val awayTeam = gameTeams.first { it.homeAway == HomeAway.AWAY }
+            homeTeam.addScore(3)
+            awayTeam.addScore(3)
+
+            // when
+            game.callGame(gameTeams = gameTeams)
+
+            // then
+            assertThat(homeTeam.result).isEqualTo(GameResult.DRAW)
+            assertThat(awayTeam.result).isEqualTo(GameResult.DRAW)
+        }
+
+        @Test
+        fun `gameTeams 없이 콜드게임 처리하면 result는 UNDECIDED 유지`() {
+            // given
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = true
+                }
+            val gameTeams = game.gameTeams
+
+            // when
+            game.callGame()
+
+            // then
+            gameTeams.forEach { assertThat(it.result).isEqualTo(GameResult.UNDECIDED) }
         }
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
@@ -63,14 +63,19 @@ class GameLifecycleServiceImpl(
             throw InvalidGameStateException("진행 중인 경기만 종료할 수 있습니다. 현재 상태: ${game.status.displayName}")
         }
 
+        val gameTeams = gameTeamRepository.findAllByGameId(gameId)
+
         when (reason) {
-            GameEndReason.REGULATION -> game.finish()
-            GameEndReason.MERCY_RULE -> game.callGame(reason = "콜드게임 (점수차)")
-            GameEndReason.WEATHER -> game.callGame(reason = "콜드게임 (기상 조건)")
+            GameEndReason.REGULATION -> game.finish(gameTeams)
+            GameEndReason.MERCY_RULE ->
+                game.callGame(reason = "콜드게임 (점수차)", gameTeams = gameTeams)
+            GameEndReason.WEATHER ->
+                game.callGame(reason = "콜드게임 (기상 조건)", gameTeams = gameTeams)
             GameEndReason.FORFEIT -> throw InvalidGameStateException(
                 "몰수 처리는 전용 API를 사용해주세요.",
             )
-            GameEndReason.OTHER -> game.callGame(reason = "기타 사유")
+            GameEndReason.OTHER ->
+                game.callGame(reason = "기타 사유", gameTeams = gameTeams)
         }
 
         val savedGame = gameRepository.save(game)

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -165,6 +165,7 @@ class GameScorerServiceImplTest {
             // given
             val game = createGame(1L, GameStatus.IN_PROGRESS)
             every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameTeamRepository.findAllByGameId(1L) } returns game.gameTeams
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
@@ -180,6 +181,7 @@ class GameScorerServiceImplTest {
             // given
             val game = createGame(1L, GameStatus.IN_PROGRESS)
             every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameTeamRepository.findAllByGameId(1L) } returns game.gameTeams
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
@@ -195,6 +197,7 @@ class GameScorerServiceImplTest {
             // given
             val game = createGame(1L, GameStatus.IN_PROGRESS)
             every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameTeamRepository.findAllByGameId(1L) } returns game.gameTeams
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
@@ -221,6 +224,7 @@ class GameScorerServiceImplTest {
             // given
             val game = createGame(1L, GameStatus.IN_PROGRESS)
             every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameTeamRepository.findAllByGameId(1L) } returns game.gameTeams
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
@@ -1039,7 +1043,9 @@ class GameScorerServiceImplTest {
             val homeGameTeam = createMockGameTeam(1L, game, homeTeam)
 
             every { gameRepository.findByIdOrNull(1L) } returns game
-            every { gameTeamRepository.findAllByGameId(1L) } returns listOf(homeGameTeam)
+            // 첫 호출(endGame에서 finish용): 정상 2개, 이후 호출(assignPitchingDecisions/publishGameResultEvent): 1개
+            every { gameTeamRepository.findAllByGameId(1L) } returnsMany
+                listOf(game.gameTeams, listOf(homeGameTeam), listOf(homeGameTeam))
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when


### PR DESCRIPTION
## Summary

>- close #327

경기 정상 종료(`finish()`) 및 콜드게임(`callGame()`) 시 GameTeam의 result가 UNDECIDED로 남아있던 CRITICAL 버그를 수정합니다. 점수 비교 후 WIN/LOSS/DRAW를 올바르게 설정합니다.

## Tasks

- Game.finish()/callGame() 호출 시 GameTeam result 설정 로직 추가
- 홈팀 승/원정팀 승/동점 시나리오 테스트 작성
- 기존 forfeit() 동작 영향 없음 확인

## To Reviewer

감사 보고서 C-1 (CRITICAL) 항목입니다. 순위표(standings)가 정상 종료 경기를 반영하지 못하는 핵심 버그 수정입니다.