### PR TITLE
fix: BookingControllerTest 예약 취소 테스트 slot 상태 수정

### DIFF
--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingControllerTest.kt
@@ -125,6 +125,7 @@ class BookingControllerTest {
             // given
             val stadium = createStadium(1L, "잠실 야구장")
             val slot = createSlot(1L, stadium)
+            slot.book()
             val booking = createBooking(1L, slot, 100L, 200L)
             booking.cancel()
             every { stadiumService.cancelBooking(1L) } returns booking


### PR DESCRIPTION
## Summary

>- close #없음 (pre-existing bug fix)

**develop 브랜치의 BookingControllerTest 실패 수정**

예약 취소 테스트(`should cancel booking successfully`)에서 `StadiumSlot`이 `AVAILABLE` 상태인 채로 `booking.cancel()`을 호출하면, `StadiumBooking.cancel()` 내부에서 `slot.cancel()`을 호출할 때 `SlotNotAvailableException`이 발생합니다.

`slot.book()`을 먼저 호출하여 slot을 `BOOKED` 상태로 전환한 후 cancel할 수 있도록 수정합니다.

## Tasks

- [x] BookingControllerTest의 cancel 테스트에서 slot.book() 호출 추가
- [ ] - [x] slot이 BOOKED 상태에서 cancel되도록 fixture 수정

## To Reviewer

develop 브랜치에서 pre-existing으로 실패하던 테스트를 수정합니다.\n여러 feature PR(#358, #360 등)의 CI 통과를 위해 필요합니다.

변경사항은 테스트 코드 1줄 추가(`slot.book()`)뿐이며, 프로덕션 코드 변경은 없습니다.