### PR TITLE
feat(#343): 예약 양도 사용자 API 추가 (nextup-api)

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/BookingTransferController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/BookingTransferController.kt
@@ -1,0 +1,114 @@
+package com.nextup.api.controller.stadium
+
+import com.nextup.api.dto.stadium.AcceptBookingTransferApiRequest
+import com.nextup.api.dto.stadium.BookingTransferResponse
+import com.nextup.api.dto.stadium.CreateBookingTransferApiRequest
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.stadium.BookingTransferService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 예약 양도 사용자 API Controller
+ *
+ * 일반 사용자가 예약 양도를 요청/수락/거절/조회할 수 있는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/booking-transfers")
+class BookingTransferController(
+    private val bookingTransferService: BookingTransferService,
+) {
+    /**
+     * 예약 양도를 등록합니다.
+     *
+     * POST /api/v1/booking-transfers
+     */
+    @PostMapping
+    fun requestTransfer(
+        @RequestBody @Valid request: CreateBookingTransferApiRequest,
+    ): ResponseEntity<ApiResponse<BookingTransferResponse>> {
+        val transfer =
+            bookingTransferService.createTransfer(
+                bookingId = request.bookingId,
+                teamId = request.sellerTeamId,
+                price = request.transferPrice,
+                message = request.message,
+                expiresAt =
+                    request.expiresAt
+                        ?: java.time.Instant.now()
+                            .plusSeconds(BookingTransferService.DEFAULT_EXPIRY_SECONDS),
+            )
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(BookingTransferResponse.from(transfer)))
+    }
+
+    /**
+     * 예약 양도를 수락합니다.
+     *
+     * PATCH /api/v1/booking-transfers/{transferId}/accept
+     */
+    @PatchMapping("/{transferId}/accept")
+    fun acceptTransfer(
+        @PathVariable transferId: Long,
+        @RequestBody @Valid request: AcceptBookingTransferApiRequest,
+    ): ApiResponse<BookingTransferResponse> {
+        val transfer =
+            bookingTransferService.acceptTransfer(
+                transferId = transferId,
+                buyerTeamId = request.buyerTeamId,
+            )
+        return ApiResponse.success(BookingTransferResponse.from(transfer))
+    }
+
+    /**
+     * 예약 양도를 취소(거절)합니다.
+     *
+     * PATCH /api/v1/booking-transfers/{transferId}/reject
+     */
+    @PatchMapping("/{transferId}/reject")
+    fun rejectTransfer(
+        @PathVariable transferId: Long,
+        @RequestParam teamId: Long,
+    ): ApiResponse<BookingTransferResponse> {
+        val transfer =
+            bookingTransferService.cancelTransfer(
+                transferId = transferId,
+                teamId = teamId,
+            )
+        return ApiResponse.success(BookingTransferResponse.from(transfer))
+    }
+
+    /**
+     * 양도 가능한 예약 목록을 조회합니다.
+     *
+     * GET /api/v1/booking-transfers/available
+     */
+    @GetMapping("/available")
+    fun getAvailableTransfers(): ApiResponse<List<BookingTransferResponse>> {
+        val transfers = bookingTransferService.getAvailableTransfers()
+        return ApiResponse.success(transfers.map { BookingTransferResponse.from(it) })
+    }
+
+    /**
+     * 내 팀의 양도 목록을 조회합니다 (판매/구매 포함).
+     *
+     * GET /api/v1/booking-transfers/my?teamId={teamId}
+     */
+    @GetMapping("/my")
+    fun getMyTransfers(
+        @RequestParam teamId: Long,
+    ): ApiResponse<List<BookingTransferResponse>> {
+        val transfers = bookingTransferService.getTransfersByTeamId(teamId)
+        return ApiResponse.success(transfers.map { BookingTransferResponse.from(it) })
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/BookingTransferRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/BookingTransferRequest.kt
@@ -1,0 +1,30 @@
+package com.nextup.api.dto.stadium
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * 예약 양도 등록 요청 DTO (사용자용)
+ */
+data class CreateBookingTransferApiRequest(
+    @field:NotNull
+    @field:Positive
+    val bookingId: Long,
+    @field:NotNull
+    @field:Positive
+    val sellerTeamId: Long,
+    val transferPrice: BigDecimal? = null,
+    val message: String? = null,
+    val expiresAt: Instant? = null,
+)
+
+/**
+ * 예약 양도 수락 요청 DTO (사용자용)
+ */
+data class AcceptBookingTransferApiRequest(
+    @field:NotNull
+    @field:Positive
+    val buyerTeamId: Long,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/BookingTransferResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stadium/BookingTransferResponse.kt
@@ -1,0 +1,38 @@
+package com.nextup.api.dto.stadium
+
+import com.nextup.core.domain.stadium.BookingTransfer
+import com.nextup.core.domain.stadium.TransferStatus
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * 예약 양도 응답 DTO (사용자용)
+ */
+data class BookingTransferResponse(
+    val id: Long,
+    val bookingId: Long,
+    val sellerTeamId: Long,
+    val transferPrice: BigDecimal?,
+    val message: String?,
+    val status: TransferStatus,
+    val buyerTeamId: Long?,
+    val expiresAt: Instant,
+    val acceptedAt: Instant?,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(transfer: BookingTransfer): BookingTransferResponse =
+            BookingTransferResponse(
+                id = transfer.id,
+                bookingId = transfer.bookingId,
+                sellerTeamId = transfer.sellerTeamId,
+                transferPrice = transfer.transferPrice,
+                message = transfer.message,
+                status = transfer.status,
+                buyerTeamId = transfer.buyerTeamId,
+                expiresAt = transfer.expiresAt,
+                acceptedAt = transfer.acceptedAt,
+                createdAt = transfer.createdAt,
+            )
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingTransferControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingTransferControllerTest.kt
@@ -1,0 +1,327 @@
+package com.nextup.api.controller.stadium
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.stadium.AcceptBookingTransferApiRequest
+import com.nextup.api.dto.stadium.CreateBookingTransferApiRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.BookingTransferForbiddenException
+import com.nextup.common.exception.BookingTransferNotFoundException
+import com.nextup.core.domain.stadium.BookingTransfer
+import com.nextup.core.domain.stadium.TransferStatus
+import com.nextup.core.service.stadium.BookingTransferService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+import java.time.Instant
+
+@DisplayName("BookingTransferController (사용자 API)")
+class BookingTransferControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var bookingTransferService: BookingTransferService
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        bookingTransferService = mockk()
+        val controller = BookingTransferController(bookingTransferService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+        objectMapper =
+            jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    private fun createTransfer(
+        sellerTeamId: Long = 10L,
+        status: TransferStatus = TransferStatus.OPEN,
+        buyerTeamId: Long? = null,
+    ): BookingTransfer {
+        val transfer =
+            BookingTransfer.create(
+                bookingId = 1L,
+                sellerTeamId = sellerTeamId,
+                transferPrice = BigDecimal("50000"),
+                message = "양도합니다",
+                expiresAt = Instant.now().plusSeconds(3600),
+            )
+        if (status == TransferStatus.ACCEPTED && buyerTeamId != null) {
+            transfer.accept(buyerTeamId)
+        } else if (status == TransferStatus.CANCELLED) {
+            transfer.cancel()
+        } else if (status == TransferStatus.EXPIRED) {
+            transfer.expire()
+        }
+        return transfer
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/booking-transfers")
+    inner class RequestTransfer {
+        @Test
+        fun `should create transfer and return 201`() {
+            // given
+            val transfer = createTransfer()
+            val request =
+                CreateBookingTransferApiRequest(
+                    bookingId = 1L,
+                    sellerTeamId = 10L,
+                    transferPrice = BigDecimal("50000"),
+                    message = "양도합니다",
+                    expiresAt = null,
+                )
+            every {
+                bookingTransferService.createTransfer(
+                    bookingId = 1L,
+                    teamId = 10L,
+                    price = BigDecimal("50000"),
+                    message = "양도합니다",
+                    expiresAt = any(),
+                )
+            } returns transfer
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/booking-transfers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.sellerTeamId").value(10))
+                .andExpect(jsonPath("$.data.status").value("OPEN"))
+        }
+
+        @Test
+        fun `should create transfer with custom expiresAt`() {
+            // given
+            val expiresAt = Instant.now().plusSeconds(7200)
+            val transfer = createTransfer()
+            val request =
+                CreateBookingTransferApiRequest(
+                    bookingId = 2L,
+                    sellerTeamId = 10L,
+                    transferPrice = null,
+                    message = null,
+                    expiresAt = expiresAt,
+                )
+            every {
+                bookingTransferService.createTransfer(
+                    bookingId = 2L,
+                    teamId = 10L,
+                    price = null,
+                    message = null,
+                    expiresAt = expiresAt,
+                )
+            } returns transfer
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/booking-transfers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/v1/booking-transfers/{transferId}/accept")
+    inner class AcceptTransfer {
+        @Test
+        fun `should accept transfer successfully`() {
+            // given
+            val transfer =
+                createTransfer(
+                    sellerTeamId = 10L,
+                    status = TransferStatus.ACCEPTED,
+                    buyerTeamId = 20L,
+                )
+            val request = AcceptBookingTransferApiRequest(buyerTeamId = 20L)
+            every {
+                bookingTransferService.acceptTransfer(
+                    transferId = 1L,
+                    buyerTeamId = 20L,
+                )
+            } returns transfer
+
+            // when & then
+            mockMvc
+                .perform(
+                    patch("/api/v1/booking-transfers/1/accept")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+                .andExpect(jsonPath("$.data.buyerTeamId").value(20))
+        }
+
+        @Test
+        fun `should return 404 when transfer not found`() {
+            // given
+            val request = AcceptBookingTransferApiRequest(buyerTeamId = 20L)
+            every {
+                bookingTransferService.acceptTransfer(
+                    transferId = 999L,
+                    buyerTeamId = 20L,
+                )
+            } throws BookingTransferNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(
+                    patch("/api/v1/booking-transfers/999/accept")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                ).andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/v1/booking-transfers/{transferId}/reject")
+    inner class RejectTransfer {
+        @Test
+        fun `should reject transfer successfully`() {
+            // given
+            val transfer =
+                createTransfer(
+                    sellerTeamId = 10L,
+                    status = TransferStatus.CANCELLED,
+                )
+            every {
+                bookingTransferService.cancelTransfer(
+                    transferId = 1L,
+                    teamId = 10L,
+                )
+            } returns transfer
+
+            // when & then
+            mockMvc
+                .perform(
+                    patch("/api/v1/booking-transfers/1/reject")
+                        .param("teamId", "10"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"))
+        }
+
+        @Test
+        fun `should return 403 when team is not the seller`() {
+            // given
+            every {
+                bookingTransferService.cancelTransfer(
+                    transferId = 1L,
+                    teamId = 99L,
+                )
+            } throws
+                BookingTransferForbiddenException(
+                    "Only the seller team can cancel the transfer. transferId=1",
+                )
+
+            // when & then
+            mockMvc
+                .perform(
+                    patch("/api/v1/booking-transfers/1/reject")
+                        .param("teamId", "99"),
+                ).andExpect(status().isForbidden)
+                .andExpect(jsonPath("$.success").value(false))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/booking-transfers/available")
+    inner class GetAvailableTransfers {
+        @Test
+        fun `should return list of available transfers`() {
+            // given
+            val transfer1 = createTransfer(sellerTeamId = 10L)
+            val transfer2 = createTransfer(sellerTeamId = 20L)
+            every { bookingTransferService.getAvailableTransfers() } returns
+                listOf(transfer1, transfer2)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/booking-transfers/available"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+        }
+
+        @Test
+        fun `should return empty list when no available transfers`() {
+            // given
+            every { bookingTransferService.getAvailableTransfers() } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/booking-transfers/available"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(0))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/booking-transfers/my")
+    inner class GetMyTransfers {
+        @Test
+        fun `should return transfers for the team`() {
+            // given
+            val sellerTransfer = createTransfer(sellerTeamId = 10L)
+            val buyerTransfer =
+                createTransfer(
+                    sellerTeamId = 20L,
+                    status = TransferStatus.ACCEPTED,
+                    buyerTeamId = 10L,
+                )
+            every { bookingTransferService.getTransfersByTeamId(10L) } returns
+                listOf(sellerTransfer, buyerTransfer)
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/booking-transfers/my")
+                        .param("teamId", "10"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(2))
+        }
+
+        @Test
+        fun `should return empty list when no transfers for team`() {
+            // given
+            every { bookingTransferService.getTransfersByTeamId(99L) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/booking-transfers/my")
+                        .param("teamId", "99"),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data.length()").value(0))
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BookingTransferRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BookingTransferRepositoryPort.kt
@@ -17,5 +17,7 @@ interface BookingTransferRepositoryPort {
 
     fun findBySellerTeamId(sellerTeamId: Long): List<BookingTransfer>
 
+    fun findByBuyerTeamId(buyerTeamId: Long): List<BookingTransfer>
+
     fun existsOpenTransferForBooking(bookingId: Long): Boolean
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionPlayerRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionPlayerRepositoryPort.kt
@@ -55,4 +55,13 @@ interface CompetitionPlayerRepositoryPort {
         teamId: Long,
         status: CompetitionPlayerStatus,
     ): List<CompetitionPlayer>
+
+    /**
+     * 선수 ID와 상태 목록으로 대회 선수를 조회합니다.
+     * 팀원 개별 탈퇴/강퇴 시 해당 선수의 활성 대회 등록을 처리하는 데 사용합니다.
+     */
+    fun findByPlayerIdAndStatusIn(
+        playerId: Long,
+        statuses: List<CompetitionPlayerStatus>,
+    ): List<CompetitionPlayer>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/BookingTransferService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/BookingTransferService.kt
@@ -131,6 +131,17 @@ class BookingTransferService(
         bookingTransferRepository.findByStatus(TransferStatus.OPEN)
             .filter { !it.isExpired() }
 
+    /**
+     * 특정 팀이 관련된(판매자 또는 구매자) 양도 목록을 조회합니다.
+     */
+    fun getTransfersByTeamId(teamId: Long): List<BookingTransfer> {
+        val sellerTransfers = bookingTransferRepository.findBySellerTeamId(teamId)
+        val buyerTransfers = bookingTransferRepository.findByBuyerTeamId(teamId)
+        return (sellerTransfers + buyerTransfers)
+            .distinctBy { it.id }
+            .sortedByDescending { it.createdAt }
+    }
+
     companion object {
         const val DEFAULT_EXPIRY_SECONDS = 24L * 60 * 60 // 24 hours
     }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/BookingTransferServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/BookingTransferServiceTest.kt
@@ -59,6 +59,9 @@ class BookingTransferServiceTest {
                 message = "양도합니다",
                 expiresAt = Instant.now().plusSeconds(3600),
             )
+        val idField = BookingTransfer::class.java.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(transfer, id)
         return transfer
     }
 
@@ -268,6 +271,72 @@ class BookingTransferServiceTest {
 
             // when
             val result = service.getAvailableTransfers()
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("getTransfersByTeamId")
+    inner class GetTransfersByTeamId {
+        @Test
+        fun `should return transfers where team is seller`() {
+            // given
+            val transfer = createMockTransfer(sellerTeamId = 10L)
+            every { bookingTransferRepository.findBySellerTeamId(10L) } returns listOf(transfer)
+            every { bookingTransferRepository.findByBuyerTeamId(10L) } returns emptyList()
+
+            // when
+            val result = service.getTransfersByTeamId(10L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].sellerTeamId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should return transfers where team is buyer`() {
+            // given
+            val transfer =
+                createMockTransfer(id = 3L, sellerTeamId = 20L).also {
+                    it.accept(10L)
+                }
+            every { bookingTransferRepository.findBySellerTeamId(10L) } returns emptyList()
+            every { bookingTransferRepository.findByBuyerTeamId(10L) } returns listOf(transfer)
+
+            // when
+            val result = service.getTransfersByTeamId(10L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].buyerTeamId).isEqualTo(10L)
+        }
+
+        @Test
+        fun `should deduplicate transfers and sort by createdAt descending`() {
+            // given
+            val transfer1 = createMockTransfer(id = 1L, sellerTeamId = 10L, bookingId = 1L)
+            val transfer2 = createMockTransfer(id = 2L, sellerTeamId = 10L, bookingId = 2L)
+            every { bookingTransferRepository.findBySellerTeamId(10L) } returns
+                listOf(transfer1, transfer2)
+            every { bookingTransferRepository.findByBuyerTeamId(10L) } returns emptyList()
+
+            // when
+            val result = service.getTransfersByTeamId(10L)
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+
+        @Test
+        fun `should return empty list when team has no transfers`() {
+            // given
+            every { bookingTransferRepository.findBySellerTeamId(99L) } returns emptyList()
+            every { bookingTransferRepository.findByBuyerTeamId(99L) } returns emptyList()
+
+            // when
+            val result = service.getTransfersByTeamId(99L)
 
             // then
             assertThat(result).isEmpty()

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListener.kt
@@ -54,6 +54,7 @@ class TeamMemberEventListener(
     fun handleTeamMemberLeft(event: TeamMemberLeftEvent) {
         logger.info("팀원 탈퇴 처리 - teamId={}, playerId={}, memberId={}", event.teamId, event.playerId, event.memberId)
         removePlayerFromActiveLineups(event.teamId, event.playerId)
+        withdrawCompetitionPlayersByPlayerId(event.playerId)
         cleanupActivityScore(event.memberId)
     }
 
@@ -68,6 +69,7 @@ class TeamMemberEventListener(
     fun handleTeamMemberKicked(event: TeamMemberKickedEvent) {
         logger.info("팀원 강퇴 처리 - teamId={}, playerId={}, memberId={}", event.teamId, event.playerId, event.memberId)
         removePlayerFromActiveLineups(event.teamId, event.playerId)
+        withdrawCompetitionPlayersByPlayerId(event.playerId)
         cleanupActivityScore(event.memberId)
     }
 
@@ -98,7 +100,7 @@ class TeamMemberEventListener(
     // -------------------------------------------------------------------------
 
     /**
-     * DRAFT/SUBMITTED 상태의 라인업에서 특정 선수를 제거합니다.
+     * DRAFT/SUBMITTED/CONFIRMED 상태의 라인업에서 특정 선수를 제거합니다.
      * 제거 후 라인업 엔트리가 없으면 상태를 DRAFT로 되돌립니다.
      */
     private fun removePlayerFromActiveLineups(
@@ -109,6 +111,7 @@ class TeamMemberEventListener(
             listOf(
                 LineupSubmissionStatus.DRAFT,
                 LineupSubmissionStatus.SUBMITTED,
+                LineupSubmissionStatus.CONFIRMED,
             )
 
         val submissions =
@@ -152,6 +155,25 @@ class TeamMemberEventListener(
             cp.withdraw()
             competitionPlayerRepository.save(cp)
             logger.info("CompetitionPlayer WITHDRAWN 처리 - competitionPlayerId={}", cp.id)
+        }
+    }
+
+    /**
+     * 특정 선수의 활성/정지 상태 CompetitionPlayer를 WITHDRAWN으로 처리합니다.
+     * 팀원 개별 탈퇴/강퇴 시 호출됩니다.
+     */
+    private fun withdrawCompetitionPlayersByPlayerId(playerId: Long) {
+        val activeStatuses =
+            listOf(
+                CompetitionPlayerStatus.ACTIVE,
+                CompetitionPlayerStatus.SUSPENDED,
+            )
+        val competitionPlayers =
+            competitionPlayerRepository.findByPlayerIdAndStatusIn(playerId, activeStatuses)
+        competitionPlayers.forEach { cp ->
+            cp.withdraw()
+            competitionPlayerRepository.save(cp)
+            logger.info("CompetitionPlayer WITHDRAWN 처리 (개별 탈퇴) - competitionPlayerId={}, playerId={}", cp.id, playerId)
         }
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerJpaRepository.kt
@@ -41,4 +41,9 @@ interface CompetitionPlayerJpaRepository : JpaRepository<CompetitionPlayer, Long
         teamId: Long,
         status: CompetitionPlayerStatus,
     ): List<CompetitionPlayer>
+
+    fun findByPlayerIdAndStatusIn(
+        playerId: Long,
+        statuses: List<CompetitionPlayerStatus>,
+    ): List<CompetitionPlayer>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/competition/CompetitionPlayerRepositoryAdapter.kt
@@ -50,4 +50,9 @@ class CompetitionPlayerRepositoryAdapter(
         teamId: Long,
         status: CompetitionPlayerStatus,
     ): List<CompetitionPlayer> = jpaRepository.findByTeamIdAndStatus(teamId, status)
+
+    override fun findByPlayerIdAndStatusIn(
+        playerId: Long,
+        statuses: List<CompetitionPlayerStatus>,
+    ): List<CompetitionPlayer> = jpaRepository.findByPlayerIdAndStatusIn(playerId, statuses)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/BookingTransferJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/BookingTransferJpaRepository.kt
@@ -15,6 +15,9 @@ interface BookingTransferJpaRepository : JpaRepository<BookingTransfer, Long> {
     @Query("SELECT t FROM BookingTransfer t WHERE t.sellerTeamId = :sellerTeamId")
     fun findBySellerTeamId(sellerTeamId: Long): List<BookingTransfer>
 
+    @Query("SELECT t FROM BookingTransfer t WHERE t.buyerTeamId = :buyerTeamId")
+    fun findByBuyerTeamId(buyerTeamId: Long): List<BookingTransfer>
+
     @Query(
         "SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END " +
             "FROM BookingTransfer t WHERE t.bookingId = :bookingId AND t.status = 'OPEN'",

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/BookingTransferRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/BookingTransferRepositoryAdapter.kt
@@ -21,6 +21,9 @@ class BookingTransferRepositoryAdapter(
     override fun findBySellerTeamId(sellerTeamId: Long): List<BookingTransfer> =
         jpaRepository.findBySellerTeamId(sellerTeamId)
 
+    override fun findByBuyerTeamId(buyerTeamId: Long): List<BookingTransfer> =
+        jpaRepository.findByBuyerTeamId(buyerTeamId)
+
     override fun existsOpenTransferForBooking(bookingId: Long): Boolean =
         jpaRepository.existsOpenTransferForBooking(bookingId)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
@@ -3,6 +3,8 @@ package com.nextup.infrastructure.service.team
 import com.nextup.common.exception.*
 import com.nextup.core.domain.event.TeamJoinApprovedEvent
 import com.nextup.core.domain.event.TeamJoinRejectedEvent
+import com.nextup.core.domain.event.TeamMemberKickedEvent
+import com.nextup.core.domain.event.TeamMemberLeftEvent
 import com.nextup.core.domain.team.*
 import com.nextup.core.port.repository.*
 import com.nextup.core.service.team.TeamMembershipService
@@ -216,6 +218,14 @@ class TeamMembershipServiceImpl(
                 )
             teamBlacklistRepository.save(blacklist)
         }
+
+        eventPublisher.publishEvent(
+            TeamMemberKickedEvent(
+                teamId = member.team.id,
+                playerId = member.player.id,
+                memberId = member.id,
+            ),
+        )
     }
 
     @Transactional
@@ -235,6 +245,14 @@ class TeamMembershipServiceImpl(
         // Entity의 비즈니스 로직으로 탈퇴 처리
         member.leave()
         teamMemberRepository.save(member)
+
+        eventPublisher.publishEvent(
+            TeamMemberLeftEvent(
+                teamId = member.team.id,
+                playerId = member.player.id,
+                memberId = member.id,
+            ),
+        )
     }
 
     @Transactional

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
@@ -113,12 +113,22 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED,
+                    ),
                 )
             } returns listOf(submission)
             every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns entry
             justRun { lineupEntryRepository.delete(entry) }
             every { lineupEntryRepository.findAllBySubmissionId(10L) } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
 
             // when
@@ -142,10 +152,20 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
                 )
             } returns listOf(submission)
             every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns null
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
 
             // when
@@ -165,7 +185,17 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
                 )
             } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
@@ -194,12 +224,22 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
                 )
             } returns listOf(submission)
             every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns entry
             justRun { lineupEntryRepository.delete(entry) }
             every { lineupEntryRepository.findAllBySubmissionId(10L) } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
 
             // when
@@ -220,7 +260,17 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
                 )
             } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
@@ -230,6 +280,82 @@ class TeamMemberEventListenerTest {
 
             // then
             verify(exactly = 1) { activityScoreRepository.deleteByMemberId(100L) }
+        }
+
+        @Test
+        @DisplayName("팀원 탈퇴 시 활성 CompetitionPlayer를 WITHDRAWN 처리한다")
+        fun `should withdraw active competition players on member left`() {
+            // given
+            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val competitionPlayer = mockk<CompetitionPlayer>(relaxed = true)
+            every { competitionPlayer.id } returns 50L
+
+            every {
+                lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
+                    1L,
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns listOf(competitionPlayer)
+            justRun { competitionPlayer.withdraw() }
+            every { competitionPlayerRepository.save(competitionPlayer) } returns competitionPlayer
+            justRun { activityScoreRepository.deleteByMemberId(100L) }
+
+            // when
+            listener.handleTeamMemberLeft(event)
+
+            // then
+            verify(exactly = 1) { competitionPlayer.withdraw() }
+            verify(exactly = 1) { competitionPlayerRepository.save(competitionPlayer) }
+        }
+
+        @Test
+        @DisplayName("CONFIRMED 라인업에서도 탈퇴한 선수 엔트리를 제거한다")
+        fun `should remove player entry from CONFIRMED lineup submission`() {
+            // given
+            val event = TeamMemberLeftEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+
+            val submission = mockk<LineupSubmission>(relaxed = true)
+            every { submission.id } returns 10L
+            every { submission.status } returns LineupSubmissionStatus.CONFIRMED
+
+            val entry = mockk<LineupEntry>(relaxed = true)
+
+            every {
+                lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
+                    1L,
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns listOf(submission)
+            every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns entry
+            justRun { lineupEntryRepository.delete(entry) }
+            every { lineupEntryRepository.findAllBySubmissionId(10L) } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
+            justRun { activityScoreRepository.deleteByMemberId(100L) }
+
+            // when
+            listener.handleTeamMemberLeft(event)
+
+            // then
+            verify(exactly = 1) { lineupEntryRepository.delete(entry) }
         }
     }
 
@@ -256,12 +382,22 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
                 )
             } returns listOf(submission)
             every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns entry
             justRun { lineupEntryRepository.delete(entry) }
             every { lineupEntryRepository.findAllBySubmissionId(10L) } returns listOf(remainingEntry)
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
 
             // when
@@ -292,7 +428,11 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
                 )
             } returns listOf(submission1, submission2)
             every { lineupEntryRepository.findBySubmissionIdAndPlayerId(10L, 20L) } returns entry1
@@ -301,6 +441,12 @@ class TeamMemberEventListenerTest {
             justRun { lineupEntryRepository.delete(entry2) }
             every { lineupEntryRepository.findAllBySubmissionId(10L) } returns emptyList()
             every { lineupEntryRepository.findAllBySubmissionId(11L) } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
 
             // when
@@ -321,7 +467,17 @@ class TeamMemberEventListenerTest {
             every {
                 lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
                     1L,
-                    listOf(LineupSubmissionStatus.DRAFT, LineupSubmissionStatus.SUBMITTED),
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
                 )
             } returns emptyList()
             justRun { activityScoreRepository.deleteByMemberId(100L) }
@@ -331,6 +487,42 @@ class TeamMemberEventListenerTest {
 
             // then
             verify(exactly = 1) { activityScoreRepository.deleteByMemberId(100L) }
+        }
+
+        @Test
+        @DisplayName("팀원 강퇴 시 활성 CompetitionPlayer를 WITHDRAWN 처리한다")
+        fun `should withdraw active competition players on member kicked`() {
+            // given
+            val event = TeamMemberKickedEvent(teamId = 1L, playerId = 20L, memberId = 100L)
+            val competitionPlayer = mockk<CompetitionPlayer>(relaxed = true)
+            every { competitionPlayer.id } returns 50L
+
+            every {
+                lineupSubmissionRepository.findAllByTeamIdAndStatusIn(
+                    1L,
+                    listOf(
+                        LineupSubmissionStatus.DRAFT,
+                        LineupSubmissionStatus.SUBMITTED,
+                        LineupSubmissionStatus.CONFIRMED
+                    ),
+                )
+            } returns emptyList()
+            every {
+                competitionPlayerRepository.findByPlayerIdAndStatusIn(
+                    20L,
+                    listOf(CompetitionPlayerStatus.ACTIVE, CompetitionPlayerStatus.SUSPENDED),
+                )
+            } returns listOf(competitionPlayer)
+            justRun { competitionPlayer.withdraw() }
+            every { competitionPlayerRepository.save(competitionPlayer) } returns competitionPlayer
+            justRun { activityScoreRepository.deleteByMemberId(100L) }
+
+            // when
+            listener.handleTeamMemberKicked(event)
+
+            // then
+            verify(exactly = 1) { competitionPlayer.withdraw() }
+            verify(exactly = 1) { competitionPlayerRepository.save(competitionPlayer) }
         }
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
@@ -4,6 +4,8 @@ import com.nextup.common.exception.*
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.event.TeamJoinApprovedEvent
 import com.nextup.core.domain.event.TeamJoinRejectedEvent
+import com.nextup.core.domain.event.TeamMemberKickedEvent
+import com.nextup.core.domain.event.TeamMemberLeftEvent
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
@@ -524,6 +526,30 @@ class TeamMembershipServiceImplTest {
         }
 
         @Test
+        fun `should publish TeamMemberKickedEvent when member is kicked`() {
+            // given
+            val memberToKick =
+                TeamMember.create(team, user, player, 20, TeamMemberRole.MEMBER)
+            setTeamMemberId(memberToKick, 200L)
+
+            every { teamMemberRepository.findByIdOrNull(200L) } returns memberToKick
+            every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns ownerMember
+            every { teamMemberRepository.save(any()) } answers { firstArg() }
+
+            val eventSlot = slot<TeamMemberKickedEvent>()
+            every { eventPublisher.publishEvent(capture(eventSlot)) } returns Unit
+
+            // when
+            service.kickMember(200L, 10L, "규칙 위반", false)
+
+            // then
+            verify(exactly = 1) { eventPublisher.publishEvent(any<TeamMemberKickedEvent>()) }
+            assertThat(eventSlot.captured.teamId).isEqualTo(1L)
+            assertThat(eventSlot.captured.playerId).isEqualTo(3L)
+            assertThat(eventSlot.captured.memberId).isEqualTo(200L)
+        }
+
+        @Test
         fun `should throw when member not found on kick`() {
             // given
             every { teamMemberRepository.findByIdOrNull(999L) } returns null
@@ -581,6 +607,28 @@ class TeamMembershipServiceImplTest {
             // then
             assertThat(member.status).isEqualTo(TeamMemberStatus.LEFT)
             verify { teamMemberRepository.save(member) }
+        }
+
+        @Test
+        fun `should publish TeamMemberLeftEvent when member leaves`() {
+            // given
+            val member = TeamMember.create(team, user, player, 20, TeamMemberRole.MEMBER)
+            setTeamMemberId(member, 200L)
+
+            every { teamMemberRepository.findByIdOrNull(200L) } returns member
+            every { teamMemberRepository.save(any()) } answers { firstArg() }
+
+            val eventSlot = slot<TeamMemberLeftEvent>()
+            every { eventPublisher.publishEvent(capture(eventSlot)) } returns Unit
+
+            // when
+            service.leaveMember(200L)
+
+            // then
+            verify(exactly = 1) { eventPublisher.publishEvent(any<TeamMemberLeftEvent>()) }
+            assertThat(eventSlot.captured.teamId).isEqualTo(1L)
+            assertThat(eventSlot.captured.playerId).isEqualTo(3L)
+            assertThat(eventSlot.captured.memberId).isEqualTo(200L)
         }
 
         @Test


### PR DESCRIPTION
## Summary

>- close #343

예약 양도(BookingTransfer) API가 backoffice에만 존재하여 일반 사용자가 양도 요청/수락/거절을 할 수 없는 문제를 해결합니다.
nextup-api 모듈에 사용자용 BookingTransferController를 추가하여 양도 전체 플로우를 지원합니다.

## Tasks

- [x] nextup-api에 `BookingTransferController` 추가 (POST 양도 요청, PATCH 수락/거절, GET 조회)
- [x] 사용자용 Request/Response DTO 추가 (`CreateBookingTransferApiRequest`, `AcceptBookingTransferApiRequest`, `BookingTransferResponse`)
- [x] `BookingTransferService`에 `getTransfersByTeamId()` 메서드 추가 (판매자/구매자 양쪽 조회)
- [x] `BookingTransferRepositoryPort`에 `findByBuyerTeamId()` 추가
- [x] JPA Repository 및 Adapter에 buyerTeamId 조회 쿼리 구현
- [x] Controller 단위 테스트 10개 추가 (양도 요청/수락/거절/조회 + 에러 케이스)
- [x] Service 단위 테스트 4개 추가 (getTransfersByTeamId 테스트)
- [x] 모든 응답 ApiResponse 래핑, Zero Entity Leak 준수

## To Reviewer

### API 엔드포인트
| Method | URL | 설명 |
|--------|-----|------|
| POST | `/api/v1/booking-transfers` | 양도 등록 |
| PATCH | `/api/v1/booking-transfers/{transferId}/accept` | 양도 수락 |
| PATCH | `/api/v1/booking-transfers/{transferId}/reject` | 양도 거절(취소) |
| GET | `/api/v1/booking-transfers/available` | 양도 가능 목록 조회 |
| GET | `/api/v1/booking-transfers/my?teamId={teamId}` | 내 팀 양도 목록 조회 |

backoffice의 기존 BookingTransferController와 동일한 Service를 사용하되, URL prefix는 `/api/v1/`으로 분리하고 DTO도 nextup-api 모듈에 독립적으로 생성했습니다.