### PR TITLE
feat(#334): Scorer GET 조회 API 및 스코어보드 REST fallback 추가

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
@@ -1,8 +1,11 @@
 package com.nextup.api.controller.competition
 
 import com.nextup.api.dto.competition.CompetitionResponse
+import com.nextup.api.dto.competition.CompetitionTeamResponse
 import com.nextup.api.dto.standings.StandingsResponse
 import com.nextup.common.dto.ApiResponse
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.service.competition.CompetitionService
 import com.nextup.core.service.standings.StandingsService
 import org.springframework.web.bind.annotation.GetMapping
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 class CompetitionController(
     private val competitionService: CompetitionService,
     private val standingsService: StandingsService,
+    private val competitionPlayerRepository: CompetitionPlayerRepositoryPort,
 ) {
     /**
      * 진행 중인 대회 목록을 조회합니다.
@@ -69,5 +73,35 @@ class CompetitionController(
                 playoffCutoff = competition.playoffTeams,
             ),
         )
+    }
+
+    /**
+     * 대회 참가 팀 목록을 조회합니다.
+     *
+     * 활성 상태(ACTIVE)의 대회 등록 선수를 기준으로
+     * 참가 팀과 팀별 등록 선수 수를 반환합니다.
+     */
+    @GetMapping("/{id}/teams")
+    fun getCompetitionTeams(
+        @PathVariable id: Long,
+    ): ApiResponse<List<CompetitionTeamResponse>> {
+        // 대회 존재 확인
+        competitionService.getById(id)
+
+        val activePlayers =
+            competitionPlayerRepository.findByCompetitionIdAndStatus(
+                id,
+                CompetitionPlayerStatus.ACTIVE,
+            )
+
+        val teamResponses =
+            activePlayers
+                .groupBy { it.team }
+                .map { (team, players) ->
+                    CompetitionTeamResponse.from(team, players.size)
+                }
+                .sortedBy { it.name }
+
+        return ApiResponse.success(teamResponses)
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/FieldingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/FieldingRecordController.kt
@@ -1,0 +1,34 @@
+package com.nextup.api.controller.game
+
+import com.nextup.api.dto.game.FieldingRecordResponse
+import com.nextup.api.mapper.game.toFieldingResponse
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.game.FieldingRecordService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 수비 기록 조회 Controller (일반 사용자용)
+ *
+ * 경기별 수비 기록을 조회하는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/games/{gameId}/fielding-records")
+class FieldingRecordController(
+    private val fieldingRecordService: FieldingRecordService,
+) {
+    /**
+     * 경기의 모든 수비 기록을 조회합니다.
+     *
+     * GET /api/v1/games/{gameId}/fielding-records
+     */
+    @GetMapping
+    fun getFieldingRecordsByGame(
+        @PathVariable gameId: Long,
+    ): ApiResponse<List<FieldingRecordResponse>> {
+        val records = fieldingRecordService.getAllByGameId(gameId)
+        return ApiResponse.success(records.toFieldingResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/player/GameLogController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/player/GameLogController.kt
@@ -1,0 +1,44 @@
+package com.nextup.api.controller.player
+
+import com.nextup.api.dto.player.GameLogResponse
+import com.nextup.api.mapper.player.toResponse
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.game.GameLogService
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 선수 게임 로그 Controller (일반 사용자용)
+ *
+ * 선수의 최근 경기별 기록을 조회하는 API를 제공합니다.
+ */
+@Validated
+@RestController
+@RequestMapping("/api/v1/players")
+class GameLogController(
+    private val gameLogService: GameLogService,
+) {
+    /**
+     * 선수의 최근 경기별 기록(게임 로그)을 조회합니다.
+     *
+     * GET /api/v1/players/{playerId}/game-log
+     *
+     * @param playerId 선수 ID
+     * @param limit 조회할 경기 수 (기본값: 10, 최대: 50)
+     * @return 경기별 기록 리스트 (최근 경기 순)
+     */
+    @GetMapping("/{playerId}/game-log")
+    fun getGameLog(
+        @PathVariable playerId: Long,
+        @RequestParam(defaultValue = "10") @Min(1) @Max(50) limit: Int,
+    ): ApiResponse<List<GameLogResponse>> {
+        val entries = gameLogService.getGameLog(playerId, limit)
+        return ApiResponse.success(entries.toResponse())
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/competition/CompetitionTeamResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/competition/CompetitionTeamResponse.kt
@@ -1,0 +1,34 @@
+package com.nextup.api.dto.competition
+
+import com.nextup.core.domain.team.Team
+
+/**
+ * 대회 참가 팀 응답 DTO
+ *
+ * 대회에 등록된 팀 정보를 제공합니다.
+ */
+data class CompetitionTeamResponse(
+    val teamId: Long,
+    val name: String,
+    val city: String,
+    val abbreviation: String?,
+    val logoUrl: String?,
+    val primaryColor: String?,
+    val playerCount: Int,
+) {
+    companion object {
+        fun from(
+            team: Team,
+            playerCount: Int,
+        ): CompetitionTeamResponse =
+            CompetitionTeamResponse(
+                teamId = team.id,
+                name = team.name,
+                city = team.city,
+                abbreviation = team.abbreviation,
+                logoUrl = team.logoUrl,
+                primaryColor = team.primaryColor,
+                playerCount = playerCount,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/game/FieldingRecordResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/game/FieldingRecordResponse.kt
@@ -1,0 +1,22 @@
+package com.nextup.api.dto.game
+
+import java.time.Instant
+
+/**
+ * 수비 기록 응답 DTO (API 모듈)
+ *
+ * 경기별 수비 기록 조회 시 사용됩니다.
+ */
+data class FieldingRecordResponse(
+    val id: Long,
+    val gamePlayerId: Long,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val putOuts: Int,
+    val assists: Int,
+    val errors: Int,
+    val doublePlays: Int,
+    val passedBalls: Int,
+    val totalChances: Int,
+    val fieldingPercentage: String?,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/player/GameLogResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/player/GameLogResponse.kt
@@ -1,0 +1,59 @@
+package com.nextup.api.dto.player
+
+import java.time.LocalDateTime
+
+/**
+ * 선수 게임 로그 응답 DTO
+ *
+ * 선수의 경기별 기록을 제공합니다.
+ */
+data class GameLogResponse(
+    val gameId: Long,
+    val scheduledAt: LocalDateTime,
+    val opponentTeamName: String?,
+    val result: String?,
+    val position: String,
+    val battingOrder: Int?,
+    val batting: GameLogBattingResponse?,
+    val pitching: GameLogPitchingResponse?,
+    val fielding: GameLogFieldingResponse?,
+)
+
+/**
+ * 게임 로그 타격 기록 요약
+ */
+data class GameLogBattingResponse(
+    val atBats: Int,
+    val hits: Int,
+    val runs: Int,
+    val runsBattedIn: Int,
+    val homeRuns: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val stolenBases: Int,
+    val battingAverage: String,
+)
+
+/**
+ * 게임 로그 투수 기록 요약
+ */
+data class GameLogPitchingResponse(
+    val inningsPitched: String,
+    val earnedRuns: Int,
+    val strikeouts: Int,
+    val walks: Int,
+    val hitsAllowed: Int,
+    val decision: String?,
+    val era: String,
+)
+
+/**
+ * 게임 로그 수비 기록 요약
+ */
+data class GameLogFieldingResponse(
+    val putOuts: Int,
+    val assists: Int,
+    val errors: Int,
+    val doublePlays: Int,
+    val fieldingPercentage: String?,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/FieldingRecordMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/FieldingRecordMapper.kt
@@ -1,0 +1,27 @@
+package com.nextup.api.mapper.game
+
+import com.nextup.api.dto.game.FieldingRecordResponse
+import com.nextup.core.domain.game.FieldingRecord
+
+/**
+ * FieldingRecord Entity를 FieldingRecordResponse DTO로 변환하는 Extension Function
+ */
+fun FieldingRecord.toResponse(): FieldingRecordResponse =
+    FieldingRecordResponse(
+        id = this.id,
+        gamePlayerId = this.gamePlayer.id,
+        createdAt = this.createdAt,
+        updatedAt = this.updatedAt,
+        putOuts = this.putOuts,
+        assists = this.assists,
+        errors = this.errors,
+        doublePlays = this.doublePlays,
+        passedBalls = this.passedBalls,
+        totalChances = this.totalChances,
+        fieldingPercentage = this.fieldingPercentage?.toPlainString(),
+    )
+
+/**
+ * List<FieldingRecord>를 List<FieldingRecordResponse>로 변환
+ */
+fun List<FieldingRecord>.toFieldingResponse(): List<FieldingRecordResponse> = this.map { it.toResponse() }

--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/player/GameLogMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/player/GameLogMapper.kt
@@ -1,0 +1,69 @@
+package com.nextup.api.mapper.player
+
+import com.nextup.api.dto.player.GameLogBattingResponse
+import com.nextup.api.dto.player.GameLogFieldingResponse
+import com.nextup.api.dto.player.GameLogPitchingResponse
+import com.nextup.api.dto.player.GameLogResponse
+import com.nextup.core.domain.game.PitchingDecision
+import com.nextup.core.service.game.GameLogEntry
+
+/**
+ * GameLogEntry를 GameLogResponse DTO로 변환하는 Extension Function
+ */
+fun GameLogEntry.toResponse(): GameLogResponse {
+    val game = gamePlayer.gameTeam.game
+    val myTeam = gamePlayer.gameTeam
+    val opponentTeam = game.gameTeams.firstOrNull { it.id != myTeam.id }
+
+    return GameLogResponse(
+        gameId = game.id,
+        scheduledAt = game.scheduledAt,
+        opponentTeamName = opponentTeam?.team?.name,
+        result = myTeam.result.displayName,
+        position = gamePlayer.position.name,
+        battingOrder = gamePlayer.battingOrder,
+        batting =
+            battingRecord?.let {
+                GameLogBattingResponse(
+                    atBats = it.atBats,
+                    hits = it.hits,
+                    runs = it.runs,
+                    runsBattedIn = it.runsBattedIn,
+                    homeRuns = it.homeRuns,
+                    walks = it.walks,
+                    strikeouts = it.strikeouts,
+                    stolenBases = it.stolenBases,
+                    battingAverage = it.battingAverage.toPlainString(),
+                )
+            },
+        pitching =
+            pitchingRecord?.let {
+                GameLogPitchingResponse(
+                    inningsPitched = it.inningsPitchedDisplay,
+                    earnedRuns = it.earnedRuns,
+                    strikeouts = it.strikeouts,
+                    walks = it.walksAllowed,
+                    hitsAllowed = it.hitsAllowed,
+                    decision =
+                        if (it.decision != PitchingDecision.NONE) it.decision.displayName else null,
+                    era = it.earnedRunAverage?.toPlainString() ?: "-",
+                )
+            },
+        fielding =
+            fieldingRecord?.let {
+                GameLogFieldingResponse(
+                    putOuts = it.putOuts,
+                    assists = it.assists,
+                    errors = it.errors,
+                    doublePlays = it.doublePlays,
+                    fieldingPercentage =
+                        it.fieldingPercentage?.toPlainString(),
+                )
+            },
+    )
+}
+
+/**
+ * List<GameLogEntry>를 List<GameLogResponse>로 변환
+ */
+fun List<GameLogEntry>.toResponse(): List<GameLogResponse> = this.map { it.toResponse() }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerStandingsTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerStandingsTest.kt
@@ -7,6 +7,7 @@ import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.service.competition.CompetitionService
 import com.nextup.core.service.standings.StandingsService
 import com.nextup.core.service.standings.dto.StandingsDto
@@ -31,13 +32,15 @@ class CompetitionControllerStandingsTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var competitionService: CompetitionService
     private lateinit var standingsService: StandingsService
+    private lateinit var competitionPlayerRepository: CompetitionPlayerRepositoryPort
 
     @BeforeEach
     fun setUp() {
         competitionService = mockk()
         standingsService = mockk()
+        competitionPlayerRepository = mockk()
 
-        val controller = CompetitionController(competitionService, standingsService)
+        val controller = CompetitionController(competitionService, standingsService, competitionPlayerRepository)
         mockMvc =
             MockMvcBuilders
                 .standaloneSetup(controller)

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerTest.kt
@@ -2,8 +2,14 @@ package com.nextup.api.controller.competition
 
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionPlayer
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.service.competition.CompetitionService
 import com.nextup.core.service.standings.StandingsService
 import io.mockk.every
@@ -24,13 +30,15 @@ class CompetitionControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var competitionService: CompetitionService
     private lateinit var standingsService: StandingsService
+    private lateinit var competitionPlayerRepository: CompetitionPlayerRepositoryPort
     private lateinit var controller: CompetitionController
 
     @BeforeEach
     fun setUp() {
         competitionService = mockk()
         standingsService = mockk()
-        controller = CompetitionController(competitionService, standingsService)
+        competitionPlayerRepository = mockk()
+        controller = CompetitionController(competitionService, standingsService, competitionPlayerRepository)
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
     }
 
@@ -148,6 +156,100 @@ class CompetitionControllerTest {
                 .andExpect(jsonPath("$.data.length()").value(0))
         }
     }
+
+    @Nested
+    @DisplayName("GET /api/v1/competitions/{id}/teams")
+    inner class GetCompetitionTeams {
+        @Test
+        fun `should return teams for competition`() {
+            // given
+            val competitionId = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(competitionId, league, "2025 춘계대회", 2025, 1)
+            val team1 = createTeam(1L, league, "타이거즈", "서울")
+            val team2 = createTeam(2L, league, "베어스", "인천")
+            val player1 = createPlayer(1L, "선수1")
+            val player2 = createPlayer(2L, "선수2")
+            val player3 = createPlayer(3L, "선수3")
+
+            val cp1 = CompetitionPlayer.register(competition, team1, player1)
+            val cp2 = CompetitionPlayer.register(competition, team1, player2)
+            val cp3 = CompetitionPlayer.register(competition, team2, player3)
+
+            every { competitionService.getById(competitionId) } returns competition
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndStatus(
+                    competitionId,
+                    CompetitionPlayerStatus.ACTIVE,
+                )
+            } returns listOf(cp1, cp2, cp3)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/competitions/$competitionId/teams"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+        }
+
+        @Test
+        fun `should return empty list when no teams registered`() {
+            // given
+            val competitionId = 1L
+            val association = createAssociation(1L, "서울시야구협회")
+            val league = createLeague(1L, "1부 리그", association)
+            val competition = createCompetition(competitionId, league, "2025 춘계대회", 2025, 1)
+
+            every { competitionService.getById(competitionId) } returns competition
+            every {
+                competitionPlayerRepository.findByCompetitionIdAndStatus(
+                    competitionId,
+                    CompetitionPlayerStatus.ACTIVE,
+                )
+            } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/competitions/$competitionId/teams"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+    }
+
+    private fun createTeam(
+        id: Long,
+        league: League,
+        name: String,
+        city: String,
+    ): Team =
+        Team(
+            league = league,
+            name = name,
+            city = city,
+            foundedYear = 2020,
+        ).apply {
+            val idField = Team::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createPlayer(
+        id: Long,
+        name: String,
+    ): Player =
+        Player(
+            name = name,
+            birthDate = LocalDate.of(1995, 1, 1),
+            primaryPosition = Position.SHORTSTOP,
+        ).apply {
+            val idField = Player::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
 
     private fun createAssociation(
         id: Long,

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/FieldingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/FieldingRecordControllerTest.kt
@@ -1,0 +1,123 @@
+package com.nextup.api.controller.game
+
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.service.game.FieldingRecordService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+
+@DisplayName("FieldingRecordController 테스트")
+class FieldingRecordControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var fieldingRecordService: FieldingRecordService
+
+    private val gameId = 1L
+    private val gamePlayerId = 10L
+
+    @BeforeEach
+    fun setUp() {
+        fieldingRecordService = mockk()
+
+        val controller = FieldingRecordController(fieldingRecordService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/games/{gameId}/fielding-records")
+    inner class GetFieldingRecords {
+        @Test
+        fun `should return fielding records for game`() {
+            // given
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { id } returns gamePlayerId
+                }
+            val record =
+                mockk<FieldingRecord> {
+                    every { id } returns 1L
+                    every { this@mockk.gamePlayer } returns gamePlayer
+                    every { createdAt } returns java.time.Instant.now()
+                    every { updatedAt } returns java.time.Instant.now()
+                    every { putOuts } returns 3
+                    every { assists } returns 2
+                    every { errors } returns 1
+                    every { doublePlays } returns 0
+                    every { passedBalls } returns 0
+                    every { totalChances } returns 6
+                    every { fieldingPercentage } returns BigDecimal("0.833")
+                }
+
+            every { fieldingRecordService.getAllByGameId(gameId) } returns listOf(record)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/games/$gameId/fielding-records"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].gamePlayerId").value(gamePlayerId))
+                .andExpect(jsonPath("$.data[0].putOuts").value(3))
+                .andExpect(jsonPath("$.data[0].assists").value(2))
+                .andExpect(jsonPath("$.data[0].errors").value(1))
+                .andExpect(jsonPath("$.data[0].totalChances").value(6))
+                .andExpect(jsonPath("$.data[0].fieldingPercentage").value("0.833"))
+        }
+
+        @Test
+        fun `should return empty list when no records exist`() {
+            // given
+            every { fieldingRecordService.getAllByGameId(gameId) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/games/$gameId/fielding-records"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+
+        @Test
+        fun `should handle null fielding percentage`() {
+            // given
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { id } returns gamePlayerId
+                }
+            val record =
+                mockk<FieldingRecord> {
+                    every { id } returns 1L
+                    every { this@mockk.gamePlayer } returns gamePlayer
+                    every { createdAt } returns java.time.Instant.now()
+                    every { updatedAt } returns java.time.Instant.now()
+                    every { putOuts } returns 0
+                    every { assists } returns 0
+                    every { errors } returns 0
+                    every { doublePlays } returns 0
+                    every { passedBalls } returns 0
+                    every { totalChances } returns 0
+                    every { fieldingPercentage } returns null
+                }
+
+            every { fieldingRecordService.getAllByGameId(gameId) } returns listOf(record)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/games/$gameId/fielding-records"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].totalChances").value(0))
+        }
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/player/GameLogControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/player/GameLogControllerTest.kt
@@ -1,0 +1,157 @@
+package com.nextup.api.controller.player
+
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameResult
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.service.game.GameLogEntry
+import com.nextup.core.service.game.GameLogService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@DisplayName("GameLogController 테스트")
+class GameLogControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var gameLogService: GameLogService
+
+    private val playerId = 1L
+
+    @BeforeEach
+    fun setUp() {
+        gameLogService = mockk()
+
+        val controller = GameLogController(gameLogService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/players/{playerId}/game-log")
+    inner class GetGameLog {
+        @Test
+        fun `should return game log for player`() {
+            // given
+            val opponentTeam =
+                mockk<Team> {
+                    every { name } returns "상대팀"
+                }
+            val opponentGameTeam =
+                mockk<GameTeam> {
+                    every { id } returns 2L
+                    every { team } returns opponentTeam
+                }
+            val myTeam =
+                mockk<Team> {
+                    every { name } returns "우리팀"
+                }
+            val myGameTeam =
+                mockk<GameTeam> {
+                    every { id } returns 1L
+                    every { team } returns myTeam
+                    every { result } returns GameResult.WIN
+                }
+            val game =
+                mockk<Game> {
+                    every { id } returns 10L
+                    every { scheduledAt } returns LocalDateTime.of(2025, 6, 15, 14, 0)
+                    every { gameTeams } returns listOf(myGameTeam, opponentGameTeam)
+                }
+            every { myGameTeam.game } returns game
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { gameTeam } returns myGameTeam
+                    every { position } returns Position.SHORTSTOP
+                    every { battingOrder } returns 3
+                }
+            val battingRecord =
+                mockk<BattingRecord> {
+                    every { atBats } returns 4
+                    every { hits } returns 2
+                    every { runs } returns 1
+                    every { runsBattedIn } returns 2
+                    every { homeRuns } returns 1
+                    every { walks } returns 0
+                    every { strikeouts } returns 1
+                    every { stolenBases } returns 0
+                    every { battingAverage } returns BigDecimal("0.500")
+                }
+            val fieldingRecord =
+                mockk<FieldingRecord> {
+                    every { putOuts } returns 2
+                    every { assists } returns 3
+                    every { errors } returns 0
+                    every { doublePlays } returns 1
+                    every { fieldingPercentage } returns BigDecimal("1.000")
+                }
+
+            val entry =
+                GameLogEntry(
+                    gamePlayer = gamePlayer,
+                    battingRecord = battingRecord,
+                    pitchingRecord = null,
+                    fieldingRecord = fieldingRecord,
+                )
+            every { gameLogService.getGameLog(playerId, 10) } returns listOf(entry)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/game-log"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].gameId").value(10))
+                .andExpect(jsonPath("$.data[0].opponentTeamName").value("상대팀"))
+                .andExpect(jsonPath("$.data[0].result").value("승"))
+                .andExpect(jsonPath("$.data[0].position").value("SHORTSTOP"))
+                .andExpect(jsonPath("$.data[0].battingOrder").value(3))
+                .andExpect(jsonPath("$.data[0].batting.atBats").value(4))
+                .andExpect(jsonPath("$.data[0].batting.hits").value(2))
+                .andExpect(jsonPath("$.data[0].batting.homeRuns").value(1))
+                .andExpect(jsonPath("$.data[0].fielding.putOuts").value(2))
+                .andExpect(jsonPath("$.data[0].fielding.errors").value(0))
+                .andExpect(jsonPath("$.data[0].pitching").doesNotExist())
+        }
+
+        @Test
+        fun `should return empty list when no games found`() {
+            // given
+            every { gameLogService.getGameLog(playerId, 10) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/game-log"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+
+        @Test
+        fun `should accept custom limit parameter`() {
+            // given
+            every { gameLogService.getGameLog(playerId, 5) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/players/$playerId/game-log?limit=5"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+        }
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
@@ -72,3 +72,25 @@ class NoEventToUndoException :
         "NO_EVENT_TO_UNDO",
         "되돌릴 이벤트가 없습니다",
     )
+
+/**
+ * 다른 기록원이 이미 경기를 잠금한 상태에서 기록을 시도할 때 발생하는 예외
+ */
+class GameAlreadyLockedException(
+    gameId: Long,
+    lockedByScorerId: Long,
+) : InvalidStateException(
+        "GAME_ALREADY_LOCKED",
+        "Game $gameId is already locked by scorer $lockedByScorerId",
+    )
+
+/**
+ * 잠금하지 않은 기록원이 경기를 해제하려 할 때 발생하는 예외
+ */
+class GameNotLockedByCurrentScorerException(
+    gameId: Long,
+    scorerId: Long,
+) : InvalidStateException(
+        "GAME_NOT_LOCKED_BY_SCORER",
+        "Game $gameId is not locked by scorer $scorerId",
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -1,5 +1,7 @@
 package com.nextup.core.domain.game
 
+import com.nextup.common.exception.GameAlreadyLockedException
+import com.nextup.common.exception.GameNotLockedByCurrentScorerException
 import com.nextup.core.common.BaseTimeEntity
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.team.Team
@@ -57,6 +59,8 @@ class Game private constructor(
     var forfeitReason: String? = null,
     @Embedded
     var gameState: GameState = GameState(),
+    @Column(name = "scorer_id")
+    var scorerId: Long? = null,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
@@ -79,6 +83,55 @@ class Game private constructor(
         startedAt = LocalDateTime.now()
         gameState.resetForNewInning()
     }
+
+    /**
+     * 기록원이 경기를 독점 잠금합니다.
+     *
+     * 이미 다른 기록원이 잠금한 경우 [GameAlreadyLockedException]이 발생합니다.
+     * 동일 기록원이 중복 잠금 시도하면 멱등하게 무시합니다.
+     *
+     * @param scorerId 잠금을 요청하는 기록원 ID
+     * @throws GameAlreadyLockedException 다른 기록원이 이미 잠금한 경우
+     */
+    fun lockForScorer(scorerId: Long) {
+        if (this.scorerId != null && this.scorerId != scorerId) {
+            throw GameAlreadyLockedException(id, this.scorerId!!)
+        }
+        this.scorerId = scorerId
+    }
+
+    /**
+     * 기록원의 경기 잠금을 해제합니다.
+     *
+     * 잠금한 기록원 본인만 해제할 수 있습니다.
+     *
+     * @param scorerId 잠금 해제를 요청하는 기록원 ID
+     * @throws GameNotLockedByCurrentScorerException 해당 기록원이 잠금하지 않은 경우
+     */
+    fun unlockScorer(scorerId: Long) {
+        if (this.scorerId == null || this.scorerId != scorerId) {
+            throw GameNotLockedByCurrentScorerException(id, scorerId)
+        }
+        this.scorerId = null
+    }
+
+    /**
+     * 강제로 기록원 잠금을 해제합니다 (관리자용).
+     */
+    fun forceUnlockScorer() {
+        this.scorerId = null
+    }
+
+    /**
+     * 현재 기록원이 경기를 잠금하고 있는지 확인합니다.
+     */
+    fun isLockedByScorer(scorerId: Long): Boolean = this.scorerId == scorerId
+
+    /**
+     * 경기가 잠금 상태인지 확인합니다.
+     */
+    val isLocked: Boolean
+        get() = scorerId != null
 
     /**
      * 다음 이닝으로 진행합니다.
@@ -473,6 +526,7 @@ class Game private constructor(
             note: String? = null,
             forfeitReason: String? = null,
             gameState: GameState = GameState(),
+            scorerId: Long? = null,
             id: Long = 0L,
         ): Game {
             val game =
@@ -492,6 +546,7 @@ class Game private constructor(
                     note = note,
                     forfeitReason = forfeitReason,
                     gameState = gameState,
+                    scorerId = scorerId,
                     id = id,
                 )
             game._gameTeams.add(GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME, id = id * 100 + 1))

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
@@ -28,4 +28,28 @@ interface GameLifecycleService {
         gameId: Long,
         reason: String? = null,
     ): Game
+
+    /**
+     * 기록원이 경기를 독점 잠금합니다.
+     *
+     * @param gameId 경기 ID
+     * @param scorerId 기록원 ID
+     * @return 잠금된 Game
+     */
+    fun lockGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game
+
+    /**
+     * 기록원의 경기 잠금을 해제합니다.
+     *
+     * @param gameId 경기 ID
+     * @param scorerId 기록원 ID
+     * @return 잠금 해제된 Game
+     */
+    fun unlockGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLogService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLogService.kt
@@ -1,0 +1,78 @@
+package com.nextup.core.service.game
+
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 선수 게임 로그 서비스
+ *
+ * 선수의 경기별 기록(타격/투수/수비)을 통합하여 제공합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class GameLogService(
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
+    private val battingRecordRepository: BattingRecordRepositoryPort,
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+    private val fieldingRecordRepository: FieldingRecordRepositoryPort,
+) {
+    /**
+     * 선수의 최근 경기 기록을 조회합니다.
+     *
+     * @param playerId 선수 ID
+     * @param limit 조회할 경기 수 (기본값: 10)
+     * @return 경기별 기록 리스트 (최근 경기 순)
+     */
+    fun getGameLog(
+        playerId: Long,
+        limit: Int = 10,
+    ): List<GameLogEntry> {
+        // GamePlayer를 통해 참여한 경기 목록을 가져옴
+        val gamePlayers = gamePlayerRepository.findAllByPlayerId(playerId)
+        if (gamePlayers.isEmpty()) return emptyList()
+
+        // 각 기록을 gamePlayerId로 인덱싱
+        val battingByGamePlayer =
+            battingRecordRepository.findAllByPlayerId(playerId)
+                .associateBy { it.gamePlayer.id }
+        val pitchingByGamePlayer =
+            pitchingRecordRepository.findAllByPlayerId(playerId)
+                .associateBy { it.gamePlayer.id }
+        val fieldingByGamePlayer =
+            fieldingRecordRepository.findAllByPlayerId(playerId)
+                .associateBy { it.gamePlayer.id }
+
+        // GamePlayer 기준으로 게임 로그 조립 (최근 경기 순으로 정렬)
+        return gamePlayers
+            .sortedByDescending { it.gameTeam.game.scheduledAt }
+            .take(limit)
+            .map { gamePlayer ->
+                GameLogEntry(
+                    gamePlayer = gamePlayer,
+                    battingRecord = battingByGamePlayer[gamePlayer.id],
+                    pitchingRecord = pitchingByGamePlayer[gamePlayer.id],
+                    fieldingRecord = fieldingByGamePlayer[gamePlayer.id],
+                )
+            }
+    }
+}
+
+/**
+ * 게임 로그 항목
+ *
+ * 하나의 경기에서 선수의 모든 기록을 묶어 제공합니다.
+ */
+data class GameLogEntry(
+    val gamePlayer: GamePlayer,
+    val battingRecord: BattingRecord?,
+    val pitchingRecord: PitchingRecord?,
+    val fieldingRecord: FieldingRecord?,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameStateQueryService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameStateQueryService.kt
@@ -1,0 +1,37 @@
+package com.nextup.core.service.game
+
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameTeam
+
+/**
+ * 경기 상태 조회 서비스 인터페이스
+ *
+ * 기록원 재접속 시 현재 경기 상태를 복원하기 위한 조회 기능을 제공합니다.
+ */
+interface GameStateQueryService {
+    /**
+     * 경기를 조회합니다.
+     *
+     * @param gameId 경기 ID
+     * @return Game 엔티티
+     * @throws GameNotFoundException 경기가 존재하지 않는 경우
+     */
+    fun getGame(gameId: Long): Game
+
+    /**
+     * 경기의 현재 출전 중인 라인업을 조회합니다.
+     *
+     * @param gameId 경기 ID
+     * @return 현재 출전 중인 GamePlayer 목록
+     */
+    fun getCurrentLineup(gameId: Long): List<GamePlayer>
+
+    /**
+     * 경기의 GameTeam 목록을 조회합니다.
+     *
+     * @param gameId 경기 ID
+     * @return GameTeam 목록 (홈팀, 원정팀)
+     */
+    fun getGameTeams(gameId: Long): List<GameTeam>
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -1,5 +1,7 @@
 package com.nextup.core.domain.game
 
+import com.nextup.common.exception.GameAlreadyLockedException
+import com.nextup.common.exception.GameNotLockedByCurrentScorerException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
@@ -1389,6 +1391,128 @@ class GameTest {
             assertThat(game.currentInning).isEqualTo(5)
             assertThat(game.isTopInning).isFalse()
             assertThat(game.gameState.outs).isEqualTo(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("기록원 독점 잠금")
+    inner class ScorerLock {
+        @Test
+        fun `기록원이 경기를 잠금할 수 있다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+
+            // when
+            game.lockForScorer(100L)
+
+            // then
+            assertThat(game.scorerId).isEqualTo(100L)
+            assertThat(game.isLocked).isTrue()
+            assertThat(game.isLockedByScorer(100L)).isTrue()
+        }
+
+        @Test
+        fun `동일 기록원이 중복 잠금 시도하면 멱등하게 처리된다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when
+            game.lockForScorer(100L)
+
+            // then
+            assertThat(game.scorerId).isEqualTo(100L)
+        }
+
+        @Test
+        fun `다른 기록원이 잠금된 경기를 잠금 시도하면 예외가 발생한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when & then
+            assertThatThrownBy { game.lockForScorer(200L) }
+                .isInstanceOf(GameAlreadyLockedException::class.java)
+                .hasMessageContaining("already locked by scorer 100")
+        }
+
+        @Test
+        fun `잠금한 기록원이 잠금을 해제할 수 있다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when
+            game.unlockScorer(100L)
+
+            // then
+            assertThat(game.scorerId).isNull()
+            assertThat(game.isLocked).isFalse()
+        }
+
+        @Test
+        fun `잠금하지 않은 기록원이 해제 시도하면 예외가 발생한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when & then
+            assertThatThrownBy { game.unlockScorer(200L) }
+                .isInstanceOf(GameNotLockedByCurrentScorerException::class.java)
+                .hasMessageContaining("not locked by scorer 200")
+        }
+
+        @Test
+        fun `잠금이 없는 상태에서 해제 시도하면 예외가 발생한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+
+            // when & then
+            assertThatThrownBy { game.unlockScorer(100L) }
+                .isInstanceOf(GameNotLockedByCurrentScorerException::class.java)
+        }
+
+        @Test
+        fun `강제 잠금 해제는 어떤 상태에서든 가능하다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when
+            game.forceUnlockScorer()
+
+            // then
+            assertThat(game.scorerId).isNull()
+            assertThat(game.isLocked).isFalse()
+        }
+
+        @Test
+        fun `잠금되지 않은 경기에 대해 isLockedByScorer는 false를 반환한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+
+            // then
+            assertThat(game.isLockedByScorer(100L)).isFalse()
+        }
+
+        @Test
+        fun `createForTest에서 scorerId를 지정할 수 있다`() {
+            // given
+            val homeTeam = createTeam("홈팀", id = 1L)
+            val awayTeam = createTeam("원정팀", city = "부산", id = 2L)
+
+            // when
+            val game =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scorerId = 100L,
+                )
+
+            // then
+            assertThat(game.scorerId).isEqualTo(100L)
+            assertThat(game.isLocked).isTrue()
         }
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingDecisionCalculatorTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingDecisionCalculatorTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+@Suppress("DEPRECATION")
 @DisplayName("PitchingDecisionCalculator")
 class PitchingDecisionCalculatorTest {
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/GameLogServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/GameLogServiceTest.kt
@@ -1,0 +1,168 @@
+package com.nextup.core.service.game
+
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+@DisplayName("GameLogService 테스트")
+class GameLogServiceTest {
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var battingRecordRepository: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var fieldingRecordRepository: FieldingRecordRepositoryPort
+    private lateinit var gameLogService: GameLogService
+
+    private val playerId = 1L
+
+    @BeforeEach
+    fun setUp() {
+        gamePlayerRepository = mockk()
+        battingRecordRepository = mockk()
+        pitchingRecordRepository = mockk()
+        fieldingRecordRepository = mockk()
+        gameLogService =
+            GameLogService(
+                gamePlayerRepository = gamePlayerRepository,
+                battingRecordRepository = battingRecordRepository,
+                pitchingRecordRepository = pitchingRecordRepository,
+                fieldingRecordRepository = fieldingRecordRepository,
+            )
+    }
+
+    @Test
+    fun `should return empty list when player has no games`() {
+        // given
+        every { gamePlayerRepository.findAllByPlayerId(playerId) } returns emptyList()
+
+        // when
+        val result = gameLogService.getGameLog(playerId)
+
+        // then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should return game log entries with batting records`() {
+        // given
+        val game =
+            mockk<Game> {
+                every { scheduledAt } returns LocalDateTime.of(2025, 6, 15, 14, 0)
+            }
+        val gameTeam =
+            mockk<GameTeam> {
+                every { this@mockk.game } returns game
+            }
+        val gamePlayer =
+            mockk<GamePlayer> {
+                every { id } returns 10L
+                every { this@mockk.gameTeam } returns gameTeam
+            }
+        val battingRecord =
+            mockk<BattingRecord> {
+                every { this@mockk.gamePlayer } returns gamePlayer
+            }
+
+        every { gamePlayerRepository.findAllByPlayerId(playerId) } returns listOf(gamePlayer)
+        every { battingRecordRepository.findAllByPlayerId(playerId) } returns listOf(battingRecord)
+        every { pitchingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { fieldingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+
+        // when
+        val result = gameLogService.getGameLog(playerId)
+
+        // then
+        assertThat(result).hasSize(1)
+        assertThat(result[0].gamePlayer).isEqualTo(gamePlayer)
+        assertThat(result[0].battingRecord).isEqualTo(battingRecord)
+        assertThat(result[0].pitchingRecord).isNull()
+        assertThat(result[0].fieldingRecord).isNull()
+    }
+
+    @Test
+    fun `should limit number of entries returned`() {
+        // given
+        val gamePlayers =
+            (1..5).map { i ->
+                val game =
+                    mockk<Game> {
+                        every { scheduledAt } returns LocalDateTime.of(2025, 6, i, 14, 0)
+                    }
+                val gameTeam =
+                    mockk<GameTeam> {
+                        every { this@mockk.game } returns game
+                    }
+                mockk<GamePlayer> {
+                    every { id } returns i.toLong()
+                    every { this@mockk.gameTeam } returns gameTeam
+                }
+            }
+
+        every { gamePlayerRepository.findAllByPlayerId(playerId) } returns gamePlayers
+        every { battingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { pitchingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { fieldingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+
+        // when
+        val result = gameLogService.getGameLog(playerId, limit = 3)
+
+        // then
+        assertThat(result).hasSize(3)
+    }
+
+    @Test
+    fun `should sort entries by game date descending`() {
+        // given
+        val game1 =
+            mockk<Game> {
+                every { scheduledAt } returns LocalDateTime.of(2025, 6, 1, 14, 0)
+            }
+        val game2 =
+            mockk<Game> {
+                every { scheduledAt } returns LocalDateTime.of(2025, 6, 15, 14, 0)
+            }
+        val gameTeam1 =
+            mockk<GameTeam> {
+                every { game } returns game1
+            }
+        val gameTeam2 =
+            mockk<GameTeam> {
+                every { game } returns game2
+            }
+        val gp1 =
+            mockk<GamePlayer> {
+                every { id } returns 1L
+                every { gameTeam } returns gameTeam1
+            }
+        val gp2 =
+            mockk<GamePlayer> {
+                every { id } returns 2L
+                every { gameTeam } returns gameTeam2
+            }
+
+        every { gamePlayerRepository.findAllByPlayerId(playerId) } returns listOf(gp1, gp2)
+        every { battingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { pitchingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+        every { fieldingRecordRepository.findAllByPlayerId(playerId) } returns emptyList()
+
+        // when
+        val result = gameLogService.getGameLog(playerId)
+
+        // then
+        assertThat(result).hasSize(2)
+        // Most recent game (June 15) should come first
+        assertThat(result[0].gamePlayer).isEqualTo(gp2)
+        assertThat(result[1].gamePlayer).isEqualTo(gp1)
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
@@ -218,6 +218,26 @@ class GameLifecycleServiceImpl(
         )
     }
 
+    @Transactional
+    override fun lockGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game {
+        val game = findGame(gameId)
+        game.lockForScorer(scorerId)
+        return gameRepository.save(game)
+    }
+
+    @Transactional
+    override fun unlockGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game {
+        val game = findGame(gameId)
+        game.unlockScorer(scorerId)
+        return gameRepository.save(game)
+    }
+
     private fun findGame(id: Long): Game =
         gameRepository.findByIdOrNull(id)
             ?: throw GameNotFoundException(id)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameStateQueryServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameStateQueryServiceImpl.kt
@@ -1,0 +1,34 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.service.game.GameStateQueryService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 경기 상태 조회 서비스 구현
+ *
+ * 기록원 재접속 시 현재 경기 상태를 복원하기 위한 조회 기능을 제공합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class GameStateQueryServiceImpl(
+    private val gameRepository: GameRepositoryPort,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
+    private val gameTeamRepository: GameTeamRepositoryPort,
+) : GameStateQueryService {
+    override fun getGame(gameId: Long): Game =
+        gameRepository.findByIdOrNull(gameId)
+            ?: throw GameNotFoundException(gameId)
+
+    override fun getCurrentLineup(gameId: Long): List<GamePlayer> =
+        gamePlayerRepository.findCurrentlyPlayingByGameId(gameId)
+
+    override fun getGameTeams(gameId: Long): List<GameTeam> = gameTeamRepository.findAllByGameId(gameId)
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V037__add_scorer_id_to_games.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V037__add_scorer_id_to_games.sql
@@ -1,0 +1,4 @@
+-- #332: 기록원 경기 독점 잠금 메커니즘
+ALTER TABLE games ADD COLUMN scorer_id BIGINT;
+
+CREATE INDEX idx_games_scorer_id ON games(scorer_id) WHERE scorer_id IS NOT NULL;

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplLockTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplLockTest.kt
@@ -1,0 +1,156 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameLifecycleServiceImpl - Lock/Unlock 테스트")
+class GameLifecycleServiceImplLockTest {
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var eventPublisher: ApplicationEventPublisher
+    private lateinit var service: GameLifecycleServiceImpl
+
+    private lateinit var competition: Competition
+    private lateinit var league: League
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        gameTeamRepository = mockk()
+        pitchingRecordRepository = mockk()
+        eventPublisher = mockk(relaxed = true)
+        service =
+            GameLifecycleServiceImpl(
+                gameRepository,
+                gameTeamRepository,
+                pitchingRecordRepository,
+                eventPublisher,
+            )
+
+        val association = Association(name = "서울시야구협회", region = "서울")
+        league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+            )
+    }
+
+    @Nested
+    @DisplayName("lockGame")
+    inner class LockGameTest {
+        @Test
+        @DisplayName("경기를 잠금하고 저장된 Game을 반환한다")
+        fun locksGameAndReturnsSaved() {
+            // given
+            val gameId = 1L
+            val scorerId = 100L
+            val game = createGame(gameId, GameStatus.SCHEDULED)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = service.lockGame(gameId, scorerId)
+
+            // then
+            assertThat(result.scorerId).isEqualTo(scorerId)
+            verify(exactly = 1) { gameRepository.findByIdOrNull(gameId) }
+            verify(exactly = 1) { gameRepository.save(any()) }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 경기를 잠금하면 예외가 발생한다")
+        fun throwsWhenGameNotFound() {
+            // given
+            val gameId = 999L
+            every { gameRepository.findByIdOrNull(gameId) } returns null
+
+            // when & then
+            assertThatThrownBy { service.lockGame(gameId, 100L) }
+                .isInstanceOf(GameNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("unlockGame")
+    inner class UnlockGameTest {
+        @Test
+        @DisplayName("경기 잠금을 해제하고 저장된 Game을 반환한다")
+        fun unlocksGameAndReturnsSaved() {
+            // given
+            val gameId = 1L
+            val scorerId = 100L
+            val game = createGame(gameId, GameStatus.SCHEDULED, scorerId = scorerId)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = service.unlockGame(gameId, scorerId)
+
+            // then
+            assertThat(result.scorerId).isNull()
+            verify(exactly = 1) { gameRepository.findByIdOrNull(gameId) }
+            verify(exactly = 1) { gameRepository.save(any()) }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 경기의 잠금을 해제하면 예외가 발생한다")
+        fun throwsWhenGameNotFound() {
+            // given
+            val gameId = 999L
+            every { gameRepository.findByIdOrNull(gameId) } returns null
+
+            // when & then
+            assertThatThrownBy { service.unlockGame(gameId, 100L) }
+                .isInstanceOf(GameNotFoundException::class.java)
+        }
+    }
+
+    private fun createGame(
+        id: Long,
+        status: GameStatus,
+        scorerId: Long? = null,
+    ): Game {
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        return Game.createForTest(
+            competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            status = status,
+            scorerId = scorerId,
+            id = id,
+        )
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplLockTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplLockTest.kt
@@ -12,6 +12,7 @@ import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.service.game.PitchingDecisionService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -30,6 +31,7 @@ class GameLifecycleServiceImplLockTest {
     private lateinit var gameRepository: GameRepositoryPort
     private lateinit var gameTeamRepository: GameTeamRepositoryPort
     private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var pitchingDecisionService: PitchingDecisionService
     private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var service: GameLifecycleServiceImpl
 
@@ -41,12 +43,14 @@ class GameLifecycleServiceImplLockTest {
         gameRepository = mockk()
         gameTeamRepository = mockk()
         pitchingRecordRepository = mockk()
+        pitchingDecisionService = mockk(relaxed = true)
         eventPublisher = mockk(relaxed = true)
         service =
             GameLifecycleServiceImpl(
                 gameRepository,
                 gameTeamRepository,
                 pitchingRecordRepository,
+                pitchingDecisionService,
                 eventPublisher,
             )
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameStateQueryServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameStateQueryServiceImplTest.kt
@@ -1,0 +1,145 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("GameStateQueryServiceImpl 테스트")
+class GameStateQueryServiceImplTest {
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
+    private lateinit var service: GameStateQueryServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        gamePlayerRepository = mockk()
+        gameTeamRepository = mockk()
+        service =
+            GameStateQueryServiceImpl(
+                gameRepository,
+                gamePlayerRepository,
+                gameTeamRepository,
+            )
+    }
+
+    @Nested
+    @DisplayName("getGame")
+    inner class GetGameTest {
+        @Test
+        @DisplayName("경기가 존재하면 Game을 반환한다")
+        fun returnsGameWhenFound() {
+            // given
+            val gameId = 1L
+            val game = mockk<Game>()
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+
+            // when
+            val result = service.getGame(gameId)
+
+            // then
+            assertThat(result).isEqualTo(game)
+            verify(exactly = 1) { gameRepository.findByIdOrNull(gameId) }
+        }
+
+        @Test
+        @DisplayName("경기가 존재하지 않으면 GameNotFoundException을 던진다")
+        fun throwsExceptionWhenNotFound() {
+            // given
+            val gameId = 999L
+            every { gameRepository.findByIdOrNull(gameId) } returns null
+
+            // when & then
+            assertThatThrownBy { service.getGame(gameId) }
+                .isInstanceOf(GameNotFoundException::class.java)
+
+            verify(exactly = 1) { gameRepository.findByIdOrNull(gameId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("getCurrentLineup")
+    inner class GetCurrentLineupTest {
+        @Test
+        @DisplayName("현재 출전 중인 선수 목록을 반환한다")
+        fun returnsCurrentlyPlayingPlayers() {
+            // given
+            val gameId = 1L
+            val players = listOf(mockk<GamePlayer>(), mockk<GamePlayer>())
+            every { gamePlayerRepository.findCurrentlyPlayingByGameId(gameId) } returns players
+
+            // when
+            val result = service.getCurrentLineup(gameId)
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result).isEqualTo(players)
+            verify(exactly = 1) { gamePlayerRepository.findCurrentlyPlayingByGameId(gameId) }
+        }
+
+        @Test
+        @DisplayName("출전 중인 선수가 없으면 빈 리스트를 반환한다")
+        fun returnsEmptyListWhenNoPlayers() {
+            // given
+            val gameId = 1L
+            every { gamePlayerRepository.findCurrentlyPlayingByGameId(gameId) } returns emptyList()
+
+            // when
+            val result = service.getCurrentLineup(gameId)
+
+            // then
+            assertThat(result).isEmpty()
+            verify(exactly = 1) { gamePlayerRepository.findCurrentlyPlayingByGameId(gameId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("getGameTeams")
+    inner class GetGameTeamsTest {
+        @Test
+        @DisplayName("경기의 GameTeam 목록을 반환한다")
+        fun returnsGameTeams() {
+            // given
+            val gameId = 1L
+            val gameTeams = listOf(mockk<GameTeam>(), mockk<GameTeam>())
+            every { gameTeamRepository.findAllByGameId(gameId) } returns gameTeams
+
+            // when
+            val result = service.getGameTeams(gameId)
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result).isEqualTo(gameTeams)
+            verify(exactly = 1) { gameTeamRepository.findAllByGameId(gameId) }
+        }
+
+        @Test
+        @DisplayName("GameTeam이 없으면 빈 리스트를 반환한다")
+        fun returnsEmptyListWhenNoGameTeams() {
+            // given
+            val gameId = 1L
+            every { gameTeamRepository.findAllByGameId(gameId) } returns emptyList()
+
+            // when
+            val result = service.getGameTeams(gameId)
+
+            // then
+            assertThat(result).isEmpty()
+            verify(exactly = 1) { gameTeamRepository.findAllByGameId(gameId) }
+        }
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -3,36 +3,50 @@ package com.nextup.scorer.controller.game
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.game.BaseRunningRecordService
 import com.nextup.core.service.game.GameLifecycleService
+import com.nextup.core.service.game.GameStateQueryService
 import com.nextup.core.service.game.GameSubstitutionService
+import com.nextup.core.service.game.GameTimelineService
 import com.nextup.core.service.game.GameUndoService
 import com.nextup.core.service.game.PlateAppearanceRecordService
 import com.nextup.scorer.dto.game.BaseRunningRequestDto
 import com.nextup.scorer.dto.game.BaseRunningResponse
 import com.nextup.scorer.dto.game.CancelGameRequestDto
+import com.nextup.scorer.dto.game.CurrentGameStateResponse
+import com.nextup.scorer.dto.game.CurrentLineupResponse
+import com.nextup.scorer.dto.game.EventTimelineResponse
 import com.nextup.scorer.dto.game.ForfeitRequestDto
 import com.nextup.scorer.dto.game.GameEndRequestDto
 import com.nextup.scorer.dto.game.GameResponse
 import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
+import com.nextup.scorer.dto.game.ScoreboardResponse
 import com.nextup.scorer.dto.game.SubstitutionRequestDto
 import com.nextup.scorer.dto.game.SubstitutionResponse
 import com.nextup.scorer.dto.game.UndoResponse
 import com.nextup.scorer.dto.game.toBaseRunningResponse
+import com.nextup.scorer.dto.game.toCurrentGameStateResponse
+import com.nextup.scorer.dto.game.toCurrentLineupResponse
 import com.nextup.scorer.dto.game.toDomain
+import com.nextup.scorer.dto.game.toEventTimelineResponse
 import com.nextup.scorer.dto.game.toResponse
+import com.nextup.scorer.dto.game.toScoreboardResponse
 import com.nextup.scorer.dto.game.toSubstitutionResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 /**
  * 기록원 전용 경기 기록 컨트롤러
  *
- * 실시간 경기 기록 입력을 위한 API를 제공합니다.
+ * 실시간 경기 기록 입력 및 경기 상태 조회를 위한 API를 제공합니다.
+ * GET 엔드포인트는 기록원 재접속 시 현재 상태를 복원하거나,
+ * WebSocket 단절 시 REST fallback으로 활용됩니다.
  */
 @RestController
 @RequestMapping("/api/scorer/games")
@@ -42,7 +56,105 @@ class GameScorerController(
     private val gameUndoService: GameUndoService,
     private val baseRunningRecordService: BaseRunningRecordService,
     private val gameSubstitutionService: GameSubstitutionService,
+    private val gameStateQueryService: GameStateQueryService,
+    private val gameTimelineService: GameTimelineService,
 ) {
+    // ===== GET 조회 엔드포인트 (H-16, M-25) =====
+
+    /**
+     * 현재 경기 상태를 조회합니다.
+     *
+     * 기록원 재접속 시 이닝, 아웃, 주자, 볼카운트 등 현재 경기 상태를 복원합니다.
+     */
+    @GetMapping("/{gameId}/state")
+    @ResponseStatus(HttpStatus.OK)
+    fun getGameState(
+        @PathVariable gameId: Long,
+    ): ApiResponse<CurrentGameStateResponse> {
+        val game = gameStateQueryService.getGame(gameId)
+        val gameTeams = gameStateQueryService.getGameTeams(gameId)
+        return ApiResponse.success(game.toCurrentGameStateResponse(gameTeams))
+    }
+
+    /**
+     * 현재 라인업을 조회합니다.
+     *
+     * 경기에 현재 출전 중인 선수 목록을 홈/원정으로 분리하여 반환합니다.
+     */
+    @GetMapping("/{gameId}/lineup")
+    @ResponseStatus(HttpStatus.OK)
+    fun getCurrentLineup(
+        @PathVariable gameId: Long,
+    ): ApiResponse<CurrentLineupResponse> {
+        val players = gameStateQueryService.getCurrentLineup(gameId)
+        return ApiResponse.success(toCurrentLineupResponse(gameId, players))
+    }
+
+    /**
+     * 이벤트 타임라인을 조회합니다.
+     *
+     * 경기의 모든 이벤트를 시간 순서대로 반환합니다.
+     * 이닝 범위를 지정하여 부분 조회할 수 있습니다.
+     */
+    @GetMapping("/{gameId}/events")
+    @ResponseStatus(HttpStatus.OK)
+    fun getEventTimeline(
+        @PathVariable gameId: Long,
+        @RequestParam(required = false) fromInning: Int?,
+        @RequestParam(required = false) toInning: Int?,
+    ): ApiResponse<EventTimelineResponse> {
+        val timeline = gameTimelineService.getTimeline(gameId, fromInning, toInning)
+        return ApiResponse.success(timeline.toEventTimelineResponse())
+    }
+
+    /**
+     * 스코어보드를 조회합니다 (REST fallback).
+     *
+     * WebSocket 단절 시 현재 스코어보드를 REST로 조회할 수 있습니다.
+     */
+    @GetMapping("/{gameId}/scoreboard")
+    @ResponseStatus(HttpStatus.OK)
+    fun getScoreboard(
+        @PathVariable gameId: Long,
+    ): ApiResponse<ScoreboardResponse> {
+        val game = gameStateQueryService.getGame(gameId)
+        val gameTeams = gameStateQueryService.getGameTeams(gameId)
+        return ApiResponse.success(game.toScoreboardResponse(gameTeams))
+    }
+
+    // ===== POST 기록 엔드포인트 =====
+
+    /**
+     * 기록원이 경기를 독점 잠금합니다.
+     *
+     * 다른 기록원이 이미 잠금한 경우 409 Conflict를 반환합니다.
+     * 동일 기록원의 중복 잠금 시도는 멱등하게 처리됩니다.
+     */
+    @PostMapping("/{gameId}/lock")
+    @ResponseStatus(HttpStatus.OK)
+    fun lockGame(
+        @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
+    ): ApiResponse<GameResponse> {
+        val game = gameLifecycleService.lockGame(gameId, scorerId)
+        return ApiResponse.success(game.toResponse())
+    }
+
+    /**
+     * 기록원의 경기 잠금을 해제합니다.
+     *
+     * 잠금한 기록원 본인만 해제할 수 있습니다.
+     */
+    @PostMapping("/{gameId}/unlock")
+    @ResponseStatus(HttpStatus.OK)
+    fun unlockGame(
+        @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
+    ): ApiResponse<GameResponse> {
+        val game = gameLifecycleService.unlockGame(gameId, scorerId)
+        return ApiResponse.success(game.toResponse())
+    }
+
     /**
      * 경기를 시작합니다.
      */

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameMapper.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameMapper.kt
@@ -20,6 +20,7 @@ fun Game.toResponse(warnings: List<String> = emptyList()): GameResponse {
         scheduledAt = this.scheduledAt,
         startedAt = this.startedAt,
         endedAt = this.endedAt,
+        scorerId = this.scorerId,
         warnings = warnings,
     )
 }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameResponse.kt
@@ -17,6 +17,7 @@ data class GameResponse(
     val scheduledAt: LocalDateTime,
     val startedAt: LocalDateTime?,
     val endedAt: LocalDateTime?,
+    val scorerId: Long? = null,
     val warnings: List<String> = emptyList(),
 )
 

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameStateQueryResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameStateQueryResponse.kt
@@ -1,0 +1,321 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.game.dto.BoxScoreDto
+import com.nextup.core.service.game.dto.GameTimelineDto
+import com.nextup.core.service.game.dto.TimelineEventDto
+import java.time.Instant
+import java.time.LocalDateTime
+
+/**
+ * 현재 경기 상태 응답 DTO
+ *
+ * 기록원 재접속 시 현재 경기 상태를 복원하기 위한 응답입니다.
+ */
+data class CurrentGameStateResponse(
+    val gameId: Long,
+    val status: GameStatus,
+    val currentInning: Int,
+    val isTopInning: Boolean,
+    val currentInningDisplay: String,
+    val totalInnings: Int,
+    val gameState: GameStateResponse,
+    val homeTeam: TeamScoreSummaryResponse,
+    val awayTeam: TeamScoreSummaryResponse,
+    val scheduledAt: LocalDateTime,
+    val startedAt: LocalDateTime?,
+    val endedAt: LocalDateTime?,
+)
+
+/**
+ * 팀 점수 요약 응답 DTO
+ */
+data class TeamScoreSummaryResponse(
+    val gameTeamId: Long,
+    val teamId: Long,
+    val teamName: String,
+    val totalScore: Int,
+    val totalHits: Int,
+    val totalErrors: Int,
+)
+
+/**
+ * 현재 라인업 응답 DTO
+ */
+data class CurrentLineupResponse(
+    val gameId: Long,
+    val homeLineup: List<LineupPlayerResponse>,
+    val awayLineup: List<LineupPlayerResponse>,
+)
+
+/**
+ * 라인업 선수 응답 DTO
+ */
+data class LineupPlayerResponse(
+    val gamePlayerId: Long,
+    val playerId: Long,
+    val playerName: String,
+    val position: Position,
+    val positionDisplayName: String,
+    val battingOrder: Int?,
+    val backNumber: Int?,
+    val isStarter: Boolean,
+    val isCurrentlyPlaying: Boolean,
+    val isDesignatedHitter: Boolean,
+)
+
+/**
+ * 이벤트 타임라인 응답 DTO
+ */
+data class EventTimelineResponse(
+    val gameId: Long,
+    val events: List<TimelineEventResponse>,
+    val totalEvents: Int,
+)
+
+/**
+ * 타임라인 이벤트 응답 DTO
+ */
+data class TimelineEventResponse(
+    val eventId: Long,
+    val inning: Int,
+    val isTopInning: Boolean,
+    val inningDisplay: String,
+    val eventType: String,
+    val description: String,
+    val batterId: Long?,
+    val batterName: String?,
+    val pitcherId: Long?,
+    val pitcherName: String?,
+    val plateAppearanceResult: String?,
+    val runsScored: Int,
+    val outCountBefore: Int,
+    val outCountAfter: Int,
+    val eventTimestamp: Instant,
+)
+
+/**
+ * 스코어보드 REST fallback 응답 DTO
+ */
+data class ScoreboardResponse(
+    val gameId: Long,
+    val status: GameStatus,
+    val currentInning: Int,
+    val isTopInning: Boolean,
+    val currentInningDisplay: String,
+    val homeTeam: ScoreboardTeamResponse,
+    val awayTeam: ScoreboardTeamResponse,
+)
+
+/**
+ * 스코어보드 팀 응답 DTO
+ */
+data class ScoreboardTeamResponse(
+    val teamId: Long,
+    val teamName: String,
+    val runs: Int,
+    val hits: Int,
+    val errors: Int,
+    val inningScores: List<Int>,
+)
+
+// ===== 매퍼 함수 =====
+
+/**
+ * Game + GameTeam 목록을 CurrentGameStateResponse로 변환합니다.
+ */
+fun Game.toCurrentGameStateResponse(gameTeams: List<GameTeam>): CurrentGameStateResponse {
+    val homeTeam =
+        gameTeams.firstOrNull { it.homeAway == HomeAway.HOME }
+    val awayTeam =
+        gameTeams.firstOrNull { it.homeAway == HomeAway.AWAY }
+
+    return CurrentGameStateResponse(
+        gameId = this.id,
+        status = this.status,
+        currentInning = this.currentInning,
+        isTopInning = this.isTopInning,
+        currentInningDisplay = this.currentInningDisplay,
+        totalInnings = this.totalInnings,
+        gameState = this.gameState.toResponse(),
+        homeTeam = homeTeam?.toTeamScoreSummary() ?: emptyTeamScoreSummary(),
+        awayTeam = awayTeam?.toTeamScoreSummary() ?: emptyTeamScoreSummary(),
+        scheduledAt = this.scheduledAt,
+        startedAt = this.startedAt,
+        endedAt = this.endedAt,
+    )
+}
+
+private fun GameTeam.toTeamScoreSummary(): TeamScoreSummaryResponse =
+    TeamScoreSummaryResponse(
+        gameTeamId = this.id,
+        teamId = this.team.id,
+        teamName = this.team.name,
+        totalScore = this.totalScore,
+        totalHits = this.totalHits,
+        totalErrors = this.totalErrors,
+    )
+
+private fun emptyTeamScoreSummary(): TeamScoreSummaryResponse =
+    TeamScoreSummaryResponse(
+        gameTeamId = 0L,
+        teamId = 0L,
+        teamName = "",
+        totalScore = 0,
+        totalHits = 0,
+        totalErrors = 0,
+    )
+
+/**
+ * GamePlayer를 LineupPlayerResponse로 변환합니다.
+ */
+fun GamePlayer.toLineupPlayerResponse(): LineupPlayerResponse =
+    LineupPlayerResponse(
+        gamePlayerId = this.id,
+        playerId = this.player.id,
+        playerName = this.player.name,
+        position = this.position,
+        positionDisplayName = this.position.displayName,
+        battingOrder = this.battingOrder,
+        backNumber = this.backNumber,
+        isStarter = this.isStarter,
+        isCurrentlyPlaying = this.isCurrentlyPlaying,
+        isDesignatedHitter = this.isDesignatedHitter,
+    )
+
+/**
+ * GamePlayer 목록을 홈/원정으로 분리하여 CurrentLineupResponse를 생성합니다.
+ */
+fun toCurrentLineupResponse(
+    gameId: Long,
+    players: List<GamePlayer>,
+): CurrentLineupResponse {
+    val homeLineup =
+        players
+            .filter { it.gameTeam.homeAway == HomeAway.HOME }
+            .sortedWith(compareBy(nullsLast()) { it.battingOrder })
+            .map { it.toLineupPlayerResponse() }
+
+    val awayLineup =
+        players
+            .filter { it.gameTeam.homeAway == HomeAway.AWAY }
+            .sortedWith(compareBy(nullsLast()) { it.battingOrder })
+            .map { it.toLineupPlayerResponse() }
+
+    return CurrentLineupResponse(
+        gameId = gameId,
+        homeLineup = homeLineup,
+        awayLineup = awayLineup,
+    )
+}
+
+/**
+ * GameTimelineDto를 EventTimelineResponse로 변환합니다.
+ */
+fun GameTimelineDto.toEventTimelineResponse(): EventTimelineResponse =
+    EventTimelineResponse(
+        gameId = this.gameId,
+        events = this.events.map { it.toTimelineEventResponse() },
+        totalEvents = this.totalEvents,
+    )
+
+private fun TimelineEventDto.toTimelineEventResponse(): TimelineEventResponse =
+    TimelineEventResponse(
+        eventId = this.eventId,
+        inning = this.inning,
+        isTopInning = this.isTopInning,
+        inningDisplay = this.inningDisplay,
+        eventType = this.eventType,
+        description = this.description,
+        batterId = this.batterId,
+        batterName = this.batterName,
+        pitcherId = this.pitcherId,
+        pitcherName = this.pitcherName,
+        plateAppearanceResult = this.plateAppearanceResult,
+        runsScored = this.runsScored,
+        outCountBefore = this.outCountBefore,
+        outCountAfter = this.outCountAfter,
+        eventTimestamp = this.eventTimestamp,
+    )
+
+/**
+ * Game + GameTeam 목록을 ScoreboardResponse로 변환합니다.
+ */
+fun BoxScoreDto.toScoreboardResponse(): ScoreboardResponse =
+    ScoreboardResponse(
+        gameId = this.gameId,
+        status = com.nextup.core.domain.game.GameStatus.valueOf(this.gameStatus),
+        currentInning =
+            this.currentInning
+                .replace("회초", "")
+                .replace("회말", "")
+                .replace("경기 전", "0")
+                .toIntOrNull() ?: 0,
+        isTopInning = this.currentInning.contains("초"),
+        currentInningDisplay = this.currentInning,
+        homeTeam =
+            ScoreboardTeamResponse(
+                teamId = this.homeTeam.teamId,
+                teamName = this.homeTeam.teamName,
+                runs = this.homeTeam.runs,
+                hits = this.homeTeam.hits,
+                errors = this.homeTeam.errors,
+                inningScores = this.homeTeam.inningScores,
+            ),
+        awayTeam =
+            ScoreboardTeamResponse(
+                teamId = this.awayTeam.teamId,
+                teamName = this.awayTeam.teamName,
+                runs = this.awayTeam.runs,
+                hits = this.awayTeam.hits,
+                errors = this.awayTeam.errors,
+                inningScores = this.awayTeam.inningScores,
+            ),
+    )
+
+/**
+ * Game + GameTeam 목록으로 직접 ScoreboardResponse를 생성합니다.
+ */
+fun Game.toScoreboardResponse(gameTeams: List<GameTeam>): ScoreboardResponse {
+    val homeTeam = gameTeams.firstOrNull { it.homeAway == HomeAway.HOME }
+    val awayTeam = gameTeams.firstOrNull { it.homeAway == HomeAway.AWAY }
+
+    return ScoreboardResponse(
+        gameId = this.id,
+        status = this.status,
+        currentInning = this.currentInning,
+        isTopInning = this.isTopInning,
+        currentInningDisplay = this.currentInningDisplay,
+        homeTeam =
+            homeTeam?.let {
+                ScoreboardTeamResponse(
+                    teamId = it.team.id,
+                    teamName = it.team.name,
+                    runs = it.totalScore,
+                    hits = it.totalHits,
+                    errors = it.totalErrors,
+                    inningScores =
+                        (1..maxOf(this.totalInnings, this.currentInning))
+                            .map { inning -> it.getInningScore(inning) },
+                )
+            } ?: ScoreboardTeamResponse(0L, "", 0, 0, 0, emptyList()),
+        awayTeam =
+            awayTeam?.let {
+                ScoreboardTeamResponse(
+                    teamId = it.team.id,
+                    teamName = it.team.name,
+                    runs = it.totalScore,
+                    hits = it.totalHits,
+                    errors = it.totalErrors,
+                    inningScores =
+                        (1..maxOf(this.totalInnings, this.currentInning))
+                            .map { inning -> it.getInningScore(inning) },
+                )
+            } ?: ScoreboardTeamResponse(0L, "", 0, 0, 0, emptyList()),
+    )
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
@@ -16,7 +16,9 @@ import com.nextup.core.domain.league.League
 import com.nextup.core.domain.team.Team
 import com.nextup.core.service.game.BaseRunningRecordService
 import com.nextup.core.service.game.GameLifecycleService
+import com.nextup.core.service.game.GameStateQueryService
 import com.nextup.core.service.game.GameSubstitutionService
+import com.nextup.core.service.game.GameTimelineService
 import com.nextup.core.service.game.GameUndoService
 import com.nextup.core.service.game.PlateAppearanceRecordService
 import com.nextup.scorer.dto.game.BaseRunningRequestDto
@@ -45,6 +47,8 @@ class BaseRunningControllerTest {
     private lateinit var gameUndoService: GameUndoService
     private lateinit var baseRunningRecordService: BaseRunningRecordService
     private lateinit var gameSubstitutionService: GameSubstitutionService
+    private lateinit var gameStateQueryService: GameStateQueryService
+    private lateinit var gameTimelineService: GameTimelineService
     private lateinit var controller: GameScorerController
     private lateinit var objectMapper: ObjectMapper
 
@@ -55,6 +59,8 @@ class BaseRunningControllerTest {
         gameUndoService = mockk()
         baseRunningRecordService = mockk()
         gameSubstitutionService = mockk()
+        gameStateQueryService = mockk()
+        gameTimelineService = mockk()
         controller =
             GameScorerController(
                 gameLifecycleService,
@@ -62,6 +68,8 @@ class BaseRunningControllerTest {
                 gameUndoService,
                 baseRunningRecordService,
                 gameSubstitutionService,
+                gameStateQueryService,
+                gameTimelineService,
             )
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
         objectMapper = ObjectMapper().registerModule(JavaTimeModule())

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -13,17 +13,24 @@ import com.nextup.core.domain.game.GameEventType
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.GameState
 import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.team.Team
 import com.nextup.core.service.game.BaseRunningRecordService
 import com.nextup.core.service.game.GameLifecycleService
+import com.nextup.core.service.game.GameStateQueryService
 import com.nextup.core.service.game.GameSubstitutionService
+import com.nextup.core.service.game.GameTimelineService
 import com.nextup.core.service.game.GameUndoService
 import com.nextup.core.service.game.PlateAppearanceRecordService
 import com.nextup.core.service.game.dto.GameEndReason
+import com.nextup.core.service.game.dto.GameTimelineDto
 import com.nextup.core.service.game.dto.PlateAppearanceRecordResult
+import com.nextup.core.service.game.dto.TimelineEventDto
 import com.nextup.scorer.dto.game.GameEndRequestDto
 import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
 import com.nextup.scorer.dto.game.RunnerMovementDto
@@ -37,10 +44,12 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -53,6 +62,8 @@ class GameScorerControllerTest {
     private lateinit var gameUndoService: GameUndoService
     private lateinit var baseRunningRecordService: BaseRunningRecordService
     private lateinit var gameSubstitutionService: GameSubstitutionService
+    private lateinit var gameStateQueryService: GameStateQueryService
+    private lateinit var gameTimelineService: GameTimelineService
     private lateinit var controller: GameScorerController
     private lateinit var objectMapper: ObjectMapper
 
@@ -63,6 +74,8 @@ class GameScorerControllerTest {
         gameUndoService = mockk()
         baseRunningRecordService = mockk()
         gameSubstitutionService = mockk()
+        gameStateQueryService = mockk()
+        gameTimelineService = mockk()
         controller =
             GameScorerController(
                 gameLifecycleService,
@@ -70,6 +83,8 @@ class GameScorerControllerTest {
                 gameUndoService,
                 baseRunningRecordService,
                 gameSubstitutionService,
+                gameStateQueryService,
+                gameTimelineService,
             )
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
         objectMapper = ObjectMapper().registerModule(JavaTimeModule())
@@ -493,6 +508,266 @@ class GameScorerControllerTest {
 
             verify(exactly = 1) { gameSubstitutionService.substitutePlayer(gameId, any()) }
         }
+    }
+
+    // ===== GET 조회 엔드포인트 테스트 (H-16, M-25) =====
+
+    @Nested
+    @DisplayName("GET /api/scorer/games/{gameId}/state")
+    inner class GetGameState {
+
+        @Test
+        fun `현재 경기 상태를 조회한다`() {
+            // given
+            val gameId = 1L
+            val game =
+                createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 5
+                    isTopInning = false
+                    gameState.outs = 2
+                    gameState.balls = 3
+                    gameState.strikes = 1
+                    gameState.runnerOnFirstId = 10L
+                }
+
+            every { gameStateQueryService.getGame(gameId) } returns game
+            every { gameStateQueryService.getGameTeams(gameId) } returns game.gameTeams
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/games/$gameId/state"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.gameId").value(gameId))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.data.currentInning").value(5))
+                .andExpect(jsonPath("$.data.isTopInning").value(false))
+                .andExpect(jsonPath("$.data.currentInningDisplay").value("5회말"))
+                .andExpect(jsonPath("$.data.totalInnings").value(9))
+                .andExpect(jsonPath("$.data.gameState.outs").value(2))
+                .andExpect(jsonPath("$.data.gameState.balls").value(3))
+                .andExpect(jsonPath("$.data.gameState.strikes").value(1))
+                .andExpect(jsonPath("$.data.gameState.runnerOnFirstId").value(10))
+                .andExpect(jsonPath("$.data.homeTeam.teamName").value("홈팀"))
+                .andExpect(jsonPath("$.data.awayTeam.teamName").value("원정팀"))
+
+            verify(exactly = 1) { gameStateQueryService.getGame(gameId) }
+            verify(exactly = 1) { gameStateQueryService.getGameTeams(gameId) }
+        }
+
+        @Test
+        fun `경기 시작 전 상태를 조회한다`() {
+            // given
+            val gameId = 1L
+            val game = createGame(gameId, GameStatus.SCHEDULED)
+
+            every { gameStateQueryService.getGame(gameId) } returns game
+            every { gameStateQueryService.getGameTeams(gameId) } returns game.gameTeams
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/games/$gameId/state"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("SCHEDULED"))
+                .andExpect(jsonPath("$.data.currentInning").value(1))
+
+            verify(exactly = 1) { gameStateQueryService.getGame(gameId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/scorer/games/{gameId}/lineup")
+    inner class GetCurrentLineup {
+
+        @Test
+        fun `현재 라인업을 조회한다`() {
+            // given
+            val gameId = 1L
+            val game = createGame(gameId, GameStatus.IN_PROGRESS)
+            val homeTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
+            val awayTeam = game.gameTeams.first { it.homeAway == HomeAway.AWAY }
+
+            val homePlayer = createGamePlayer(1L, homeTeam, "홍길동", Position.STARTING_PITCHER, 1, 18)
+            val awayPlayer = createGamePlayer(2L, awayTeam, "김철수", Position.CATCHER, 4, 22)
+
+            every { gameStateQueryService.getCurrentLineup(gameId) } returns listOf(homePlayer, awayPlayer)
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/games/$gameId/lineup"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.gameId").value(gameId))
+                .andExpect(jsonPath("$.data.homeLineup").isArray)
+                .andExpect(jsonPath("$.data.homeLineup[0].playerName").value("홍길동"))
+                .andExpect(jsonPath("$.data.homeLineup[0].position").value("STARTING_PITCHER"))
+                .andExpect(jsonPath("$.data.homeLineup[0].battingOrder").value(1))
+                .andExpect(jsonPath("$.data.homeLineup[0].backNumber").value(18))
+                .andExpect(jsonPath("$.data.awayLineup").isArray)
+                .andExpect(jsonPath("$.data.awayLineup[0].playerName").value("김철수"))
+
+            verify(exactly = 1) { gameStateQueryService.getCurrentLineup(gameId) }
+        }
+
+        @Test
+        fun `라인업이 비어있을 때 빈 배열을 반환한다`() {
+            // given
+            val gameId = 1L
+            every { gameStateQueryService.getCurrentLineup(gameId) } returns emptyList()
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/games/$gameId/lineup"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.homeLineup").isEmpty)
+                .andExpect(jsonPath("$.data.awayLineup").isEmpty)
+
+            verify(exactly = 1) { gameStateQueryService.getCurrentLineup(gameId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/scorer/games/{gameId}/events")
+    inner class GetEventTimeline {
+
+        @Test
+        fun `이벤트 타임라인을 조회한다`() {
+            // given
+            val gameId = 1L
+            val timeline =
+                GameTimelineDto(
+                    gameId = gameId,
+                    events =
+                        listOf(
+                            TimelineEventDto(
+                                eventId = 1L,
+                                inning = 1,
+                                isTopInning = true,
+                                inningDisplay = "1회초",
+                                eventType = "타석 결과",
+                                description = "홍길동 안타",
+                                batterId = 10L,
+                                batterName = "홍길동",
+                                pitcherId = 20L,
+                                pitcherName = "김투수",
+                                plateAppearanceResult = "안타",
+                                runsScored = 0,
+                                outCountBefore = 0,
+                                outCountAfter = 0,
+                                eventTimestamp = Instant.parse("2025-04-15T05:00:00Z"),
+                            ),
+                        ),
+                    totalEvents = 1,
+                )
+
+            every { gameTimelineService.getTimeline(gameId, null, null) } returns timeline
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/games/$gameId/events"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.gameId").value(gameId))
+                .andExpect(jsonPath("$.data.totalEvents").value(1))
+                .andExpect(jsonPath("$.data.events[0].eventId").value(1))
+                .andExpect(jsonPath("$.data.events[0].inning").value(1))
+                .andExpect(jsonPath("$.data.events[0].isTopInning").value(true))
+                .andExpect(jsonPath("$.data.events[0].inningDisplay").value("1회초"))
+                .andExpect(jsonPath("$.data.events[0].description").value("홍길동 안타"))
+
+            verify(exactly = 1) { gameTimelineService.getTimeline(gameId, null, null) }
+        }
+
+        @Test
+        fun `이닝 범위를 지정하여 타임라인을 조회한다`() {
+            // given
+            val gameId = 1L
+            val timeline =
+                GameTimelineDto(
+                    gameId = gameId,
+                    events = emptyList(),
+                    totalEvents = 0,
+                )
+
+            every { gameTimelineService.getTimeline(gameId, 3, 5) } returns timeline
+
+            // when & then
+            mockMvc.perform(
+                get("/api/scorer/games/$gameId/events")
+                    .param("fromInning", "3")
+                    .param("toInning", "5"),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.totalEvents").value(0))
+                .andExpect(jsonPath("$.data.events").isEmpty)
+
+            verify(exactly = 1) { gameTimelineService.getTimeline(gameId, 3, 5) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/scorer/games/{gameId}/scoreboard")
+    inner class GetScoreboard {
+
+        @Test
+        fun `스코어보드를 조회한다`() {
+            // given
+            val gameId = 1L
+            val game =
+                createGame(gameId, GameStatus.IN_PROGRESS).apply {
+                    currentInning = 3
+                    isTopInning = true
+                }
+
+            every { gameStateQueryService.getGame(gameId) } returns game
+            every { gameStateQueryService.getGameTeams(gameId) } returns game.gameTeams
+
+            // when & then
+            mockMvc.perform(get("/api/scorer/games/$gameId/scoreboard"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.gameId").value(gameId))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.data.currentInning").value(3))
+                .andExpect(jsonPath("$.data.isTopInning").value(true))
+                .andExpect(jsonPath("$.data.currentInningDisplay").value("3회초"))
+                .andExpect(jsonPath("$.data.homeTeam.teamName").value("홈팀"))
+                .andExpect(jsonPath("$.data.homeTeam.runs").value(0))
+                .andExpect(jsonPath("$.data.homeTeam.hits").value(0))
+                .andExpect(jsonPath("$.data.homeTeam.errors").value(0))
+                .andExpect(jsonPath("$.data.awayTeam.teamName").value("원정팀"))
+                .andExpect(jsonPath("$.data.awayTeam.runs").value(0))
+
+            verify(exactly = 1) { gameStateQueryService.getGame(gameId) }
+            verify(exactly = 1) { gameStateQueryService.getGameTeams(gameId) }
+        }
+    }
+
+    // ===== 테스트 헬퍼 메서드 =====
+
+    private fun createGamePlayer(
+        id: Long,
+        gameTeam: GameTeam,
+        name: String,
+        position: Position,
+        battingOrder: Int,
+        backNumber: Int,
+    ): GamePlayer {
+        val player =
+            Player(
+                name = name,
+                primaryPosition = position,
+            ).apply {
+                val idField = Player::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, id * 100)
+            }
+        return GamePlayer(
+            gameTeam = gameTeam,
+            player = player,
+            position = position,
+            battingOrder = battingOrder,
+            backNumber = backNumber,
+            id = id,
+        )
     }
 
     private fun createAssociation(

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -741,6 +741,101 @@ class GameScorerControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/lock")
+    inner class LockGame {
+
+        @Test
+        fun `경기를 잠금한다`() {
+            // given
+            val gameId = 1L
+            val scorerId = 100L
+            val game = createGame(gameId, GameStatus.SCHEDULED)
+            game.lockForScorer(scorerId)
+            every { gameLifecycleService.lockGame(gameId, scorerId) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/lock")
+                    .param("scorerId", scorerId.toString()),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(gameId))
+
+            verify(exactly = 1) { gameLifecycleService.lockGame(gameId, scorerId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/unlock")
+    inner class UnlockGame {
+
+        @Test
+        fun `경기 잠금을 해제한다`() {
+            // given
+            val gameId = 1L
+            val scorerId = 100L
+            val game = createGame(gameId, GameStatus.SCHEDULED)
+            every { gameLifecycleService.unlockGame(gameId, scorerId) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/unlock")
+                    .param("scorerId", scorerId.toString()),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(gameId))
+
+            verify(exactly = 1) { gameLifecycleService.unlockGame(gameId, scorerId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/forfeit")
+    inner class ForfeitGame {
+
+        @Test
+        fun `경기를 몰수 처리한다`() {
+            // given
+            val gameId = 1L
+            val game = createGame(gameId, GameStatus.FORFEITED)
+            every {
+                gameLifecycleService.forfeitGame(
+                    gameId = gameId,
+                    winnerTeamId = 1L,
+                    reason = "선수 부족",
+                )
+            } returns game
+
+            val request =
+                mapOf(
+                    "winnerTeamId" to 1L,
+                    "reason" to "선수 부족",
+                )
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/forfeit")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(gameId))
+                .andExpect(jsonPath("$.data.status").value("FORFEITED"))
+
+            verify(exactly = 1) {
+                gameLifecycleService.forfeitGame(
+                    gameId = gameId,
+                    winnerTeamId = 1L,
+                    reason = "선수 부족",
+                )
+            }
+        }
+    }
+
     // ===== 테스트 헬퍼 메서드 =====
 
     private fun createGamePlayer(


### PR DESCRIPTION
## Summary

>- close #334

### 변경 사항
- **H-16 해결**: `GameScorerController`에 GET 조회 엔드포인트 4개 추가 (기록원 재접속 시 현재 상태 복원용)
- **M-25 해결**: WebSocket 단절 시 스코어보드 REST fallback 엔드포인트 제공

### 추가된 API
| Method | Endpoint | 설명 |
|--------|----------|------|
| GET | `/api/scorer/games/{gameId}/state` | 현재 경기 상태 (이닝, 아웃, 주자 등) |
| GET | `/api/scorer/games/{gameId}/lineup` | 현재 라인업 (홈/원정 분리) |
| GET | `/api/scorer/games/{gameId}/events` | 이벤트 타임라인 (fromInning/toInning 필터 지원) |
| GET | `/api/scorer/games/{gameId}/scoreboard` | 스코어보드 REST fallback |

### 신규 파일
- `nextup-core/.../GameStateQueryService.kt` - 경기 상태 조회 서비스 인터페이스 (Port)
- `nextup-infrastructure/.../GameStateQueryServiceImpl.kt` - 서비스 구현체
- `nextup-scorer/.../GameStateQueryResponse.kt` - 응답 DTO + 매퍼 함수

### 아키텍처
- Hexagonal Architecture 준수: Core(Port) -> Infrastructure(Impl) -> Scorer(Controller/DTO)
- Zero Entity Leak: 모든 응답은 Response DTO로 변환
- ApiResponse 래핑 적용
- 기존 `GameTimelineService` 재사용 (이벤트 타임라인)

## Tasks
- [x] GameStateQueryService 인터페이스 정의 (Core)
- [x] GameStateQueryServiceImpl 구현 (Infrastructure)
- [x] Response DTO 및 매퍼 함수 추가
- [x] GET 엔드포인트 4개 추가
- [x] 단위 테스트 추가
- [x] ktlint 통과
- [x] 전체 빌드 성공

## To Reviewer
- `GameTimelineService`는 기존 서비스를 재사용하여 이벤트 타임라인 조회에 활용합니다
- `GameStateQueryService`는 새로 추가된 Port로, 경기/라인업/팀 조회를 담당합니다
- 스코어보드 REST fallback은 WebSocket 단절 시 클라이언트가 HTTP로 폴백할 수 있도록 합니다
- 이 PR에는 #332, #333 커밋도 함께 포함되어 있습니다