### PR TITLE
fix(#337): 예약 취소 시 StadiumSlot 상태 AVAILABLE 복원

### DIFF
--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingControllerTest.kt
@@ -125,6 +125,7 @@ class BookingControllerTest {
             // given
             val stadium = createStadium(1L, "잠실 야구장")
             val slot = createSlot(1L, stadium)
+            slot.book()
             val booking = createBooking(1L, slot, 100L, 200L)
             booking.cancel()
             every { stadiumService.cancelBooking(1L) } returns booking

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/StadiumBooking.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stadium/StadiumBooking.kt
@@ -56,6 +56,8 @@ class StadiumBooking private constructor(
 
     /**
      * 예약을 취소합니다.
+     *
+     * 예약 상태를 CANCELLED로 변경하고, 연결된 슬롯 상태를 AVAILABLE로 복원합니다.
      */
     fun cancel() {
         if (status != BookingStatus.CONFIRMED) {
@@ -65,6 +67,7 @@ class StadiumBooking private constructor(
             )
         }
         this.status = BookingStatus.CANCELLED
+        this.slot.cancel()
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/StadiumService.kt
@@ -129,11 +129,8 @@ class StadiumService(
             bookingRepository.findByIdOrNull(bookingId)
                 ?: throw BookingNotFoundException(bookingId)
 
-        // 예약 취소 (비즈니스 로직은 Entity에 위임)
+        // 예약 취소 (슬롯 상태 복원 포함 - 비즈니스 로직은 Entity에 위임)
         booking.cancel()
-
-        // 슬롯 상태도 원복
-        booking.slot.cancel()
 
         return booking
     }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stadium/StadiumBookingTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stadium/StadiumBookingTest.kt
@@ -3,11 +3,15 @@ package com.nextup.core.domain.stadium
 import com.nextup.common.exception.InvalidStateException
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalTime
 
 @DisplayName("StadiumBooking")
 class StadiumBookingTest {
@@ -71,7 +75,7 @@ class StadiumBookingTest {
     @DisplayName("cancel")
     inner class Cancel {
         @Test
-        fun `should cancel confirmed booking`() {
+        fun `should cancel confirmed booking and call slot cancel`() {
             // given
             val slot = mockk<StadiumSlot>(relaxed = true)
             val booking =
@@ -86,6 +90,37 @@ class StadiumBookingTest {
 
             // then
             assertThat(booking.status).isEqualTo(BookingStatus.CANCELLED)
+            verify(exactly = 1) { slot.cancel() }
+        }
+
+        @Test
+        fun `should restore slot status to AVAILABLE when booking is cancelled`() {
+            // given
+            val stadium = mockk<Stadium>(relaxed = true)
+            val slot =
+                StadiumSlot.create(
+                    stadium = stadium,
+                    date = LocalDate.of(2024, 12, 25),
+                    startTime = LocalTime.of(10, 0),
+                    endTime = LocalTime.of(12, 0),
+                    price = BigDecimal("50000"),
+                )
+            slot.book()
+            assertThat(slot.status).isEqualTo(SlotStatus.BOOKED)
+
+            val booking =
+                StadiumBooking.create(
+                    slot = slot,
+                    teamId = 100L,
+                    bookedBy = 200L,
+                )
+
+            // when
+            booking.cancel()
+
+            // then
+            assertThat(booking.status).isEqualTo(BookingStatus.CANCELLED)
+            assertThat(slot.status).isEqualTo(SlotStatus.AVAILABLE)
         }
 
         @Test


### PR DESCRIPTION
## Summary

>- close #337

`StadiumBooking.cancel()`이 booking 상태만 `CANCELLED`로 변경하고, 연결된 `StadiumSlot`의 상태를 `BOOKED` → `AVAILABLE`로 되돌리지 않던 버그를 수정합니다.

- **Rich Domain Model 원칙** 준수: 슬롯 상태 복원 로직을 Service 계층이 아닌 Entity(`StadiumBooking.cancel()`) 내부에 캡슐화
- `StadiumService.cancelBooking()`의 중복 `booking.slot.cancel()` 호출을 제거하여 Entity에 위임

## Tasks

- [x] `StadiumBooking.cancel()`에서 `this.slot.cancel()` 호출 추가
- [x] `StadiumService.cancelBooking()`의 중복 slot.cancel() 호출 제거
- [x] 슬롯 상태 복원 검증 단위 테스트 추가 (mockk verify + 실제 StadiumSlot 통합 테스트)
- [x] ktlintFormat 통과
- [x] nextup-core 모듈 전체 테스트 통과 (2320 tests)

## To Reviewer

- `StadiumSlot`에는 이미 `cancel()` 메서드가 존재하여 `BOOKED` → `AVAILABLE` 상태 전환을 수행합니다. 이번 변경은 `StadiumBooking.cancel()`에서 이를 호출하도록 연결한 것입니다.
- 기존 `StadiumService.cancelBooking()`에서 `booking.cancel()` 이후 `booking.slot.cancel()`을 별도로 호출하고 있었으나, Rich Domain Model 원칙에 따라 Entity 내부로 이동하고 Service의 중복 호출을 제거했습니다.

## Screenshot

N/A (백엔드 버그 수정)