### PR TITLE
fix(#332): 기록원 경기 독점 잠금 메커니즘 구현

### DIFF
--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
@@ -72,3 +72,25 @@ class NoEventToUndoException :
         "NO_EVENT_TO_UNDO",
         "되돌릴 이벤트가 없습니다",
     )
+
+/**
+ * 다른 기록원이 이미 경기를 잠금한 상태에서 기록을 시도할 때 발생하는 예외
+ */
+class GameAlreadyLockedException(
+    gameId: Long,
+    lockedByScorerId: Long,
+) : InvalidStateException(
+        "GAME_ALREADY_LOCKED",
+        "Game $gameId is already locked by scorer $lockedByScorerId",
+    )
+
+/**
+ * 잠금하지 않은 기록원이 경기를 해제하려 할 때 발생하는 예외
+ */
+class GameNotLockedByCurrentScorerException(
+    gameId: Long,
+    scorerId: Long,
+) : InvalidStateException(
+        "GAME_NOT_LOCKED_BY_SCORER",
+        "Game $gameId is not locked by scorer $scorerId",
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -1,5 +1,7 @@
 package com.nextup.core.domain.game
 
+import com.nextup.common.exception.GameAlreadyLockedException
+import com.nextup.common.exception.GameNotLockedByCurrentScorerException
 import com.nextup.core.common.BaseTimeEntity
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.team.Team
@@ -56,6 +58,8 @@ class Game private constructor(
     var forfeitReason: String? = null,
     @Embedded
     var gameState: GameState = GameState(),
+    @Column(name = "scorer_id")
+    var scorerId: Long? = null,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
@@ -78,6 +82,55 @@ class Game private constructor(
         startedAt = LocalDateTime.now()
         gameState.resetForNewInning()
     }
+
+    /**
+     * 기록원이 경기를 독점 잠금합니다.
+     *
+     * 이미 다른 기록원이 잠금한 경우 [GameAlreadyLockedException]이 발생합니다.
+     * 동일 기록원이 중복 잠금 시도하면 멱등하게 무시합니다.
+     *
+     * @param scorerId 잠금을 요청하는 기록원 ID
+     * @throws GameAlreadyLockedException 다른 기록원이 이미 잠금한 경우
+     */
+    fun lockForScorer(scorerId: Long) {
+        if (this.scorerId != null && this.scorerId != scorerId) {
+            throw GameAlreadyLockedException(id, this.scorerId!!)
+        }
+        this.scorerId = scorerId
+    }
+
+    /**
+     * 기록원의 경기 잠금을 해제합니다.
+     *
+     * 잠금한 기록원 본인만 해제할 수 있습니다.
+     *
+     * @param scorerId 잠금 해제를 요청하는 기록원 ID
+     * @throws GameNotLockedByCurrentScorerException 해당 기록원이 잠금하지 않은 경우
+     */
+    fun unlockScorer(scorerId: Long) {
+        if (this.scorerId == null || this.scorerId != scorerId) {
+            throw GameNotLockedByCurrentScorerException(id, scorerId)
+        }
+        this.scorerId = null
+    }
+
+    /**
+     * 강제로 기록원 잠금을 해제합니다 (관리자용).
+     */
+    fun forceUnlockScorer() {
+        this.scorerId = null
+    }
+
+    /**
+     * 현재 기록원이 경기를 잠금하고 있는지 확인합니다.
+     */
+    fun isLockedByScorer(scorerId: Long): Boolean = this.scorerId == scorerId
+
+    /**
+     * 경기가 잠금 상태인지 확인합니다.
+     */
+    val isLocked: Boolean
+        get() = scorerId != null
 
     /**
      * 다음 이닝으로 진행합니다.
@@ -414,6 +467,7 @@ class Game private constructor(
             note: String? = null,
             forfeitReason: String? = null,
             gameState: GameState = GameState(),
+            scorerId: Long? = null,
             id: Long = 0L,
         ): Game {
             val game =
@@ -433,6 +487,7 @@ class Game private constructor(
                     note = note,
                     forfeitReason = forfeitReason,
                     gameState = gameState,
+                    scorerId = scorerId,
                     id = id,
                 )
             game._gameTeams.add(GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME, id = id * 100 + 1))

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
@@ -28,4 +28,28 @@ interface GameLifecycleService {
         gameId: Long,
         reason: String? = null,
     ): Game
+
+    /**
+     * 기록원이 경기를 독점 잠금합니다.
+     *
+     * @param gameId 경기 ID
+     * @param scorerId 기록원 ID
+     * @return 잠금된 Game
+     */
+    fun lockGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game
+
+    /**
+     * 기록원의 경기 잠금을 해제합니다.
+     *
+     * @param gameId 경기 ID
+     * @param scorerId 기록원 ID
+     * @return 잠금 해제된 Game
+     */
+    fun unlockGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -1,5 +1,7 @@
 package com.nextup.core.domain.game
 
+import com.nextup.common.exception.GameAlreadyLockedException
+import com.nextup.common.exception.GameNotLockedByCurrentScorerException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
@@ -1250,6 +1252,128 @@ class GameTest {
             assertThat(game.currentInning).isEqualTo(5)
             assertThat(game.isTopInning).isFalse()
             assertThat(game.gameState.outs).isEqualTo(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("기록원 독점 잠금")
+    inner class ScorerLock {
+        @Test
+        fun `기록원이 경기를 잠금할 수 있다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+
+            // when
+            game.lockForScorer(100L)
+
+            // then
+            assertThat(game.scorerId).isEqualTo(100L)
+            assertThat(game.isLocked).isTrue()
+            assertThat(game.isLockedByScorer(100L)).isTrue()
+        }
+
+        @Test
+        fun `동일 기록원이 중복 잠금 시도하면 멱등하게 처리된다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when
+            game.lockForScorer(100L)
+
+            // then
+            assertThat(game.scorerId).isEqualTo(100L)
+        }
+
+        @Test
+        fun `다른 기록원이 잠금된 경기를 잠금 시도하면 예외가 발생한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when & then
+            assertThatThrownBy { game.lockForScorer(200L) }
+                .isInstanceOf(GameAlreadyLockedException::class.java)
+                .hasMessageContaining("already locked by scorer 100")
+        }
+
+        @Test
+        fun `잠금한 기록원이 잠금을 해제할 수 있다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when
+            game.unlockScorer(100L)
+
+            // then
+            assertThat(game.scorerId).isNull()
+            assertThat(game.isLocked).isFalse()
+        }
+
+        @Test
+        fun `잠금하지 않은 기록원이 해제 시도하면 예외가 발생한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when & then
+            assertThatThrownBy { game.unlockScorer(200L) }
+                .isInstanceOf(GameNotLockedByCurrentScorerException::class.java)
+                .hasMessageContaining("not locked by scorer 200")
+        }
+
+        @Test
+        fun `잠금이 없는 상태에서 해제 시도하면 예외가 발생한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+
+            // when & then
+            assertThatThrownBy { game.unlockScorer(100L) }
+                .isInstanceOf(GameNotLockedByCurrentScorerException::class.java)
+        }
+
+        @Test
+        fun `강제 잠금 해제는 어떤 상태에서든 가능하다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when
+            game.forceUnlockScorer()
+
+            // then
+            assertThat(game.scorerId).isNull()
+            assertThat(game.isLocked).isFalse()
+        }
+
+        @Test
+        fun `잠금되지 않은 경기에 대해 isLockedByScorer는 false를 반환한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+
+            // then
+            assertThat(game.isLockedByScorer(100L)).isFalse()
+        }
+
+        @Test
+        fun `createForTest에서 scorerId를 지정할 수 있다`() {
+            // given
+            val homeTeam = createTeam("홈팀", id = 1L)
+            val awayTeam = createTeam("원정팀", city = "부산", id = 2L)
+
+            // when
+            val game =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scorerId = 100L,
+                )
+
+            // then
+            assertThat(game.scorerId).isEqualTo(100L)
+            assertThat(game.isLocked).isTrue()
         }
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
@@ -197,6 +197,26 @@ class GameLifecycleServiceImpl(
         )
     }
 
+    @Transactional
+    override fun lockGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game {
+        val game = findGame(gameId)
+        game.lockForScorer(scorerId)
+        return gameRepository.save(game)
+    }
+
+    @Transactional
+    override fun unlockGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game {
+        val game = findGame(gameId)
+        game.unlockScorer(scorerId)
+        return gameRepository.save(game)
+    }
+
     private fun findGame(id: Long): Game =
         gameRepository.findByIdOrNull(id)
             ?: throw GameNotFoundException(id)

--- a/nextup-infrastructure/src/main/resources/db/migration/V037__add_scorer_id_to_games.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V037__add_scorer_id_to_games.sql
@@ -1,0 +1,4 @@
+-- #332: 기록원 경기 독점 잠금 메커니즘
+ALTER TABLE games ADD COLUMN scorer_id BIGINT;
+
+CREATE INDEX idx_games_scorer_id ON games(scorer_id) WHERE scorer_id IS NOT NULL;

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -3,36 +3,50 @@ package com.nextup.scorer.controller.game
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.game.BaseRunningRecordService
 import com.nextup.core.service.game.GameLifecycleService
+import com.nextup.core.service.game.GameStateQueryService
 import com.nextup.core.service.game.GameSubstitutionService
+import com.nextup.core.service.game.GameTimelineService
 import com.nextup.core.service.game.GameUndoService
 import com.nextup.core.service.game.PlateAppearanceRecordService
 import com.nextup.scorer.dto.game.BaseRunningRequestDto
 import com.nextup.scorer.dto.game.BaseRunningResponse
 import com.nextup.scorer.dto.game.CancelGameRequestDto
+import com.nextup.scorer.dto.game.CurrentGameStateResponse
+import com.nextup.scorer.dto.game.CurrentLineupResponse
+import com.nextup.scorer.dto.game.EventTimelineResponse
 import com.nextup.scorer.dto.game.ForfeitRequestDto
 import com.nextup.scorer.dto.game.GameEndRequestDto
 import com.nextup.scorer.dto.game.GameResponse
 import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
+import com.nextup.scorer.dto.game.ScoreboardResponse
 import com.nextup.scorer.dto.game.SubstitutionRequestDto
 import com.nextup.scorer.dto.game.SubstitutionResponse
 import com.nextup.scorer.dto.game.UndoResponse
 import com.nextup.scorer.dto.game.toBaseRunningResponse
+import com.nextup.scorer.dto.game.toCurrentGameStateResponse
+import com.nextup.scorer.dto.game.toCurrentLineupResponse
 import com.nextup.scorer.dto.game.toDomain
+import com.nextup.scorer.dto.game.toEventTimelineResponse
 import com.nextup.scorer.dto.game.toResponse
+import com.nextup.scorer.dto.game.toScoreboardResponse
 import com.nextup.scorer.dto.game.toSubstitutionResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 /**
  * 기록원 전용 경기 기록 컨트롤러
  *
- * 실시간 경기 기록 입력을 위한 API를 제공합니다.
+ * 실시간 경기 기록 입력 및 경기 상태 조회를 위한 API를 제공합니다.
+ * GET 엔드포인트는 기록원 재접속 시 현재 상태를 복원하거나,
+ * WebSocket 단절 시 REST fallback으로 활용됩니다.
  */
 @RestController
 @RequestMapping("/api/scorer/games")
@@ -42,7 +56,105 @@ class GameScorerController(
     private val gameUndoService: GameUndoService,
     private val baseRunningRecordService: BaseRunningRecordService,
     private val gameSubstitutionService: GameSubstitutionService,
+    private val gameStateQueryService: GameStateQueryService,
+    private val gameTimelineService: GameTimelineService,
 ) {
+    // ===== GET 조회 엔드포인트 (H-16, M-25) =====
+
+    /**
+     * 현재 경기 상태를 조회합니다.
+     *
+     * 기록원 재접속 시 이닝, 아웃, 주자, 볼카운트 등 현재 경기 상태를 복원합니다.
+     */
+    @GetMapping("/{gameId}/state")
+    @ResponseStatus(HttpStatus.OK)
+    fun getGameState(
+        @PathVariable gameId: Long,
+    ): ApiResponse<CurrentGameStateResponse> {
+        val game = gameStateQueryService.getGame(gameId)
+        val gameTeams = gameStateQueryService.getGameTeams(gameId)
+        return ApiResponse.success(game.toCurrentGameStateResponse(gameTeams))
+    }
+
+    /**
+     * 현재 라인업을 조회합니다.
+     *
+     * 경기에 현재 출전 중인 선수 목록을 홈/원정으로 분리하여 반환합니다.
+     */
+    @GetMapping("/{gameId}/lineup")
+    @ResponseStatus(HttpStatus.OK)
+    fun getCurrentLineup(
+        @PathVariable gameId: Long,
+    ): ApiResponse<CurrentLineupResponse> {
+        val players = gameStateQueryService.getCurrentLineup(gameId)
+        return ApiResponse.success(toCurrentLineupResponse(gameId, players))
+    }
+
+    /**
+     * 이벤트 타임라인을 조회합니다.
+     *
+     * 경기의 모든 이벤트를 시간 순서대로 반환합니다.
+     * 이닝 범위를 지정하여 부분 조회할 수 있습니다.
+     */
+    @GetMapping("/{gameId}/events")
+    @ResponseStatus(HttpStatus.OK)
+    fun getEventTimeline(
+        @PathVariable gameId: Long,
+        @RequestParam(required = false) fromInning: Int?,
+        @RequestParam(required = false) toInning: Int?,
+    ): ApiResponse<EventTimelineResponse> {
+        val timeline = gameTimelineService.getTimeline(gameId, fromInning, toInning)
+        return ApiResponse.success(timeline.toEventTimelineResponse())
+    }
+
+    /**
+     * 스코어보드를 조회합니다 (REST fallback).
+     *
+     * WebSocket 단절 시 현재 스코어보드를 REST로 조회할 수 있습니다.
+     */
+    @GetMapping("/{gameId}/scoreboard")
+    @ResponseStatus(HttpStatus.OK)
+    fun getScoreboard(
+        @PathVariable gameId: Long,
+    ): ApiResponse<ScoreboardResponse> {
+        val game = gameStateQueryService.getGame(gameId)
+        val gameTeams = gameStateQueryService.getGameTeams(gameId)
+        return ApiResponse.success(game.toScoreboardResponse(gameTeams))
+    }
+
+    // ===== POST 기록 엔드포인트 =====
+
+    /**
+     * 기록원이 경기를 독점 잠금합니다.
+     *
+     * 다른 기록원이 이미 잠금한 경우 409 Conflict를 반환합니다.
+     * 동일 기록원의 중복 잠금 시도는 멱등하게 처리됩니다.
+     */
+    @PostMapping("/{gameId}/lock")
+    @ResponseStatus(HttpStatus.OK)
+    fun lockGame(
+        @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
+    ): ApiResponse<GameResponse> {
+        val game = gameLifecycleService.lockGame(gameId, scorerId)
+        return ApiResponse.success(game.toResponse())
+    }
+
+    /**
+     * 기록원의 경기 잠금을 해제합니다.
+     *
+     * 잠금한 기록원 본인만 해제할 수 있습니다.
+     */
+    @PostMapping("/{gameId}/unlock")
+    @ResponseStatus(HttpStatus.OK)
+    fun unlockGame(
+        @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
+    ): ApiResponse<GameResponse> {
+        val game = gameLifecycleService.unlockGame(gameId, scorerId)
+        return ApiResponse.success(game.toResponse())
+    }
+
     /**
      * 경기를 시작합니다.
      */

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameMapper.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameMapper.kt
@@ -20,6 +20,7 @@ fun Game.toResponse(warnings: List<String> = emptyList()): GameResponse {
         scheduledAt = this.scheduledAt,
         startedAt = this.startedAt,
         endedAt = this.endedAt,
+        scorerId = this.scorerId,
         warnings = warnings,
     )
 }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/GameResponse.kt
@@ -17,6 +17,7 @@ data class GameResponse(
     val scheduledAt: LocalDateTime,
     val startedAt: LocalDateTime?,
     val endedAt: LocalDateTime?,
+    val scorerId: Long? = null,
     val warnings: List<String> = emptyList(),
 )
 


### PR DESCRIPTION
## Summary

>- close #332

**PR #356에 #332 변경사항이 이미 포함되어 있어 중복 PR로 닫습니다.**

See: #356 (feat/334-scorer-get-apis) — #332, #333, #334 통합 PR