### PR TITLE
fix(#328): 팀원 강퇴/탈퇴 시 이벤트 발행 및 리스너 활성화

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionPlayerRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionPlayerRepositoryPort.kt
@@ -55,4 +55,13 @@ interface CompetitionPlayerRepositoryPort {
         teamId: Long,
         status: CompetitionPlayerStatus,
     ): List<CompetitionPlayer>
+
+    /**
+     * 선수 ID와 상태 목록으로 대회 선수를 조회합니다.
+     * 팀원 개별 탈퇴/강퇴 시 해당 선수의 활성 대회 등록을 처리하는 데 사용합니다.
+     */
+    fun findByPlayerIdAndStatusIn(
+        playerId: Long,
+        statuses: List<CompetitionPlayerStatus>,
+    ): List<CompetitionPlayer>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListener.kt
@@ -54,6 +54,7 @@ class TeamMemberEventListener(
     fun handleTeamMemberLeft(event: TeamMemberLeftEvent) {
         logger.info("팀원 탈퇴 처리 - teamId={}, playerId={}, memberId={}", event.teamId, event.playerId, event.memberId)
         removePlayerFromActiveLineups(event.teamId, event.playerId)
+        withdrawCompetitionPlayersByPlayerId(event.playerId)
         cleanupActivityScore(event.memberId)
     }
 
@@ -68,6 +69,7 @@ class TeamMemberEventListener(
     fun handleTeamMemberKicked(event: TeamMemberKickedEvent) {
         logger.info("팀원 강퇴 처리 - teamId={}, playerId={}, memberId={}", event.teamId, event.playerId, event.memberId)
         removePlayerFromActiveLineups(event.teamId, event.playerId)
+        withdrawCompetitionPlayersByPlayerId(event.playerId)
         cleanupActivityScore(event.memberId)
     }
 
@@ -98,7 +100,7 @@ class TeamMemberEventListener(
     // -------------------------------------------------------------------------
 
     /**
-     * DRAFT/SUBMITTED 상태의 라인업에서 특정 선수를 제거합니다.
+     * DRAFT/SUBMITTED/CONFIRMED 상태의 라인업에서 특정 선수를 제거합니다.
      * 제거 후 라인업 엔트리가 없으면 상태를 DRAFT로 되돌립니다.
      */
     private fun removePlayerFromActiveLineups(
@@ -109,6 +111,7 @@ class TeamMemberEventListener(
             listOf(
                 LineupSubmissionStatus.DRAFT,
                 LineupSubmissionStatus.SUBMITTED,
+                LineupSubmissionStatus.CONFIRMED,
             )
 
         val submissions =
@@ -152,6 +155,25 @@ class TeamMemberEventListener(
             cp.withdraw()
             competitionPlayerRepository.save(cp)
             logger.info("CompetitionPlayer WITHDRAWN 처리 - competitionPlayerId={}", cp.id)
+        }
+    }
+
+    /**
+     * 특정 선수의 활성/정지 상태 CompetitionPlayer를 WITHDRAWN으로 처리합니다.
+     * 팀원 개별 탈퇴/강퇴 시 호출됩니다.
+     */
+    private fun withdrawCompetitionPlayersByPlayerId(playerId: Long) {
+        val activeStatuses =
+            listOf(
+                CompetitionPlayerStatus.ACTIVE,
+                CompetitionPlayerStatus.SUSPENDED,
+            )
+        val competitionPlayers =
+            competitionPlayerRepository.findByPlayerIdAndStatusIn(playerId, activeStatuses)
+        competitionPlayers.forEach { cp ->
+            cp.withdraw()
+            competitionPlayerRepository.save(cp)
+            logger.info("CompetitionPlayer WITHDRAWN 처리 (개별 탈퇴) - competitionPlayerId={}, playerId={}", cp.id, playerId)
         }
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerJpaRepository.kt
@@ -41,4 +41,9 @@ interface CompetitionPlayerJpaRepository : JpaRepository<CompetitionPlayer, Long
         teamId: Long,
         status: CompetitionPlayerStatus,
     ): List<CompetitionPlayer>
+
+    fun findByPlayerIdAndStatusIn(
+        playerId: Long,
+        statuses: List<CompetitionPlayerStatus>,
+    ): List<CompetitionPlayer>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapter.kt
@@ -50,4 +50,9 @@ class CompetitionPlayerRepositoryAdapter(
         teamId: Long,
         status: CompetitionPlayerStatus,
     ): List<CompetitionPlayer> = jpaRepository.findByTeamIdAndStatus(teamId, status)
+
+    override fun findByPlayerIdAndStatusIn(
+        playerId: Long,
+        statuses: List<CompetitionPlayerStatus>,
+    ): List<CompetitionPlayer> = jpaRepository.findByPlayerIdAndStatusIn(playerId, statuses)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
@@ -3,6 +3,8 @@ package com.nextup.infrastructure.service.team
 import com.nextup.common.exception.*
 import com.nextup.core.domain.event.TeamJoinApprovedEvent
 import com.nextup.core.domain.event.TeamJoinRejectedEvent
+import com.nextup.core.domain.event.TeamMemberKickedEvent
+import com.nextup.core.domain.event.TeamMemberLeftEvent
 import com.nextup.core.domain.team.*
 import com.nextup.core.port.repository.*
 import com.nextup.core.service.team.TeamMembershipService
@@ -216,6 +218,14 @@ class TeamMembershipServiceImpl(
                 )
             teamBlacklistRepository.save(blacklist)
         }
+
+        eventPublisher.publishEvent(
+            TeamMemberKickedEvent(
+                teamId = member.team.id,
+                playerId = member.player.id,
+                memberId = member.id,
+            ),
+        )
     }
 
     @Transactional
@@ -235,6 +245,14 @@ class TeamMembershipServiceImpl(
         // Entity의 비즈니스 로직으로 탈퇴 처리
         member.leave()
         teamMemberRepository.save(member)
+
+        eventPublisher.publishEvent(
+            TeamMemberLeftEvent(
+                teamId = member.team.id,
+                playerId = member.player.id,
+                memberId = member.id,
+            ),
+        )
     }
 
     @Transactional

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
@@ -113,12 +113,22 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED,
+                    ),
                 )
             } returns listOf(submission)
             every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns entry
             justRun { lineupEntryRepository.delete(entry) }
             every { lineupEntryRepository.findAllBySubmissionId(10L) } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
 
             // when
@@ -142,10 +152,20 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
                 )
             } returns listOf(submission)
             every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns null
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
 
             // when
@@ -165,7 +185,17 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
                 )
             } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
@@ -194,12 +224,22 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
                 )
             } returns listOf(submission)
             every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns entry
             justRun { lineupEntryRepository.delete(entry) }
             every { lineupEntryRepository.findAllBySubmissionId(10L) } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
 
             // when
@@ -220,7 +260,17 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
                 )
             } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
@@ -230,6 +280,82 @@ class TeamMemberEventListenerTest {
 
             // then
             verify(exactly = 1) { activityScoreRepository.deleteByMemberId(100L) }
+        }
+
+        @Test
+        @DisplayName("팀원 탈퇴 시 활성 CompetitionPlayer를 WITHDRAWN 처리한다")
+        fun `should withdraw active competition players on member left`() {
+            // given
+            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val competitionPlayer = mockk<CompetitionPlayer>(relaxed = true)
+            every { competitionPlayer.id } returns 50L
+
+            every {
+                lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
+                    1L,
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns listOf(competitionPlayer)
+            justRun { competitionPlayer.withdraw() }
+            every { competitionPlayerRepository.save(competitionPlayer) } returns competitionPlayer
+            justRun { activityScoreRepository.deleteByMemberId(100L) }
+
+            // when
+            listener.handleTeamMemberLeft(event)
+
+            // then
+            verify(exactly = 1) { competitionPlayer.withdraw() }
+            verify(exactly = 1) { competitionPlayerRepository.save(competitionPlayer) }
+        }
+
+        @Test
+        @DisplayName("CONFIRMED 라인업에서도 탈퇴한 선수 엔트리를 제거한다")
+        fun `should remove player entry from CONFIRMED lineup submission`() {
+            // given
+            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+
+            val submission = mockk<LineupSubmission>(relaxed = true)
+            every { submission.id } returns 10L
+            every { submission.status } returns LineupSubmissionStatus.CONFIRMED
+
+            val entry = mockk<LineupEntry>(relaxed = true)
+
+            every {
+                lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
+                    1L,
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns listOf(submission)
+            every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns entry
+            justRun { lineupEntryRepository.delete(entry) }
+            every { lineupEntryRepository.findAllBySubmissionId(10L) } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
+            justRun { activityScoreRepository.deleteByMemberId(100L) }
+
+            // when
+            listener.handleTeamMemberLeft(event)
+
+            // then
+            verify(exactly = 1) { lineupEntryRepository.delete(entry) }
         }
     }
 
@@ -256,12 +382,22 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
                 )
             } returns listOf(submission)
             every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns entry
             justRun { lineupEntryRepository.delete(entry) }
             every { lineupEntryRepository.findAllBySubmissionId(10L) } returns listOf(remainingEntry)
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
 
             // when
@@ -292,7 +428,11 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
                 )
             } returns listOf(submission1, submission2)
             every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns entry1
@@ -301,6 +441,12 @@ class TeamMemberEventListenerTest {
             justRun { lineupEntryRepository.delete(entry2) }
             every { lineupEntryRepository.findAllBySubmissionId(10L) } returns emptyList()
             every { lineupEntryRepository.findAllBySubmissionId(11L) } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
 
             // when
@@ -321,7 +467,17 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
                 )
             } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
@@ -331,6 +487,42 @@ class TeamMemberEventListenerTest {
 
             // then
             verify(exactly = 1) { activityScoreRepository.deleteByMemberId(100L) }
+        }
+
+        @Test
+        @DisplayName("팀원 강퇴 시 활성 CompetitionPlayer를 WITHDRAWN 처리한다")
+        fun `should withdraw active competition players on member kicked`() {
+            // given
+            val event = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val competitionPlayer = mockk<CompetitionPlayer>(relaxed = true)
+            every { competitionPlayer.id } returns 50L
+
+            every {
+                lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
+                    1L,
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns listOf(competitionPlayer)
+            justRun { competitionPlayer.withdraw() }
+            every { competitionPlayerRepository.save(competitionPlayer) } returns competitionPlayer
+            justRun { activityScoreRepository.deleteByMemberId(100L) }
+
+            // when
+            listener.handleTeamMemberKicked(event)
+
+            // then
+            verify(exactly = 1) { competitionPlayer.withdraw() }
+            verify(exactly = 1) { competitionPlayerRepository.save(competitionPlayer) }
         }
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
@@ -4,6 +4,8 @@ import com.nextup.common.exception.*
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.event.TeamJoinApprovedEvent
 import com.nextup.core.domain.event.TeamJoinRejectedEvent
+import com.nextup.core.domain.event.TeamMemberKickedEvent
+import com.nextup.core.domain.event.TeamMemberLeftEvent
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
@@ -524,6 +526,30 @@ class TeamMembershipServiceImplTest {
         }
 
         @Test
+        fun `should publish TeamMemberKickedEvent when member is kicked`() {
+            // given
+            val memberToKick =
+                TeamMember.create(team, user, player, 20, TeamMemberRole.MEMBER)
+            setTeamMemberId(memberToKick, 200L)
+
+            every { teamMemberRepository.findByIdOrNull(200L) } returns memberToKick
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns ownerMember
+            every { teamMemberRepository.save(any()) } answers { firstArg() }
+
+            val eventSlot = slot<TeamMemberKickedEvent>()
+            every { eventPublisher.publishEvent(capture(eventSlot)) } returns Unit
+
+            // when
+            service.kickMember(200L, 10L, "규칙 위반", false)
+
+            // then
+            verify(exactly = 1) { eventPublisher.publishEvent(any<TeamMemberKickedEvent>()) }
+            assertThat(eventSlot.captured.teamId).isEqualTo(1L)
+            assertThat(eventSlot.captured.playerId).isEqualTo(3L)
+            assertThat(eventSlot.captured.memberId).isEqualTo(200L)
+        }
+
+        @Test
         fun `should throw when member not found on kick`() {
             // given
             every { teamMemberRepository.findByIdOrNull(999L) } returns null
@@ -581,6 +607,28 @@ class TeamMembershipServiceImplTest {
             // then
             assertThat(member.status).isEqualTo(TeamMemberStatus.LEFT)
             verify { teamMemberRepository.save(member) }
+        }
+
+        @Test
+        fun `should publish TeamMemberLeftEvent when member leaves`() {
+            // given
+            val member = TeamMember.create(team, user, player, 20, TeamMemberRole.MEMBER)
+            setTeamMemberId(member, 200L)
+
+            every { teamMemberRepository.findByIdOrNull(200L) } returns member
+            every { teamMemberRepository.save(any()) } answers { firstArg() }
+
+            val eventSlot = slot<TeamMemberLeftEvent>()
+            every { eventPublisher.publishEvent(capture(eventSlot)) } returns Unit
+
+            // when
+            service.leaveMember(200L)
+
+            // then
+            verify(exactly = 1) { eventPublisher.publishEvent(any<TeamMemberLeftEvent>()) }
+            assertThat(eventSlot.captured.teamId).isEqualTo(1L)
+            assertThat(eventSlot.captured.playerId).isEqualTo(3L)
+            assertThat(eventSlot.captured.memberId).isEqualTo(200L)
         }
 
         @Test


### PR DESCRIPTION
## Summary

>- close #328

`kickMember()`/`leaveMember()`에서 이벤트를 발행하지 않아 이미 구현된 리스너(라인업 제거, CompetitionPlayer 갱신, 활동 점수 삭제 등)가 동작하지 않던 문제를 수정합니다.

## Tasks

- [x] kickMember()에 TeamMemberKickedEvent 발행 추가 (H-1)
- [x] leaveMember()에 TeamMemberLeftEvent 발행 추가 (H-1)
- [x] 개별 탈퇴/강퇴 시 CompetitionPlayer WITHDRAWN 처리 추가 (H-2)
- [x] CONFIRMED 라인업에서도 탈퇴 선수 제거 처리 추가 (H-5)
- [x] CompetitionPlayerRepositoryPort에 findByPlayerIdAndStatusIn 메서드 추가
- [x] 이벤트 발행 및 리스너 동작 테스트 작성

## To Reviewer

감사 보고서 H-1, H-2, H-5 통합 수정입니다. 이벤트 미발행으로 인해 dead code 상태였던 `TeamMemberEventListener`가 정상 동작하도록 합니다.

### 변경 파일 요약

| 파일 | 변경 내용 |
|------|-----------|
| `CompetitionPlayerRepositoryPort` | `findByPlayerIdAndStatusIn` 메서드 추가 |
| `CompetitionPlayerJpaRepository` | JPA 쿼리 메서드 추가 |
| `CompetitionPlayerRepositoryAdapter` | Adapter 구현 추가 |
| `TeamMembershipServiceImpl` | `kickMember()`/`leaveMember()`에 이벤트 발행 추가 |
| `TeamMemberEventListener` | 개별 탈퇴/강퇴 시 CompetitionPlayer WITHDRAWN 처리, CONFIRMED 라인업 처리 추가 |
| `TeamMembershipServiceImplTest` | 이벤트 발행 검증 테스트 2건 추가 |
| `TeamMemberEventListenerTest` | CompetitionPlayer WITHDRAWN 테스트 2건, CONFIRMED 라인업 테스트 1건 추가 |