### PR TITLE
fix(#338): 팀 해산 시 진행 중 경기 몰수승 연쇄 처리 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionPlayerRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionPlayerRepositoryPort.kt
@@ -55,4 +55,10 @@ interface CompetitionPlayerRepositoryPort {
         teamId: Long,
         status: CompetitionPlayerStatus,
     ): List<CompetitionPlayer>
+
+    /**
+     * 팀이 참가 중인(WITHDRAWN이 아닌) 대회 ID 목록을 조회합니다.
+     * 팀 해산 시 해당 팀이 참가 중인 대회들을 식별하는 데 사용합니다.
+     */
+    fun findActiveCompetitionIdsByTeamId(teamId: Long): Set<Long>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListener.kt
@@ -2,17 +2,22 @@ package com.nextup.infrastructure.listener
 
 import com.nextup.core.domain.attendance.PollStatus
 import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.election.ElectionStatus
 import com.nextup.core.domain.event.TeamDisbandedEvent
 import com.nextup.core.domain.event.TeamMemberKickedEvent
 import com.nextup.core.domain.event.TeamMemberLeftEvent
+import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.LineupSubmissionStatus
 import com.nextup.core.domain.stadium.BookingStatus
 import com.nextup.core.domain.team.JoinRequestStatus
 import com.nextup.core.port.attendance.ActivityScoreRepositoryPort
 import com.nextup.core.port.attendance.AttendancePollRepositoryPort
+import com.nextup.core.port.repository.BracketEntryRepositoryPort
 import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
+import com.nextup.core.port.repository.CompetitionRepositoryPort
 import com.nextup.core.port.repository.ElectionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.LineupEntryRepositoryPort
 import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
 import com.nextup.core.port.repository.StadiumBookingRepositoryPort
@@ -35,6 +40,9 @@ class TeamMemberEventListener(
     private val lineupSubmissionRepository: LineupSubmissionRepositoryPort,
     private val lineupEntryRepository: LineupEntryRepositoryPort,
     private val competitionPlayerRepository: CompetitionPlayerRepositoryPort,
+    private val competitionRepository: CompetitionRepositoryPort,
+    private val gameRepository: GameRepositoryPort,
+    private val bracketEntryRepository: BracketEntryRepositoryPort,
     private val stadiumBookingRepository: StadiumBookingRepositoryPort,
     private val attendancePollRepository: AttendancePollRepositoryPort,
     private val electionRepository: ElectionRepositoryPort,
@@ -74,7 +82,7 @@ class TeamMemberEventListener(
     /**
      * 팀 해산 이벤트를 처리합니다.
      *
-     * - 진행중 CompetitionPlayer → WITHDRAWN 처리
+     * - 진행중 대회에서 팀 탈퇴: CompetitionPlayer WITHDRAWN + 경기 몰수승 + 대진표 부전승 처리
      * - CONFIRMED 상태의 StadiumBooking → CANCELLED
      * - OPEN 상태의 AttendancePoll → CLOSED
      * - PENDING/IN_PROGRESS 상태의 Election → CANCELLED
@@ -85,7 +93,7 @@ class TeamMemberEventListener(
     fun handleTeamDisbanded(event: TeamDisbandedEvent) {
         logger.info("팀 해산 연쇄 처리 - teamId={}", event.teamId)
 
-        withdrawCompetitionPlayers(event.teamId)
+        withdrawFromCompetitions(event.teamId)
         cancelStadiumBookings(event.teamId)
         closeAttendancePolls(event.teamId)
         cancelElections(event.teamId)
@@ -143,15 +151,105 @@ class TeamMemberEventListener(
     }
 
     /**
-     * 팀의 활성 CompetitionPlayer를 WITHDRAWN으로 처리합니다.
+     * 팀이 참가 중인 대회에서 탈퇴 처리합니다.
+     *
+     * 1. CompetitionPlayer를 WITHDRAWN으로 처리
+     * 2. 진행 중 대회의 잔여 경기(SCHEDULED/IN_PROGRESS/POSTPONED)에 몰수승 처리
+     * 3. 진행 중 대회의 대진표(BracketEntry) 부전승 처리
      */
-    private fun withdrawCompetitionPlayers(teamId: Long) {
+    private fun withdrawFromCompetitions(teamId: Long) {
+        // 팀이 참가 중인 대회 ID 목록 조회 (WITHDRAWN 제외)
+        val activeCompetitionIds =
+            competitionPlayerRepository.findActiveCompetitionIdsByTeamId(teamId)
+
+        if (activeCompetitionIds.isEmpty()) {
+            logger.info("팀이 참가 중인 대회 없음 - teamId={}", teamId)
+            return
+        }
+
+        // CompetitionPlayer WITHDRAWN 처리
         val activePlayers =
             competitionPlayerRepository.findByTeamIdAndStatus(teamId, CompetitionPlayerStatus.ACTIVE)
         activePlayers.forEach { cp ->
             cp.withdraw()
             competitionPlayerRepository.save(cp)
             logger.info("CompetitionPlayer WITHDRAWN 처리 - competitionPlayerId={}", cp.id)
+        }
+
+        // 각 대회에 대해 몰수승/부전승 처리
+        activeCompetitionIds.forEach { competitionId ->
+            val competition = competitionRepository.findByIdOrNull(competitionId)
+            if (competition != null && competition.status == CompetitionStatus.IN_PROGRESS) {
+                forfeitGamesForTeam(competitionId, teamId)
+                processBracketEntriesForTeam(competitionId, teamId)
+            }
+        }
+    }
+
+    /**
+     * 대회에서 해당 팀의 잔여 경기를 몰수승 처리합니다.
+     */
+    private fun forfeitGamesForTeam(
+        competitionId: Long,
+        teamId: Long,
+    ) {
+        val games = gameRepository.findByCompetitionId(competitionId)
+        games.forEach { game ->
+            if (game.status == GameStatus.SCHEDULED ||
+                game.status == GameStatus.IN_PROGRESS ||
+                game.status == GameStatus.POSTPONED
+            ) {
+                val gameTeams = game.gameTeams
+                val isTeamInGame = gameTeams.any { it.team.id == teamId }
+                if (isTeamInGame) {
+                    val opponentTeam = gameTeams.first { it.team.id != teamId }
+                    game.forfeit(
+                        winnerTeamId = opponentTeam.team.id,
+                        reason = "팀 해산으로 인한 몰수패",
+                        gameTeams = gameTeams,
+                    )
+                    gameRepository.save(game)
+                    logger.info(
+                        "경기 몰수승 처리 - gameId={}, competitionId={}, winnerTeamId={}",
+                        game.id,
+                        competitionId,
+                        opponentTeam.team.id,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * 대회에서 해당 팀의 대진표 엔트리를 부전승 처리합니다.
+     */
+    private fun processBracketEntriesForTeam(
+        competitionId: Long,
+        teamId: Long,
+    ) {
+        val bracketEntries = bracketEntryRepository.findByCompetitionId(competitionId)
+        bracketEntries.forEach { entry ->
+            if (!entry.isCompleted()) {
+                val isTeam1 = entry.team1?.id == teamId
+                val isTeam2 = entry.team2?.id == teamId
+                if (isTeam1 && entry.team2 != null) {
+                    entry.recordWinner(entry.team2!!)
+                    bracketEntryRepository.save(entry)
+                    logger.info(
+                        "대진표 부전승 처리 - bracketEntryId={}, winnerTeamId={}",
+                        entry.id,
+                        entry.team2!!.id,
+                    )
+                } else if (isTeam2 && entry.team1 != null) {
+                    entry.recordWinner(entry.team1!!)
+                    bracketEntryRepository.save(entry)
+                    logger.info(
+                        "대진표 부전승 처리 - bracketEntryId={}, winnerTeamId={}",
+                        entry.id,
+                        entry.team1!!.id,
+                    )
+                }
+            }
         }
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerJpaRepository.kt
@@ -41,4 +41,10 @@ interface CompetitionPlayerJpaRepository : JpaRepository<CompetitionPlayer, Long
         teamId: Long,
         status: CompetitionPlayerStatus,
     ): List<CompetitionPlayer>
+
+    @Query(
+        "SELECT DISTINCT cp.competition.id FROM CompetitionPlayer cp " +
+            "WHERE cp.team.id = :teamId AND cp.status <> 'WITHDRAWN'",
+    )
+    fun findActiveCompetitionIdsByTeamId(teamId: Long): Set<Long>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapter.kt
@@ -50,4 +50,7 @@ class CompetitionPlayerRepositoryAdapter(
         teamId: Long,
         status: CompetitionPlayerStatus,
     ): List<CompetitionPlayer> = jpaRepository.findByTeamIdAndStatus(teamId, status)
+
+    override fun findActiveCompetitionIdsByTeamId(teamId: Long): Set<Long> =
+        jpaRepository.findActiveCompetitionIdsByTeamId(teamId)
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
@@ -3,6 +3,7 @@ package com.nextup.infrastructure.listener
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.attendance.AttendancePoll
 import com.nextup.core.domain.attendance.PollStatus
+import com.nextup.core.domain.competition.BracketEntry
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionPlayer
 import com.nextup.core.domain.competition.CompetitionPlayerStatus
@@ -838,6 +839,384 @@ class TeamMemberEventListenerTest {
             verify(exactly = 1) { competitionPlayerRepository.save(any()) }
             verify(exactly = 0) { gameRepository.findByCompetitionId(any()) }
             verify(exactly = 0) { gameRepository.save(any()) }
+        }
+
+        @Test
+        @DisplayName("팀 해산 시 대진표에서 team1이 해산팀이면 team2가 부전승 처리된다")
+        fun `should give walkover win to team2 when team1 is disbanded team in bracket`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            val opponentTeam =
+                Team(league = league, name = "라이언즈", city = "부산", foundedYear = 2016)
+            setFieldId(opponentTeam, Team::class.java, 2L)
+
+            val competition =
+                Competition(
+                    league = league,
+                    name = "2026 토너먼트",
+                    year = 2026,
+                    season = 1,
+                    type = CompetitionType.TOURNAMENT,
+                    startDate = LocalDate.of(2026, 3, 1),
+                )
+            setFieldId(competition, Competition::class.java, 100L)
+            competition.start()
+
+            // team1이 해산팀(id=1L), team2가 상대팀
+            val bracketEntry =
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = 1,
+                    team1 = team,
+                    team2 = opponentTeam,
+                )
+            setFieldId(bracketEntry, BracketEntry::class.java, 500L)
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+            every { competitionRepository.findByIdOrNull(100L) } returns competition
+            every { gameRepository.findByCompetitionId(100L) } returns emptyList()
+            every { bracketEntryRepository.findByCompetitionId(100L) } returns listOf(bracketEntry)
+            every { bracketEntryRepository.save(any()) } returnsArgument 0
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            verify(exactly = 1) { bracketEntryRepository.save(bracketEntry) }
+            assert(bracketEntry.winner == opponentTeam)
+        }
+
+        @Test
+        @DisplayName("팀 해산 시 대진표에서 team2가 해산팀이면 team1이 부전승 처리된다")
+        fun `should give walkover win to team1 when team2 is disbanded team in bracket`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            val opponentTeam =
+                Team(league = league, name = "라이언즈", city = "부산", foundedYear = 2016)
+            setFieldId(opponentTeam, Team::class.java, 2L)
+
+            val competition =
+                Competition(
+                    league = league,
+                    name = "2026 토너먼트",
+                    year = 2026,
+                    season = 1,
+                    type = CompetitionType.TOURNAMENT,
+                    startDate = LocalDate.of(2026, 3, 1),
+                )
+            setFieldId(competition, Competition::class.java, 100L)
+            competition.start()
+
+            // team1이 상대팀, team2가 해산팀(id=1L)
+            val bracketEntry =
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = 1,
+                    team1 = opponentTeam,
+                    team2 = team,
+                )
+            setFieldId(bracketEntry, BracketEntry::class.java, 501L)
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+            every { competitionRepository.findByIdOrNull(100L) } returns competition
+            every { gameRepository.findByCompetitionId(100L) } returns emptyList()
+            every { bracketEntryRepository.findByCompetitionId(100L) } returns listOf(bracketEntry)
+            every { bracketEntryRepository.save(any()) } returnsArgument 0
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            verify(exactly = 1) { bracketEntryRepository.save(bracketEntry) }
+            assert(bracketEntry.winner == opponentTeam)
+        }
+
+        @Test
+        @DisplayName("이미 완료된 대진표 엔트리는 부전승 처리하지 않는다")
+        fun `should skip completed bracket entries`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            val opponentTeam =
+                Team(league = league, name = "라이언즈", city = "부산", foundedYear = 2016)
+            setFieldId(opponentTeam, Team::class.java, 2L)
+
+            val competition =
+                Competition(
+                    league = league,
+                    name = "2026 토너먼트",
+                    year = 2026,
+                    season = 1,
+                    type = CompetitionType.TOURNAMENT,
+                    startDate = LocalDate.of(2026, 3, 1),
+                )
+            setFieldId(competition, Competition::class.java, 100L)
+            competition.start()
+
+            // 이미 승자가 결정된 대진표 엔트리
+            val completedEntry =
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = 1,
+                    team1 = team,
+                    team2 = opponentTeam,
+                    winner = opponentTeam,
+                )
+            setFieldId(completedEntry, BracketEntry::class.java, 502L)
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+            every { competitionRepository.findByIdOrNull(100L) } returns competition
+            every { gameRepository.findByCompetitionId(100L) } returns emptyList()
+            every { bracketEntryRepository.findByCompetitionId(100L) } returns listOf(completedEntry)
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            verify(exactly = 0) { bracketEntryRepository.save(any()) }
+        }
+
+        @Test
+        @DisplayName("대진표에서 상대팀이 null이면 부전승 처리하지 않는다")
+        fun `should not process bracket entry when opponent team is null`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            val competition =
+                Competition(
+                    league = league,
+                    name = "2026 토너먼트",
+                    year = 2026,
+                    season = 1,
+                    type = CompetitionType.TOURNAMENT,
+                    startDate = LocalDate.of(2026, 3, 1),
+                )
+            setFieldId(competition, Competition::class.java, 100L)
+            competition.start()
+
+            // team1이 해산팀이고 team2가 null (이미 bye 상태이므로 isCompleted=true)
+            val byeEntry =
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = 1,
+                    team1 = team,
+                    team2 = null,
+                )
+            setFieldId(byeEntry, BracketEntry::class.java, 503L)
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+            every { competitionRepository.findByIdOrNull(100L) } returns competition
+            every { gameRepository.findByCompetitionId(100L) } returns emptyList()
+            every { bracketEntryRepository.findByCompetitionId(100L) } returns listOf(byeEntry)
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            verify(exactly = 0) { bracketEntryRepository.save(any()) }
+        }
+
+        @Test
+        @DisplayName("대회가 조회되지 않으면 몰수승/부전승 처리를 건너뛴다")
+        fun `should skip forfeit when competition not found`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+            // 대회 조회 시 null 반환
+            every { competitionRepository.findByIdOrNull(100L) } returns null
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            verify(exactly = 0) { gameRepository.findByCompetitionId(any()) }
+            verify(exactly = 0) { gameRepository.save(any()) }
+            verify(exactly = 0) { bracketEntryRepository.findByCompetitionId(any()) }
+            verify(exactly = 0) { bracketEntryRepository.save(any()) }
+        }
+
+        @Test
+        @DisplayName("경기에 해산팀이 포함되지 않으면 몰수승 처리하지 않는다")
+        fun `should not forfeit game when disbanded team is not in the game`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            val otherTeam1 =
+                Team(league = league, name = "라이언즈", city = "부산", foundedYear = 2016)
+            setFieldId(otherTeam1, Team::class.java, 2L)
+
+            val otherTeam2 =
+                Team(league = league, name = "이글스", city = "대전", foundedYear = 2017)
+            setFieldId(otherTeam2, Team::class.java, 3L)
+
+            val competition =
+                Competition(
+                    league = league,
+                    name = "2026 시즌",
+                    year = 2026,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2026, 3, 1),
+                )
+            setFieldId(competition, Competition::class.java, 100L)
+            competition.start()
+
+            // 해산팀(teamId=1L)이 포함되지 않은 경기
+            val gameNotInvolvingTeam =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = otherTeam1,
+                    awayTeam = otherTeam2,
+                    scheduledAt = LocalDateTime.now().plusDays(1),
+                    status = GameStatus.SCHEDULED,
+                    id = 1000L,
+                )
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+            every { competitionRepository.findByIdOrNull(100L) } returns competition
+            every { gameRepository.findByCompetitionId(100L) } returns listOf(gameNotInvolvingTeam)
+            every { bracketEntryRepository.findByCompetitionId(100L) } returns emptyList()
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            verify(exactly = 0) { gameRepository.save(any()) }
+            assert(gameNotInvolvingTeam.status == GameStatus.SCHEDULED)
+        }
+
+        @Test
+        @DisplayName("대진표에 해산팀과 무관한 엔트리는 부전승 처리하지 않는다")
+        fun `should not process bracket entry when disbanded team is not involved`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            val otherTeam1 =
+                Team(league = league, name = "라이언즈", city = "부산", foundedYear = 2016)
+            setFieldId(otherTeam1, Team::class.java, 2L)
+
+            val otherTeam2 =
+                Team(league = league, name = "이글스", city = "대전", foundedYear = 2017)
+            setFieldId(otherTeam2, Team::class.java, 3L)
+
+            val competition =
+                Competition(
+                    league = league,
+                    name = "2026 토너먼트",
+                    year = 2026,
+                    season = 1,
+                    type = CompetitionType.TOURNAMENT,
+                    startDate = LocalDate.of(2026, 3, 1),
+                )
+            setFieldId(competition, Competition::class.java, 100L)
+            competition.start()
+
+            // 해산팀과 무관한 대진표 엔트리
+            val unrelatedEntry =
+                BracketEntry(
+                    competition = competition,
+                    roundNumber = 1,
+                    matchNumber = 1,
+                    team1 = otherTeam1,
+                    team2 = otherTeam2,
+                )
+            setFieldId(unrelatedEntry, BracketEntry::class.java, 504L)
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+            every { competitionRepository.findByIdOrNull(100L) } returns competition
+            every { gameRepository.findByCompetitionId(100L) } returns emptyList()
+            every { bracketEntryRepository.findByCompetitionId(100L) } returns listOf(unrelatedEntry)
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            verify(exactly = 0) { bracketEntryRepository.save(any()) }
+            assert(unrelatedEntry.winner == null)
         }
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
@@ -3,14 +3,19 @@ package com.nextup.infrastructure.listener
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.attendance.AttendancePoll
 import com.nextup.core.domain.attendance.PollStatus
+import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionPlayer
 import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.election.Election
 import com.nextup.core.domain.election.ElectionStatus
 import com.nextup.core.domain.election.ElectionType
 import com.nextup.core.domain.event.TeamDisbandedEvent
 import com.nextup.core.domain.event.TeamMemberKickedEvent
 import com.nextup.core.domain.event.TeamMemberLeftEvent
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.LineupEntry
 import com.nextup.core.domain.game.LineupSubmission
 import com.nextup.core.domain.game.LineupSubmissionStatus
@@ -27,8 +32,11 @@ import com.nextup.core.domain.team.TeamMemberRole
 import com.nextup.core.domain.user.User
 import com.nextup.core.port.attendance.ActivityScoreRepositoryPort
 import com.nextup.core.port.attendance.AttendancePollRepositoryPort
+import com.nextup.core.port.repository.BracketEntryRepositoryPort
 import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
+import com.nextup.core.port.repository.CompetitionRepositoryPort
 import com.nextup.core.port.repository.ElectionRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.LineupEntryRepositoryPort
 import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
 import com.nextup.core.port.repository.StadiumBookingRepositoryPort
@@ -42,12 +50,17 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 @DisplayName("TeamMemberEventListener")
 class TeamMemberEventListenerTest {
     private val lineupSubmissionRepository = mockk<LineupSubmissionRepositoryPort>()
     private val lineupEntryRepository = mockk<LineupEntryRepositoryPort>()
     private val competitionPlayerRepository = mockk<CompetitionPlayerRepositoryPort>()
+    private val competitionRepository = mockk<CompetitionRepositoryPort>()
+    private val gameRepository = mockk<GameRepositoryPort>()
+    private val bracketEntryRepository = mockk<BracketEntryRepositoryPort>()
     private val stadiumBookingRepository = mockk<StadiumBookingRepositoryPort>()
     private val attendancePollRepository = mockk<AttendancePollRepositoryPort>()
     private val electionRepository = mockk<ElectionRepositoryPort>()
@@ -59,6 +72,9 @@ class TeamMemberEventListenerTest {
             lineupSubmissionRepository = lineupSubmissionRepository,
             lineupEntryRepository = lineupEntryRepository,
             competitionPlayerRepository = competitionPlayerRepository,
+            competitionRepository = competitionRepository,
+            gameRepository = gameRepository,
+            bracketEntryRepository = bracketEntryRepository,
             stadiumBookingRepository = stadiumBookingRepository,
             attendancePollRepository = attendancePollRepository,
             electionRepository = electionRepository,
@@ -341,6 +357,20 @@ class TeamMemberEventListenerTest {
     @Nested
     @DisplayName("handleTeamDisbanded")
     inner class HandleTeamDisbanded {
+        private fun stubEmptyDisbandDefaults() {
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns emptySet()
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+        }
+
         @Test
         @DisplayName("팀 해산 시 활성 CompetitionPlayer를 WITHDRAWN 처리한다")
         fun `should withdraw active competition players on team disband`() {
@@ -350,10 +380,18 @@ class TeamMemberEventListenerTest {
             every { competitionPlayer.id } returns 50L
 
             every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
+            every {
                 competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
             } returns listOf(competitionPlayer)
             justRun { competitionPlayer.withdraw() }
             every { competitionPlayerRepository.save(competitionPlayer) } returns competitionPlayer
+
+            // 대회가 IN_PROGRESS가 아닌 경우 (몰수승 처리 안 함)
+            val competition = mockk<Competition>(relaxed = true)
+            every { competition.status } returns CompetitionStatus.SCHEDULED
+            every { competitionRepository.findByIdOrNull(100L) } returns competition
 
             every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
             every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
@@ -377,6 +415,9 @@ class TeamMemberEventListenerTest {
             val booking = mockk<StadiumBooking>(relaxed = true)
             every { booking.id } returns 60L
 
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns emptySet()
             every {
                 competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
             } returns emptyList()
@@ -406,6 +447,9 @@ class TeamMemberEventListenerTest {
             val poll = mockk<AttendancePoll>(relaxed = true)
             every { poll.id } returns 70L
 
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns emptySet()
             every {
                 competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
             } returns emptyList()
@@ -460,6 +504,9 @@ class TeamMemberEventListenerTest {
                 }
 
             every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns emptySet()
+            every {
                 competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
             } returns emptyList()
             every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
@@ -493,6 +540,9 @@ class TeamMemberEventListenerTest {
             every { approvedRequest.status } returns JoinRequestStatus.APPROVED
 
             every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns emptySet()
+            every {
                 competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
             } returns emptyList()
             every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
@@ -517,15 +567,7 @@ class TeamMemberEventListenerTest {
         fun `should not call save when no entities to process on team disband`() {
             // given
             val event = TeamDisbandedEvent(teamId = 1L)
-
-            every {
-                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
-            } returns emptyList()
-            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
-            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
-            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
-            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
-            justRun { activityScoreRepository.deleteByTeamId(1L) }
+            stubEmptyDisbandDefaults()
 
             // when
             listener.handleTeamDisbanded(event)
@@ -536,6 +578,8 @@ class TeamMemberEventListenerTest {
             verify(exactly = 0) { attendancePollRepository.save(any()) }
             verify(exactly = 0) { electionRepository.save(any()) }
             verify(exactly = 0) { teamJoinRequestRepository.save(any()) }
+            verify(exactly = 0) { gameRepository.save(any()) }
+            verify(exactly = 0) { bracketEntryRepository.save(any()) }
         }
 
         @Test
@@ -543,10 +587,82 @@ class TeamMemberEventListenerTest {
         fun `should delete all activity scores for team on team disband`() {
             // given
             val event = TeamDisbandedEvent(teamId = 1L)
+            stubEmptyDisbandDefaults()
 
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            verify(exactly = 1) { activityScoreRepository.deleteByTeamId(1L) }
+        }
+
+        @Test
+        @DisplayName("팀 해산 시 진행 중 대회의 잔여 경기를 몰수승 처리한다")
+        fun `should forfeit remaining games in in-progress competition on team disband`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            val opponentTeam = Team(league = league, name = "라이언즈", city = "부산", foundedYear = 2016)
+            setFieldId(opponentTeam, Team::class.java, 2L)
+
+            val competition =
+                Competition(
+                    league = league,
+                    name = "2026 시즌",
+                    year = 2026,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2026, 3, 1),
+                )
+            setFieldId(competition, Competition::class.java, 100L)
+            competition.start()
+
+            // SCHEDULED 경기 - 몰수승 처리 대상
+            val scheduledGame =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = team,
+                    awayTeam = opponentTeam,
+                    scheduledAt = LocalDateTime.now().plusDays(1),
+                    status = GameStatus.SCHEDULED,
+                    id = 1000L,
+                )
+
+            // IN_PROGRESS 경기 - 몰수승 처리 대상
+            val inProgressGame =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = opponentTeam,
+                    awayTeam = team,
+                    scheduledAt = LocalDateTime.now(),
+                    status = GameStatus.IN_PROGRESS,
+                    currentInning = 3,
+                    id = 1001L,
+                )
+
+            // FINISHED 경기 - 몰수승 처리 대상이 아님
+            val finishedGame =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = team,
+                    awayTeam = opponentTeam,
+                    scheduledAt = LocalDateTime.now().minusDays(1),
+                    status = GameStatus.FINISHED,
+                    id = 1002L,
+                )
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
             every {
                 competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
             } returns emptyList()
+            every { competitionRepository.findByIdOrNull(100L) } returns competition
+            every { gameRepository.findByCompetitionId(100L) } returns
+                listOf(scheduledGame, inProgressGame, finishedGame)
+            every { gameRepository.save(any()) } returnsArgument 0
+            every { bracketEntryRepository.findByCompetitionId(100L) } returns emptyList()
+
             every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
             every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
             every { electionRepository.findAllByTeamId(1L) } returns emptyList()
@@ -557,7 +673,171 @@ class TeamMemberEventListenerTest {
             listener.handleTeamDisbanded(event)
 
             // then
-            verify(exactly = 1) { activityScoreRepository.deleteByTeamId(1L) }
+            verify(exactly = 2) { gameRepository.save(any()) }
+            assert(scheduledGame.status == GameStatus.FORFEITED)
+            assert(inProgressGame.status == GameStatus.FORFEITED)
+            assert(finishedGame.status == GameStatus.FINISHED)
+        }
+
+        @Test
+        @DisplayName("대회 미참가 팀 해산 시 에러 없이 통과한다")
+        fun `should pass without error when team is not in any competition`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns emptySet()
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            verify(exactly = 0) { gameRepository.findByCompetitionId(any()) }
+            verify(exactly = 0) { gameRepository.save(any()) }
+            verify(exactly = 0) { bracketEntryRepository.findByCompetitionId(any()) }
+        }
+
+        @Test
+        @DisplayName("여러 대회에 참가 중인 팀 해산 시 모든 대회에서 탈퇴하고 몰수승 처리한다")
+        fun `should withdraw from all competitions and forfeit games when team in multiple competitions`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            val opponentTeam1 = Team(league = league, name = "라이언즈", city = "부산", foundedYear = 2016)
+            setFieldId(opponentTeam1, Team::class.java, 2L)
+
+            val opponentTeam2 = Team(league = league, name = "이글스", city = "대전", foundedYear = 2017)
+            setFieldId(opponentTeam2, Team::class.java, 3L)
+
+            // 대회 1 - IN_PROGRESS
+            val competition1 =
+                Competition(
+                    league = league,
+                    name = "2026 시즌 1",
+                    year = 2026,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2026, 3, 1),
+                )
+            setFieldId(competition1, Competition::class.java, 100L)
+            competition1.start()
+
+            // 대회 2 - IN_PROGRESS
+            val competition2 =
+                Competition(
+                    league = league,
+                    name = "2026 시즌 2",
+                    year = 2026,
+                    season = 2,
+                    type = CompetitionType.TOURNAMENT,
+                    startDate = LocalDate.of(2026, 6, 1),
+                )
+            setFieldId(competition2, Competition::class.java, 200L)
+            competition2.start()
+
+            val game1 =
+                Game.createForTest(
+                    competition = competition1,
+                    homeTeam = team,
+                    awayTeam = opponentTeam1,
+                    scheduledAt = LocalDateTime.now().plusDays(1),
+                    status = GameStatus.SCHEDULED,
+                    id = 1000L,
+                )
+
+            val game2 =
+                Game.createForTest(
+                    competition = competition2,
+                    homeTeam = opponentTeam2,
+                    awayTeam = team,
+                    scheduledAt = LocalDateTime.now().plusDays(2),
+                    status = GameStatus.POSTPONED,
+                    id = 2000L,
+                )
+
+            val cp1 = mockk<CompetitionPlayer>(relaxed = true)
+            every { cp1.id } returns 50L
+            val cp2 = mockk<CompetitionPlayer>(relaxed = true)
+            every { cp2.id } returns 51L
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L, 200L)
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns listOf(cp1, cp2)
+            every { competitionPlayerRepository.save(any()) } returnsArgument 0
+
+            every { competitionRepository.findByIdOrNull(100L) } returns competition1
+            every { competitionRepository.findByIdOrNull(200L) } returns competition2
+            every { gameRepository.findByCompetitionId(100L) } returns listOf(game1)
+            every { gameRepository.findByCompetitionId(200L) } returns listOf(game2)
+            every { gameRepository.save(any()) } returnsArgument 0
+            every { bracketEntryRepository.findByCompetitionId(100L) } returns emptyList()
+            every { bracketEntryRepository.findByCompetitionId(200L) } returns emptyList()
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            verify(exactly = 2) { competitionPlayerRepository.save(any()) }
+            verify(exactly = 2) { gameRepository.save(any()) }
+            assert(game1.status == GameStatus.FORFEITED)
+            assert(game2.status == GameStatus.FORFEITED)
+        }
+
+        @Test
+        @DisplayName("팀 해산 시 IN_PROGRESS가 아닌 대회에서는 몰수승 처리를 하지 않는다")
+        fun `should not forfeit games for non-in-progress competitions`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            val cp = mockk<CompetitionPlayer>(relaxed = true)
+            every { cp.id } returns 50L
+
+            // SCHEDULED 상태 대회
+            val competition = mockk<Competition>(relaxed = true)
+            every { competition.status } returns CompetitionStatus.SCHEDULED
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns listOf(cp)
+            every { competitionPlayerRepository.save(any()) } returnsArgument 0
+            every { competitionRepository.findByIdOrNull(100L) } returns competition
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            // CompetitionPlayer는 WITHDRAWN 처리되지만 경기 몰수승은 안 함
+            verify(exactly = 1) { competitionPlayerRepository.save(any()) }
+            verify(exactly = 0) { gameRepository.findByCompetitionId(any()) }
+            verify(exactly = 0) { gameRepository.save(any()) }
         }
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapterTest.kt
@@ -450,4 +450,37 @@ class CompetitionPlayerRepositoryAdapterTest {
             assertThat(result[0].status).isEqualTo(CompetitionPlayerStatus.WITHDRAWN)
         }
     }
+
+    @Nested
+    @DisplayName("findActiveCompetitionIdsByTeamId")
+    inner class FindActiveCompetitionIdsByTeamId {
+        @Test
+        fun `팀이 참가 중인 대회 ID 목록을 반환한다`() {
+            // given
+            val teamId = 1L
+            val expectedIds = setOf(10L, 20L, 30L)
+            every { jpaRepository.findActiveCompetitionIdsByTeamId(teamId) } returns expectedIds
+
+            // when
+            val result = adapter.findActiveCompetitionIdsByTeamId(teamId)
+
+            // then
+            assertThat(result).isEqualTo(expectedIds)
+            verify { jpaRepository.findActiveCompetitionIdsByTeamId(teamId) }
+        }
+
+        @Test
+        fun `참가 중인 대회가 없으면 빈 Set을 반환한다`() {
+            // given
+            val teamId = 999L
+            every { jpaRepository.findActiveCompetitionIdsByTeamId(teamId) } returns emptySet()
+
+            // when
+            val result = adapter.findActiveCompetitionIdsByTeamId(teamId)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findActiveCompetitionIdsByTeamId(teamId) }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

>- close #338

- `TeamDisbandedEvent` 리스너가 CompetitionPlayer WITHDRAWN 처리만 수행하고, 해당 팀이 참여 중인 IN_PROGRESS 경기에 대한 몰수승 처리를 하지 않던 버그를 수정합니다.
- 팀 해산 시 진행 중 대회의 잔여 경기(SCHEDULED/IN_PROGRESS/POSTPONED)에 몰수승 처리 및 대진표 부전승 처리를 추가합니다.

## Tasks

- [x] `CompetitionPlayerRepositoryPort`에 `findActiveCompetitionIdsByTeamId()` 메서드 추가
- [x] `CompetitionPlayerJpaRepository`에 JPQL 쿼리 구현
- [x] `CompetitionPlayerRepositoryAdapter`에 위임 메서드 추가
- [x] `TeamMemberEventListener.withdrawCompetitionPlayers()` → `withdrawFromCompetitions()`으로 리팩토링
- [x] 진행 중(IN_PROGRESS) 대회의 잔여 경기 몰수승 처리 로직 추가 (`forfeitGamesForTeam()`)
- [x] 진행 중 대회의 대진표 부전승 처리 로직 추가 (`processBracketEntriesForTeam()`)
- [x] 테스트 추가: 팀 해산 → 진행 중 대회 경기 몰수승 처리 검증
- [x] 테스트 추가: 대회 미참가 팀 해산 시 에러 없이 통과 검증
- [x] 테스트 추가: 여러 대회 참가 중 팀 해산 시 모든 대회 처리 검증
- [x] 테스트 추가: IN_PROGRESS가 아닌 대회에서는 몰수승 미처리 검증
- [x] 빌드 및 전체 테스트 통과 확인

## To Reviewer

- `CompetitionService.withdrawTeam()`에 이미 몰수승 로직이 구현되어 있으나, 이벤트 리스너에서 직접 호출하지 않고 동일한 패턴으로 직접 구현했습니다. 이는 `CompetitionService`가 Core 모듈의 서비스이고, 이벤트 리스너는 Infrastructure 계층에 있어 서비스 의존 없이 Repository Port만으로 처리하는 것이 더 적합하기 때문입니다.
- IN_PROGRESS 상태가 아닌 대회(SCHEDULED 등)에서는 CompetitionPlayer WITHDRAWN 처리만 수행하고, 경기 몰수승 처리는 하지 않습니다.

## Screenshot

N/A (백엔드 변경)