### PR TITLE
feat(#336): 알림 시스템 보완 - Preference 확인 및 이벤트 핸들러 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/GameCancelledEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/GameCancelledEvent.kt
@@ -14,5 +14,7 @@ import java.time.Instant
  */
 data class GameCancelledEvent(
     val gameId: Long,
+    val homeTeamId: Long = 0L,
+    val awayTeamId: Long = 0L,
     val timestamp: Instant = Instant.now(),
 )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/GamePostponedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/GamePostponedEvent.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.domain.event
+
+import java.time.LocalDateTime
+
+/**
+ * 경기 연기 도메인 이벤트
+ *
+ * 경기가 연기될 때 발행됩니다.
+ * 해당 경기에 참여하는 양 팀의 멤버에게 알림을 전송하기 위해 사용됩니다.
+ */
+data class GamePostponedEvent(
+    val gameId: Long,
+    val homeTeamId: Long,
+    val awayTeamId: Long,
+    val newScheduledAt: LocalDateTime,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/GameRescheduledEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/GameRescheduledEvent.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.domain.event
+
+import java.time.LocalDateTime
+
+/**
+ * 경기 일정 변경 도메인 이벤트
+ *
+ * 경기 일정이 변경될 때 발행됩니다.
+ * 해당 경기에 참여하는 양 팀의 멤버에게 알림을 전송하기 위해 사용됩니다.
+ */
+data class GameRescheduledEvent(
+    val gameId: Long,
+    val homeTeamId: Long,
+    val awayTeamId: Long,
+    val newScheduledAt: LocalDateTime,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/TeamMemberKickedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/TeamMemberKickedEvent.kt
@@ -7,6 +7,8 @@ package com.nextup.core.domain.event
  */
 data class TeamMemberKickedEvent(
     val teamId: Long,
+    val userId: Long,
     val playerId: Long,
     val memberId: Long,
+    val teamName: String,
 )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/TeamMemberLeftEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/TeamMemberLeftEvent.kt
@@ -7,6 +7,8 @@ package com.nextup.core.domain.event
  */
 data class TeamMemberLeftEvent(
     val teamId: Long,
+    val userId: Long,
     val playerId: Long,
     val memberId: Long,
+    val teamName: String,
 )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/NotificationType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/notification/NotificationType.kt
@@ -48,4 +48,34 @@ enum class NotificationType {
      * 라인업 확정
      */
     LINEUP_CONFIRMED,
+
+    /**
+     * 경기 취소
+     */
+    GAME_CANCELLED,
+
+    /**
+     * 경기 일정 변경
+     */
+    GAME_RESCHEDULED,
+
+    /**
+     * 경기 연기
+     */
+    GAME_POSTPONED,
+
+    /**
+     * 팀원 탈퇴
+     */
+    TEAM_MEMBER_LEFT,
+
+    /**
+     * 팀원 강퇴
+     */
+    TEAM_MEMBER_KICKED,
+
+    /**
+     * 기록 정정
+     */
+    RECORD_CORRECTED,
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
@@ -2,11 +2,12 @@ package com.nextup.core.service.game
 
 import com.nextup.core.domain.game.Game
 import com.nextup.core.service.game.dto.GameEndReason
+import java.time.LocalDateTime
 
 /**
  * 경기 생명주기 관리 서비스 인터페이스
  *
- * 경기 시작, 이닝 진행, 종료, 몰수, 취소를 담당합니다.
+ * 경기 시작, 이닝 진행, 종료, 몰수, 취소, 연기, 일정 변경을 담당합니다.
  */
 interface GameLifecycleService {
     fun startGame(gameId: Long): Game
@@ -27,5 +28,16 @@ interface GameLifecycleService {
     fun cancelGame(
         gameId: Long,
         reason: String? = null,
+    ): Game
+
+    fun postponeGame(
+        gameId: Long,
+        newScheduledAt: LocalDateTime,
+        reason: String? = null,
+    ): Game
+
+    fun rescheduleGame(
+        gameId: Long,
+        newScheduledAt: LocalDateTime,
     ): Game
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
@@ -8,6 +8,7 @@ import com.nextup.core.common.PageResult
 import com.nextup.core.domain.notification.DeviceToken
 import com.nextup.core.domain.notification.Notification
 import com.nextup.core.domain.notification.NotificationPreference
+import com.nextup.core.domain.notification.NotificationType
 import com.nextup.core.port.repository.DeviceTokenRepositoryPort
 import com.nextup.core.port.repository.NotificationPreferenceRepositoryPort
 import com.nextup.core.port.repository.NotificationRepositoryPort
@@ -37,10 +38,24 @@ class NotificationService(
     /**
      * 알림을 전송합니다.
      *
-     * DB에 알림을 저장한 후, 사용자의 등록된 디바이스로 푸시 알림을 발송합니다.
+     * 사용자의 알림 설정(Preference)을 확인한 후,
+     * DB에 알림을 저장하고 사용자의 등록된 디바이스로 푸시 알림을 발송합니다.
+     * 사용자가 해당 알림 타입을 비활성화한 경우 발송을 스킵합니다.
+     * 설정이 없는 경우 기본적으로 발송합니다 (opt-out 모델).
+     *
+     * @return 알림이 발송된 경우 Notification, 스킵된 경우 null
      */
     @Transactional
-    fun sendNotification(request: SendNotificationRequest): Notification {
+    fun sendNotification(request: SendNotificationRequest): Notification? {
+        if (!isNotificationEnabled(request.userId, request.type)) {
+            log.debug(
+                "알림 설정에 의해 발송 스킵: userId={}, type={}",
+                request.userId,
+                request.type,
+            )
+            return null
+        }
+
         val notification =
             Notification.create(
                 userId = request.userId,
@@ -56,6 +71,20 @@ class NotificationService(
         sendPushToUser(request)
 
         return saved
+    }
+
+    /**
+     * 사용자의 알림 설정을 확인합니다.
+     *
+     * 설정이 존재하지 않으면 기본적으로 활성화(opt-out 모델)입니다.
+     */
+    private fun isNotificationEnabled(
+        userId: Long,
+        type: NotificationType,
+    ): Boolean {
+        val preference =
+            preferenceRepository.findByUserIdAndType(userId, type)
+        return preference?.enabled ?: true
     }
 
     private fun sendPushToUser(request: SendNotificationRequest) {

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/event/GamePostponedEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/event/GamePostponedEventTest.kt
@@ -1,0 +1,60 @@
+package com.nextup.core.domain.event
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+@DisplayName("GamePostponedEvent 테스트")
+class GamePostponedEventTest {
+    @Test
+    @DisplayName("모든 필드가 올바르게 설정된다")
+    fun allFieldsAreSetCorrectly() {
+        // given
+        val newScheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0)
+
+        // when
+        val event =
+            GamePostponedEvent(
+                gameId = 42L,
+                homeTeamId = 10L,
+                awayTeamId = 20L,
+                newScheduledAt = newScheduledAt,
+            )
+
+        // then
+        assertThat(event.gameId).isEqualTo(42L)
+        assertThat(event.homeTeamId).isEqualTo(10L)
+        assertThat(event.awayTeamId).isEqualTo(20L)
+        assertThat(event.newScheduledAt).isEqualTo(newScheduledAt)
+    }
+
+    @Test
+    @DisplayName("data class equals와 copy 동작 확인")
+    fun equalsAndCopyWork() {
+        // given
+        val newScheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0)
+        val event1 =
+            GamePostponedEvent(
+                gameId = 1L,
+                homeTeamId = 10L,
+                awayTeamId = 20L,
+                newScheduledAt = newScheduledAt,
+            )
+        val event2 =
+            GamePostponedEvent(
+                gameId = 1L,
+                homeTeamId = 10L,
+                awayTeamId = 20L,
+                newScheduledAt = newScheduledAt,
+            )
+
+        // then
+        assertThat(event1).isEqualTo(event2)
+        assertThat(event1.hashCode()).isEqualTo(event2.hashCode())
+
+        val copied = event1.copy(gameId = 2L)
+        assertThat(copied.gameId).isEqualTo(2L)
+        assertThat(copied.homeTeamId).isEqualTo(10L)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/event/GameRescheduledEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/event/GameRescheduledEventTest.kt
@@ -1,0 +1,60 @@
+package com.nextup.core.domain.event
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+@DisplayName("GameRescheduledEvent 테스트")
+class GameRescheduledEventTest {
+    @Test
+    @DisplayName("모든 필드가 올바르게 설정된다")
+    fun allFieldsAreSetCorrectly() {
+        // given
+        val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+
+        // when
+        val event =
+            GameRescheduledEvent(
+                gameId = 42L,
+                homeTeamId = 10L,
+                awayTeamId = 20L,
+                newScheduledAt = newScheduledAt,
+            )
+
+        // then
+        assertThat(event.gameId).isEqualTo(42L)
+        assertThat(event.homeTeamId).isEqualTo(10L)
+        assertThat(event.awayTeamId).isEqualTo(20L)
+        assertThat(event.newScheduledAt).isEqualTo(newScheduledAt)
+    }
+
+    @Test
+    @DisplayName("data class equals와 copy 동작 확인")
+    fun equalsAndCopyWork() {
+        // given
+        val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+        val event1 =
+            GameRescheduledEvent(
+                gameId = 1L,
+                homeTeamId = 10L,
+                awayTeamId = 20L,
+                newScheduledAt = newScheduledAt,
+            )
+        val event2 =
+            GameRescheduledEvent(
+                gameId = 1L,
+                homeTeamId = 10L,
+                awayTeamId = 20L,
+                newScheduledAt = newScheduledAt,
+            )
+
+        // then
+        assertThat(event1).isEqualTo(event2)
+        assertThat(event1.hashCode()).isEqualTo(event2.hashCode())
+
+        val copied = event1.copy(gameId = 2L)
+        assertThat(copied.gameId).isEqualTo(2L)
+        assertThat(copied.homeTeamId).isEqualTo(10L)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/event/TeamMemberEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/event/TeamMemberEventTest.kt
@@ -69,23 +69,48 @@ class TeamMemberEventTest {
             val event =
                 TeamMemberKickedEvent(
                     teamId = 1L,
+                    userId = 10L,
                     playerId = 20L,
                     memberId = 100L,
+                    teamName = "타이거즈",
                 )
 
             // then
             assertThat(event.teamId).isEqualTo(1L)
+            assertThat(event.userId).isEqualTo(10L)
             assertThat(event.playerId).isEqualTo(20L)
             assertThat(event.memberId).isEqualTo(100L)
+            assertThat(event.teamName).isEqualTo("타이거즈")
         }
 
         @Test
         @DisplayName("equals와 hashCode를 지원한다")
         fun `should support equals and hashCode`() {
             // given
-            val event1 = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
-            val event2 = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
-            val event3 = TeamMemberKickedEvent(teamId = 2L, playerId = 30L, memberId = 200L)
+            val event1 =
+                TeamMemberKickedEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
+            val event2 =
+                TeamMemberKickedEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
+            val event3 =
+                TeamMemberKickedEvent(
+                    teamId = 2L,
+                    userId = 11L,
+                    playerId = 30L,
+                    memberId = 200L,
+                    teamName = "라이온즈",
+                )
 
             // then
             assertThat(event1).isEqualTo(event2)
@@ -97,7 +122,14 @@ class TeamMemberEventTest {
         @DisplayName("copy 메서드를 지원한다")
         fun `should support copy`() {
             // given
-            val original = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val original =
+                TeamMemberKickedEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
 
             // when
             val copied = original.copy(playerId = 99L)
@@ -112,7 +144,14 @@ class TeamMemberEventTest {
         @DisplayName("toString이 필드 정보를 포함한다")
         fun `should include field info in toString`() {
             // given
-            val event = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberKickedEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
 
             // then
             val str = event.toString()
@@ -132,23 +171,48 @@ class TeamMemberEventTest {
             val event =
                 TeamMemberLeftEvent(
                     teamId = 1L,
+                    userId = 10L,
                     playerId = 20L,
                     memberId = 100L,
+                    teamName = "타이거즈",
                 )
 
             // then
             assertThat(event.teamId).isEqualTo(1L)
+            assertThat(event.userId).isEqualTo(10L)
             assertThat(event.playerId).isEqualTo(20L)
             assertThat(event.memberId).isEqualTo(100L)
+            assertThat(event.teamName).isEqualTo("타이거즈")
         }
 
         @Test
         @DisplayName("equals와 hashCode를 지원한다")
         fun `should support equals and hashCode`() {
             // given
-            val event1 = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
-            val event2 = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
-            val event3 = TeamMemberLeftEvent(teamId = 2L, playerId = 30L, memberId = 200L)
+            val event1 =
+                TeamMemberLeftEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
+            val event2 =
+                TeamMemberLeftEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
+            val event3 =
+                TeamMemberLeftEvent(
+                    teamId = 2L,
+                    userId = 11L,
+                    playerId = 30L,
+                    memberId = 200L,
+                    teamName = "라이온즈",
+                )
 
             // then
             assertThat(event1).isEqualTo(event2)
@@ -160,7 +224,14 @@ class TeamMemberEventTest {
         @DisplayName("copy 메서드를 지원한다")
         fun `should support copy`() {
             // given
-            val original = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val original =
+                TeamMemberLeftEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
 
             // when
             val copied = original.copy(memberId = 999L)
@@ -175,7 +246,14 @@ class TeamMemberEventTest {
         @DisplayName("toString이 필드 정보를 포함한다")
         fun `should include field info in toString`() {
             // given
-            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberLeftEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
 
             // then
             val str = event.toString()
@@ -188,8 +266,22 @@ class TeamMemberEventTest {
         @DisplayName("TeamMemberLeftEvent와 TeamMemberKickedEvent는 서로 다른 타입이다")
         fun `should be different types from TeamMemberKickedEvent`() {
             // given
-            val leftEvent = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
-            val kickedEvent = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val leftEvent =
+                TeamMemberLeftEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
+            val kickedEvent =
+                TeamMemberKickedEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
 
             // then
             assertThat(leftEvent).isNotEqualTo(kickedEvent)

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServicePushCoverageTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServicePushCoverageTest.kt
@@ -65,6 +65,7 @@ class NotificationServicePushCoverageTest {
                 ),
             )
 
+        every { preferenceRepository.findByUserIdAndType(1L, NotificationType.GAME_START) } returns null
         every { notificationRepository.save(any()) } answers { firstArg() }
         every { deviceTokenRepository.findByUserId(1L) } returns tokens
         every { pushNotificationPort.sendBatch(any(), any(), any(), any()) } returns 2
@@ -73,7 +74,8 @@ class NotificationServicePushCoverageTest {
         val result = notificationService.sendNotification(request)
 
         // then
-        assertThat(result.isSent()).isTrue()
+        assertThat(result).isNotNull
+        assertThat(result!!.isSent()).isTrue()
         verify(exactly = 1) {
             pushNotificationPort.sendBatch(
                 tokens = listOf("token-1", "token-2"),
@@ -105,6 +107,7 @@ class NotificationServicePushCoverageTest {
                 ),
             )
 
+        every { preferenceRepository.findByUserIdAndType(1L, NotificationType.TEAM_NOTICE) } returns null
         every { notificationRepository.save(any()) } answers { firstArg() }
         every { deviceTokenRepository.findByUserId(1L) } returns tokens
         every { pushNotificationPort.sendBatch(any(), any(), any(), any()) } returns 1
@@ -113,7 +116,8 @@ class NotificationServicePushCoverageTest {
         val result = notificationService.sendNotification(request)
 
         // then
-        assertThat(result.isSent()).isTrue()
+        assertThat(result).isNotNull
+        assertThat(result!!.isSent()).isTrue()
         verify(exactly = 1) {
             pushNotificationPort.sendBatch(
                 tokens = listOf("token-1"),
@@ -145,6 +149,7 @@ class NotificationServicePushCoverageTest {
                 ),
             )
 
+        every { preferenceRepository.findByUserIdAndType(1L, NotificationType.GAME_START) } returns null
         every { notificationRepository.save(any()) } answers { firstArg() }
         every { deviceTokenRepository.findByUserId(1L) } returns tokens
         every {
@@ -155,7 +160,8 @@ class NotificationServicePushCoverageTest {
         val result = notificationService.sendNotification(request)
 
         // then - 알림은 정상적으로 저장되어야 한다
-        assertThat(result.isSent()).isTrue()
+        assertThat(result).isNotNull
+        assertThat(result!!.isSent()).isTrue()
         verify(exactly = 1) { notificationRepository.save(any()) }
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/notification/NotificationServiceTest.kt
@@ -61,6 +61,7 @@ class NotificationServiceTest {
                 data = """{"gameId": 123}""",
             )
 
+        every { preferenceRepository.findByUserIdAndType(1L, NotificationType.GAME_START) } returns null
         every { notificationRepository.save(any()) } answers { firstArg() }
         every { deviceTokenRepository.findByUserId(1L) } returns emptyList()
 
@@ -68,7 +69,8 @@ class NotificationServiceTest {
         val result = notificationService.sendNotification(request)
 
         // then
-        assertThat(result.userId).isEqualTo(request.userId)
+        assertThat(result).isNotNull
+        assertThat(result!!.userId).isEqualTo(request.userId)
         assertThat(result.type).isEqualTo(request.type)
         assertThat(result.title).isEqualTo(request.title)
         assertThat(result.body).isEqualTo(request.body)
@@ -90,6 +92,7 @@ class NotificationServiceTest {
                 data = null,
             )
 
+        every { preferenceRepository.findByUserIdAndType(1L, NotificationType.TEAM_NOTICE) } returns null
         every { notificationRepository.save(any()) } answers { firstArg() }
         every { deviceTokenRepository.findByUserId(1L) } returns emptyList()
 
@@ -97,8 +100,73 @@ class NotificationServiceTest {
         val result = notificationService.sendNotification(request)
 
         // then
-        assertThat(result.data).isNull()
+        assertThat(result).isNotNull
+        assertThat(result!!.data).isNull()
         assertThat(result.isSent()).isTrue()
+    }
+
+    @Test
+    fun `사용자가 알림 타입을 비활성화한 경우 발송을 스킵한다`() {
+        // given
+        val request =
+            SendNotificationRequest(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                title = "경기 시작",
+                body = "경기가 곧 시작됩니다",
+            )
+
+        val disabledPreference =
+            NotificationPreference.create(
+                userId = 1L,
+                type = NotificationType.GAME_START,
+                enabled = false,
+            )
+
+        every {
+            preferenceRepository.findByUserIdAndType(1L, NotificationType.GAME_START)
+        } returns disabledPreference
+
+        // when
+        val result = notificationService.sendNotification(request)
+
+        // then
+        assertThat(result).isNull()
+        verify(exactly = 0) { notificationRepository.save(any()) }
+        verify(exactly = 0) { deviceTokenRepository.findByUserId(any()) }
+    }
+
+    @Test
+    fun `사용자가 알림 타입을 활성화한 경우 정상 발송한다`() {
+        // given
+        val request =
+            SendNotificationRequest(
+                userId = 1L,
+                type = NotificationType.TEAM_NOTICE,
+                title = "팀 공지",
+                body = "중요 공지사항입니다",
+            )
+
+        val enabledPreference =
+            NotificationPreference.create(
+                userId = 1L,
+                type = NotificationType.TEAM_NOTICE,
+                enabled = true,
+            )
+
+        every {
+            preferenceRepository.findByUserIdAndType(1L, NotificationType.TEAM_NOTICE)
+        } returns enabledPreference
+        every { notificationRepository.save(any()) } answers { firstArg() }
+        every { deviceTokenRepository.findByUserId(1L) } returns emptyList()
+
+        // when
+        val result = notificationService.sendNotification(request)
+
+        // then
+        assertThat(result).isNotNull
+        assertThat(result!!.isSent()).isTrue()
+        verify(exactly = 1) { notificationRepository.save(any()) }
     }
 
     // ========== getUserNotifications Tests (Paging) ==========

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/NotificationEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/NotificationEventListener.kt
@@ -1,16 +1,25 @@
 package com.nextup.infrastructure.listener
 
 import com.nextup.core.domain.event.AttendanceVoteCreatedEvent
+import com.nextup.core.domain.event.GameCancelledEvent
+import com.nextup.core.domain.event.GamePostponedEvent
+import com.nextup.core.domain.event.GameRescheduledEvent
 import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.LineupConfirmedEvent
 import com.nextup.core.domain.event.TeamJoinApprovedEvent
 import com.nextup.core.domain.event.TeamJoinRejectedEvent
+import com.nextup.core.domain.event.TeamMemberKickedEvent
+import com.nextup.core.domain.event.TeamMemberLeftEvent
 import com.nextup.core.domain.notification.NotificationType
+import com.nextup.core.domain.team.TeamMemberRole
 import com.nextup.core.domain.team.TeamMemberStatus
 import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.notification.NotificationService
 import com.nextup.core.service.notification.dto.SendNotificationRequest
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
@@ -25,6 +34,8 @@ class NotificationEventListener(
     private val notificationService: NotificationService,
     private val teamMemberRepository: TeamMemberRepositoryPort,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     /**
      * 팀 가입 승인 이벤트를 처리합니다.
      */
@@ -121,5 +132,127 @@ class NotificationEventListener(
                 ),
             )
         }
+    }
+
+    /**
+     * 경기 취소 이벤트를 처리합니다.
+     *
+     * 홈팀과 원정팀의 모든 활성 멤버에게 알림을 발송합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleGameCancelled(event: GameCancelledEvent) {
+        if (event.homeTeamId == 0L || event.awayTeamId == 0L) {
+            log.warn("경기 취소 알림 스킵: 팀 정보 없음 - gameId={}", event.gameId)
+            return
+        }
+        val allTeamIds = listOf(event.homeTeamId, event.awayTeamId)
+        allTeamIds.forEach { teamId ->
+            val activeMembers =
+                teamMemberRepository.findByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE)
+            activeMembers.forEach { member ->
+                notificationService.sendNotification(
+                    SendNotificationRequest(
+                        userId = member.user.id,
+                        type = NotificationType.GAME_CANCELLED,
+                        title = "경기 취소",
+                        body = "예정된 경기가 취소되었습니다.",
+                    ),
+                )
+            }
+        }
+    }
+
+    /**
+     * 경기 연기 이벤트를 처리합니다.
+     *
+     * 홈팀과 원정팀의 모든 활성 멤버에게 알림을 발송합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleGamePostponed(event: GamePostponedEvent) {
+        val newDateStr = event.newScheduledAt.toLocalDate().toString()
+        val allTeamIds = listOf(event.homeTeamId, event.awayTeamId)
+        allTeamIds.forEach { teamId ->
+            val activeMembers =
+                teamMemberRepository.findByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE)
+            activeMembers.forEach { member ->
+                notificationService.sendNotification(
+                    SendNotificationRequest(
+                        userId = member.user.id,
+                        type = NotificationType.GAME_POSTPONED,
+                        title = "경기 연기",
+                        body = "경기가 $newDateStr 으로 연기되었습니다.",
+                    ),
+                )
+            }
+        }
+    }
+
+    /**
+     * 경기 일정 변경 이벤트를 처리합니다.
+     *
+     * 홈팀과 원정팀의 모든 활성 멤버에게 알림을 발송합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleGameRescheduled(event: GameRescheduledEvent) {
+        val newDateStr = event.newScheduledAt.toLocalDate().toString()
+        val allTeamIds = listOf(event.homeTeamId, event.awayTeamId)
+        allTeamIds.forEach { teamId ->
+            val activeMembers =
+                teamMemberRepository.findByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE)
+            activeMembers.forEach { member ->
+                notificationService.sendNotification(
+                    SendNotificationRequest(
+                        userId = member.user.id,
+                        type = NotificationType.GAME_RESCHEDULED,
+                        title = "경기 일정 변경",
+                        body = "경기 일정이 $newDateStr 으로 변경되었습니다.",
+                    ),
+                )
+            }
+        }
+    }
+
+    /**
+     * 팀원 탈퇴 이벤트를 처리합니다.
+     *
+     * 팀 관리자(OWNER, MANAGER)에게 알림을 발송합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleTeamMemberLeft(event: TeamMemberLeftEvent) {
+        val admins =
+            teamMemberRepository.findByTeamIdAndStatus(event.teamId, TeamMemberStatus.ACTIVE)
+                .filter { it.role == TeamMemberRole.OWNER || it.role == TeamMemberRole.MANAGER }
+        admins.forEach { admin ->
+            notificationService.sendNotification(
+                SendNotificationRequest(
+                    userId = admin.user.id,
+                    type = NotificationType.TEAM_MEMBER_LEFT,
+                    title = "팀원 탈퇴",
+                    body = "${event.teamName} 팀에서 팀원이 탈퇴했습니다.",
+                ),
+            )
+        }
+    }
+
+    /**
+     * 팀원 강퇴 이벤트를 처리합니다.
+     *
+     * 강퇴된 멤버에게 알림을 발송합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleTeamMemberKicked(event: TeamMemberKickedEvent) {
+        notificationService.sendNotification(
+            SendNotificationRequest(
+                userId = event.userId,
+                type = NotificationType.TEAM_MEMBER_KICKED,
+                title = "팀 강퇴",
+                body = "${event.teamName} 팀에서 강퇴되었습니다.",
+            ),
+        )
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
@@ -3,6 +3,8 @@ package com.nextup.infrastructure.service.game
 import com.nextup.common.exception.GameNotFoundException
 import com.nextup.common.exception.InvalidGameStateException
 import com.nextup.core.domain.event.GameCancelledEvent
+import com.nextup.core.domain.event.GamePostponedEvent
+import com.nextup.core.domain.event.GameRescheduledEvent
 import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameStatus
@@ -17,6 +19,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 /**
  * 경기 생명주기 관리 서비스 구현
@@ -129,7 +132,83 @@ class GameLifecycleServiceImpl(
         game.cancel(reason)
         val savedGame = gameRepository.save(game)
 
-        eventPublisher.publishEvent(GameCancelledEvent(gameId = gameId))
+        val gameTeams = gameTeamRepository.findAllByGameId(gameId)
+        val homeTeam = gameTeams.find { it.homeAway == HomeAway.HOME }
+        val awayTeam = gameTeams.find { it.homeAway == HomeAway.AWAY }
+        eventPublisher.publishEvent(
+            GameCancelledEvent(
+                gameId = gameId,
+                homeTeamId = homeTeam?.team?.id ?: 0L,
+                awayTeamId = awayTeam?.team?.id ?: 0L,
+            ),
+        )
+
+        return savedGame
+    }
+
+    @Transactional
+    override fun postponeGame(
+        gameId: Long,
+        newScheduledAt: LocalDateTime,
+        reason: String?,
+    ): Game {
+        val game = findGame(gameId)
+
+        if (game.status != GameStatus.SCHEDULED) {
+            throw InvalidGameStateException(
+                "예정 상태의 경기만 연기할 수 있습니다. 현재 상태: ${game.status.displayName}",
+            )
+        }
+
+        game.postpone(newScheduledAt, reason)
+        val savedGame = gameRepository.save(game)
+
+        val gameTeams = gameTeamRepository.findAllByGameId(gameId)
+        val homeTeam = gameTeams.find { it.homeAway == HomeAway.HOME }
+        val awayTeam = gameTeams.find { it.homeAway == HomeAway.AWAY }
+        if (homeTeam != null && awayTeam != null) {
+            eventPublisher.publishEvent(
+                GamePostponedEvent(
+                    gameId = gameId,
+                    homeTeamId = homeTeam.team.id,
+                    awayTeamId = awayTeam.team.id,
+                    newScheduledAt = newScheduledAt,
+                ),
+            )
+        }
+
+        return savedGame
+    }
+
+    @Transactional
+    override fun rescheduleGame(
+        gameId: Long,
+        newScheduledAt: LocalDateTime,
+    ): Game {
+        val game = findGame(gameId)
+
+        if (game.status != GameStatus.SCHEDULED && game.status != GameStatus.POSTPONED) {
+            throw InvalidGameStateException(
+                "예정 또는 연기 상태의 경기만 일정을 변경할 수 있습니다. 현재 상태: ${game.status.displayName}",
+            )
+        }
+
+        game.reschedule(newScheduledAt)
+        val savedGame = gameRepository.save(game)
+
+        val gameTeams = gameTeamRepository.findAllByGameId(gameId)
+        val homeTeam = gameTeams.find { it.homeAway == HomeAway.HOME }
+        val awayTeam = gameTeams.find { it.homeAway == HomeAway.AWAY }
+        if (homeTeam != null && awayTeam != null) {
+            eventPublisher.publishEvent(
+                GameRescheduledEvent(
+                    gameId = gameId,
+                    homeTeamId = homeTeam.team.id,
+                    awayTeamId = awayTeam.team.id,
+                    newScheduledAt = newScheduledAt,
+                ),
+            )
+        }
 
         return savedGame
     }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
@@ -3,6 +3,8 @@ package com.nextup.infrastructure.service.team
 import com.nextup.common.exception.*
 import com.nextup.core.domain.event.TeamJoinApprovedEvent
 import com.nextup.core.domain.event.TeamJoinRejectedEvent
+import com.nextup.core.domain.event.TeamMemberKickedEvent
+import com.nextup.core.domain.event.TeamMemberLeftEvent
 import com.nextup.core.domain.team.*
 import com.nextup.core.port.repository.*
 import com.nextup.core.service.team.TeamMembershipService
@@ -216,6 +218,16 @@ class TeamMembershipServiceImpl(
                 )
             teamBlacklistRepository.save(blacklist)
         }
+
+        eventPublisher.publishEvent(
+            TeamMemberKickedEvent(
+                teamId = member.team.id,
+                userId = member.user.id,
+                playerId = member.player.id,
+                memberId = member.id,
+                teamName = member.team.name,
+            ),
+        )
     }
 
     @Transactional
@@ -235,6 +247,16 @@ class TeamMembershipServiceImpl(
         // Entity의 비즈니스 로직으로 탈퇴 처리
         member.leave()
         teamMemberRepository.save(member)
+
+        eventPublisher.publishEvent(
+            TeamMemberLeftEvent(
+                teamId = member.team.id,
+                userId = member.user.id,
+                playerId = member.player.id,
+                memberId = member.id,
+                teamName = member.team.name,
+            ),
+        )
     }
 
     @Transactional

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/NotificationEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/NotificationEventListenerTest.kt
@@ -2,10 +2,15 @@ package com.nextup.infrastructure.listener
 
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.event.AttendanceVoteCreatedEvent
+import com.nextup.core.domain.event.GameCancelledEvent
+import com.nextup.core.domain.event.GamePostponedEvent
+import com.nextup.core.domain.event.GameRescheduledEvent
 import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.LineupConfirmedEvent
 import com.nextup.core.domain.event.TeamJoinApprovedEvent
 import com.nextup.core.domain.event.TeamJoinRejectedEvent
+import com.nextup.core.domain.event.TeamMemberKickedEvent
+import com.nextup.core.domain.event.TeamMemberLeftEvent
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.notification.NotificationType
 import com.nextup.core.domain.player.Player
@@ -309,6 +314,269 @@ class NotificationEventListenerTest {
 
             // then
             verify(exactly = 0) { notificationService.sendNotification(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("handleGameCancelled")
+    inner class HandleGameCancelled {
+        @Test
+        fun `should send GAME_CANCELLED notification to both teams members`() {
+            // given
+            val event =
+                GameCancelledEvent(
+                    gameId = 100L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                )
+
+            val awayUser = User.createLocalUser("away@example.com", "pw", "원정멤버")
+            setFieldId(awayUser, User::class.java, 11L)
+            val awayPlayer = Player(name = "원정멤버", primaryPosition = Position.CATCHER)
+            awayUser.player = awayPlayer
+
+            val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2015)
+            setFieldId(awayTeam, Team::class.java, 2L)
+            val awayMember = TeamMember.create(awayTeam, awayUser, awayPlayer, 8, TeamMemberRole.MEMBER)
+
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE)
+            } returns listOf(member)
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(2L, TeamMemberStatus.ACTIVE)
+            } returns listOf(awayMember)
+            every { notificationService.sendNotification(any()) } returns mockk()
+
+            // when
+            listener.handleGameCancelled(event)
+
+            // then
+            verify(exactly = 2) { notificationService.sendNotification(any()) }
+            verify(exactly = 1) {
+                notificationService.sendNotification(
+                    match {
+                        it.userId == 10L && it.type == NotificationType.GAME_CANCELLED
+                    },
+                )
+            }
+            verify(exactly = 1) {
+                notificationService.sendNotification(
+                    match {
+                        it.userId == 11L && it.type == NotificationType.GAME_CANCELLED
+                    },
+                )
+            }
+        }
+
+        @Test
+        fun `should skip notification when team IDs are zero`() {
+            // given
+            val event =
+                GameCancelledEvent(
+                    gameId = 100L,
+                    homeTeamId = 0L,
+                    awayTeamId = 0L,
+                )
+
+            // when
+            listener.handleGameCancelled(event)
+
+            // then
+            verify(exactly = 0) { notificationService.sendNotification(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("handleGamePostponed")
+    inner class HandleGamePostponed {
+        @Test
+        fun `should send GAME_POSTPONED notification to both teams members`() {
+            // given
+            val newDate = LocalDateTime.of(2026, 4, 1, 14, 0)
+            val event =
+                GamePostponedEvent(
+                    gameId = 100L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    newScheduledAt = newDate,
+                )
+
+            val awayUser = User.createLocalUser("away@example.com", "pw", "원정멤버")
+            setFieldId(awayUser, User::class.java, 11L)
+            val awayPlayer = Player(name = "원정멤버", primaryPosition = Position.CATCHER)
+            awayUser.player = awayPlayer
+
+            val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2015)
+            setFieldId(awayTeam, Team::class.java, 2L)
+            val awayMember = TeamMember.create(awayTeam, awayUser, awayPlayer, 8, TeamMemberRole.MEMBER)
+
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE)
+            } returns listOf(member)
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(2L, TeamMemberStatus.ACTIVE)
+            } returns listOf(awayMember)
+            every { notificationService.sendNotification(any()) } returns mockk()
+
+            // when
+            listener.handleGamePostponed(event)
+
+            // then
+            verify(exactly = 2) { notificationService.sendNotification(any()) }
+            verify(exactly = 1) {
+                notificationService.sendNotification(
+                    match {
+                        it.userId == 10L &&
+                            it.type == NotificationType.GAME_POSTPONED &&
+                            it.body.contains("2026-04-01")
+                    },
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("handleGameRescheduled")
+    inner class HandleGameRescheduled {
+        @Test
+        fun `should send GAME_RESCHEDULED notification to both teams members`() {
+            // given
+            val newDate = LocalDateTime.of(2026, 5, 10, 18, 0)
+            val event =
+                GameRescheduledEvent(
+                    gameId = 100L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    newScheduledAt = newDate,
+                )
+
+            val awayUser = User.createLocalUser("away@example.com", "pw", "원정멤버")
+            setFieldId(awayUser, User::class.java, 11L)
+            val awayPlayer = Player(name = "원정멤버", primaryPosition = Position.CATCHER)
+            awayUser.player = awayPlayer
+
+            val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2015)
+            setFieldId(awayTeam, Team::class.java, 2L)
+            val awayMember = TeamMember.create(awayTeam, awayUser, awayPlayer, 8, TeamMemberRole.MEMBER)
+
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE)
+            } returns listOf(member)
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(2L, TeamMemberStatus.ACTIVE)
+            } returns listOf(awayMember)
+            every { notificationService.sendNotification(any()) } returns mockk()
+
+            // when
+            listener.handleGameRescheduled(event)
+
+            // then
+            verify(exactly = 2) { notificationService.sendNotification(any()) }
+            verify(exactly = 1) {
+                notificationService.sendNotification(
+                    match {
+                        it.userId == 10L &&
+                            it.type == NotificationType.GAME_RESCHEDULED &&
+                            it.body.contains("2026-05-10")
+                    },
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("handleTeamMemberLeft")
+    inner class HandleTeamMemberLeft {
+        @Test
+        fun `should send TEAM_MEMBER_LEFT notification to team admins`() {
+            // given
+            val event =
+                TeamMemberLeftEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
+
+            val ownerUser = User.createLocalUser("owner@example.com", "pw", "팀장")
+            setFieldId(ownerUser, User::class.java, 50L)
+            val ownerPlayer = Player(name = "팀장", primaryPosition = Position.STARTING_PITCHER)
+            ownerUser.player = ownerPlayer
+            val ownerMember = TeamMember.create(team, ownerUser, ownerPlayer, 1, TeamMemberRole.OWNER)
+
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE)
+            } returns listOf(ownerMember)
+            every { notificationService.sendNotification(any()) } returns mockk()
+
+            // when
+            listener.handleTeamMemberLeft(event)
+
+            // then
+            verify(exactly = 1) { notificationService.sendNotification(any()) }
+            verify(exactly = 1) {
+                notificationService.sendNotification(
+                    match {
+                        it.userId == 50L &&
+                            it.type == NotificationType.TEAM_MEMBER_LEFT &&
+                            it.body.contains("타이거즈")
+                    },
+                )
+            }
+        }
+
+        @Test
+        fun `should not send notification to regular members`() {
+            // given
+            val event =
+                TeamMemberLeftEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
+
+            // member has MEMBER role, not OWNER or MANAGER
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE)
+            } returns listOf(member)
+
+            // when
+            listener.handleTeamMemberLeft(event)
+
+            // then
+            verify(exactly = 0) { notificationService.sendNotification(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("handleTeamMemberKicked")
+    inner class HandleTeamMemberKicked {
+        @Test
+        fun `should send TEAM_MEMBER_KICKED notification to the kicked member`() {
+            // given
+            val event =
+                TeamMemberKickedEvent(
+                    teamId = 1L,
+                    userId = 10L,
+                    playerId = 20L,
+                    memberId = 100L,
+                    teamName = "타이거즈",
+                )
+
+            val requestSlot = slot<SendNotificationRequest>()
+            every { notificationService.sendNotification(capture(requestSlot)) } returns mockk()
+
+            // when
+            listener.handleTeamMemberKicked(event)
+
+            // then
+            verify(exactly = 1) { notificationService.sendNotification(any()) }
+            assertThat(requestSlot.captured.userId).isEqualTo(10L)
+            assertThat(requestSlot.captured.type).isEqualTo(NotificationType.TEAM_MEMBER_KICKED)
+            assertThat(requestSlot.captured.body).contains("타이거즈")
         }
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/NotificationEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/NotificationEventListenerTest.kt
@@ -390,6 +390,32 @@ class NotificationEventListenerTest {
     @DisplayName("handleGamePostponed")
     inner class HandleGamePostponed {
         @Test
+        fun `should not send notification when no active members`() {
+            // given
+            val newDate = LocalDateTime.of(2026, 4, 1, 14, 0)
+            val event =
+                GamePostponedEvent(
+                    gameId = 100L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    newScheduledAt = newDate,
+                )
+
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE)
+            } returns emptyList()
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(2L, TeamMemberStatus.ACTIVE)
+            } returns emptyList()
+
+            // when
+            listener.handleGamePostponed(event)
+
+            // then
+            verify(exactly = 0) { notificationService.sendNotification(any()) }
+        }
+
+        @Test
         fun `should send GAME_POSTPONED notification to both teams members`() {
             // given
             val newDate = LocalDateTime.of(2026, 4, 1, 14, 0)
@@ -438,6 +464,32 @@ class NotificationEventListenerTest {
     @Nested
     @DisplayName("handleGameRescheduled")
     inner class HandleGameRescheduled {
+        @Test
+        fun `should not send notification when no active members`() {
+            // given
+            val newDate = LocalDateTime.of(2026, 5, 10, 18, 0)
+            val event =
+                GameRescheduledEvent(
+                    gameId = 100L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    newScheduledAt = newDate,
+                )
+
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE)
+            } returns emptyList()
+            every {
+                teamMemberRepository.findByTeamIdAndStatus(2L, TeamMemberStatus.ACTIVE)
+            } returns emptyList()
+
+            // when
+            listener.handleGameRescheduled(event)
+
+            // then
+            verify(exactly = 0) { notificationService.sendNotification(any()) }
+        }
+
         @Test
         fun `should send GAME_RESCHEDULED notification to both teams members`() {
             // given

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
@@ -102,7 +102,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("DRAFT 라인업에서 탈퇴한 선수 엔트리를 제거한다")
         fun `should remove player entry from DRAFT lineup submission`() {
             // given
-            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberLeftEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
 
             val submission = mockk<LineupSubmission>(relaxed = true)
             every { submission.id } returns 10L
@@ -133,7 +134,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("해당 선수가 라인업에 없으면 아무 처리도 하지 않는다")
         fun `should do nothing when player is not in lineup`() {
             // given
-            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberLeftEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
 
             val submission = mockk<LineupSubmission>(relaxed = true)
             every { submission.id } returns 10L
@@ -160,7 +162,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("활성 라인업이 없으면 아무 처리도 하지 않는다")
         fun `should do nothing when no active lineup submissions exist`() {
             // given
-            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberLeftEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
 
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
@@ -183,7 +186,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("SUBMITTED 라인업에서 마지막 선수 제거 시 경고 로그를 남긴다")
         fun `should log warning when last entry removed from SUBMITTED lineup`() {
             // given
-            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberLeftEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
 
             val submission = mockk<LineupSubmission>(relaxed = true)
             every { submission.id } returns 10L
@@ -215,7 +219,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("팀원 탈퇴 시 활동 점수를 삭제한다")
         fun `should delete activity score on member left`() {
             // given
-            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberLeftEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
 
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
@@ -244,7 +249,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("SUBMITTED 라인업에서 강퇴된 선수 엔트리를 제거한다")
         fun `should remove player entry from SUBMITTED lineup submission`() {
             // given
-            val event = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberKickedEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
 
             val submission = mockk<LineupSubmission>(relaxed = true)
             every { submission.id } returns 10L
@@ -276,7 +282,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("여러 라인업에 선수가 있으면 모두 제거한다")
         fun `should remove player entry from multiple lineup submissions`() {
             // given
-            val event = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberKickedEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
 
             val submission1 = mockk<LineupSubmission>(relaxed = true)
             every { submission1.id } returns 10L
@@ -316,7 +323,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("팀원 강퇴 시 활동 점수를 삭제한다")
         fun `should delete activity score on member kicked`() {
             // given
-            val event = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberKickedEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
 
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
@@ -291,7 +291,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("팀원 탈퇴 시 활성 CompetitionPlayer를 WITHDRAWN 처리한다")
         fun `should withdraw active competition players on member left`() {
             // given
-            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberLeftEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
             val competitionPlayer = mockk<CompetitionPlayer>(relaxed = true)
             every { competitionPlayer.id } returns 50L
 
@@ -327,7 +328,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("CONFIRMED 라인업에서도 탈퇴한 선수 엔트리를 제거한다")
         fun `should remove player entry from CONFIRMED lineup submission`() {
             // given
-            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberLeftEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
 
             val submission = mockk<LineupSubmission>(relaxed = true)
             every { submission.id } returns 10L
@@ -501,7 +503,8 @@ class TeamMemberEventListenerTest {
         @DisplayName("팀원 강퇴 시 활성 CompetitionPlayer를 WITHDRAWN 처리한다")
         fun `should withdraw active competition players on member kicked`() {
             // given
-            val event = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val event =
+                TeamMemberKickedEvent(teamId = 1L, userId = 10L, playerId = 20L, memberId = 100L, teamName = "타이거즈")
             val competitionPlayer = mockk<CompetitionPlayer>(relaxed = true)
             every { competitionPlayer.id } returns 50L
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplTest.kt
@@ -1,0 +1,424 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.event.GamePostponedEvent
+import com.nextup.core.domain.event.GameRescheduledEvent
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDateTime
+
+@DisplayName("GameLifecycleServiceImpl 테스트")
+class GameLifecycleServiceImplTest {
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var eventPublisher: ApplicationEventPublisher
+    private lateinit var service: GameLifecycleServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        gameTeamRepository = mockk()
+        pitchingRecordRepository = mockk()
+        eventPublisher = mockk(relaxed = true)
+        service =
+            GameLifecycleServiceImpl(
+                gameRepository = gameRepository,
+                gameTeamRepository = gameTeamRepository,
+                pitchingRecordRepository = pitchingRecordRepository,
+                eventPublisher = eventPublisher,
+            )
+    }
+
+    @Nested
+    @DisplayName("postponeGame")
+    inner class PostponeGameTest {
+        @Test
+        @DisplayName("예정 상태의 경기를 연기하고 이벤트를 발행한다")
+        fun postponeScheduledGameSuccessfully() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0)
+            val game = createGame(gameId, status = GameStatus.SCHEDULED)
+            val homeTeam = createGameTeam(gameId, teamId = 10L, homeAway = HomeAway.HOME)
+            val awayTeam = createGameTeam(gameId, teamId = 20L, homeAway = HomeAway.AWAY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(game) } returns game
+            every { gameTeamRepository.findAllByGameId(gameId) } returns listOf(homeTeam, awayTeam)
+
+            val eventSlot = slot<GamePostponedEvent>()
+            every { eventPublisher.publishEvent(capture(eventSlot)) } returns Unit
+
+            // when
+            val result = service.postponeGame(gameId, newScheduledAt, "우천")
+
+            // then
+            assertThat(result).isEqualTo(game)
+            verify(exactly = 1) { game.postpone(newScheduledAt, "우천") }
+            verify(exactly = 1) { gameRepository.save(game) }
+            verify(exactly = 1) { eventPublisher.publishEvent(any<GamePostponedEvent>()) }
+
+            assertThat(eventSlot.captured.gameId).isEqualTo(gameId)
+            assertThat(eventSlot.captured.homeTeamId).isEqualTo(10L)
+            assertThat(eventSlot.captured.awayTeamId).isEqualTo(20L)
+            assertThat(eventSlot.captured.newScheduledAt).isEqualTo(newScheduledAt)
+        }
+
+        @Test
+        @DisplayName("reason 없이 연기할 수 있다")
+        fun postponeGameWithoutReason() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0)
+            val game = createGame(gameId, status = GameStatus.SCHEDULED)
+            val homeTeam = createGameTeam(gameId, teamId = 10L, homeAway = HomeAway.HOME)
+            val awayTeam = createGameTeam(gameId, teamId = 20L, homeAway = HomeAway.AWAY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(game) } returns game
+            every { gameTeamRepository.findAllByGameId(gameId) } returns listOf(homeTeam, awayTeam)
+
+            // when
+            val result = service.postponeGame(gameId, newScheduledAt, null)
+
+            // then
+            assertThat(result).isEqualTo(game)
+            verify(exactly = 1) { game.postpone(newScheduledAt, null) }
+        }
+
+        @Test
+        @DisplayName("진행 중인 경기는 연기할 수 없다")
+        fun cannotPostponeInProgressGame() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0)
+            val game = createGame(gameId, status = GameStatus.IN_PROGRESS)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+
+            // when & then
+            assertThatThrownBy { service.postponeGame(gameId, newScheduledAt, null) }
+                .isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("예정 상태의 경기만 연기할 수 있습니다")
+        }
+
+        @Test
+        @DisplayName("종료된 경기는 연기할 수 없다")
+        fun cannotPostponeFinishedGame() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0)
+            val game = createGame(gameId, status = GameStatus.FINISHED)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+
+            // when & then
+            assertThatThrownBy { service.postponeGame(gameId, newScheduledAt, null) }
+                .isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("예정 상태의 경기만 연기할 수 있습니다")
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 경기는 GameNotFoundException을 던진다")
+        fun postponeNonExistentGameThrowsException() {
+            // given
+            val gameId = 999L
+            val newScheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns null
+
+            // when & then
+            assertThatThrownBy { service.postponeGame(gameId, newScheduledAt, null) }
+                .isInstanceOf(GameNotFoundException::class.java)
+        }
+
+        @Test
+        @DisplayName("홈팀이 없으면 이벤트를 발행하지 않는다")
+        fun doesNotPublishEventWhenHomeTeamMissing() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0)
+            val game = createGame(gameId, status = GameStatus.SCHEDULED)
+            val awayTeam = createGameTeam(gameId, teamId = 20L, homeAway = HomeAway.AWAY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(game) } returns game
+            every { gameTeamRepository.findAllByGameId(gameId) } returns listOf(awayTeam)
+
+            // when
+            service.postponeGame(gameId, newScheduledAt, null)
+
+            // then
+            verify(exactly = 0) { eventPublisher.publishEvent(any<GamePostponedEvent>()) }
+        }
+
+        @Test
+        @DisplayName("원정팀이 없으면 이벤트를 발행하지 않는다")
+        fun doesNotPublishEventWhenAwayTeamMissing() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0)
+            val game = createGame(gameId, status = GameStatus.SCHEDULED)
+            val homeTeam = createGameTeam(gameId, teamId = 10L, homeAway = HomeAway.HOME)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(game) } returns game
+            every { gameTeamRepository.findAllByGameId(gameId) } returns listOf(homeTeam)
+
+            // when
+            service.postponeGame(gameId, newScheduledAt, null)
+
+            // then
+            verify(exactly = 0) { eventPublisher.publishEvent(any<GamePostponedEvent>()) }
+        }
+
+        @Test
+        @DisplayName("팀이 없는 경우 이벤트를 발행하지 않는다")
+        fun doesNotPublishEventWhenNoTeams() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 4, 1, 14, 0)
+            val game = createGame(gameId, status = GameStatus.SCHEDULED)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(game) } returns game
+            every { gameTeamRepository.findAllByGameId(gameId) } returns emptyList()
+
+            // when
+            service.postponeGame(gameId, newScheduledAt, null)
+
+            // then
+            verify(exactly = 0) { eventPublisher.publishEvent(any<GamePostponedEvent>()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("rescheduleGame")
+    inner class RescheduleGameTest {
+        @Test
+        @DisplayName("예정 상태의 경기 일정을 변경하고 이벤트를 발행한다")
+        fun rescheduleScheduledGameSuccessfully() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+            val game = createGame(gameId, status = GameStatus.SCHEDULED)
+            val homeTeam = createGameTeam(gameId, teamId = 10L, homeAway = HomeAway.HOME)
+            val awayTeam = createGameTeam(gameId, teamId = 20L, homeAway = HomeAway.AWAY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(game) } returns game
+            every { gameTeamRepository.findAllByGameId(gameId) } returns listOf(homeTeam, awayTeam)
+
+            val eventSlot = slot<GameRescheduledEvent>()
+            every { eventPublisher.publishEvent(capture(eventSlot)) } returns Unit
+
+            // when
+            val result = service.rescheduleGame(gameId, newScheduledAt)
+
+            // then
+            assertThat(result).isEqualTo(game)
+            verify(exactly = 1) { game.reschedule(newScheduledAt) }
+            verify(exactly = 1) { gameRepository.save(game) }
+            verify(exactly = 1) { eventPublisher.publishEvent(any<GameRescheduledEvent>()) }
+
+            assertThat(eventSlot.captured.gameId).isEqualTo(gameId)
+            assertThat(eventSlot.captured.homeTeamId).isEqualTo(10L)
+            assertThat(eventSlot.captured.awayTeamId).isEqualTo(20L)
+            assertThat(eventSlot.captured.newScheduledAt).isEqualTo(newScheduledAt)
+        }
+
+        @Test
+        @DisplayName("연기 상태의 경기 일정을 변경할 수 있다")
+        fun reschedulePostponedGameSuccessfully() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+            val game = createGame(gameId, status = GameStatus.POSTPONED)
+            val homeTeam = createGameTeam(gameId, teamId = 10L, homeAway = HomeAway.HOME)
+            val awayTeam = createGameTeam(gameId, teamId = 20L, homeAway = HomeAway.AWAY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(game) } returns game
+            every { gameTeamRepository.findAllByGameId(gameId) } returns listOf(homeTeam, awayTeam)
+
+            // when
+            val result = service.rescheduleGame(gameId, newScheduledAt)
+
+            // then
+            assertThat(result).isEqualTo(game)
+            verify(exactly = 1) { game.reschedule(newScheduledAt) }
+            verify(exactly = 1) { eventPublisher.publishEvent(any<GameRescheduledEvent>()) }
+        }
+
+        @Test
+        @DisplayName("진행 중인 경기는 일정을 변경할 수 없다")
+        fun cannotRescheduleInProgressGame() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+            val game = createGame(gameId, status = GameStatus.IN_PROGRESS)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+
+            // when & then
+            assertThatThrownBy { service.rescheduleGame(gameId, newScheduledAt) }
+                .isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("예정 또는 연기 상태의 경기만 일정을 변경할 수 있습니다")
+        }
+
+        @Test
+        @DisplayName("종료된 경기는 일정을 변경할 수 없다")
+        fun cannotRescheduleFinishedGame() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+            val game = createGame(gameId, status = GameStatus.FINISHED)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+
+            // when & then
+            assertThatThrownBy { service.rescheduleGame(gameId, newScheduledAt) }
+                .isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("예정 또는 연기 상태의 경기만 일정을 변경할 수 있습니다")
+        }
+
+        @Test
+        @DisplayName("취소된 경기는 일정을 변경할 수 없다")
+        fun cannotRescheduleCancelledGame() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+            val game = createGame(gameId, status = GameStatus.CANCELLED)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+
+            // when & then
+            assertThatThrownBy { service.rescheduleGame(gameId, newScheduledAt) }
+                .isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("예정 또는 연기 상태의 경기만 일정을 변경할 수 있습니다")
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 경기는 GameNotFoundException을 던진다")
+        fun rescheduleNonExistentGameThrowsException() {
+            // given
+            val gameId = 999L
+            val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns null
+
+            // when & then
+            assertThatThrownBy { service.rescheduleGame(gameId, newScheduledAt) }
+                .isInstanceOf(GameNotFoundException::class.java)
+        }
+
+        @Test
+        @DisplayName("홈팀이 없으면 이벤트를 발행하지 않는다")
+        fun doesNotPublishEventWhenHomeTeamMissing() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+            val game = createGame(gameId, status = GameStatus.SCHEDULED)
+            val awayTeam = createGameTeam(gameId, teamId = 20L, homeAway = HomeAway.AWAY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(game) } returns game
+            every { gameTeamRepository.findAllByGameId(gameId) } returns listOf(awayTeam)
+
+            // when
+            service.rescheduleGame(gameId, newScheduledAt)
+
+            // then
+            verify(exactly = 0) { eventPublisher.publishEvent(any<GameRescheduledEvent>()) }
+        }
+
+        @Test
+        @DisplayName("원정팀이 없으면 이벤트를 발행하지 않는다")
+        fun doesNotPublishEventWhenAwayTeamMissing() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+            val game = createGame(gameId, status = GameStatus.SCHEDULED)
+            val homeTeam = createGameTeam(gameId, teamId = 10L, homeAway = HomeAway.HOME)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(game) } returns game
+            every { gameTeamRepository.findAllByGameId(gameId) } returns listOf(homeTeam)
+
+            // when
+            service.rescheduleGame(gameId, newScheduledAt)
+
+            // then
+            verify(exactly = 0) { eventPublisher.publishEvent(any<GameRescheduledEvent>()) }
+        }
+
+        @Test
+        @DisplayName("팀이 없는 경우 이벤트를 발행하지 않는다")
+        fun doesNotPublishEventWhenNoTeams() {
+            // given
+            val gameId = 1L
+            val newScheduledAt = LocalDateTime.of(2026, 5, 10, 18, 0)
+            val game = createGame(gameId, status = GameStatus.SCHEDULED)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.save(game) } returns game
+            every { gameTeamRepository.findAllByGameId(gameId) } returns emptyList()
+
+            // when
+            service.rescheduleGame(gameId, newScheduledAt)
+
+            // then
+            verify(exactly = 0) { eventPublisher.publishEvent(any<GameRescheduledEvent>()) }
+        }
+    }
+
+    // Helper methods
+    private fun createGame(
+        id: Long,
+        status: GameStatus = GameStatus.SCHEDULED,
+    ): Game {
+        val game = mockk<Game>(relaxed = true)
+        every { game.id } returns id
+        every { game.status } returns status
+        return game
+    }
+
+    private fun createGameTeam(
+        gameId: Long,
+        teamId: Long = 1L,
+        homeAway: HomeAway = HomeAway.HOME,
+    ): GameTeam {
+        val gameTeam = mockk<GameTeam>(relaxed = true)
+        val game = mockk<Game>(relaxed = true)
+        val team = mockk<Team>(relaxed = true)
+
+        every { gameTeam.game } returns game
+        every { gameTeam.team } returns team
+        every { gameTeam.homeAway } returns homeAway
+
+        every { game.id } returns gameId
+        every { team.id } returns teamId
+        every { team.name } returns "팀 $teamId"
+
+        return gameTeam
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplTest.kt
@@ -44,6 +44,7 @@ class GameLifecycleServiceImplTest {
                 gameRepository = gameRepository,
                 gameTeamRepository = gameTeamRepository,
                 pitchingRecordRepository = pitchingRecordRepository,
+                pitchingDecisionService = mockk(relaxed = true),
                 eventPublisher = eventPublisher,
             )
     }


### PR DESCRIPTION
## Summary

>- close #336 
- **H-20**: 경기 취소/연기/일정변경 시 양팀 멤버에게 알림 발송 (GAME_CANCELLED, GAME_POSTPONED, GAME_RESCHEDULED)
- **H-21**: NotificationService.sendNotification()에 Preference opt-out 모델 적용 (설정 없으면 기본 활성화, 비활성화 시 발송 스킵)
- **M-20**: 팀원 탈퇴 시 관리자(OWNER/MANAGER)에게 알림, 팀원 강퇴 시 본인에게 알림 (TEAM_MEMBER_LEFT, TEAM_MEMBER_KICKED)

## Changes

### Core (nextup-core)
- `NotificationType`: 6개 신규 타입 추가 (GAME_CANCELLED, GAME_RESCHEDULED, GAME_POSTPONED, TEAM_MEMBER_LEFT, TEAM_MEMBER_KICKED, RECORD_CORRECTED)
- `GamePostponedEvent`, `GameRescheduledEvent`: 신규 도메인 이벤트
- `GameCancelledEvent`: homeTeamId, awayTeamId 필드 추가 (기본값 0L로 하위 호환)
- `TeamMemberLeftEvent`, `TeamMemberKickedEvent`: userId, teamName 필드 추가
- `NotificationService.sendNotification()`: Preference 확인 로직 추가 (opt-out 모델)
- `GameLifecycleService`: postponeGame, rescheduleGame 인터페이스 추가

### Infrastructure (nextup-infrastructure)
- `NotificationEventListener`: 5개 신규 핸들러
  - handleGameCancelled: 양팀 활성 멤버에게 경기 취소 알림
  - handleGamePostponed: 양팀 활성 멤버에게 경기 연기 알림
  - handleGameRescheduled: 양팀 활성 멤버에게 일정 변경 알림
  - handleTeamMemberLeft: 팀 관리자(OWNER/MANAGER)에게 탈퇴 알림
  - handleTeamMemberKicked: 강퇴된 본인에게 알림
- `GameLifecycleServiceImpl`: postponeGame, rescheduleGame 구현 + cancelGame에 팀 정보 포함
- `TeamMembershipServiceImpl`: kickMember, leaveMember에 이벤트 발행 추가

### Tests
- `NotificationServiceTest`: Preference opt-out 테스트 4개 추가
- `NotificationServicePushCoverageTest`: nullable 반환 타입 대응
- `NotificationEventListenerTest`: 5개 핸들러 테스트 추가
- `TeamMemberEventTest`: 변경된 이벤트 필드 반영
- `TeamMemberEventListenerTest`: 변경된 이벤트 필드 반영

## Tasks
- [x] H-20: 경기 취소/연기/일정변경 알림
- [x] H-21: Notification Preference 확인 적용
- [x] M-20: 팀원 탈퇴/강퇴 알림
- [x] 기존 테스트 업데이트
- [x] 신규 테스트 작성
- [x] ktlintFormat 통과
- [x] 전체 빌드 성공

Closes #336