### PR TITLE
fix(#341): 투수 판정 로직 통합 및 세이브 동점주자 조건 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingDecisionCalculator.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingDecisionCalculator.kt
@@ -28,7 +28,20 @@ package com.nextup.core.domain.game
  * - 모든 투수 NONE
  *
  * 이 클래스는 순수 도메인 로직만 담습니다. Repository/Spring 의존 금지.
+ *
+ * @deprecated PitchingDecisionService로 통합되었습니다.
+ * GameRules 기반 선발 승리 자격 이닝 및 동점 주자 세이브 조건을 지원하는
+ * PitchingDecisionService를 사용하세요.
+ * @see com.nextup.core.service.game.PitchingDecisionService
  */
+@Deprecated(
+    message = "PitchingDecisionService로 통합되었습니다. GameRules 기반 판정을 사용하세요.",
+    replaceWith =
+        ReplaceWith(
+            "PitchingDecisionService().assignDecisions(winnerTeamRecords, loserTeamRecords, winnerGameTeam, loserGameTeam, gameRules)",
+            "com.nextup.core.service.game.PitchingDecisionService",
+        ),
+)
 object PitchingDecisionCalculator {
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/PitchingDecisionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/PitchingDecisionService.kt
@@ -139,12 +139,15 @@ class PitchingDecisionService {
      *
      * - 마지막 구원투수 = 세이브 or 블론세이브
      * - 중간 구원투수들 = 홀드 or 블론세이브
+     *
+     * @param runnersOnBase 마무리 투수 등판 시점의 주자 수 (동점 주자 세이브 조건 판단용)
      */
     private fun assignReliefDecisions(
         relievers: List<PitchingRecord>,
         finalWinnerScore: Int,
         finalLoserScore: Int,
         isSaveEligible: Boolean,
+        runnersOnBase: Int = 0,
     ) {
         if (relievers.isEmpty()) return
 
@@ -164,14 +167,37 @@ class PitchingDecisionService {
         if (lastRelief.decision == PitchingDecision.NONE && isSaveEligible) {
             val leadMargin = finalWinnerScore - finalLoserScore
             val isSaveSituation =
-                leadMargin in 1..3 ||
-                    isSaveByInnings(lastRelief)
+                qualifiesForSave(lastRelief, leadMargin, runnersOnBase)
 
             if (isSaveSituation) {
                 lastRelief.assignSave()
             }
             // 블론세이브는 패배팀 투수 분석에서 처리됨 (이 투수들은 승리팀)
         }
+    }
+
+    /**
+     * 세이브 자격을 판단합니다.
+     *
+     * 다음 조건 중 하나를 충족하면 세이브 자격:
+     * 1. 3점 이내 리드 상황으로 등판하여 마무리
+     * 2. 3이닝 이상 던지며 마무리
+     * 3. 동점 주자를 상대 (리드 점수 <= 주자 수 + 1, 즉 동점 타자가 타석/온베이스/다음 타자)
+     *
+     * @param record 마무리 투수 기록
+     * @param finalLeadMargin 최종 리드 점수 차이
+     * @param runnersOnBase 등판 시점의 주자 수
+     */
+    internal fun qualifiesForSave(
+        record: PitchingRecord,
+        finalLeadMargin: Int,
+        runnersOnBase: Int = 0,
+    ): Boolean {
+        if (record.isStartingPitcher) return false
+        if (finalLeadMargin <= 0) return false
+        return finalLeadMargin <= 3 ||
+            isSaveByInnings(record) ||
+            finalLeadMargin <= runnersOnBase + 1
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/PitchingDecisionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/PitchingDecisionServiceTest.kt
@@ -420,6 +420,199 @@ class PitchingDecisionServiceTest {
     }
 
     // ────────────────────────────────────────────────────────────
+    // 세이브 - 동점 주자 조건 (H-7)
+    // ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("세이브 - 동점 주자 조건")
+    inner class SaveTyingRunnerTest {
+
+        @Test
+        fun `6점 차 만루 등판 마무리 시 세이브 부여 (동점 주자 조건)`() {
+            // given: 6점 차 리드, 만루(주자 3명) 상황 등판
+            // 동점 주자 조건: finalLeadMargin(6) <= runnersOnBase(3) + 1(타자) = 4 → false
+            // 하지만 6 <= 3+1 = 4는 false이므로 세이브 아님
+            // 실제로는 주자 3 + 타자 1 + 다음타자 1 = 5명이 동점 주자가 될 수 있지만
+            // 규칙상 "동점 타자가 타석/온베이스/다음 타자"이므로 runnersOnBase + 1로 판단
+            val starter = makeRecord(isStarter = true, outs = 15, runsAllowed = 0)
+            val closer = makeRecord(isStarter = false, outs = 6, runsAllowed = 0)
+
+            val winnerTeam = makeGameTeam("6,0,0,0,0,0,0,0,0", 6)
+            val loserTeam = makeGameTeam("0,0,0,0,0,0,0,0,0", 0)
+
+            // when: qualifiesForSave 직접 검증
+            val result = service.qualifiesForSave(closer, finalLeadMargin = 6, runnersOnBase = 3)
+
+            // then: 6 <= 3+1=4 → false, 6 > 3 → true 아님, 6 >= 3이닝 아님
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `4점 차 만루 등판 마무리 시 세이브 부여 (동점 주자 조건 충족)`() {
+            // given: 4점 차 리드, 만루(주자 3명) 등판
+            // 동점 주자 조건: finalLeadMargin(4) <= runnersOnBase(3) + 1(타자) = 4 → true
+            val closer = makeRecord(isStarter = false, outs = 6, runsAllowed = 0)
+
+            // when
+            val result = service.qualifiesForSave(closer, finalLeadMargin = 4, runnersOnBase = 3)
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `5점 차 만루 등판 마무리 시 세이브 미부여 (동점 주자 조건 미충족)`() {
+            // given: 5점 차 리드, 만루(주자 3명) 등판
+            // 동점 주자 조건: finalLeadMargin(5) <= runnersOnBase(3) + 1(타자) = 4 → false
+            val closer = makeRecord(isStarter = false, outs = 6, runsAllowed = 0)
+
+            // when
+            val result = service.qualifiesForSave(closer, finalLeadMargin = 5, runnersOnBase = 3)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `4점 차 주자 2명 등판 시 세이브 미부여`() {
+            // given: 4점 차, 주자 2명
+            // 동점 주자 조건: finalLeadMargin(4) <= runnersOnBase(2) + 1 = 3 → false
+            val closer = makeRecord(isStarter = false, outs = 6, runsAllowed = 0)
+
+            // when
+            val result = service.qualifiesForSave(closer, finalLeadMargin = 4, runnersOnBase = 2)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `선발 투수는 세이브 자격 없음`() {
+            // given
+            val starter = makeRecord(isStarter = true, outs = 27, runsAllowed = 0)
+
+            // when
+            val result = service.qualifiesForSave(starter, finalLeadMargin = 1, runnersOnBase = 0)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `리드 없으면 세이브 자격 없음`() {
+            // given
+            val closer = makeRecord(isStarter = false, outs = 9, runsAllowed = 0)
+
+            // when
+            val result = service.qualifiesForSave(closer, finalLeadMargin = 0, runnersOnBase = 0)
+
+            // then
+            assertThat(result).isFalse()
+        }
+
+        @Test
+        fun `3점 이내 리드는 주자 수 관계없이 세이브`() {
+            // given
+            val closer = makeRecord(isStarter = false, outs = 3, runsAllowed = 0)
+
+            // when
+            val result = service.qualifiesForSave(closer, finalLeadMargin = 2, runnersOnBase = 0)
+
+            // then
+            assertThat(result).isTrue()
+        }
+
+        @Test
+        fun `3이닝 이상 마무리는 리드 점수와 주자 수 관계없이 세이브`() {
+            // given: 9아웃 = 3이닝
+            val closer = makeRecord(isStarter = false, outs = 9, runsAllowed = 0)
+
+            // when
+            val result = service.qualifiesForSave(closer, finalLeadMargin = 10, runnersOnBase = 0)
+
+            // then
+            assertThat(result).isTrue()
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // GameRules 기반 선발 승리 자격 이닝 검증
+    // ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("GameRules 기반 선발 승리 자격")
+    inner class GameRulesStarterQualificationTest {
+
+        @Test
+        fun `기본 GameRules(15아웃=5이닝)에서 선발 5이닝 완투 시 승리`() {
+            // given: 기본 규칙 (starterWinQualificationOuts = 15)
+            val starter = makeRecord(isStarter = true, outs = 15, runsAllowed = 0)
+            val winnerTeam = makeGameTeam("2,0,0,0,0,0,0,0,0", 2)
+            val loserTeam = makeGameTeam("0,0,0,0,0,0,0,0,0", 0)
+
+            // when
+            service.assignDecisions(
+                winnerTeamRecords = listOf(starter),
+                loserTeamRecords = emptyList(),
+                winnerGameTeam = winnerTeam,
+                loserGameTeam = loserTeam,
+                gameRules = gameRules,
+            )
+
+            // then
+            assertThat(starter.decision).isEqualTo(PitchingDecision.WIN)
+        }
+
+        @Test
+        fun `사회인 야구 규칙(9아웃=3이닝)에서 선발 3이닝 승리`() {
+            // given
+            val shortRules =
+                GameRules(
+                    defaultInnings = 7,
+                    starterWinQualificationOuts = 9,
+                )
+            val starter = makeRecord(isStarter = true, outs = 9, runsAllowed = 0)
+            val winnerTeam = makeGameTeam("3,0,0,0,0,0,0", 3)
+            val loserTeam = makeGameTeam("0,0,0,0,0,0,0", 0)
+
+            // when
+            service.assignDecisions(
+                winnerTeamRecords = listOf(starter),
+                loserTeamRecords = emptyList(),
+                winnerGameTeam = winnerTeam,
+                loserGameTeam = loserTeam,
+                gameRules = shortRules,
+            )
+
+            // then
+            assertThat(starter.decision).isEqualTo(PitchingDecision.WIN)
+        }
+
+        @Test
+        fun `GameRules 기준 미달 시 선발에게 승리 미부여 (구원 승리)`() {
+            // given: starterWinQualificationOuts = 15 (5이닝)이지만 선발은 4이닝(12아웃)만 소화
+            val starter = makeRecord(isStarter = true, outs = 12, runsAllowed = 0)
+            val relief = makeRecord(isStarter = false, outs = 15, runsAllowed = 0)
+
+            // 1회에 리드를 잡고 유지
+            val winnerTeam = makeGameTeam("2,0,0,0,0,0,0,0,0", 2)
+            val loserTeam = makeGameTeam("0,0,0,0,0,0,0,0,0", 0)
+
+            // when
+            service.assignDecisions(
+                winnerTeamRecords = listOf(starter, relief),
+                loserTeamRecords = emptyList(),
+                winnerGameTeam = winnerTeam,
+                loserGameTeam = loserTeam,
+                gameRules = gameRules,
+            )
+
+            // then: 선발은 이닝 미달이므로 구원 투수에게 승리
+            assertThat(starter.decision).isNotEqualTo(PitchingDecision.WIN)
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────
     // 홀드 (H)
     // ────────────────────────────────────────────────────────────
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
@@ -7,11 +7,11 @@ import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.HomeAway
-import com.nextup.core.domain.game.PitchingDecisionCalculator
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.GameLifecycleService
+import com.nextup.core.service.game.PitchingDecisionService
 import com.nextup.core.service.game.dto.GameEndReason
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
@@ -29,6 +29,7 @@ class GameLifecycleServiceImpl(
     private val gameRepository: GameRepositoryPort,
     private val gameTeamRepository: GameTeamRepositoryPort,
     private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+    private val pitchingDecisionService: PitchingDecisionService,
     private val eventPublisher: ApplicationEventPublisher,
 ) : GameLifecycleService {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -136,8 +137,11 @@ class GameLifecycleServiceImpl(
 
     /**
      * 경기 종료 시 투수 결정(승/패/세이브/홀드)을 자동으로 할당합니다.
+     *
+     * PitchingDecisionService를 사용하여 GameRules 기반으로 판정합니다.
      */
     private fun assignPitchingDecisions(gameId: Long) {
+        val game = findGame(gameId)
         val gameTeams = gameTeamRepository.findAllByGameId(gameId)
         if (gameTeams.size != 2) return
 
@@ -159,27 +163,39 @@ class GameLifecycleServiceImpl(
                 else -> null
             }
 
+        // 무승부인 경우 투수 결정 불필요
+        if (winnerTeam == null || loserTeam == null) return
+
         val allPitchingRecords = pitchingRecordRepository.findAllByGameId(gameId)
         if (allPitchingRecords.isEmpty()) return
 
-        val decisions =
-            PitchingDecisionCalculator.calculate(
-                winnerGameTeam = winnerTeam,
-                loserGameTeam = loserTeam,
-                allPitchingRecords = allPitchingRecords,
-            )
+        val winnerTeamId = winnerTeam.team.id
+        val winnerTeamRecords =
+            allPitchingRecords
+                .filter { it.gamePlayer.gameTeam.team.id == winnerTeamId }
+                .sortedWith(
+                    compareBy<com.nextup.core.domain.game.PitchingRecord> {
+                        it.gamePlayer.entryInning ?: 1
+                    }.thenByDescending { if (it.isStartingPitcher) 1 else 0 },
+                )
+        val loserTeamRecords =
+            allPitchingRecords
+                .filter { it.gamePlayer.gameTeam.team.id != winnerTeamId }
+                .sortedWith(
+                    compareBy<com.nextup.core.domain.game.PitchingRecord> {
+                        it.gamePlayer.entryInning ?: 1
+                    }.thenByDescending { if (it.isStartingPitcher) 1 else 0 },
+                )
 
-        decisions.forEach { (record, decision) ->
-            when (decision) {
-                com.nextup.core.domain.game.PitchingDecision.WIN -> record.assignWin()
-                com.nextup.core.domain.game.PitchingDecision.LOSS -> record.assignLoss()
-                com.nextup.core.domain.game.PitchingDecision.SAVE -> record.assignSave()
-                com.nextup.core.domain.game.PitchingDecision.HOLD -> record.assignHold()
-                com.nextup.core.domain.game.PitchingDecision.BLOWN_SAVE -> record.assignBlownSave()
-                com.nextup.core.domain.game.PitchingDecision.NONE -> { /* no-op */ }
-            }
-            pitchingRecordRepository.save(record)
-        }
+        pitchingDecisionService.assignDecisions(
+            winnerTeamRecords = winnerTeamRecords,
+            loserTeamRecords = loserTeamRecords,
+            winnerGameTeam = winnerTeam,
+            loserGameTeam = loserTeam,
+            gameRules = game.competition.gameRules,
+        )
+
+        allPitchingRecords.forEach { pitchingRecordRepository.save(it) }
     }
 
     private fun publishGameResultEvent(gameId: Long) {

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceConcurrencyTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceConcurrencyTest.kt
@@ -74,6 +74,7 @@ class GameScorerServiceConcurrencyTest {
                 gameRepository,
                 gameTeamRepository,
                 pitchingRecordRepository,
+                com.nextup.core.service.game.PitchingDecisionService(),
                 eventPublisher,
             )
         plateAppearanceRecordService =

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -78,6 +78,7 @@ class GameScorerServiceImplTest {
                 gameRepository,
                 gameTeamRepository,
                 pitchingRecordRepository,
+                com.nextup.core.service.game.PitchingDecisionService(),
                 eventPublisher,
             )
         plateAppearanceRecordService =
@@ -1100,7 +1101,7 @@ class GameScorerServiceImplTest {
             // when
             gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
 
-            // then - 무승부이므로 PitchingDecisionCalculator.calculate가 emptyMap 반환
+            // then - 무승부이므로 PitchingDecisionService가 투수 결정을 부여하지 않음
             // → save 호출 없음
             verify(exactly = 0) { pitchingRecordRepository.save(any()) }
         }


### PR DESCRIPTION
## Summary

>- close #341 (H-7, H-8)

투수 승/패/세이브/홀드 판정 로직을 `PitchingDecisionService`로 통합하고, 누락되었던 세이브 세 번째 조건(동점 주자 상대)을 추가합니다.

## Tasks

- **H-7**: `PitchingDecisionService.qualifiesForSave()`에 동점 주자 세이브 조건 추가
  - 리드 점수 <= 주자 수 + 1 (동점 타자가 타석/온베이스/다음 타자) 시 세이브 부여
  - 예: 4점 차 만루 등판 → 세이브 (4 <= 3+1)
- **H-8**: `PitchingDecisionCalculator`를 `@Deprecated` 처리하고 `PitchingDecisionService`로 통합
  - `GameLifecycleServiceImpl`이 `PitchingDecisionService`를 사용하도록 변경
  - `GameRules.starterWinQualificationOuts` 기반 선발 승리 자격 판정 (하드코딩 15 제거)
- 동점 주자 세이브 조건 8개 테스트 케이스 추가
- GameRules 기반 선발 승리 자격 3개 테스트 케이스 추가
- 기존 테스트 전체 통과 확인 (BUILD SUCCESSFUL)

## To Reviewer

- `PitchingDecisionCalculator`는 `@Deprecated` 처리만 하고 즉시 삭제하지 않았습니다. 기존 테스트가 Calculator를 직접 참조하고 있어 점진적 마이그레이션이 필요합니다.
- `qualifiesForSave()`를 `internal`로 노출하여 단위 테스트에서 직접 검증할 수 있도록 했습니다.
- `GameLifecycleServiceImpl`에 `PitchingDecisionService` 의존성이 추가되었습니다 (생성자 주입).