### PR TITLE
feat(#342): 노히트/퍼펙트게임 자동 감지 및 기록

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/SpecialGameRecordDetectedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/SpecialGameRecordDetectedEvent.kt
@@ -1,0 +1,15 @@
+package com.nextup.core.domain.event
+
+import com.nextup.core.domain.game.SpecialGameRecord
+
+/**
+ * 특수 경기 기록 감지 이벤트
+ *
+ * 경기 종료 후 노히트/퍼펙트게임이 감지되었을 때 발행됩니다.
+ */
+data class SpecialGameRecordDetectedEvent(
+    val gameId: Long,
+    val teamId: Long,
+    val opponentTeamId: Long,
+    val record: SpecialGameRecord,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
@@ -14,4 +14,6 @@ enum class GameEventType(
     GAME_STATUS("경기 상태 변경"),
     POSITION_CHANGE("포지션 변경"),
     EJECTION("퇴장"),
+    NO_HITTER("노히트노런"),
+    PERFECT_GAME("퍼펙트게임"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/SpecialGameRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/SpecialGameRecord.kt
@@ -1,0 +1,17 @@
+package com.nextup.core.domain.game
+
+/**
+ * 특수 경기 기록 유형
+ *
+ * 경기 종료 후 자동으로 감지되는 특수 기록을 나타냅니다.
+ */
+enum class SpecialGameRecord(
+    val displayName: String,
+    val description: String,
+) {
+    /** 노히트 노런 (안타 허용 0, 볼넷/사구/실책은 허용 가능) */
+    NO_HITTER("노히트노런", "상대 팀에게 안타를 하나도 허용하지 않은 경기"),
+
+    /** 퍼펙트 게임 (안타 0, 볼넷 0, 사구 0, 실책 0 - 모든 주자 출루 없음) */
+    PERFECT_GAME("퍼펙트게임", "상대 팀의 모든 타자를 한 명도 출루시키지 않은 경기"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/SpecialGameRecordDetector.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/SpecialGameRecordDetector.kt
@@ -1,0 +1,127 @@
+package com.nextup.core.domain.game
+
+/**
+ * 특수 경기 기록 감지기
+ *
+ * 경기 종료 시 양 팀의 기록을 분석하여 노히트/퍼펙트게임을 감지합니다.
+ * 각 팀이 상대 팀에 대해 달성한 특수 기록을 개별적으로 감지합니다.
+ *
+ * 감지 기준:
+ * - 노히트: 상대 팀의 총 안타 수(GameTeam.totalHits) = 0
+ * - 퍼펙트게임: 노히트 조건 + 상대 투수 기록에서 볼넷/사구 허용 = 0 + 수비 실책 = 0
+ * - 몰수승/취소/중단 경기에서는 감지하지 않음 (정상 종료/콜드게임만 대상)
+ */
+object SpecialGameRecordDetector {
+    /**
+     * 특수 기록 감지 결과
+     *
+     * @property teamId 특수 기록을 달성한 팀 ID
+     * @property opponentTeamId 상대 팀 ID
+     * @property record 달성한 특수 기록 유형
+     */
+    data class DetectionResult(
+        val teamId: Long,
+        val opponentTeamId: Long,
+        val record: SpecialGameRecord,
+    )
+
+    /**
+     * 경기의 특수 기록을 감지합니다.
+     *
+     * 양 팀 모두 개별적으로 검사하여, 각각 노히트/퍼펙트게임을 달성했는지 확인합니다.
+     * 정상 종료(FINISHED) 또는 콜드게임(CALLED) 상태의 경기만 대상으로 합니다.
+     *
+     * @param game 검사할 경기
+     * @param gameTeams 경기에 참여한 팀 목록 (정확히 2개)
+     * @param battingRecordsByTeamId 팀 ID별 상대 팀의 타격 기록 맵 (key: 수비 팀 ID, value: 상대 타격 기록)
+     * @param pitchingRecordsByTeamId 팀 ID별 투수 기록 맵
+     * @param fieldingRecordsByTeamId 팀 ID별 수비 기록 맵
+     * @return 감지된 특수 기록 목록 (없으면 빈 리스트)
+     */
+    fun detect(
+        game: Game,
+        gameTeams: List<GameTeam>,
+        battingRecordsByTeamId: Map<Long, List<BattingRecord>>,
+        pitchingRecordsByTeamId: Map<Long, List<PitchingRecord>>,
+        fieldingRecordsByTeamId: Map<Long, List<FieldingRecord>>,
+    ): List<DetectionResult> {
+        if (!isEligibleForDetection(game)) {
+            return emptyList()
+        }
+
+        if (gameTeams.size != 2) {
+            return emptyList()
+        }
+
+        val results = mutableListOf<DetectionResult>()
+
+        for (pitchingTeam in gameTeams) {
+            val opponentTeam =
+                gameTeams.first { it.id != pitchingTeam.id }
+
+            val result =
+                detectForTeam(
+                    pitchingTeamId = pitchingTeam.team.id,
+                    opponentTeam = opponentTeam,
+                    pitchingRecords = pitchingRecordsByTeamId[pitchingTeam.team.id] ?: emptyList(),
+                    fieldingRecords = fieldingRecordsByTeamId[pitchingTeam.team.id] ?: emptyList(),
+                )
+
+            if (result != null) {
+                results.add(result)
+            }
+        }
+
+        return results
+    }
+
+    /**
+     * 특정 팀의 특수 기록을 감지합니다.
+     *
+     * @param pitchingTeamId 투수 팀 ID (특수 기록을 달성한 팀)
+     * @param opponentTeam 상대 팀 GameTeam (안타 허용 수 확인용)
+     * @param pitchingRecords 투수 팀의 투수 기록 목록
+     * @param fieldingRecords 투수 팀의 수비 기록 목록
+     * @return 감지된 특수 기록 (없으면 null)
+     */
+    private fun detectForTeam(
+        pitchingTeamId: Long,
+        opponentTeam: GameTeam,
+        pitchingRecords: List<PitchingRecord>,
+        fieldingRecords: List<FieldingRecord>,
+    ): DetectionResult? {
+        // 상대 팀의 총 안타가 0이 아니면 노히트 아님
+        if (opponentTeam.totalHits > 0) {
+            return null
+        }
+
+        // 투수 기록에서 볼넷/사구 합산
+        val totalWalksAllowed = pitchingRecords.sumOf { it.walksAllowed }
+        val totalHitBatsmen = pitchingRecords.sumOf { it.hitBatsmen }
+
+        // 수비 기록에서 실책 합산
+        val totalErrors = fieldingRecords.sumOf { it.errors }
+
+        val record =
+            if (totalWalksAllowed == 0 && totalHitBatsmen == 0 && totalErrors == 0) {
+                SpecialGameRecord.PERFECT_GAME
+            } else {
+                SpecialGameRecord.NO_HITTER
+            }
+
+        return DetectionResult(
+            teamId = pitchingTeamId,
+            opponentTeamId = opponentTeam.team.id,
+            record = record,
+        )
+    }
+
+    /**
+     * 경기가 특수 기록 감지 대상인지 확인합니다.
+     *
+     * 정상 종료(FINISHED) 또는 콜드게임(CALLED)만 대상입니다.
+     * 몰수승(FORFEITED), 취소(CANCELLED), 중단(SUSPENDED) 등은 제외합니다.
+     */
+    private fun isEligibleForDetection(game: Game): Boolean =
+        game.status == GameStatus.FINISHED || game.status == GameStatus.CALLED
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/SpecialGameRecordDetectorTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/SpecialGameRecordDetectorTest.kt
@@ -1,0 +1,490 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("SpecialGameRecordDetector 테스트")
+class SpecialGameRecordDetectorTest {
+    private lateinit var competition: Competition
+    private lateinit var homeTeam: Team
+    private lateinit var awayTeam: Team
+    private lateinit var game: Game
+    private lateinit var homeGameTeam: GameTeam
+    private lateinit var awayGameTeam: GameTeam
+
+    @BeforeEach
+    fun setUp() {
+        val association = Association(name = "서울시야구협회", region = "서울")
+        val league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+
+        competition =
+            Competition(
+                league = league,
+                name = "테스트 대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+            )
+
+        game =
+            Game.createForTest(
+                competition = competition,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledAt = LocalDateTime.of(2025, 5, 10, 14, 0),
+                status = GameStatus.FINISHED,
+                currentInning = 9,
+                isTopInning = false,
+                totalInnings = 9,
+                id = 10L,
+            )
+
+        homeGameTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
+        awayGameTeam = game.gameTeams.first { it.homeAway == HomeAway.AWAY }
+    }
+
+    private fun createGamePlayer(
+        gameTeam: GameTeam,
+        position: Position = Position.STARTING_PITCHER,
+        id: Long = 0L,
+    ): GamePlayer {
+        val player =
+            Player(
+                name = "테스트선수",
+                birthDate = LocalDate.of(1990, 1, 1),
+                primaryPosition = position,
+                id = id,
+            )
+        return GamePlayer(
+            gameTeam = gameTeam,
+            player = player,
+            position = position,
+            battingOrder = 1,
+            id = id,
+        )
+    }
+
+    @Nested
+    @DisplayName("퍼펙트게임 감지")
+    inner class PerfectGameDetection {
+        @Test
+        fun `안타 0, 볼넷 0, 사구 0, 실책 0이면 퍼펙트게임으로 감지`() {
+            // given - 홈팀이 원정팀을 상대로 퍼펙트게임 달성
+            awayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+            homeGameTeam.updateScore(totalScore = 3, totalHits = 5, totalErrors = 0)
+
+            val homePitcher = createGamePlayer(homeGameTeam, Position.STARTING_PITCHER, 100L)
+            val homePitchingRecord =
+                PitchingRecord.create(homePitcher, isStartingPitcher = true)
+            // 투수 기록: 볼넷 0, 사구 0
+            // (기본값이 모두 0이므로 추가 설정 불필요)
+
+            val homeFielder = createGamePlayer(homeGameTeam, Position.SHORTSTOP, 101L)
+            val homeFieldingRecord = FieldingRecord.create(homeFielder)
+            // 수비 기록: 실책 0 (기본값)
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = game,
+                    gameTeams = listOf(homeGameTeam, awayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId = mapOf(homeTeam.id to listOf(homePitchingRecord)),
+                    fieldingRecordsByTeamId = mapOf(homeTeam.id to listOf(homeFieldingRecord)),
+                )
+
+            // then
+            assertThat(results).hasSize(1)
+            assertThat(results[0].record).isEqualTo(SpecialGameRecord.PERFECT_GAME)
+            assertThat(results[0].teamId).isEqualTo(homeTeam.id)
+            assertThat(results[0].opponentTeamId).isEqualTo(awayTeam.id)
+        }
+    }
+
+    @Nested
+    @DisplayName("노히트노런 감지")
+    inner class NoHitterDetection {
+        @Test
+        fun `안타 0이지만 볼넷이 있으면 노히트노런으로 감지`() {
+            // given - 홈팀이 원정팀을 상대로 노히트 (볼넷 허용)
+            awayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+            homeGameTeam.updateScore(totalScore = 5, totalHits = 8, totalErrors = 0)
+
+            val homePitcher = createGamePlayer(homeGameTeam, Position.STARTING_PITCHER, 100L)
+            val homePitchingRecord =
+                PitchingRecord.create(homePitcher, isStartingPitcher = true)
+            homePitchingRecord.recordWalk() // 볼넷 1개 허용
+
+            val homeFielder = createGamePlayer(homeGameTeam, Position.SHORTSTOP, 101L)
+            val homeFieldingRecord = FieldingRecord.create(homeFielder)
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = game,
+                    gameTeams = listOf(homeGameTeam, awayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId = mapOf(homeTeam.id to listOf(homePitchingRecord)),
+                    fieldingRecordsByTeamId = mapOf(homeTeam.id to listOf(homeFieldingRecord)),
+                )
+
+            // then
+            assertThat(results).hasSize(1)
+            assertThat(results[0].record).isEqualTo(SpecialGameRecord.NO_HITTER)
+            assertThat(results[0].teamId).isEqualTo(homeTeam.id)
+        }
+
+        @Test
+        fun `안타 0이지만 사구가 있으면 노히트노런으로 감지`() {
+            // given
+            awayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+            homeGameTeam.updateScore(totalScore = 2, totalHits = 4, totalErrors = 0)
+
+            val homePitcher = createGamePlayer(homeGameTeam, Position.STARTING_PITCHER, 100L)
+            val homePitchingRecord =
+                PitchingRecord.create(homePitcher, isStartingPitcher = true)
+            homePitchingRecord.recordHitByPitch() // 사구 1개
+
+            val homeFielder = createGamePlayer(homeGameTeam, Position.SHORTSTOP, 101L)
+            val homeFieldingRecord = FieldingRecord.create(homeFielder)
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = game,
+                    gameTeams = listOf(homeGameTeam, awayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId = mapOf(homeTeam.id to listOf(homePitchingRecord)),
+                    fieldingRecordsByTeamId = mapOf(homeTeam.id to listOf(homeFieldingRecord)),
+                )
+
+            // then
+            assertThat(results).hasSize(1)
+            assertThat(results[0].record).isEqualTo(SpecialGameRecord.NO_HITTER)
+        }
+
+        @Test
+        fun `안타 0이지만 실책이 있으면 노히트노런으로 감지`() {
+            // given
+            awayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 1)
+            homeGameTeam.updateScore(totalScore = 3, totalHits = 5, totalErrors = 0)
+
+            val homePitcher = createGamePlayer(homeGameTeam, Position.STARTING_PITCHER, 100L)
+            val homePitchingRecord =
+                PitchingRecord.create(homePitcher, isStartingPitcher = true)
+
+            val homeFielder = createGamePlayer(homeGameTeam, Position.SHORTSTOP, 101L)
+            val homeFieldingRecord = FieldingRecord.create(homeFielder)
+            homeFieldingRecord.recordError() // 실책 1개
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = game,
+                    gameTeams = listOf(homeGameTeam, awayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId = mapOf(homeTeam.id to listOf(homePitchingRecord)),
+                    fieldingRecordsByTeamId = mapOf(homeTeam.id to listOf(homeFieldingRecord)),
+                )
+
+            // then
+            assertThat(results).hasSize(1)
+            assertThat(results[0].record).isEqualTo(SpecialGameRecord.NO_HITTER)
+        }
+    }
+
+    @Nested
+    @DisplayName("미감지 케이스")
+    inner class NoDetection {
+        @Test
+        fun `안타가 있으면 특수 기록 미감지`() {
+            // given - 정상 경기 (양 팀 모두 안타 있음)
+            homeGameTeam.updateScore(totalScore = 5, totalHits = 8, totalErrors = 1)
+            awayGameTeam.updateScore(totalScore = 3, totalHits = 6, totalErrors = 0)
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = game,
+                    gameTeams = listOf(homeGameTeam, awayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId = emptyMap(),
+                    fieldingRecordsByTeamId = emptyMap(),
+                )
+
+            // then
+            assertThat(results).isEmpty()
+        }
+
+        @Test
+        fun `몰수승 경기에서는 특수 기록 미감지`() {
+            // given
+            val forfeitedGame =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 5, 10, 14, 0),
+                    status = GameStatus.FORFEITED,
+                    id = 20L,
+                )
+
+            val fHomeGameTeam = forfeitedGame.gameTeams.first { it.homeAway == HomeAway.HOME }
+            val fAwayGameTeam = forfeitedGame.gameTeams.first { it.homeAway == HomeAway.AWAY }
+            fAwayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = forfeitedGame,
+                    gameTeams = listOf(fHomeGameTeam, fAwayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId = emptyMap(),
+                    fieldingRecordsByTeamId = emptyMap(),
+                )
+
+            // then
+            assertThat(results).isEmpty()
+        }
+
+        @Test
+        fun `취소 경기에서는 특수 기록 미감지`() {
+            // given
+            val cancelledGame =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 5, 10, 14, 0),
+                    status = GameStatus.CANCELLED,
+                    id = 30L,
+                )
+
+            val cHomeGameTeam = cancelledGame.gameTeams.first { it.homeAway == HomeAway.HOME }
+            val cAwayGameTeam = cancelledGame.gameTeams.first { it.homeAway == HomeAway.AWAY }
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = cancelledGame,
+                    gameTeams = listOf(cHomeGameTeam, cAwayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId = emptyMap(),
+                    fieldingRecordsByTeamId = emptyMap(),
+                )
+
+            // then
+            assertThat(results).isEmpty()
+        }
+
+        @Test
+        fun `중단 경기에서는 특수 기록 미감지`() {
+            // given
+            val suspendedGame =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 5, 10, 14, 0),
+                    status = GameStatus.SUSPENDED,
+                    id = 40L,
+                )
+
+            val sHomeGameTeam = suspendedGame.gameTeams.first { it.homeAway == HomeAway.HOME }
+            val sAwayGameTeam = suspendedGame.gameTeams.first { it.homeAway == HomeAway.AWAY }
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = suspendedGame,
+                    gameTeams = listOf(sHomeGameTeam, sAwayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId = emptyMap(),
+                    fieldingRecordsByTeamId = emptyMap(),
+                )
+
+            // then
+            assertThat(results).isEmpty()
+        }
+
+        @Test
+        fun `팀이 2개가 아니면 특수 기록 미감지`() {
+            // given
+            awayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = game,
+                    gameTeams = listOf(homeGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId = emptyMap(),
+                    fieldingRecordsByTeamId = emptyMap(),
+                )
+
+            // then
+            assertThat(results).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("콜드게임 특수 기록 감지")
+    inner class CalledGameDetection {
+        @Test
+        fun `콜드게임에서도 특수 기록 감지 가능`() {
+            // given
+            val calledGame =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 5, 10, 14, 0),
+                    status = GameStatus.CALLED,
+                    currentInning = 7,
+                    isTopInning = false,
+                    totalInnings = 9,
+                    id = 50L,
+                )
+
+            val cHomeGameTeam = calledGame.gameTeams.first { it.homeAway == HomeAway.HOME }
+            val cAwayGameTeam = calledGame.gameTeams.first { it.homeAway == HomeAway.AWAY }
+
+            cAwayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+            cHomeGameTeam.updateScore(totalScore = 10, totalHits = 12, totalErrors = 0)
+
+            val homePitcher = createGamePlayer(cHomeGameTeam, Position.STARTING_PITCHER, 100L)
+            val homePitchingRecord =
+                PitchingRecord.create(homePitcher, isStartingPitcher = true)
+
+            val homeFielder = createGamePlayer(cHomeGameTeam, Position.SHORTSTOP, 101L)
+            val homeFieldingRecord = FieldingRecord.create(homeFielder)
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = calledGame,
+                    gameTeams = listOf(cHomeGameTeam, cAwayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId = mapOf(homeTeam.id to listOf(homePitchingRecord)),
+                    fieldingRecordsByTeamId = mapOf(homeTeam.id to listOf(homeFieldingRecord)),
+                )
+
+            // then
+            assertThat(results).hasSize(1)
+            assertThat(results[0].record).isEqualTo(SpecialGameRecord.PERFECT_GAME)
+        }
+    }
+
+    @Nested
+    @DisplayName("양 팀 동시 감지")
+    inner class BothTeamsDetection {
+        @Test
+        fun `양 팀 모두 노히트 달성 시 두 건 감지`() {
+            // given - 극히 드문 양 팀 동시 노히트 (0-0 무안타)
+            homeGameTeam.updateScore(totalScore = 1, totalHits = 0, totalErrors = 0)
+            awayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+
+            val homePitcher = createGamePlayer(homeGameTeam, Position.STARTING_PITCHER, 100L)
+            val homePitchingRecord =
+                PitchingRecord.create(homePitcher, isStartingPitcher = true)
+
+            val awayPitcher = createGamePlayer(awayGameTeam, Position.STARTING_PITCHER, 200L)
+            val awayPitchingRecord =
+                PitchingRecord.create(awayPitcher, isStartingPitcher = true)
+            awayPitchingRecord.recordWalk() // 홈팀에 볼넷 허용 (1점은 볼넷+도루+희생플라이 등으로 가정)
+
+            val homeFielder = createGamePlayer(homeGameTeam, Position.SHORTSTOP, 101L)
+            val homeFieldingRecord = FieldingRecord.create(homeFielder)
+
+            val awayFielder = createGamePlayer(awayGameTeam, Position.SHORTSTOP, 201L)
+            val awayFieldingRecord = FieldingRecord.create(awayFielder)
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = game,
+                    gameTeams = listOf(homeGameTeam, awayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId =
+                        mapOf(
+                            homeTeam.id to listOf(homePitchingRecord),
+                            awayTeam.id to listOf(awayPitchingRecord),
+                        ),
+                    fieldingRecordsByTeamId =
+                        mapOf(
+                            homeTeam.id to listOf(homeFieldingRecord),
+                            awayTeam.id to listOf(awayFieldingRecord),
+                        ),
+                )
+
+            // then
+            assertThat(results).hasSize(2)
+            val homeResult = results.first { it.teamId == homeTeam.id }
+            val awayResult = results.first { it.teamId == awayTeam.id }
+            assertThat(homeResult.record).isEqualTo(SpecialGameRecord.PERFECT_GAME)
+            assertThat(awayResult.record).isEqualTo(SpecialGameRecord.NO_HITTER)
+        }
+    }
+
+    @Nested
+    @DisplayName("복수 투수 시나리오")
+    inner class MultiplePitchersScenario {
+        @Test
+        fun `복수 투수 중 한 명이 볼넷 허용 시 노히트로 감지`() {
+            // given
+            awayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+            homeGameTeam.updateScore(totalScore = 4, totalHits = 7, totalErrors = 0)
+
+            val homePitcher1 = createGamePlayer(homeGameTeam, Position.STARTING_PITCHER, 100L)
+            val homePitchingRecord1 =
+                PitchingRecord.create(homePitcher1, isStartingPitcher = true)
+            // 선발 투수: 볼넷 0, 사구 0
+
+            val homePitcher2 = createGamePlayer(homeGameTeam, Position.STARTING_PITCHER, 102L)
+            val homePitchingRecord2 =
+                PitchingRecord.create(homePitcher2, isStartingPitcher = false)
+            homePitchingRecord2.recordWalk() // 계투 투수가 볼넷 1개 허용
+
+            val homeFielder = createGamePlayer(homeGameTeam, Position.SHORTSTOP, 101L)
+            val homeFieldingRecord = FieldingRecord.create(homeFielder)
+
+            // when
+            val results =
+                SpecialGameRecordDetector.detect(
+                    game = game,
+                    gameTeams = listOf(homeGameTeam, awayGameTeam),
+                    battingRecordsByTeamId = emptyMap(),
+                    pitchingRecordsByTeamId =
+                        mapOf(
+                            homeTeam.id to
+                                listOf(
+                                    homePitchingRecord1,
+                                    homePitchingRecord2,
+                                ),
+                        ),
+                    fieldingRecordsByTeamId = mapOf(homeTeam.id to listOf(homeFieldingRecord)),
+                )
+
+            // then
+            assertThat(results).hasSize(1)
+            assertThat(results[0].record).isEqualTo(SpecialGameRecord.NO_HITTER)
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/SpecialGameRecordEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/SpecialGameRecordEventListener.kt
@@ -1,0 +1,129 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.event.GameResultConfirmedEvent
+import com.nextup.core.domain.event.SpecialGameRecordDetectedEvent
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.domain.game.SpecialGameRecord
+import com.nextup.core.domain.game.SpecialGameRecordDetector
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * 특수 경기 기록 감지 이벤트 리스너
+ *
+ * 경기 결과 확정 이벤트를 수신하여 노히트/퍼펙트게임을 자동 감지합니다.
+ * 감지된 특수 기록은 GameEvent로 저장하고, SpecialGameRecordDetectedEvent를 발행합니다.
+ */
+@Component
+class SpecialGameRecordEventListener(
+    private val gameRepository: GameRepositoryPort,
+    private val gameTeamRepository: GameTeamRepositoryPort,
+    private val battingRecordRepository: BattingRecordRepositoryPort,
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+    private val fieldingRecordRepository: FieldingRecordRepositoryPort,
+    private val gameEventRepository: GameEventRepositoryPort,
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+    private val logger = LoggerFactory.getLogger(SpecialGameRecordEventListener::class.java)
+
+    /**
+     * 경기 결과 확정 시 특수 기록을 감지합니다.
+     *
+     * BEFORE_COMMIT 단계에서 실행하여 GameEvent 저장을 동일 트랜잭션 내에서 처리합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    fun onGameResultConfirmed(event: GameResultConfirmedEvent) {
+        val game =
+            gameRepository.findByIdOrNull(event.gameId)
+                ?: throw GameNotFoundException(event.gameId)
+
+        val gameTeams = gameTeamRepository.findAllByGameId(event.gameId)
+        if (gameTeams.size != 2) {
+            logger.debug(
+                "특수 기록 감지 건너뜀 - 팀 수가 2가 아님 (gameId={}, teamCount={})",
+                event.gameId,
+                gameTeams.size,
+            )
+            return
+        }
+
+        // 팀별 기록 조회 - 각 팀의 투수/수비 기록을 팀 ID 기준으로 그룹화
+        val allBattingRecords = battingRecordRepository.findAllByGameId(event.gameId)
+        val allPitchingRecords = pitchingRecordRepository.findAllByGameId(event.gameId)
+        val allFieldingRecords = fieldingRecordRepository.findAllByGameId(event.gameId)
+
+        val battingByTeamId =
+            allBattingRecords.groupBy { it.gamePlayer.gameTeam.team.id }
+        val pitchingByTeamId =
+            allPitchingRecords.groupBy { it.gamePlayer.gameTeam.team.id }
+        val fieldingByTeamId =
+            allFieldingRecords.groupBy { it.gamePlayer.gameTeam.team.id }
+
+        val detectionResults =
+            SpecialGameRecordDetector.detect(
+                game = game,
+                gameTeams = gameTeams,
+                battingRecordsByTeamId = battingByTeamId,
+                pitchingRecordsByTeamId = pitchingByTeamId,
+                fieldingRecordsByTeamId = fieldingByTeamId,
+            )
+
+        for (result in detectionResults) {
+            val eventType =
+                when (result.record) {
+                    SpecialGameRecord.PERFECT_GAME -> GameEventType.PERFECT_GAME
+                    SpecialGameRecord.NO_HITTER -> GameEventType.NO_HITTER
+                }
+
+            val description =
+                when (result.record) {
+                    SpecialGameRecord.PERFECT_GAME ->
+                        "퍼펙트게임 달성! 상대 팀에 안타, 볼넷, 사구, 실책 없이 경기를 마무리했습니다."
+                    SpecialGameRecord.NO_HITTER ->
+                        "노히트노런 달성! 상대 팀에 안타를 허용하지 않았습니다."
+                }
+
+            // GameEvent로 기록
+            val gameEvent =
+                GameEvent(
+                    game = game,
+                    inning = game.currentInning,
+                    isTopInning = game.isTopInning,
+                    outCountBefore = game.gameState.outs,
+                    outCountAfter = game.gameState.outs,
+                    eventType = eventType,
+                    description = description,
+                )
+            gameEventRepository.save(gameEvent)
+
+            // 후속 처리를 위한 도메인 이벤트 발행 (알림 등)
+            eventPublisher.publishEvent(
+                SpecialGameRecordDetectedEvent(
+                    gameId = event.gameId,
+                    teamId = result.teamId,
+                    opponentTeamId = result.opponentTeamId,
+                    record = result.record,
+                ),
+            )
+
+            logger.info(
+                "{} 감지 (gameId={}, teamId={}, opponentTeamId={})",
+                result.record.displayName,
+                event.gameId,
+                result.teamId,
+                result.opponentTeamId,
+            )
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/SpecialGameRecordEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/SpecialGameRecordEventListenerTest.kt
@@ -1,0 +1,314 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.event.GameResultConfirmedEvent
+import com.nextup.core.domain.event.SpecialGameRecordDetectedEvent
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.game.SpecialGameRecord
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("SpecialGameRecordEventListener 테스트")
+class SpecialGameRecordEventListenerTest {
+    private val gameRepository = mockk<GameRepositoryPort>()
+    private val gameTeamRepository = mockk<GameTeamRepositoryPort>()
+    private val battingRecordRepository = mockk<BattingRecordRepositoryPort>()
+    private val pitchingRecordRepository = mockk<PitchingRecordRepositoryPort>()
+    private val fieldingRecordRepository = mockk<FieldingRecordRepositoryPort>()
+    private val gameEventRepository = mockk<GameEventRepositoryPort>()
+    private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
+
+    private val listener =
+        SpecialGameRecordEventListener(
+            gameRepository = gameRepository,
+            gameTeamRepository = gameTeamRepository,
+            battingRecordRepository = battingRecordRepository,
+            pitchingRecordRepository = pitchingRecordRepository,
+            fieldingRecordRepository = fieldingRecordRepository,
+            gameEventRepository = gameEventRepository,
+            eventPublisher = eventPublisher,
+        )
+
+    private lateinit var competition: Competition
+    private lateinit var homeTeam: Team
+    private lateinit var awayTeam: Team
+    private lateinit var game: Game
+
+    @BeforeEach
+    fun setUp() {
+        val association = Association(name = "서울시야구협회", region = "서울")
+        val league = League(association = association, name = "1부 리그", foundedYear = 2020)
+        homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+
+        competition =
+            Competition(
+                league = league,
+                name = "테스트 대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+            )
+
+        game =
+            Game.createForTest(
+                competition = competition,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledAt = LocalDateTime.of(2025, 5, 10, 14, 0),
+                status = GameStatus.FINISHED,
+                currentInning = 9,
+                isTopInning = false,
+                totalInnings = 9,
+                id = 10L,
+            )
+    }
+
+    private fun createGamePlayer(
+        gameTeam: GameTeam,
+        position: Position = Position.STARTING_PITCHER,
+        id: Long = 0L,
+    ): GamePlayer {
+        val player =
+            Player(
+                name = "테스트선수",
+                birthDate = LocalDate.of(1990, 1, 1),
+                primaryPosition = position,
+                id = id,
+            )
+        return GamePlayer(
+            gameTeam = gameTeam,
+            player = player,
+            position = position,
+            battingOrder = 1,
+            id = id,
+        )
+    }
+
+    private fun createEvent(gameId: Long = 10L) =
+        GameResultConfirmedEvent(
+            gameId = gameId,
+            homeTeamId = 1L,
+            awayTeamId = 2L,
+            homeScore = 5,
+            awayScore = 0,
+        )
+
+    @Nested
+    @DisplayName("퍼펙트게임 감지 및 이벤트 발행")
+    inner class PerfectGameDetection {
+        @Test
+        fun `퍼펙트게임 감지 시 GameEvent 저장 및 도메인 이벤트 발행`() {
+            // given
+            val homeGameTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
+            val awayGameTeam = game.gameTeams.first { it.homeAway == HomeAway.AWAY }
+            awayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+            homeGameTeam.updateScore(totalScore = 5, totalHits = 8, totalErrors = 0)
+
+            val homePitcher = createGamePlayer(homeGameTeam, Position.STARTING_PITCHER, 100L)
+            val homePitchingRecord =
+                PitchingRecord.create(homePitcher, isStartingPitcher = true)
+
+            val homeFielder = createGamePlayer(homeGameTeam, Position.SHORTSTOP, 101L)
+            val homeFieldingRecord = FieldingRecord.create(homeFielder)
+
+            every { gameRepository.findByIdOrNull(10L) } returns game
+            every { gameTeamRepository.findAllByGameId(10L) } returns listOf(homeGameTeam, awayGameTeam)
+            every { battingRecordRepository.findAllByGameId(10L) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(10L) } returns listOf(homePitchingRecord)
+            every { fieldingRecordRepository.findAllByGameId(10L) } returns listOf(homeFieldingRecord)
+            every { gameEventRepository.save(any()) } returnsArgument 0
+
+            // when
+            listener.onGameResultConfirmed(createEvent())
+
+            // then
+            val gameEventSlot = slot<GameEvent>()
+            verify { gameEventRepository.save(capture(gameEventSlot)) }
+            assertThat(gameEventSlot.captured.eventType).isEqualTo(GameEventType.PERFECT_GAME)
+
+            val domainEventSlot = slot<SpecialGameRecordDetectedEvent>()
+            verify { eventPublisher.publishEvent(capture(domainEventSlot)) }
+            assertThat(domainEventSlot.captured.record).isEqualTo(SpecialGameRecord.PERFECT_GAME)
+            assertThat(domainEventSlot.captured.teamId).isEqualTo(homeTeam.id)
+            assertThat(domainEventSlot.captured.opponentTeamId).isEqualTo(awayTeam.id)
+        }
+    }
+
+    @Nested
+    @DisplayName("노히트노런 감지 및 이벤트 발행")
+    inner class NoHitterDetection {
+        @Test
+        fun `노히트노런 감지 시 GameEvent 저장 및 도메인 이벤트 발행`() {
+            // given
+            val homeGameTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
+            val awayGameTeam = game.gameTeams.first { it.homeAway == HomeAway.AWAY }
+            awayGameTeam.updateScore(totalScore = 0, totalHits = 0, totalErrors = 0)
+            homeGameTeam.updateScore(totalScore = 3, totalHits = 5, totalErrors = 0)
+
+            val homePitcher = createGamePlayer(homeGameTeam, Position.STARTING_PITCHER, 100L)
+            val homePitchingRecord =
+                PitchingRecord.create(homePitcher, isStartingPitcher = true)
+            homePitchingRecord.recordWalk()
+
+            val homeFielder = createGamePlayer(homeGameTeam, Position.SHORTSTOP, 101L)
+            val homeFieldingRecord = FieldingRecord.create(homeFielder)
+
+            every { gameRepository.findByIdOrNull(10L) } returns game
+            every { gameTeamRepository.findAllByGameId(10L) } returns listOf(homeGameTeam, awayGameTeam)
+            every { battingRecordRepository.findAllByGameId(10L) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(10L) } returns listOf(homePitchingRecord)
+            every { fieldingRecordRepository.findAllByGameId(10L) } returns listOf(homeFieldingRecord)
+            every { gameEventRepository.save(any()) } returnsArgument 0
+
+            // when
+            listener.onGameResultConfirmed(createEvent())
+
+            // then
+            val gameEventSlot = slot<GameEvent>()
+            verify { gameEventRepository.save(capture(gameEventSlot)) }
+            assertThat(gameEventSlot.captured.eventType).isEqualTo(GameEventType.NO_HITTER)
+
+            val domainEventSlot = slot<SpecialGameRecordDetectedEvent>()
+            verify { eventPublisher.publishEvent(capture(domainEventSlot)) }
+            assertThat(domainEventSlot.captured.record).isEqualTo(SpecialGameRecord.NO_HITTER)
+        }
+    }
+
+    @Nested
+    @DisplayName("미감지 케이스")
+    inner class NoDetection {
+        @Test
+        fun `정상 경기(안타 있음)에서는 특수 기록 미감지`() {
+            // given
+            val homeGameTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
+            val awayGameTeam = game.gameTeams.first { it.homeAway == HomeAway.AWAY }
+            awayGameTeam.updateScore(totalScore = 2, totalHits = 5, totalErrors = 1)
+            homeGameTeam.updateScore(totalScore = 5, totalHits = 8, totalErrors = 0)
+
+            every { gameRepository.findByIdOrNull(10L) } returns game
+            every { gameTeamRepository.findAllByGameId(10L) } returns listOf(homeGameTeam, awayGameTeam)
+            every { battingRecordRepository.findAllByGameId(10L) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(10L) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(10L) } returns emptyList()
+
+            // when
+            listener.onGameResultConfirmed(createEvent())
+
+            // then
+            verify(exactly = 0) { gameEventRepository.save(any()) }
+            verify(exactly = 0) { eventPublisher.publishEvent(any<SpecialGameRecordDetectedEvent>()) }
+        }
+
+        @Test
+        fun `몰수승 경기에서는 특수 기록 미감지`() {
+            // given
+            val forfeitedGame =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 5, 10, 14, 0),
+                    status = GameStatus.FORFEITED,
+                    id = 20L,
+                )
+
+            every { gameRepository.findByIdOrNull(20L) } returns forfeitedGame
+            every { gameTeamRepository.findAllByGameId(20L) } returns forfeitedGame.gameTeams
+            every { battingRecordRepository.findAllByGameId(20L) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(20L) } returns emptyList()
+            every { fieldingRecordRepository.findAllByGameId(20L) } returns emptyList()
+
+            val event =
+                GameResultConfirmedEvent(
+                    gameId = 20L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    homeScore = 7,
+                    awayScore = 0,
+                )
+
+            // when
+            listener.onGameResultConfirmed(event)
+
+            // then
+            verify(exactly = 0) { gameEventRepository.save(any()) }
+            verify(exactly = 0) { eventPublisher.publishEvent(any<SpecialGameRecordDetectedEvent>()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("에러 처리")
+    inner class ErrorHandling {
+        @Test
+        fun `경기가 존재하지 않으면 GameNotFoundException 발생`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+
+            val event =
+                GameResultConfirmedEvent(
+                    gameId = 999L,
+                    homeTeamId = 1L,
+                    awayTeamId = 2L,
+                    homeScore = 5,
+                    awayScore = 0,
+                )
+
+            // when & then
+            assertThrows<GameNotFoundException> {
+                listener.onGameResultConfirmed(event)
+            }
+        }
+
+        @Test
+        fun `팀이 2개가 아니면 감지 건너뜀`() {
+            // given
+            val homeGameTeam = game.gameTeams.first { it.homeAway == HomeAway.HOME }
+
+            every { gameRepository.findByIdOrNull(10L) } returns game
+            every { gameTeamRepository.findAllByGameId(10L) } returns listOf(homeGameTeam)
+
+            // when
+            listener.onGameResultConfirmed(createEvent())
+
+            // then
+            verify(exactly = 0) { battingRecordRepository.findAllByGameId(any()) }
+            verify(exactly = 0) { gameEventRepository.save(any()) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #342

경기 종료 시 양 팀의 기록(안타/볼넷/사구/실책)을 분석하여 노히트노런/퍼펙트게임을 자동 감지하고, GameEvent로 기록하며 후속 처리를 위한 도메인 이벤트를 발행합니다.

## Tasks

- [x] `SpecialGameRecord` enum 추가 (NO_HITTER, PERFECT_GAME)
- [x] `SpecialGameRecordDetector` 도메인 감지 로직 구현 (object)
- [x] `GameEventType`에 NO_HITTER, PERFECT_GAME 이벤트 타입 추가
- [x] `SpecialGameRecordDetectedEvent` 도메인 이벤트 추가
- [x] `SpecialGameRecordEventListener` 구현 (GameResultConfirmedEvent 수신)
- [x] 감지 조건: 정상 종료(FINISHED)/콜드게임(CALLED)만 대상
- [x] 미감지 조건: 몰수승(FORFEITED)/취소(CANCELLED)/중단(SUSPENDED) 제외
- [x] `SpecialGameRecordDetectorTest` 도메인 테스트 (11개 케이스)
- [x] `SpecialGameRecordEventListenerTest` 이벤트 리스너 테스트 (5개 케이스)
- [x] 빌드 및 전체 테스트 통과 확인

## To Reviewer

### 감지 기준
- **노히트노런**: 상대 팀 GameTeam.totalHits = 0 (볼넷/사구/실책은 허용)
- **퍼펙트게임**: 노히트 조건 + 투수 볼넷/사구 허용 = 0 + 수비 실책 = 0

### 아키텍처
- 감지 로직은 `SpecialGameRecordDetector` (Core 도메인 object)에 캡슐화
- 이벤트 리스너는 Infrastructure 계층에서 `GameResultConfirmedEvent` BEFORE_COMMIT으로 수신
- 감지 결과는 `GameEvent`로 저장 + `SpecialGameRecordDetectedEvent` 발행 (알림 등 후속 처리 가능)
- 양 팀 모두 개별 검사하여 동시 노히트 등 극단적 케이스도 대응