### PR TITLE
fix(#340): 스탯 갱신 리스너 @Version 기반 Optimistic Locking 적용

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerBattingStats.kt
@@ -29,6 +29,10 @@ class CareerBattingStats(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 ) : BaseTimeEntity() {
+    @Version
+    var version: Long = 0
+        protected set
+
     // 시즌 수
     @Column(name = "seasons_played", nullable = false)
     var seasonsPlayed: Int = 0

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerFieldingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerFieldingStats.kt
@@ -14,6 +14,7 @@ import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import jakarta.persistence.Version
 import java.math.BigDecimal
 import java.math.RoundingMode
 
@@ -38,6 +39,10 @@ class CareerFieldingStats(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 ) : BaseTimeEntity() {
+    @Version
+    var version: Long = 0
+        protected set
+
     // 시즌 수
     @Column(name = "seasons_played", nullable = false)
     var seasonsPlayed: Int = 0

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerPitchingStats.kt
@@ -29,6 +29,10 @@ class CareerPitchingStats(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 ) : BaseTimeEntity() {
+    @Version
+    var version: Long = 0
+        protected set
+
     // 시즌 수
     @Column(name = "seasons_played", nullable = false)
     var seasonsPlayed: Int = 0

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
@@ -40,6 +40,10 @@ class SeasonBattingStats(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 ) : BaseTimeEntity() {
+    @Version
+    var version: Long = 0
+        protected set
+
     // 출전 경기 수
     @Column(name = "games_played", nullable = false)
     var gamesPlayed: Int = 0

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonFieldingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonFieldingStats.kt
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import jakarta.persistence.Version
 import java.math.BigDecimal
 import java.math.RoundingMode
 
@@ -48,6 +49,10 @@ class SeasonFieldingStats(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 ) : BaseTimeEntity() {
+    @Version
+    var version: Long = 0
+        protected set
+
     // 출전 경기 수
     @Column(name = "games_played", nullable = false)
     var gamesPlayed: Int = 0

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
@@ -39,6 +39,10 @@ class SeasonPitchingStats(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 ) : BaseTimeEntity() {
+    @Version
+    var version: Long = 0
+        protected set
+
     // 출전 경기 수
     @Column(name = "games_played", nullable = false)
     var gamesPlayed: Int = 0

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
@@ -22,6 +22,9 @@ import org.springframework.transaction.event.TransactionalEventListener
  *
  * RecordCorrectedEvent 수신 시 해당 선수의 시즌/커리어 스탯에
  * 정정 델타(newValue - oldValue)를 반영합니다.
+ *
+ * Optimistic Locking(@Version) 기반 동시성 제어를 적용하여
+ * Lost Update를 방지합니다. 충돌 시 최대 3회 재시도합니다.
  */
 @Component
 class RecordCorrectionEventListener(
@@ -58,9 +61,13 @@ class RecordCorrectionEventListener(
             delta,
         )
 
-        when (event.correctionType) {
-            CorrectionType.BATTING -> applyBattingCorrection(event.playerId, year, event.fieldName, delta)
-            CorrectionType.PITCHING -> applyPitchingCorrection(event.playerId, year, event.fieldName, delta)
+        StatsEventListener.retryOnOptimisticLock("onRecordCorrected(playerId=${event.playerId})") {
+            when (event.correctionType) {
+                CorrectionType.BATTING ->
+                    applyBattingCorrection(event.playerId, year, event.fieldName, delta)
+                CorrectionType.PITCHING ->
+                    applyPitchingCorrection(event.playerId, year, event.fieldName, delta)
+            }
         }
 
         logger.info(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
@@ -20,6 +20,7 @@ import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import org.slf4j.LoggerFactory
+import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -32,6 +33,9 @@ import org.springframework.transaction.event.TransactionalEventListener
  * 경기 중 타석 이벤트를 수신하여 시즌 타격 통계를 즉시 갱신합니다.
  * 경기 종료 이벤트를 수신하여 투수 스탯 및 커리어 스탯을 집계합니다.
  * Infrastructure 계층에 위치하여 Core의 Port를 통해 데이터에 접근합니다.
+ *
+ * Optimistic Locking(@Version) 기반 동시성 제어를 적용하여
+ * Lost Update를 방지합니다. 충돌 시 최대 3회 재시도합니다.
  */
 @Component
 class StatsEventListener(
@@ -53,31 +57,35 @@ class StatsEventListener(
      *
      * 해당 선수의 시즌 타격 통계를 찾아 실시간으로 갱신합니다.
      * 시즌 통계가 없는 경우 갱신을 건너뜁니다.
+     * Optimistic Locking 충돌 시 최대 3회 재시도합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onPlateAppearanceRecorded(event: PlateAppearanceRecordedEvent) {
         val year = resolveYear(event.gameId)
-        val stats =
-            seasonBattingStatsRepository.findByPlayerIdAndYear(event.playerId, year)
-                ?: run {
-                    logger.debug(
-                        "시즌 타격 통계 없음 - 갱신 건너뜀 (playerId={}, year={})",
-                        event.playerId,
-                        year,
-                    )
-                    return
-                }
 
-        stats.applyLiveUpdate(event.result)
-        seasonBattingStatsRepository.save(stats)
+        retryOnOptimisticLock("onPlateAppearanceRecorded") {
+            val stats =
+                seasonBattingStatsRepository.findByPlayerIdAndYear(event.playerId, year)
+                    ?: run {
+                        logger.debug(
+                            "시즌 타격 통계 없음 - 갱신 건너뜀 (playerId={}, year={})",
+                            event.playerId,
+                            year,
+                        )
+                        return@retryOnOptimisticLock
+                    }
 
-        logger.debug(
-            "실시간 타격 통계 갱신 완료 (playerId={}, year={}, result={})",
-            event.playerId,
-            year,
-            event.result,
-        )
+            stats.applyLiveUpdate(event.result)
+            seasonBattingStatsRepository.save(stats)
+
+            logger.debug(
+                "실시간 타격 통계 갱신 완료 (playerId={}, year={}, result={})",
+                event.playerId,
+                year,
+                event.result,
+            )
+        }
     }
 
     /**
@@ -85,31 +93,35 @@ class StatsEventListener(
      *
      * 해당 선수의 시즌 타격 통계를 찾아 이전 타석 결과를 역산합니다.
      * 시즌 통계가 없는 경우 갱신을 건너뜁니다.
+     * Optimistic Locking 충돌 시 최대 3회 재시도합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onPlateAppearanceUndone(event: PlateAppearanceUndoneEvent) {
         val year = resolveYear(event.gameId)
-        val stats =
-            seasonBattingStatsRepository.findByPlayerIdAndYear(event.playerId, year)
-                ?: run {
-                    logger.debug(
-                        "시즌 타격 통계 없음 - Undo 건너뜀 (playerId={}, year={})",
-                        event.playerId,
-                        year,
-                    )
-                    return
-                }
 
-        stats.revertLiveUpdate(event.result)
-        seasonBattingStatsRepository.save(stats)
+        retryOnOptimisticLock("onPlateAppearanceUndone") {
+            val stats =
+                seasonBattingStatsRepository.findByPlayerIdAndYear(event.playerId, year)
+                    ?: run {
+                        logger.debug(
+                            "시즌 타격 통계 없음 - Undo 건너뜀 (playerId={}, year={})",
+                            event.playerId,
+                            year,
+                        )
+                        return@retryOnOptimisticLock
+                    }
 
-        logger.debug(
-            "실시간 타격 통계 역산 완료 (playerId={}, year={}, result={})",
-            event.playerId,
-            year,
-            event.result,
-        )
+            stats.revertLiveUpdate(event.result)
+            seasonBattingStatsRepository.save(stats)
+
+            logger.debug(
+                "실시간 타격 통계 역산 완료 (playerId={}, year={}, result={})",
+                event.playerId,
+                year,
+                event.result,
+            )
+        }
     }
 
     /**
@@ -126,6 +138,8 @@ class StatsEventListener(
      * 처리 순서:
      * 1. 투수 스탯: isFirstSeasonRecord 확인 → SeasonPitchingStats 갱신 → CareerPitchingStats 갱신
      * 2. 타자 스탯: isFirstSeasonRecord 확인 → CareerBattingStats 갱신
+     *
+     * 각 선수별 갱신에 Optimistic Locking 재시도를 적용합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -144,32 +158,35 @@ class StatsEventListener(
             val player = pitchingRecord.gamePlayer.player
             val playerId = player.id
 
-            val existingSeasonPitching =
-                seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year)
-            val isFirstPitchingSeason = existingSeasonPitching == null
+            retryOnOptimisticLock("onGameResultConfirmed-pitching(playerId=$playerId)") {
+                val existingSeasonPitching =
+                    seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year)
+                val isFirstPitchingSeason = existingSeasonPitching == null
 
-            // SeasonPitchingStats 갱신
-            val seasonPitchingStats = existingSeasonPitching ?: SeasonPitchingStats.create(player = player, year = year)
-            seasonPitchingStats.addGameRecord(pitchingRecord)
-            seasonPitchingStatsRepository.save(seasonPitchingStats)
+                // SeasonPitchingStats 갱신
+                val seasonPitchingStats =
+                    existingSeasonPitching ?: SeasonPitchingStats.create(player = player, year = year)
+                seasonPitchingStats.addGameRecord(pitchingRecord)
+                seasonPitchingStatsRepository.save(seasonPitchingStats)
 
-            // CareerPitchingStats 갱신
-            val careerPitchingStats =
-                careerPitchingStatsRepository.findByPlayerId(playerId)
-                    ?: CareerPitchingStats.create(player = player)
+                // CareerPitchingStats 갱신
+                val careerPitchingStats =
+                    careerPitchingStatsRepository.findByPlayerId(playerId)
+                        ?: CareerPitchingStats.create(player = player)
 
-            if (isFirstPitchingSeason) {
-                careerPitchingStats.addSeason()
+                if (isFirstPitchingSeason) {
+                    careerPitchingStats.addSeason()
+                }
+                careerPitchingStats.addGameRecord(pitchingRecord)
+                careerPitchingStatsRepository.save(careerPitchingStats)
+
+                logger.debug(
+                    "투수 통계 갱신 완료 (playerId={}, year={}, isFirstSeason={})",
+                    playerId,
+                    year,
+                    isFirstPitchingSeason,
+                )
             }
-            careerPitchingStats.addGameRecord(pitchingRecord)
-            careerPitchingStatsRepository.save(careerPitchingStats)
-
-            logger.debug(
-                "투수 통계 갱신 완료 (playerId={}, year={}, isFirstSeason={})",
-                playerId,
-                year,
-                isFirstPitchingSeason,
-            )
         }
 
         // 커리어 타격 스탯 집계: CareerBattingStats
@@ -179,24 +196,26 @@ class StatsEventListener(
             val player = battingRecord.gamePlayer.player
             val playerId = player.id
 
-            val isFirstBattingSeason =
-                seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year) == null
+            retryOnOptimisticLock("onGameResultConfirmed-batting(playerId=$playerId)") {
+                val isFirstBattingSeason =
+                    seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year) == null
 
-            val careerBattingStats =
-                careerBattingStatsRepository.findByPlayerId(playerId)
-                    ?: CareerBattingStats.create(player = player)
+                val careerBattingStats =
+                    careerBattingStatsRepository.findByPlayerId(playerId)
+                        ?: CareerBattingStats.create(player = player)
 
-            if (isFirstBattingSeason) {
-                careerBattingStats.addSeason()
+                if (isFirstBattingSeason) {
+                    careerBattingStats.addSeason()
+                }
+                careerBattingStats.addGameRecord(battingRecord)
+                careerBattingStatsRepository.save(careerBattingStats)
+
+                logger.debug(
+                    "커리어 타격 통계 갱신 완료 (playerId={}, isFirstSeason={})",
+                    playerId,
+                    isFirstBattingSeason,
+                )
             }
-            careerBattingStats.addGameRecord(battingRecord)
-            careerBattingStatsRepository.save(careerBattingStats)
-
-            logger.debug(
-                "커리어 타격 통계 갱신 완료 (playerId={}, isFirstSeason={})",
-                playerId,
-                isFirstBattingSeason,
-            )
         }
 
         // 수비 스탯 집계: SeasonFieldingStats + CareerFieldingStats
@@ -205,33 +224,35 @@ class StatsEventListener(
             val player = fieldingRecord.gamePlayer.player
             val playerId = player.id
 
-            val existingSeasonFielding =
-                seasonFieldingStatsRepository.findByPlayerIdAndYear(playerId, year)
-            val isFirstFieldingSeason = existingSeasonFielding == null
+            retryOnOptimisticLock("onGameResultConfirmed-fielding(playerId=$playerId)") {
+                val existingSeasonFielding =
+                    seasonFieldingStatsRepository.findByPlayerIdAndYear(playerId, year)
+                val isFirstFieldingSeason = existingSeasonFielding == null
 
-            // SeasonFieldingStats 갱신
-            val seasonFieldingStats =
-                existingSeasonFielding ?: SeasonFieldingStats.create(player = player, year = year)
-            seasonFieldingStats.addGameRecord(fieldingRecord)
-            seasonFieldingStatsRepository.save(seasonFieldingStats)
+                // SeasonFieldingStats 갱신
+                val seasonFieldingStats =
+                    existingSeasonFielding ?: SeasonFieldingStats.create(player = player, year = year)
+                seasonFieldingStats.addGameRecord(fieldingRecord)
+                seasonFieldingStatsRepository.save(seasonFieldingStats)
 
-            // CareerFieldingStats 갱신
-            val careerFieldingStats =
-                careerFieldingStatsRepository.findByPlayerId(playerId)
-                    ?: CareerFieldingStats.create(player = player)
+                // CareerFieldingStats 갱신
+                val careerFieldingStats =
+                    careerFieldingStatsRepository.findByPlayerId(playerId)
+                        ?: CareerFieldingStats.create(player = player)
 
-            if (isFirstFieldingSeason) {
-                careerFieldingStats.addSeason()
+                if (isFirstFieldingSeason) {
+                    careerFieldingStats.addSeason()
+                }
+                careerFieldingStats.addGameRecord(fieldingRecord)
+                careerFieldingStatsRepository.save(careerFieldingStats)
+
+                logger.debug(
+                    "수비 통계 갱신 완료 (playerId={}, year={}, isFirstSeason={})",
+                    playerId,
+                    year,
+                    isFirstFieldingSeason,
+                )
             }
-            careerFieldingStats.addGameRecord(fieldingRecord)
-            careerFieldingStatsRepository.save(careerFieldingStats)
-
-            logger.debug(
-                "수비 통계 갱신 완료 (playerId={}, year={}, isFirstSeason={})",
-                playerId,
-                year,
-                isFirstFieldingSeason,
-            )
         }
 
         logger.info(
@@ -248,5 +269,43 @@ class StatsEventListener(
             gameRepository.findByIdOrNull(gameId)
                 ?: throw GameNotFoundException(gameId)
         return game.scheduledAt.year
+    }
+
+    companion object {
+        private const val MAX_RETRIES = 3
+        private val log = LoggerFactory.getLogger(StatsEventListener::class.java)
+
+        /**
+         * Optimistic Locking 충돌 시 재시도하는 헬퍼 메서드.
+         *
+         * @param operationName 로깅용 작업명
+         * @param action 재시도할 작업
+         */
+        internal fun retryOnOptimisticLock(
+            operationName: String,
+            action: () -> Unit,
+        ) {
+            var lastException: ObjectOptimisticLockingFailureException? = null
+            for (attempt in 1..MAX_RETRIES) {
+                try {
+                    action()
+                    return
+                } catch (ex: ObjectOptimisticLockingFailureException) {
+                    lastException = ex
+                    log.warn(
+                        "Optimistic Locking 충돌 발생 - 재시도 {}/{} (operation={})",
+                        attempt,
+                        MAX_RETRIES,
+                        operationName,
+                    )
+                }
+            }
+            log.error(
+                "Optimistic Locking 재시도 초과 (operation={}, maxRetries={})",
+                operationName,
+                MAX_RETRIES,
+            )
+            throw lastException!!
+        }
     }
 }

--- a/nextup-infrastructure/src/main/resources/db/migration/V037__add_version_to_stats_tables.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V037__add_version_to_stats_tables.sql
@@ -1,0 +1,9 @@
+-- #340: 스탯 엔티티 @Version 기반 Optimistic Locking 적용
+-- 동시 갱신(Lost Update) 방지를 위해 version 컬럼 추가
+
+ALTER TABLE season_batting_stats ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE season_pitching_stats ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE season_fielding_stats ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE career_batting_stats ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE career_pitching_stats ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE career_fielding_stats ADD COLUMN version BIGINT NOT NULL DEFAULT 0;

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
+import org.springframework.orm.ObjectOptimisticLockingFailureException
 import java.time.LocalDateTime
 
 @DisplayName("RecordCorrectionEventListener 테스트")
@@ -80,7 +81,7 @@ class RecordCorrectionEventListenerTest {
             // given
             val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
             val careerStats = CareerBattingStats.create(testPlayer)
-            // 기존 값 설정 (불변식을 만족하는 순서: PA ≥ AB ≥ H)
+            // 기존 값 설정 (불변식을 만족하는 순서: PA >= AB >= H)
             seasonStats.applyFieldCorrection("plateAppearances", 15)
             seasonStats.applyFieldCorrection("atBats", 12)
             seasonStats.applyFieldCorrection("hits", 10)
@@ -117,7 +118,7 @@ class RecordCorrectionEventListenerTest {
         fun `음수 델타 적용 시 통계가 감소됨`() {
             // given
             val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
-            // 불변식을 만족하는 순서: PA ≥ AB ≥ H ≥ 2B+3B+HR
+            // 불변식을 만족하는 순서: PA >= AB >= H >= 2B+3B+HR
             seasonStats.applyFieldCorrection("plateAppearances", 10)
             seasonStats.applyFieldCorrection("atBats", 8)
             seasonStats.applyFieldCorrection("hits", 5)
@@ -281,7 +282,7 @@ class RecordCorrectionEventListenerTest {
         fun `자책점 감소 정정이 올바르게 반영됨`() {
             // given
             val seasonStats = SeasonPitchingStats.create(testPlayer, 2024)
-            // 불변식을 만족하는 순서: RA ≥ ER
+            // 불변식을 만족하는 순서: RA >= ER
             seasonStats.applyFieldCorrection("runsAllowed", 12)
             seasonStats.applyFieldCorrection("earnedRuns", 10)
 
@@ -358,6 +359,68 @@ class RecordCorrectionEventListenerTest {
 
             // then
             verify(exactly = 0) { cacheManager.getCache(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Optimistic Locking 재시도")
+    inner class OptimisticLockingRetry {
+        @Test
+        fun `기록 정정 시 OptimisticLocking 충돌이 발생하면 재시도하여 성공`() {
+            // given
+            val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("plateAppearances", 15)
+            seasonStats.applyFieldCorrection("atBats", 12)
+            seasonStats.applyFieldCorrection("hits", 10)
+
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            // 첫 번째 save 시 충돌, 두 번째에 성공
+            every { seasonBattingStatsRepository.save(any()) } throws
+                ObjectOptimisticLockingFailureException("conflict", null) andThen seasonStats
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "2",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: 2번 호출됨 (1번 실패 + 1번 성공)
+            verify(exactly = 2) { seasonBattingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `재시도 횟수 초과 시 예외가 전파됨`() {
+            // given
+            val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("walks", 10)
+
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonBattingStatsRepository.save(any()) } throws
+                ObjectOptimisticLockingFailureException("conflict", null)
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "walks",
+                    oldValue = "2",
+                    newValue = "3",
+                )
+
+            // when & then
+            assertThrows<ObjectOptimisticLockingFailureException> {
+                listener.onRecordCorrected(event)
+            }
         }
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.orm.ObjectOptimisticLockingFailureException
 import java.time.LocalDateTime
 
 @DisplayName("StatsEventListener 테스트")
@@ -701,6 +702,93 @@ class StatsEventListenerTest {
             assertThrows<GameNotFoundException> {
                 listener.onGameResultConfirmed(badEvent)
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("retryOnOptimisticLock - Optimistic Locking 재시도")
+    inner class RetryOnOptimisticLock {
+        @Test
+        fun `OptimisticLockingFailureException 발생 시 재시도 후 성공`() {
+            // given
+            var callCount = 0
+
+            // when
+            StatsEventListener.retryOnOptimisticLock("test") {
+                callCount++
+                if (callCount < 3) {
+                    throw ObjectOptimisticLockingFailureException("test", null)
+                }
+            }
+
+            // then: 3번째에 성공
+            assertThat(callCount).isEqualTo(3)
+        }
+
+        @Test
+        fun `재시도 횟수 초과 시 예외 전파`() {
+            // given & when & then
+            assertThrows<ObjectOptimisticLockingFailureException> {
+                StatsEventListener.retryOnOptimisticLock("test") {
+                    throw ObjectOptimisticLockingFailureException("test", null)
+                }
+            }
+        }
+
+        @Test
+        fun `첫 시도에 성공하면 한 번만 호출됨`() {
+            // given
+            var callCount = 0
+
+            // when
+            StatsEventListener.retryOnOptimisticLock("test") {
+                callCount++
+            }
+
+            // then
+            assertThat(callCount).isEqualTo(1)
+        }
+
+        @Test
+        fun `OptimisticLockingFailureException이 아닌 예외는 즉시 전파`() {
+            // given
+            var callCount = 0
+
+            // when & then
+            assertThrows<IllegalStateException> {
+                StatsEventListener.retryOnOptimisticLock("test") {
+                    callCount++
+                    throw IllegalStateException("다른 예외")
+                }
+            }
+
+            // then: 재시도 없이 1회만 호출
+            assertThat(callCount).isEqualTo(1)
+        }
+
+        @Test
+        fun `타석 기록 이벤트에서 OptimisticLocking 충돌 시 재시도하여 성공`() {
+            // given
+            val stats = SeasonBattingStats.create(testPlayer, 2024)
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns stats
+            // 첫 번째 save 시 충돌, 두 번째에 성공
+            every { seasonBattingStatsRepository.save(any()) } throws
+                ObjectOptimisticLockingFailureException("conflict", null) andThen stats
+
+            val event =
+                PlateAppearanceRecordedEvent(
+                    gameId = 10L,
+                    playerId = testPlayer.id,
+                    result = PlateAppearanceResult.SINGLE,
+                )
+
+            // when
+            listener.onPlateAppearanceRecorded(event)
+
+            // then: 2번 호출됨 (1번 실패 + 1번 성공)
+            verify(exactly = 2) { seasonBattingStatsRepository.save(any()) }
         }
     }
 }


### PR DESCRIPTION
## Summary

>- close #340

`RecordCorrectedEvent`와 `PlateAppearanceRecordedEvent`가 동시에 `SeasonBattingStats`를 갱신할 때 발생할 수 있는 Lost Update 문제를 `@Version` 기반 Optimistic Locking + 재시도(최대 3회)로 해결합니다.

## Tasks

- 6개 Stats 엔티티(`SeasonBattingStats`, `SeasonPitchingStats`, `SeasonFieldingStats`, `CareerBattingStats`, `CareerPitchingStats`, `CareerFieldingStats`)에 `@Version` 컬럼 추가
- `StatsEventListener`에 `retryOnOptimisticLock` 헬퍼 메서드 구현 및 모든 이벤트 핸들러에 적용
- `RecordCorrectionEventListener`에 동일한 재시도 로직 적용
- Flyway V037 마이그레이션으로 6개 stats 테이블에 `version BIGINT NOT NULL DEFAULT 0` 컬럼 추가
- `StatsEventListenerTest`에 Optimistic Locking 재시도 검증 테스트 5건 추가
- `RecordCorrectionEventListenerTest`에 재시도 성공/실패 테스트 2건 추가

## To Reviewer

- `retryOnOptimisticLock`은 `StatsEventListener.Companion`에 `internal`로 정의하여 `RecordCorrectionEventListener`에서도 재사용합니다.
- Spring Retry 의존성 추가 대신 수동 재시도 루프를 구현했습니다 (외부 의존성 최소화).
- `ObjectOptimisticLockingFailureException`이 아닌 다른 예외는 즉시 전파되어 재시도하지 않습니다.
- 기존 `BaseExceptionHandler`에 `ObjectOptimisticLockingFailureException` -> 409 Conflict 핸들러가 이미 존재합니다.