### PR TITLE
fix(#331): 경기 취소 시 커리어 스탯 롤백 누락 수정

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
@@ -230,6 +230,31 @@ class CareerBattingStats(
     }
 
     /**
+     * 경기 타격 기록을 롤백합니다 (경기 취소 시 사용).
+     * 모든 필드를 maxOf(0, ...) 로 보호하여 음수 방지합니다.
+     */
+    fun revertGameRecord(record: BattingRecord) {
+        gamesPlayed = maxOf(0, gamesPlayed - 1)
+        plateAppearances = maxOf(0, plateAppearances - record.plateAppearances)
+        atBats = maxOf(0, atBats - record.atBats)
+        hits = maxOf(0, hits - record.hits)
+        doubles = maxOf(0, doubles - record.doubles)
+        triples = maxOf(0, triples - record.triples)
+        homeRuns = maxOf(0, homeRuns - record.homeRuns)
+        runs = maxOf(0, runs - record.runs)
+        runsBattedIn = maxOf(0, runsBattedIn - record.runsBattedIn)
+        walks = maxOf(0, walks - record.walks)
+        intentionalWalks = maxOf(0, intentionalWalks - record.intentionalWalks)
+        hitByPitch = maxOf(0, hitByPitch - record.hitByPitch)
+        strikeouts = maxOf(0, strikeouts - record.strikeouts)
+        sacrificeBunts = maxOf(0, sacrificeBunts - record.sacrificeBunts)
+        sacrificeFlies = maxOf(0, sacrificeFlies - record.sacrificeFlies)
+        stolenBases = maxOf(0, stolenBases - record.stolenBases)
+        caughtStealing = maxOf(0, caughtStealing - record.caughtStealing)
+        groundedIntoDoublePlays = maxOf(0, groundedIntoDoublePlays - record.groundedIntoDoublePlays)
+    }
+
+    /**
      * 기록 정정에 따른 필드별 델타를 적용합니다.
      *
      * @param fieldName 정정된 필드명

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerFieldingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerFieldingStats.kt
@@ -104,6 +104,19 @@ class CareerFieldingStats(
     }
 
     /**
+     * 경기 수비 기록을 롤백합니다 (경기 취소 시 사용).
+     * 모든 필드를 maxOf(0, ...) 로 보호하여 음수 방지합니다.
+     */
+    fun revertGameRecord(record: FieldingRecord) {
+        gamesPlayed = maxOf(0, gamesPlayed - 1)
+        putOuts = maxOf(0, putOuts - record.putOuts)
+        assists = maxOf(0, assists - record.assists)
+        errors = maxOf(0, errors - record.errors)
+        doublePlays = maxOf(0, doublePlays - record.doublePlays)
+        passedBalls = maxOf(0, passedBalls - record.passedBalls)
+    }
+
+    /**
      * 시즌을 추가합니다.
      */
     fun addSeason() {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
@@ -289,6 +289,44 @@ class CareerPitchingStats(
     }
 
     /**
+     * 경기 투수 기록을 롤백합니다 (경기 취소 시 사용).
+     * 모든 필드를 maxOf(0, ...) 로 보호하여 음수 방지합니다.
+     */
+    fun revertGameRecord(record: PitchingRecord) {
+        gamesPlayed = maxOf(0, gamesPlayed - 1)
+        if (record.isStartingPitcher) {
+            gamesStarted = maxOf(0, gamesStarted - 1)
+        }
+        inningsPitchedOuts = maxOf(0, inningsPitchedOuts - record.inningsPitchedOuts)
+        earnedRuns = maxOf(0, earnedRuns - record.earnedRuns)
+        runsAllowed = maxOf(0, runsAllowed - record.runsAllowed)
+        hitsAllowed = maxOf(0, hitsAllowed - record.hitsAllowed)
+        walksAllowed = maxOf(0, walksAllowed - record.walksAllowed)
+        strikeouts = maxOf(0, strikeouts - record.strikeouts)
+        homeRunsAllowed = maxOf(0, homeRunsAllowed - record.homeRunsAllowed)
+        hitBatsmen = maxOf(0, hitBatsmen - record.hitBatsmen)
+        wildPitches = maxOf(0, wildPitches - record.wildPitches)
+        balks = maxOf(0, balks - record.balks)
+        battersFaced = maxOf(0, battersFaced - record.battersFaced)
+
+        if (record.pitchesThrown != null) {
+            pitchesThrown = maxOf(0, (pitchesThrown ?: 0) - record.pitchesThrown!!)
+        }
+        if (record.strikesThrown != null) {
+            strikesThrown = maxOf(0, (strikesThrown ?: 0) - record.strikesThrown!!)
+        }
+
+        when (record.decision) {
+            com.nextup.core.domain.game.PitchingDecision.WIN -> wins = maxOf(0, wins - 1)
+            com.nextup.core.domain.game.PitchingDecision.LOSS -> losses = maxOf(0, losses - 1)
+            com.nextup.core.domain.game.PitchingDecision.SAVE -> saves = maxOf(0, saves - 1)
+            com.nextup.core.domain.game.PitchingDecision.HOLD -> holds = maxOf(0, holds - 1)
+            com.nextup.core.domain.game.PitchingDecision.BLOWN_SAVE -> blownSaves = maxOf(0, blownSaves - 1)
+            else -> { /* NONE */ }
+        }
+    }
+
+    /**
      * 기록 정정에 따른 필드별 델타를 적용합니다.
      *
      * @param fieldName 정정된 필드명

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerBattingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerBattingStatsTest.kt
@@ -319,6 +319,90 @@ class CareerBattingStatsTest {
     }
 
     @Nested
+    @DisplayName("경기 기록 롤백")
+    inner class RevertGameRecord {
+        @Test
+        fun `should revert single game record correctly`() {
+            // given
+            val stats = CareerBattingStats.create(testPlayer)
+            val gamePlayer = mockk<GamePlayer>()
+            val record =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 5, ab = 4, h = 2, doubles = 1, bb = 1, so = 1, runs = 1, rbi = 1)
+                }
+
+            stats.addGameRecord(record)
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+            assertThat(stats.hits).isEqualTo(2)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.gamesPlayed).isEqualTo(0)
+            assertThat(stats.plateAppearances).isEqualTo(0)
+            assertThat(stats.atBats).isEqualTo(0)
+            assertThat(stats.hits).isEqualTo(0)
+            assertThat(stats.doubles).isEqualTo(0)
+            assertThat(stats.walks).isEqualTo(0)
+            assertThat(stats.strikeouts).isEqualTo(0)
+            assertThat(stats.runs).isEqualTo(0)
+            assertThat(stats.runsBattedIn).isEqualTo(0)
+        }
+
+        @Test
+        fun `should not go below zero when reverting`() {
+            // given: stats at zero
+            val stats = CareerBattingStats.create(testPlayer)
+            val gamePlayer = mockk<GamePlayer>()
+            val record =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 5, ab = 4, h = 2, doubles = 1, bb = 1, so = 1)
+                }
+
+            // when: revert on empty stats
+            stats.revertGameRecord(record)
+
+            // then: all should be 0 (not negative)
+            assertThat(stats.gamesPlayed).isEqualTo(0)
+            assertThat(stats.plateAppearances).isEqualTo(0)
+            assertThat(stats.atBats).isEqualTo(0)
+            assertThat(stats.hits).isEqualTo(0)
+        }
+
+        @Test
+        fun `should correctly revert one of multiple accumulated records`() {
+            // given
+            val stats = CareerBattingStats.create(testPlayer)
+            val gamePlayer = mockk<GamePlayer>()
+            val record1 =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 4, ab = 4, h = 2, hr = 1, runs = 2, rbi = 2)
+                }
+            val record2 =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 4, ab = 3, h = 1, bb = 1)
+                }
+
+            stats.addGameRecord(record1)
+            stats.addGameRecord(record2)
+            assertThat(stats.gamesPlayed).isEqualTo(2)
+            assertThat(stats.hits).isEqualTo(3)
+
+            // when: revert the first game only
+            stats.revertGameRecord(record1)
+
+            // then: only record2 remains
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+            assertThat(stats.plateAppearances).isEqualTo(4)
+            assertThat(stats.atBats).isEqualTo(3)
+            assertThat(stats.hits).isEqualTo(1)
+            assertThat(stats.homeRuns).isEqualTo(0)
+            assertThat(stats.walks).isEqualTo(1)
+        }
+    }
+
+    @Nested
     @DisplayName("유효성 검증")
     inner class Validation {
         @Test

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerFieldingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerFieldingStatsTest.kt
@@ -116,6 +116,89 @@ class CareerFieldingStatsTest {
     }
 
     @Nested
+    @DisplayName("경기 기록 롤백")
+    inner class RevertGameRecordTest {
+        @Test
+        fun `revertGameRecord 호출 시 gamesPlayed가 1 감소하고 수비 기록이 차감된다`() {
+            // given
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 5
+            every { record.assists } returns 3
+            every { record.errors } returns 1
+            every { record.doublePlays } returns 2
+            every { record.passedBalls } returns 1
+
+            careerFieldingStats.addGameRecord(record)
+            assertThat(careerFieldingStats.gamesPlayed).isEqualTo(1)
+
+            // when
+            careerFieldingStats.revertGameRecord(record)
+
+            // then
+            assertThat(careerFieldingStats.gamesPlayed).isEqualTo(0)
+            assertThat(careerFieldingStats.putOuts).isEqualTo(0)
+            assertThat(careerFieldingStats.assists).isEqualTo(0)
+            assertThat(careerFieldingStats.errors).isEqualTo(0)
+            assertThat(careerFieldingStats.doublePlays).isEqualTo(0)
+            assertThat(careerFieldingStats.passedBalls).isEqualTo(0)
+        }
+
+        @Test
+        fun `초기 상태에서 revertGameRecord를 호출해도 음수가 되지 않는다`() {
+            // given
+            val record = mockk<FieldingRecord>()
+            every { record.putOuts } returns 5
+            every { record.assists } returns 3
+            every { record.errors } returns 1
+            every { record.doublePlays } returns 2
+            every { record.passedBalls } returns 1
+
+            // when
+            careerFieldingStats.revertGameRecord(record)
+
+            // then
+            assertThat(careerFieldingStats.gamesPlayed).isEqualTo(0)
+            assertThat(careerFieldingStats.putOuts).isEqualTo(0)
+            assertThat(careerFieldingStats.assists).isEqualTo(0)
+            assertThat(careerFieldingStats.errors).isEqualTo(0)
+            assertThat(careerFieldingStats.doublePlays).isEqualTo(0)
+            assertThat(careerFieldingStats.passedBalls).isEqualTo(0)
+        }
+
+        @Test
+        fun `여러 경기 중 하나를 롤백하면 나머지만 남는다`() {
+            // given
+            val record1 = mockk<FieldingRecord>()
+            every { record1.putOuts } returns 3
+            every { record1.assists } returns 1
+            every { record1.errors } returns 0
+            every { record1.doublePlays } returns 0
+            every { record1.passedBalls } returns 0
+
+            val record2 = mockk<FieldingRecord>()
+            every { record2.putOuts } returns 4
+            every { record2.assists } returns 2
+            every { record2.errors } returns 1
+            every { record2.doublePlays } returns 1
+            every { record2.passedBalls } returns 0
+
+            careerFieldingStats.addGameRecord(record1)
+            careerFieldingStats.addGameRecord(record2)
+            assertThat(careerFieldingStats.gamesPlayed).isEqualTo(2)
+
+            // when: revert record1 only
+            careerFieldingStats.revertGameRecord(record1)
+
+            // then: record2 values remain
+            assertThat(careerFieldingStats.gamesPlayed).isEqualTo(1)
+            assertThat(careerFieldingStats.putOuts).isEqualTo(4)
+            assertThat(careerFieldingStats.assists).isEqualTo(2)
+            assertThat(careerFieldingStats.errors).isEqualTo(1)
+            assertThat(careerFieldingStats.doublePlays).isEqualTo(1)
+        }
+    }
+
+    @Nested
     @DisplayName("수비 기회(TC) 계산")
     inner class TotalChancesTest {
         @Test

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerPitchingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerPitchingStatsTest.kt
@@ -272,6 +272,149 @@ class CareerPitchingStatsTest {
     }
 
     @Nested
+    @DisplayName("경기 기록 롤백")
+    inner class RevertGameRecord {
+        @Test
+        fun `should revert single game record correctly`() {
+            // given
+            val stats = CareerPitchingStats.create(testPlayer)
+            val gamePlayer = mockk<GamePlayer>()
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 2,
+                        runsAllowed = 3,
+                        hitsAllowed = 5,
+                        walksAllowed = 2,
+                        strikeouts = 7,
+                        battersFaced = 25,
+                        decision = PitchingDecision.WIN,
+                    )
+                }
+
+            stats.addGameRecord(record)
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+            assertThat(stats.wins).isEqualTo(1)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.gamesPlayed).isEqualTo(0)
+            assertThat(stats.gamesStarted).isEqualTo(0)
+            assertThat(stats.inningsPitchedOuts).isEqualTo(0)
+            assertThat(stats.earnedRuns).isEqualTo(0)
+            assertThat(stats.runsAllowed).isEqualTo(0)
+            assertThat(stats.hitsAllowed).isEqualTo(0)
+            assertThat(stats.walksAllowed).isEqualTo(0)
+            assertThat(stats.strikeouts).isEqualTo(0)
+            assertThat(stats.battersFaced).isEqualTo(0)
+            assertThat(stats.wins).isEqualTo(0)
+        }
+
+        @Test
+        fun `should not go below zero when reverting`() {
+            // given: stats at zero
+            val stats = CareerPitchingStats.create(testPlayer)
+            val gamePlayer = mockk<GamePlayer>()
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 2,
+                        runsAllowed = 2,
+                        hitsAllowed = 5,
+                        strikeouts = 7,
+                        decision = PitchingDecision.WIN,
+                    )
+                }
+
+            // when: revert on empty stats
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.gamesPlayed).isEqualTo(0)
+            assertThat(stats.gamesStarted).isEqualTo(0)
+            assertThat(stats.inningsPitchedOuts).isEqualTo(0)
+            assertThat(stats.wins).isEqualTo(0)
+        }
+
+        @Test
+        fun `should revert all decision types correctly`() {
+            // given
+            val stats = CareerPitchingStats.create(testPlayer)
+            val gamePlayer = mockk<GamePlayer>()
+
+            val decisions =
+                listOf(
+                    PitchingDecision.WIN,
+                    PitchingDecision.LOSS,
+                    PitchingDecision.SAVE,
+                    PitchingDecision.HOLD,
+                    PitchingDecision.BLOWN_SAVE,
+                )
+
+            // Add one of each
+            for (decision in decisions) {
+                val record =
+                    PitchingRecord.create(gamePlayer).apply {
+                        setStats(inningsPitchedOuts = 3, decision = decision)
+                    }
+                stats.addGameRecord(record)
+            }
+
+            assertThat(stats.wins).isEqualTo(1)
+            assertThat(stats.losses).isEqualTo(1)
+            assertThat(stats.saves).isEqualTo(1)
+            assertThat(stats.holds).isEqualTo(1)
+            assertThat(stats.blownSaves).isEqualTo(1)
+
+            // when: revert each
+            for (decision in decisions) {
+                val record =
+                    PitchingRecord.create(gamePlayer).apply {
+                        setStats(inningsPitchedOuts = 3, decision = decision)
+                    }
+                stats.revertGameRecord(record)
+            }
+
+            // then
+            assertThat(stats.wins).isEqualTo(0)
+            assertThat(stats.losses).isEqualTo(0)
+            assertThat(stats.saves).isEqualTo(0)
+            assertThat(stats.holds).isEqualTo(0)
+            assertThat(stats.blownSaves).isEqualTo(0)
+        }
+
+        @Test
+        fun `should revert pitches thrown correctly`() {
+            // given
+            val stats = CareerPitchingStats.create(testPlayer)
+            val gamePlayer = mockk<GamePlayer>()
+            val record =
+                PitchingRecord.create(gamePlayer).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        pitchesThrown = 95,
+                        strikesThrown = 63,
+                    )
+                }
+
+            stats.addGameRecord(record)
+            assertThat(stats.pitchesThrown).isEqualTo(95)
+            assertThat(stats.strikesThrown).isEqualTo(63)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.pitchesThrown).isEqualTo(0)
+            assertThat(stats.strikesThrown).isEqualTo(0)
+        }
+    }
+
+    @Nested
     @DisplayName("시즌 추가")
     inner class AddSeason {
         @Test

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
@@ -2,6 +2,9 @@ package com.nextup.infrastructure.listener
 
 import com.nextup.core.domain.event.GameCancelledEvent
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
 import com.nextup.core.port.repository.FieldingRecordRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
@@ -17,11 +20,12 @@ import org.springframework.transaction.event.TransactionalEventListener
 /**
  * 경기 취소 이벤트 리스너
  *
- * GameCancelledEvent 수신 시 해당 경기에 반영된 시즌 타격/투구 통계를 롤백합니다.
+ * GameCancelledEvent 수신 시 해당 경기에 반영된 시즌/커리어 타격/투구/수비 통계를 롤백합니다.
  *
  * 롤백 정책:
- * - 취소된 경기의 BattingRecord에 집계된 타격 기여분을 SeasonBattingStats에서 차감합니다.
- * - 취소된 경기의 PitchingRecord에 집계된 투구 기여분을 SeasonPitchingStats에서 차감합니다.
+ * - 취소된 경기의 BattingRecord에 집계된 타격 기여분을 SeasonBattingStats/CareerBattingStats에서 차감합니다.
+ * - 취소된 경기의 PitchingRecord에 집계된 투구 기여분을 SeasonPitchingStats/CareerPitchingStats에서 차감합니다.
+ * - 취소된 경기의 FieldingRecord에 집계된 수비 기여분을 SeasonFieldingStats/CareerFieldingStats에서 차감합니다.
  * - 몰수(FORFEITED) 경기는 이 리스너가 처리하지 않습니다. 몰수 시점까지의 개인 기록은
  *   KBO/MLB 기준에 따라 공식 기록으로 유효합니다.
  */
@@ -30,6 +34,9 @@ class GameCancelEventListener(
     private val seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort,
     private val seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort,
     private val seasonFieldingStatsRepository: SeasonFieldingStatsRepositoryPort,
+    private val careerBattingStatsRepository: CareerBattingStatsRepositoryPort,
+    private val careerPitchingStatsRepository: CareerPitchingStatsRepositoryPort,
+    private val careerFieldingStatsRepository: CareerFieldingStatsRepositoryPort,
     private val battingRecordRepository: BattingRecordRepositoryPort,
     private val pitchingRecordRepository: PitchingRecordRepositoryPort,
     private val fieldingRecordRepository: FieldingRecordRepositoryPort,
@@ -39,7 +46,7 @@ class GameCancelEventListener(
     /**
      * 경기 취소 이벤트를 처리합니다.
      *
-     * 취소된 경기에 기여한 모든 선수의 시즌 타격/투구 통계를 롤백합니다.
+     * 취소된 경기에 기여한 모든 선수의 시즌/커리어 타격/투구/수비 통계를 롤백합니다.
      * AFTER_COMMIT 단계에서 실행하여 취소 트랜잭션이 완전히 커밋된 이후 통계를 역산합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -62,6 +69,7 @@ class GameCancelEventListener(
 
         // 타격 스탯 롤백
         if (battingRecords.isNotEmpty()) {
+            // 시즌 타격 통계 롤백
             val seasonBattingStatsList = seasonBattingStatsRepository.findAllByGameId(gameId)
             val statsByPlayerId = seasonBattingStatsList.associateBy { it.player.id }
 
@@ -85,10 +93,33 @@ class GameCancelEventListener(
                     )
                 }
             }
+
+            // 커리어 타격 통계 롤백
+            for (battingRecord in battingRecords) {
+                val playerId = battingRecord.gamePlayer.player.id
+                val careerStats = careerBattingStatsRepository.findByPlayerId(playerId)
+
+                if (careerStats == null) {
+                    logger.debug(
+                        "커리어 타격 통계 없음 - 롤백 건너뜀 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                } else {
+                    careerStats.revertGameRecord(battingRecord)
+                    careerBattingStatsRepository.save(careerStats)
+                    logger.debug(
+                        "커리어 타격 통계 롤백 완료 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                }
+            }
         }
 
         // 투구 스탯 롤백
         if (pitchingRecords.isNotEmpty()) {
+            // 시즌 투구 통계 롤백
             val seasonPitchingStatsList = seasonPitchingStatsRepository.findAllByGameId(gameId)
             val statsByPlayerId = seasonPitchingStatsList.associateBy { it.player.id }
 
@@ -112,10 +143,33 @@ class GameCancelEventListener(
                     )
                 }
             }
+
+            // 커리어 투구 통계 롤백
+            for (pitchingRecord in pitchingRecords) {
+                val playerId = pitchingRecord.gamePlayer.player.id
+                val careerStats = careerPitchingStatsRepository.findByPlayerId(playerId)
+
+                if (careerStats == null) {
+                    logger.debug(
+                        "커리어 투구 통계 없음 - 롤백 건너뜀 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                } else {
+                    careerStats.revertGameRecord(pitchingRecord)
+                    careerPitchingStatsRepository.save(careerStats)
+                    logger.debug(
+                        "커리어 투구 통계 롤백 완료 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                }
+            }
         }
 
         // 수비 스탯 롤백
         if (fieldingRecords.isNotEmpty()) {
+            // 시즌 수비 통계 롤백
             val seasonFieldingStatsList = seasonFieldingStatsRepository.findAllByGameId(gameId)
             val statsByPlayerId = seasonFieldingStatsList.associateBy { it.player.id }
 
@@ -134,6 +188,28 @@ class GameCancelEventListener(
                     seasonFieldingStatsRepository.save(stats)
                     logger.debug(
                         "시즌 수비 통계 롤백 완료 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                }
+            }
+
+            // 커리어 수비 통계 롤백
+            for (fieldingRecord in fieldingRecords) {
+                val playerId = fieldingRecord.gamePlayer.player.id
+                val careerStats = careerFieldingStatsRepository.findByPlayerId(playerId)
+
+                if (careerStats == null) {
+                    logger.debug(
+                        "커리어 수비 통계 없음 - 롤백 건너뜀 (playerId={}, gameId={})",
+                        playerId,
+                        gameId,
+                    )
+                } else {
+                    careerStats.revertGameRecord(fieldingRecord)
+                    careerFieldingStatsRepository.save(careerStats)
+                    logger.debug(
+                        "커리어 수비 통계 롤백 완료 (playerId={}, gameId={})",
                         playerId,
                         gameId,
                     )

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
@@ -10,10 +10,16 @@ import com.nextup.core.domain.player.BattingHand
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.domain.stats.CareerBattingStats
+import com.nextup.core.domain.stats.CareerFieldingStats
+import com.nextup.core.domain.stats.CareerPitchingStats
 import com.nextup.core.domain.stats.SeasonBattingStats
 import com.nextup.core.domain.stats.SeasonFieldingStats
 import com.nextup.core.domain.stats.SeasonPitchingStats
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
+import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
 import com.nextup.core.port.repository.FieldingRecordRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
@@ -33,6 +39,9 @@ class GameCancelEventListenerTest {
     private val seasonBattingStatsRepository = mockk<SeasonBattingStatsRepositoryPort>()
     private val seasonPitchingStatsRepository = mockk<SeasonPitchingStatsRepositoryPort>()
     private val seasonFieldingStatsRepository = mockk<SeasonFieldingStatsRepositoryPort>()
+    private val careerBattingStatsRepository = mockk<CareerBattingStatsRepositoryPort>()
+    private val careerPitchingStatsRepository = mockk<CareerPitchingStatsRepositoryPort>()
+    private val careerFieldingStatsRepository = mockk<CareerFieldingStatsRepositoryPort>()
     private val battingRecordRepository = mockk<BattingRecordRepositoryPort>()
     private val pitchingRecordRepository = mockk<PitchingRecordRepositoryPort>()
     private val fieldingRecordRepository = mockk<FieldingRecordRepositoryPort>()
@@ -42,6 +51,9 @@ class GameCancelEventListenerTest {
             seasonBattingStatsRepository = seasonBattingStatsRepository,
             seasonPitchingStatsRepository = seasonPitchingStatsRepository,
             seasonFieldingStatsRepository = seasonFieldingStatsRepository,
+            careerBattingStatsRepository = careerBattingStatsRepository,
+            careerPitchingStatsRepository = careerPitchingStatsRepository,
+            careerFieldingStatsRepository = careerFieldingStatsRepository,
             battingRecordRepository = battingRecordRepository,
             pitchingRecordRepository = pitchingRecordRepository,
             fieldingRecordRepository = fieldingRecordRepository,
@@ -115,6 +127,7 @@ class GameCancelEventListenerTest {
             every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns listOf(stats)
             every { seasonBattingStatsRepository.save(any()) } returns stats
             every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerBattingStatsRepository.findByPlayerId(testBatter.id) } returns null
 
             every { mockBattingRecord.plateAppearances } returns 1
             every { mockBattingRecord.atBats } returns 1
@@ -156,6 +169,9 @@ class GameCancelEventListenerTest {
             verify(exactly = 0) { seasonBattingStatsRepository.save(any()) }
             verify(exactly = 0) { seasonPitchingStatsRepository.save(any()) }
             verify(exactly = 0) { seasonFieldingStatsRepository.save(any()) }
+            verify(exactly = 0) { careerBattingStatsRepository.save(any()) }
+            verify(exactly = 0) { careerPitchingStatsRepository.save(any()) }
+            verify(exactly = 0) { careerFieldingStatsRepository.save(any()) }
         }
 
         @Test
@@ -165,6 +181,7 @@ class GameCancelEventListenerTest {
             every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
             every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns emptyList()
             every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerBattingStatsRepository.findByPlayerId(testBatter.id) } returns null
 
             // when
             listener.onGameCancelled(cancelEvent)
@@ -180,6 +197,7 @@ class GameCancelEventListenerTest {
             every { pitchingRecordRepository.findAllByGameId(gameId) } returns listOf(mockPitchingRecord)
             every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns emptyList()
             every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerPitchingStatsRepository.findByPlayerId(testPitcher.id) } returns null
 
             // when
             listener.onGameCancelled(cancelEvent)
@@ -198,6 +216,7 @@ class GameCancelEventListenerTest {
             every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns emptyList()
             every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns listOf(pitchingStats)
             every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
+            every { careerPitchingStatsRepository.findByPlayerId(testPitcher.id) } returns null
 
             every { mockPitchingRecord.isStartingPitcher } returns false
             every { mockPitchingRecord.inningsPitchedOuts } returns 0
@@ -241,6 +260,7 @@ class GameCancelEventListenerTest {
             every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
             every { seasonFieldingStatsRepository.findAllByGameId(gameId) } returns listOf(fieldingStats)
             every { seasonFieldingStatsRepository.save(any()) } returns fieldingStats
+            every { careerFieldingStatsRepository.findByPlayerId(testBatter.id) } returns null
 
             every { mockFieldingRecord.putOuts } returns 1
             every { mockFieldingRecord.assists } returns 1
@@ -264,6 +284,7 @@ class GameCancelEventListenerTest {
             every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
             every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
             every { seasonFieldingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerFieldingStatsRepository.findByPlayerId(testBatter.id) } returns null
 
             // when
             listener.onGameCancelled(cancelEvent)
@@ -284,6 +305,8 @@ class GameCancelEventListenerTest {
             every { seasonBattingStatsRepository.save(any()) } returns battingStats
             every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns listOf(pitchingStats)
             every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
+            every { careerBattingStatsRepository.findByPlayerId(testBatter.id) } returns null
+            every { careerPitchingStatsRepository.findByPlayerId(testPitcher.id) } returns null
 
             every { mockBattingRecord.plateAppearances } returns 0
             every { mockBattingRecord.atBats } returns 0
@@ -325,6 +348,237 @@ class GameCancelEventListenerTest {
             // then: 타격과 투구 모두 저장됨
             verify { seasonBattingStatsRepository.save(battingStats) }
             verify { seasonPitchingStatsRepository.save(pitchingStats) }
+        }
+    }
+
+    @Nested
+    @DisplayName("onGameCancelled - 커리어 스탯 롤백")
+    inner class CareerStatsRollback {
+        @BeforeEach
+        fun setUpDefault() {
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonFieldingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+        }
+
+        @Test
+        fun `타격 기록이 있는 경우 커리어 타격 통계도 롤백됨`() {
+            // given
+            val careerStats = CareerBattingStats.create(testBatter)
+            careerStats.addGameRecord(
+                BattingRecord(mockBatterGamePlayer).also {
+                    it.applyPlateAppearanceResult(
+                        com.nextup.core.domain.game.PlateAppearanceResult.SINGLE,
+                    )
+                },
+            )
+            val initialGamesPlayed = careerStats.gamesPlayed
+            val initialHits = careerStats.hits
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns listOf(mockBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerBattingStatsRepository.findByPlayerId(testBatter.id) } returns careerStats
+            every { careerBattingStatsRepository.save(any()) } returns careerStats
+
+            every { mockBattingRecord.plateAppearances } returns 1
+            every { mockBattingRecord.atBats } returns 1
+            every { mockBattingRecord.hits } returns 1
+            every { mockBattingRecord.doubles } returns 0
+            every { mockBattingRecord.triples } returns 0
+            every { mockBattingRecord.homeRuns } returns 0
+            every { mockBattingRecord.runs } returns 0
+            every { mockBattingRecord.runsBattedIn } returns 0
+            every { mockBattingRecord.walks } returns 0
+            every { mockBattingRecord.intentionalWalks } returns 0
+            every { mockBattingRecord.hitByPitch } returns 0
+            every { mockBattingRecord.strikeouts } returns 0
+            every { mockBattingRecord.sacrificeBunts } returns 0
+            every { mockBattingRecord.sacrificeFlies } returns 0
+            every { mockBattingRecord.stolenBases } returns 0
+            every { mockBattingRecord.caughtStealing } returns 0
+            every { mockBattingRecord.groundedIntoDoublePlays } returns 0
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            assertThat(careerStats.gamesPlayed).isEqualTo(initialGamesPlayed - 1)
+            assertThat(careerStats.hits).isEqualTo(initialHits - 1)
+            verify { careerBattingStatsRepository.save(careerStats) }
+        }
+
+        @Test
+        fun `커리어 타격 통계가 없는 선수는 건너뜀`() {
+            // given
+            every { battingRecordRepository.findAllByGameId(gameId) } returns listOf(mockBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerBattingStatsRepository.findByPlayerId(testBatter.id) } returns null
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            verify(exactly = 0) { careerBattingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `투구 기록이 있는 경우 커리어 투구 통계도 롤백됨`() {
+            // given
+            val careerStats = CareerPitchingStats.create(testPitcher)
+            careerStats.addGameRecord(mockPitchingRecord)
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns listOf(mockPitchingRecord)
+            every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerPitchingStatsRepository.findByPlayerId(testPitcher.id) } returns careerStats
+            every { careerPitchingStatsRepository.save(any()) } returns careerStats
+
+            every { mockPitchingRecord.isStartingPitcher } returns false
+            every { mockPitchingRecord.inningsPitchedOuts } returns 9
+            every { mockPitchingRecord.earnedRuns } returns 2
+            every { mockPitchingRecord.runsAllowed } returns 3
+            every { mockPitchingRecord.hitsAllowed } returns 5
+            every { mockPitchingRecord.walksAllowed } returns 1
+            every { mockPitchingRecord.strikeouts } returns 4
+            every { mockPitchingRecord.homeRunsAllowed } returns 1
+            every { mockPitchingRecord.hitBatsmen } returns 0
+            every { mockPitchingRecord.wildPitches } returns 0
+            every { mockPitchingRecord.balks } returns 0
+            every { mockPitchingRecord.battersFaced } returns 20
+            every { mockPitchingRecord.pitchesThrown } returns null
+            every { mockPitchingRecord.strikesThrown } returns null
+            every { mockPitchingRecord.decision } returns PitchingDecision.NONE
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            assertThat(careerStats.gamesPlayed).isEqualTo(0)
+            assertThat(careerStats.inningsPitchedOuts).isEqualTo(0)
+            verify { careerPitchingStatsRepository.save(careerStats) }
+        }
+
+        @Test
+        fun `커리어 투구 통계가 없는 선수는 건너뜀`() {
+            // given
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns listOf(mockPitchingRecord)
+            every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerPitchingStatsRepository.findByPlayerId(testPitcher.id) } returns null
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            verify(exactly = 0) { careerPitchingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `수비 기록이 있는 경우 커리어 수비 통계도 롤백됨`() {
+            // given
+            val careerStats = CareerFieldingStats.create(testBatter)
+            careerStats.addGameRecord(
+                FieldingRecord(mockFielderGamePlayer).also {
+                    it.recordPutOut()
+                    it.recordAssist()
+                },
+            )
+            val initialGamesPlayed = careerStats.gamesPlayed
+            val initialPutOuts = careerStats.putOuts
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
+            every { seasonFieldingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerFieldingStatsRepository.findByPlayerId(testBatter.id) } returns careerStats
+            every { careerFieldingStatsRepository.save(any()) } returns careerStats
+
+            every { mockFieldingRecord.putOuts } returns 1
+            every { mockFieldingRecord.assists } returns 1
+            every { mockFieldingRecord.errors } returns 0
+            every { mockFieldingRecord.doublePlays } returns 0
+            every { mockFieldingRecord.passedBalls } returns 0
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            assertThat(careerStats.gamesPlayed).isEqualTo(initialGamesPlayed - 1)
+            assertThat(careerStats.putOuts).isEqualTo(initialPutOuts - 1)
+            verify { careerFieldingStatsRepository.save(careerStats) }
+        }
+
+        @Test
+        fun `커리어 수비 통계가 없는 선수는 건너뜀`() {
+            // given
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns listOf(mockFieldingRecord)
+            every { seasonFieldingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerFieldingStatsRepository.findByPlayerId(testBatter.id) } returns null
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            verify(exactly = 0) { careerFieldingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `시즌과 커리어 통계가 모두 있으면 둘 다 롤백됨`() {
+            // given
+            val seasonStats = SeasonBattingStats.create(testBatter, 2024)
+            val careerStats = CareerBattingStats.create(testBatter)
+
+            // 각각 경기 기여분 추가
+            val realRecord =
+                BattingRecord(mockBatterGamePlayer).also {
+                    it.applyPlateAppearanceResult(
+                        com.nextup.core.domain.game.PlateAppearanceResult.SINGLE,
+                    )
+                }
+            seasonStats.addGameRecord(realRecord)
+            careerStats.addGameRecord(realRecord)
+
+            every { battingRecordRepository.findAllByGameId(gameId) } returns listOf(mockBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonBattingStatsRepository.findAllByGameId(gameId) } returns listOf(seasonStats)
+            every { seasonBattingStatsRepository.save(any()) } returns seasonStats
+            every { seasonPitchingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+            every { careerBattingStatsRepository.findByPlayerId(testBatter.id) } returns careerStats
+            every { careerBattingStatsRepository.save(any()) } returns careerStats
+
+            every { mockBattingRecord.plateAppearances } returns 1
+            every { mockBattingRecord.atBats } returns 1
+            every { mockBattingRecord.hits } returns 1
+            every { mockBattingRecord.doubles } returns 0
+            every { mockBattingRecord.triples } returns 0
+            every { mockBattingRecord.homeRuns } returns 0
+            every { mockBattingRecord.runs } returns 0
+            every { mockBattingRecord.runsBattedIn } returns 0
+            every { mockBattingRecord.walks } returns 0
+            every { mockBattingRecord.intentionalWalks } returns 0
+            every { mockBattingRecord.hitByPitch } returns 0
+            every { mockBattingRecord.strikeouts } returns 0
+            every { mockBattingRecord.sacrificeBunts } returns 0
+            every { mockBattingRecord.sacrificeFlies } returns 0
+            every { mockBattingRecord.stolenBases } returns 0
+            every { mockBattingRecord.caughtStealing } returns 0
+            every { mockBattingRecord.groundedIntoDoublePlays } returns 0
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then: 시즌과 커리어 모두 롤백됨
+            verify { seasonBattingStatsRepository.save(seasonStats) }
+            verify { careerBattingStatsRepository.save(careerStats) }
+            assertThat(seasonStats.gamesPlayed).isEqualTo(0)
+            assertThat(careerStats.gamesPlayed).isEqualTo(0)
         }
     }
 }


### PR DESCRIPTION
## Summary

>- close #331 
- **Critical Bug Fix**: `GameCancelEventListener`가 경기 취소 시 시즌 스탯만 롤백하고 커리어 스탯(CareerBattingStats/CareerPitchingStats/CareerFieldingStats)은 롤백하지 않던 버그 수정
- `CareerBattingStats`, `CareerPitchingStats`, `CareerFieldingStats` 3개 엔티티에 `revertGameRecord()` 메서드 추가
- `GameCancelEventListener`에 커리어 스탯 롤백 로직 추가 (시즌 스탯 롤백 직후 실행)

## Changes

### Domain Layer (nextup-core)
- `CareerBattingStats.revertGameRecord(record: BattingRecord)` - 타격 커리어 스탯 롤백
- `CareerPitchingStats.revertGameRecord(record: PitchingRecord)` - 투구 커리어 스탯 롤백 (선발 여부, 판정 결과 포함)
- `CareerFieldingStats.revertGameRecord(record: FieldingRecord)` - 수비 커리어 스탯 롤백
- 모든 rollback에서 `maxOf(0, ...)` 패턴으로 음수 방지

### Infrastructure Layer (nextup-infrastructure)
- `GameCancelEventListener`에 `CareerBattingStatsRepositoryPort`, `CareerPitchingStatsRepositoryPort`, `CareerFieldingStatsRepositoryPort` 주입
- 각 선수별 커리어 스탯을 `findByPlayerId`로 조회하여 롤백

### Tests
- `CareerBattingStatsTest` - revert 3개 테스트 추가
- `CareerPitchingStatsTest` - revert 4개 테스트 추가 (판정, 투구수 포함)
- `CareerFieldingStatsTest` - revert 3개 테스트 추가
- `GameCancelEventListenerTest` - 커리어 스탯 롤백 7개 테스트 추가 (null 안전성 포함)

## Test Plan

- [x] CareerBattingStats revert 단위 테스트 통과
- [x] CareerPitchingStats revert 단위 테스트 통과
- [x] CareerFieldingStats revert 단위 테스트 통과
- [x] GameCancelEventListener 커리어 스탯 롤백 테스트 통과
- [x] ktlintFormat 통과

Closes #331