### PR TITLE
feat(#346): API 추가 기능 보완 (M-13~M-19)

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
@@ -4,8 +4,8 @@ import com.nextup.api.dto.competition.CompetitionResponse
 import com.nextup.api.dto.competition.CompetitionTeamResponse
 import com.nextup.api.dto.standings.StandingsResponse
 import com.nextup.common.dto.ApiResponse
-import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionPlayerStatus
+import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.service.competition.CompetitionService
 import com.nextup.core.service.standings.StandingsService

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
@@ -3,11 +3,13 @@ package com.nextup.api.controller.competition
 import com.nextup.api.dto.competition.CompetitionResponse
 import com.nextup.api.dto.standings.StandingsResponse
 import com.nextup.common.dto.ApiResponse
+import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.service.competition.CompetitionService
 import com.nextup.core.service.standings.StandingsService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
@@ -20,11 +22,21 @@ class CompetitionController(
     private val standingsService: StandingsService,
 ) {
     /**
-     * 진행 중인 대회 목록을 조회합니다.
+     * 대회 목록을 조회합니다.
+     *
+     * @param status 대회 상태 필터 (SCHEDULED, IN_PROGRESS, COMPLETED, CANCELLED, POSTPONED)
+     *               null이면 진행 중인 대회만 조회합니다.
      */
     @GetMapping
-    fun getCompetitions(): ApiResponse<List<CompetitionResponse>> {
-        val competitions = competitionService.getInProgress()
+    fun getCompetitions(
+        @RequestParam(required = false) status: CompetitionStatus?,
+    ): ApiResponse<List<CompetitionResponse>> {
+        val competitions =
+            if (status != null) {
+                competitionService.getByStatus(status)
+            } else {
+                competitionService.getInProgress()
+            }
         return ApiResponse.success(
             competitions.map { CompetitionResponse.from(it) },
         )

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/lineup/LineupController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/lineup/LineupController.kt
@@ -2,6 +2,7 @@ package com.nextup.api.controller.lineup
 
 import com.nextup.api.dto.lineup.AddLineupEntryRequest
 import com.nextup.api.dto.lineup.CreateLineupRequest
+import com.nextup.api.dto.lineup.LineupDetailResponse
 import com.nextup.api.dto.lineup.LineupEntryResponse
 import com.nextup.api.dto.lineup.LineupSubmissionResponse
 import com.nextup.api.dto.lineup.LineupSubmissionSummaryResponse
@@ -82,6 +83,25 @@ class LineupController(
                 val entries = lineupService.getLineupEntries(submission.id)
                 val starterCount = entries.count { it.isStarter }
                 LineupSubmissionSummaryResponse.from(submission, starterCount)
+            }
+
+        return ResponseEntity.ok(ApiResponse.success(responses))
+    }
+
+    /**
+     * 경기 라인업 확정 상태를 상세 조회합니다.
+     *
+     * 확정 여부뿐 아니라 선수 상세 정보(이름, 포지션, 타순)를 포함합니다.
+     */
+    @GetMapping("/games/{gameId}/detail")
+    fun getLineupDetailByGame(
+        @PathVariable gameId: Long,
+    ): ResponseEntity<ApiResponse<List<LineupDetailResponse>>> {
+        val submissions = lineupService.getLineupSubmissionsByGame(gameId)
+        val responses =
+            submissions.map { submission ->
+                val entries = lineupService.getLineupEntries(submission.id)
+                LineupDetailResponse.from(submission, entries)
             }
 
         return ResponseEntity.ok(ApiResponse.success(responses))

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/match/MatchRequestController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/match/MatchRequestController.kt
@@ -6,12 +6,16 @@ import com.nextup.api.dto.match.MatchRequestResponse
 import com.nextup.api.dto.match.MatchResponseResponse
 import com.nextup.api.dto.match.RespondToMatchRequestApiRequest
 import com.nextup.common.dto.ApiResponse
+import com.nextup.core.domain.match.SkillLevel
 import com.nextup.core.service.match.MatchingService
 import com.nextup.core.service.match.dto.CreateMatchRequestDto
 import com.nextup.core.service.match.dto.CreateMatchResponseDto
+import com.nextup.core.service.match.dto.MatchRequestFilterDto
 import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
 
 /**
  * 매칭 요청 API Controller (공개 API)
@@ -47,11 +51,27 @@ class MatchRequestController(
     }
 
     /**
-     * OPEN 상태의 모든 매칭 요청을 조회합니다.
+     * OPEN 상태의 매칭 요청을 조회합니다.
+     *
+     * @param area 지역 필터 (선호 장소에 포함된 문자열)
+     * @param date 날짜 필터 (선호 날짜)
+     * @param skillLevel 실력 수준 필터
      */
     @GetMapping
-    fun getOpenMatchRequests(): ApiResponse<List<MatchRequestResponse>> {
-        val matchRequests = matchingService.getOpenRequests()
+    fun getOpenMatchRequests(
+        @RequestParam(required = false) area: String?,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        date: LocalDate?,
+        @RequestParam(required = false) skillLevel: SkillLevel?,
+    ): ApiResponse<List<MatchRequestResponse>> {
+        val filter =
+            MatchRequestFilterDto(
+                area = area,
+                date = date,
+                skillLevel = skillLevel,
+            )
+        val matchRequests = matchingService.getOpenRequests(filter)
         return ApiResponse.success(matchRequests.map { MatchRequestResponse.from(it) })
     }
 

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/notification/NotificationController.kt
@@ -119,6 +119,19 @@ class NotificationController(
     }
 
     /**
+     * 모든 알림을 읽음 처리합니다.
+     *
+     * PATCH /api/v1/notifications/read-all
+     */
+    @PatchMapping("/notifications/read-all")
+    fun markAllAsRead(
+        @AuthenticationPrincipal userId: Long,
+    ): ApiResponse<Unit> {
+        notificationService.markAllAsRead(userId)
+        return ApiResponse.success(Unit)
+    }
+
+    /**
      * 미읽은 알림 개수를 조회합니다. (A-06)
      *
      * GET /api/v1/notifications/unread-count

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/PlayerStatsController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stats/PlayerStatsController.kt
@@ -2,6 +2,8 @@ package com.nextup.api.controller.stats
 
 import com.nextup.api.dto.stats.CareerBattingStatsResponse
 import com.nextup.api.dto.stats.CareerPitchingStatsResponse
+import com.nextup.api.dto.stats.CompetitionBattingStatsResponse
+import com.nextup.api.dto.stats.CompetitionPitchingStatsResponse
 import com.nextup.api.dto.stats.SeasonBattingStatsResponse
 import com.nextup.api.dto.stats.SeasonPitchingStatsResponse
 import com.nextup.api.mapper.stats.toResponse
@@ -12,6 +14,7 @@ import com.nextup.core.service.stats.PlayerStatsService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
@@ -123,5 +126,81 @@ class PlayerStatsController(
     ): ApiResponse<List<SeasonPitchingStatsResponse>> {
         val statsList = playerStatsService.getAllSeasonPitchingStats(playerId)
         return ApiResponse.success(statsList.toSeasonPitchingResponse())
+    }
+
+    /**
+     * 대회별 타격 통계 조회
+     *
+     * GET /api/v1/players/{playerId}/stats/batting/competition?competitionId=1
+     *
+     * @param playerId 선수 ID
+     * @param competitionId 대회 ID
+     * @return 대회별 타격 통계 응답
+     */
+    @GetMapping("/batting/competition")
+    fun getBattingStatsByCompetition(
+        @PathVariable playerId: Long,
+        @RequestParam competitionId: Long,
+    ): ApiResponse<CompetitionBattingStatsResponse> {
+        val stats = playerStatsService.getBattingStatsByCompetition(playerId, competitionId)
+        return ApiResponse.success(
+            CompetitionBattingStatsResponse(
+                playerId = stats.playerId,
+                competitionId = stats.competitionId,
+                gamesPlayed = stats.gamesPlayed,
+                plateAppearances = stats.plateAppearances,
+                atBats = stats.atBats,
+                hits = stats.hits,
+                doubles = stats.doubles,
+                triples = stats.triples,
+                homeRuns = stats.homeRuns,
+                runs = stats.runs,
+                runsBattedIn = stats.runsBattedIn,
+                walks = stats.walks,
+                strikeouts = stats.strikeouts,
+                stolenBases = stats.stolenBases,
+                battingAverage = stats.battingAverage,
+                onBasePercentage = stats.onBasePercentage,
+                sluggingPercentage = stats.sluggingPercentage,
+                ops = stats.ops,
+            ),
+        )
+    }
+
+    /**
+     * 대회별 투수 통계 조회
+     *
+     * GET /api/v1/players/{playerId}/stats/pitching/competition?competitionId=1
+     *
+     * @param playerId 선수 ID
+     * @param competitionId 대회 ID
+     * @return 대회별 투수 통계 응답
+     */
+    @GetMapping("/pitching/competition")
+    fun getPitchingStatsByCompetition(
+        @PathVariable playerId: Long,
+        @RequestParam competitionId: Long,
+    ): ApiResponse<CompetitionPitchingStatsResponse> {
+        val stats = playerStatsService.getPitchingStatsByCompetition(playerId, competitionId)
+        return ApiResponse.success(
+            CompetitionPitchingStatsResponse(
+                playerId = stats.playerId,
+                competitionId = stats.competitionId,
+                gamesPlayed = stats.gamesPlayed,
+                gamesStarted = stats.gamesStarted,
+                inningsPitchedDisplay = stats.inningsPitchedDisplay,
+                wins = stats.wins,
+                losses = stats.losses,
+                saves = stats.saves,
+                holds = stats.holds,
+                earnedRuns = stats.earnedRuns,
+                hitsAllowed = stats.hitsAllowed,
+                walksAllowed = stats.walksAllowed,
+                strikeouts = stats.strikeouts,
+                homeRunsAllowed = stats.homeRunsAllowed,
+                earnedRunAverage = stats.earnedRunAverage,
+                whip = stats.whip,
+            ),
+        )
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamScheduleController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamScheduleController.kt
@@ -1,0 +1,126 @@
+package com.nextup.api.controller.team
+
+import com.nextup.api.dto.team.CreateTeamScheduleRequest
+import com.nextup.api.dto.team.TeamScheduleResponse
+import com.nextup.api.dto.team.UpdateTeamScheduleRequest
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.team.TeamScheduleService
+import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+
+/**
+ * 팀 일정 API Controller
+ *
+ * 경기 일정 외 연습/이벤트/모임 등 팀 자체 일정을 관리합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/teams/{teamId}/schedules")
+class TeamScheduleController(
+    private val teamScheduleService: TeamScheduleService,
+) {
+    /**
+     * 팀 일정을 생성합니다.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createSchedule(
+        @PathVariable teamId: Long,
+        @Valid @RequestBody request: CreateTeamScheduleRequest,
+    ): ApiResponse<TeamScheduleResponse> {
+        val schedule =
+            teamScheduleService.create(
+                teamId = teamId,
+                title = request.title,
+                description = request.description,
+                scheduleType = request.scheduleType,
+                startAt = request.startAt,
+                endAt = request.endAt,
+                location = request.location,
+            )
+        return ApiResponse.success(TeamScheduleResponse.from(schedule))
+    }
+
+    /**
+     * 팀 일정 목록을 조회합니다.
+     *
+     * @param from 시작 날짜 필터 (null이면 전체 조회)
+     * @param to 종료 날짜 필터 (null이면 전체 조회)
+     */
+    @GetMapping
+    fun getSchedules(
+        @PathVariable teamId: Long,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        from: LocalDateTime?,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        to: LocalDateTime?,
+    ): ApiResponse<List<TeamScheduleResponse>> {
+        val schedules =
+            if (from != null && to != null) {
+                teamScheduleService.getByTeamIdAndDateRange(teamId, from, to)
+            } else {
+                teamScheduleService.getByTeamId(teamId)
+            }
+        return ApiResponse.success(schedules.map { TeamScheduleResponse.from(it) })
+    }
+
+    /**
+     * 팀 일정 상세를 조회합니다.
+     */
+    @GetMapping("/{scheduleId}")
+    fun getSchedule(
+        @PathVariable teamId: Long,
+        @PathVariable scheduleId: Long,
+    ): ApiResponse<TeamScheduleResponse> {
+        val schedule = teamScheduleService.getById(scheduleId)
+        return ApiResponse.success(TeamScheduleResponse.from(schedule))
+    }
+
+    /**
+     * 팀 일정을 수정합니다.
+     */
+    @PatchMapping("/{scheduleId}")
+    fun updateSchedule(
+        @PathVariable teamId: Long,
+        @PathVariable scheduleId: Long,
+        @Valid @RequestBody request: UpdateTeamScheduleRequest,
+    ): ApiResponse<TeamScheduleResponse> {
+        val schedule =
+            teamScheduleService.update(
+                id = scheduleId,
+                title = request.title,
+                description = request.description,
+                scheduleType = request.scheduleType,
+                startAt = request.startAt,
+                endAt = request.endAt,
+                location = request.location,
+            )
+        return ApiResponse.success(TeamScheduleResponse.from(schedule))
+    }
+
+    /**
+     * 팀 일정을 삭제합니다.
+     */
+    @DeleteMapping("/{scheduleId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteSchedule(
+        @PathVariable teamId: Long,
+        @PathVariable scheduleId: Long,
+    ): ApiResponse<Unit> {
+        teamScheduleService.delete(scheduleId)
+        return ApiResponse.success(Unit)
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/lineup/LineupResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/lineup/LineupResponse.kt
@@ -120,3 +120,50 @@ data class LineupSubmissionSummaryResponse(
             )
     }
 }
+
+/**
+ * 라인업 확정 상태 상세 응답 DTO
+ *
+ * 확정 여부뿐 아니라 선수 상세 정보(이름, 포지션, 타순)를 포함합니다.
+ */
+data class LineupDetailResponse(
+    val id: Long,
+    val gameId: Long,
+    val teamId: Long,
+    val teamName: String,
+    val status: LineupSubmissionStatus,
+    val statusDisplayName: String,
+    val isConfirmed: Boolean,
+    val starterCount: Int,
+    val substituteCount: Int,
+    val submittedAt: Instant?,
+    val confirmedAt: Instant?,
+    val entries: List<LineupEntryResponse>,
+) {
+    companion object {
+        fun from(
+            submission: LineupSubmission,
+            entries: List<LineupEntry>,
+        ): LineupDetailResponse {
+            val starters = entries.count { it.isStarter }
+            val substitutes = entries.size - starters
+
+            return LineupDetailResponse(
+                id = submission.id,
+                gameId = submission.game.id,
+                teamId = submission.team.id,
+                teamName = submission.team.name,
+                status = submission.status,
+                statusDisplayName = submission.status.displayName,
+                isConfirmed =
+                    submission.status == LineupSubmissionStatus.CONFIRMED ||
+                        submission.status == LineupSubmissionStatus.EXCHANGED,
+                starterCount = starters,
+                substituteCount = substitutes,
+                submittedAt = submission.submittedAt,
+                confirmedAt = submission.confirmedAt,
+                entries = entries.map { LineupEntryResponse.from(it) },
+            )
+        }
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/CompetitionStatsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/stats/CompetitionStatsResponse.kt
@@ -1,0 +1,47 @@
+package com.nextup.api.dto.stats
+
+/**
+ * 대회별 타격 통계 응답 DTO
+ */
+data class CompetitionBattingStatsResponse(
+    val playerId: Long,
+    val competitionId: Long,
+    val gamesPlayed: Int,
+    val plateAppearances: Int,
+    val atBats: Int,
+    val hits: Int,
+    val doubles: Int,
+    val triples: Int,
+    val homeRuns: Int,
+    val runs: Int,
+    val runsBattedIn: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val stolenBases: Int,
+    val battingAverage: String,
+    val onBasePercentage: String,
+    val sluggingPercentage: String,
+    val ops: String,
+)
+
+/**
+ * 대회별 투수 통계 응답 DTO
+ */
+data class CompetitionPitchingStatsResponse(
+    val playerId: Long,
+    val competitionId: Long,
+    val gamesPlayed: Int,
+    val gamesStarted: Int,
+    val inningsPitchedDisplay: String,
+    val wins: Int,
+    val losses: Int,
+    val saves: Int,
+    val holds: Int,
+    val earnedRuns: Int,
+    val hitsAllowed: Int,
+    val walksAllowed: Int,
+    val strikeouts: Int,
+    val homeRunsAllowed: Int,
+    val earnedRunAverage: String?,
+    val whip: String,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/team/TeamScheduleDto.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/team/TeamScheduleDto.kt
@@ -1,0 +1,71 @@
+package com.nextup.api.dto.team
+
+import com.nextup.core.domain.team.TeamSchedule
+import com.nextup.core.domain.team.TeamScheduleType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.Instant
+import java.time.LocalDateTime
+
+/**
+ * 팀 일정 생성 요청 DTO
+ */
+data class CreateTeamScheduleRequest(
+    @field:NotBlank(message = "제목은 필수입니다")
+    val title: String,
+    val description: String? = null,
+    @field:NotNull(message = "일정 유형은 필수입니다")
+    val scheduleType: TeamScheduleType,
+    @field:NotNull(message = "시작 시간은 필수입니다")
+    val startAt: LocalDateTime,
+    val endAt: LocalDateTime? = null,
+    val location: String? = null,
+)
+
+/**
+ * 팀 일정 수정 요청 DTO
+ */
+data class UpdateTeamScheduleRequest(
+    val title: String? = null,
+    val description: String? = null,
+    val scheduleType: TeamScheduleType? = null,
+    val startAt: LocalDateTime? = null,
+    val endAt: LocalDateTime? = null,
+    val location: String? = null,
+)
+
+/**
+ * 팀 일정 응답 DTO
+ */
+data class TeamScheduleResponse(
+    val id: Long,
+    val teamId: Long,
+    val teamName: String,
+    val title: String,
+    val description: String?,
+    val scheduleType: TeamScheduleType,
+    val scheduleTypeDisplayName: String,
+    val startAt: LocalDateTime,
+    val endAt: LocalDateTime?,
+    val location: String?,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(schedule: TeamSchedule): TeamScheduleResponse =
+            TeamScheduleResponse(
+                id = schedule.id,
+                teamId = schedule.team.id,
+                teamName = schedule.team.name,
+                title = schedule.title,
+                description = schedule.description,
+                scheduleType = schedule.scheduleType,
+                scheduleTypeDisplayName = schedule.scheduleType.displayName,
+                startAt = schedule.startAt,
+                endAt = schedule.endAt,
+                location = schedule.location,
+                createdAt = schedule.createdAt,
+                updatedAt = schedule.updatedAt,
+            )
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/match/MatchRequestControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/match/MatchRequestControllerTest.kt
@@ -15,6 +15,7 @@ import com.nextup.core.domain.match.MatchResponseStatus
 import com.nextup.core.domain.match.SkillLevel
 import com.nextup.core.domain.team.Team
 import com.nextup.core.service.match.MatchingService
+import com.nextup.core.service.match.dto.MatchRequestFilterDto
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -161,7 +162,7 @@ class MatchRequestControllerTest {
     @Test
     fun `should get open match requests`() {
         // given
-        every { matchingService.getOpenRequests() } returns listOf(mockMatchRequest)
+        every { matchingService.getOpenRequests(any<MatchRequestFilterDto>()) } returns listOf(mockMatchRequest)
 
         // when & then
         mockMvc
@@ -172,13 +173,13 @@ class MatchRequestControllerTest {
             .andExpect(jsonPath("$.data[0].id").value(1))
             .andExpect(jsonPath("$.data[0].status").value("OPEN"))
 
-        verify(exactly = 1) { matchingService.getOpenRequests() }
+        verify(exactly = 1) { matchingService.getOpenRequests(any<MatchRequestFilterDto>()) }
     }
 
     @Test
     fun `should get empty list when no open requests`() {
         // given
-        every { matchingService.getOpenRequests() } returns emptyList()
+        every { matchingService.getOpenRequests(any<MatchRequestFilterDto>()) } returns emptyList()
 
         // when & then
         mockMvc
@@ -188,7 +189,7 @@ class MatchRequestControllerTest {
             .andExpect(jsonPath("$.data").isArray)
             .andExpect(jsonPath("$.data").isEmpty)
 
-        verify(exactly = 1) { matchingService.getOpenRequests() }
+        verify(exactly = 1) { matchingService.getOpenRequests(any<MatchRequestFilterDto>()) }
     }
 
     @Test

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/PlayerStatsControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stats/PlayerStatsControllerTest.kt
@@ -11,6 +11,8 @@ import com.nextup.core.domain.stats.CareerBattingStats
 import com.nextup.core.domain.stats.CareerPitchingStats
 import com.nextup.core.domain.stats.SeasonBattingStats
 import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.service.stats.CompetitionBattingStatsDto
+import com.nextup.core.service.stats.CompetitionPitchingStatsDto
 import com.nextup.core.service.stats.PlayerStatsService
 import io.mockk.every
 import io.mockk.mockk
@@ -307,6 +309,148 @@ class PlayerStatsControllerTest {
                 .andExpect(jsonPath("$.data.gamesPlayed").value(20))
                 .andExpect(jsonPath("$.data.wins").value(10))
                 .andExpect(jsonPath("$.data.losses").value(5))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/players/{playerId}/stats/batting/competition")
+    inner class GetBattingStatsByCompetition {
+        @Test
+        fun `should return competition batting stats successfully`() {
+            // given
+            val competitionId = 100L
+            val dto =
+                CompetitionBattingStatsDto(
+                    playerId = playerId,
+                    competitionId = competitionId,
+                    gamesPlayed = 5,
+                    plateAppearances = 22,
+                    atBats = 20,
+                    hits = 7,
+                    doubles = 2,
+                    triples = 0,
+                    homeRuns = 1,
+                    runs = 3,
+                    runsBattedIn = 5,
+                    walks = 2,
+                    strikeouts = 4,
+                    stolenBases = 1,
+                    battingAverage = "0.350",
+                    onBasePercentage = "0.409",
+                    sluggingPercentage = "0.550",
+                    ops = "0.959",
+                )
+
+            every {
+                playerStatsService.getBattingStatsByCompetition(playerId, competitionId)
+            } returns dto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/players/$playerId/stats/batting/competition")
+                        .param("competitionId", competitionId.toString()),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.playerId").value(playerId))
+                .andExpect(jsonPath("$.data.competitionId").value(competitionId))
+                .andExpect(jsonPath("$.data.gamesPlayed").value(5))
+                .andExpect(jsonPath("$.data.hits").value(7))
+                .andExpect(jsonPath("$.data.homeRuns").value(1))
+                .andExpect(jsonPath("$.data.battingAverage").value("0.350"))
+                .andExpect(jsonPath("$.data.ops").value("0.959"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/players/{playerId}/stats/pitching/competition")
+    inner class GetPitchingStatsByCompetition {
+        @Test
+        fun `should return competition pitching stats successfully`() {
+            // given
+            val competitionId = 100L
+            val dto =
+                CompetitionPitchingStatsDto(
+                    playerId = playerId,
+                    competitionId = competitionId,
+                    gamesPlayed = 3,
+                    gamesStarted = 2,
+                    inningsPitchedDisplay = "15.2",
+                    wins = 2,
+                    losses = 1,
+                    saves = 0,
+                    holds = 0,
+                    earnedRuns = 5,
+                    hitsAllowed = 12,
+                    walksAllowed = 4,
+                    strikeouts = 15,
+                    homeRunsAllowed = 2,
+                    earnedRunAverage = "2.87",
+                    whip = "1.02",
+                )
+
+            every {
+                playerStatsService.getPitchingStatsByCompetition(playerId, competitionId)
+            } returns dto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/players/$playerId/stats/pitching/competition")
+                        .param("competitionId", competitionId.toString()),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.playerId").value(playerId))
+                .andExpect(jsonPath("$.data.competitionId").value(competitionId))
+                .andExpect(jsonPath("$.data.gamesPlayed").value(3))
+                .andExpect(jsonPath("$.data.gamesStarted").value(2))
+                .andExpect(jsonPath("$.data.wins").value(2))
+                .andExpect(jsonPath("$.data.losses").value(1))
+                .andExpect(jsonPath("$.data.strikeouts").value(15))
+                .andExpect(jsonPath("$.data.earnedRunAverage").value("2.87"))
+                .andExpect(jsonPath("$.data.whip").value("1.02"))
+        }
+
+        @Test
+        fun `should return pitching stats with null ERA`() {
+            // given
+            val competitionId = 100L
+            val dto =
+                CompetitionPitchingStatsDto(
+                    playerId = playerId,
+                    competitionId = competitionId,
+                    gamesPlayed = 0,
+                    gamesStarted = 0,
+                    inningsPitchedDisplay = "0",
+                    wins = 0,
+                    losses = 0,
+                    saves = 0,
+                    holds = 0,
+                    earnedRuns = 0,
+                    hitsAllowed = 0,
+                    walksAllowed = 0,
+                    strikeouts = 0,
+                    homeRunsAllowed = 0,
+                    earnedRunAverage = null,
+                    whip = "0",
+                )
+
+            every {
+                playerStatsService.getPitchingStatsByCompetition(playerId, competitionId)
+            } returns dto
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/players/$playerId/stats/pitching/competition")
+                        .param("competitionId", competitionId.toString()),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.gamesPlayed").value(0))
+                .andExpect(jsonPath("$.data.earnedRunAverage").doesNotExist())
         }
     }
 

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamScheduleControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamScheduleControllerTest.kt
@@ -1,0 +1,264 @@
+package com.nextup.api.controller.team
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.team.CreateTeamScheduleRequest
+import com.nextup.api.dto.team.UpdateTeamScheduleRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamSchedule
+import com.nextup.core.domain.team.TeamScheduleType
+import com.nextup.core.service.team.TeamScheduleService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+import java.time.LocalDateTime
+
+@DisplayName("TeamScheduleController 테스트")
+class TeamScheduleControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var teamScheduleService: TeamScheduleService
+    private lateinit var objectMapper: ObjectMapper
+
+    private val teamId = 1L
+    private val scheduleId = 10L
+
+    private val mockTeam = mockk<Team>(relaxed = true)
+    private val mockSchedule = mockk<TeamSchedule>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        teamScheduleService = mockk()
+        objectMapper =
+            jacksonObjectMapper().registerModule(JavaTimeModule())
+
+        val controller = TeamScheduleController(teamScheduleService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        every { mockTeam.id } returns teamId
+        every { mockTeam.name } returns "테스트팀"
+        every { mockSchedule.id } returns scheduleId
+        every { mockSchedule.team } returns mockTeam
+        every { mockSchedule.title } returns "연습 일정"
+        every { mockSchedule.description } returns "정기 연습"
+        every { mockSchedule.scheduleType } returns TeamScheduleType.PRACTICE
+        every { mockSchedule.startAt } returns LocalDateTime.of(2024, 6, 1, 14, 0)
+        every { mockSchedule.endAt } returns LocalDateTime.of(2024, 6, 1, 17, 0)
+        every { mockSchedule.location } returns "서울 야구장"
+        every { mockSchedule.createdAt } returns Instant.now()
+        every { mockSchedule.updatedAt } returns Instant.now()
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/teams/{teamId}/schedules")
+    inner class CreateSchedule {
+        @Test
+        fun `should create team schedule successfully`() {
+            // given
+            val request =
+                CreateTeamScheduleRequest(
+                    title = "연습 일정",
+                    description = "정기 연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = LocalDateTime.of(2024, 6, 1, 14, 0),
+                    endAt = LocalDateTime.of(2024, 6, 1, 17, 0),
+                    location = "서울 야구장",
+                )
+
+            every {
+                teamScheduleService.create(
+                    teamId = teamId,
+                    title = request.title,
+                    description = request.description,
+                    scheduleType = request.scheduleType,
+                    startAt = request.startAt,
+                    endAt = request.endAt,
+                    location = request.location,
+                )
+            } returns mockSchedule
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/teams/$teamId/schedules")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(scheduleId))
+                .andExpect(jsonPath("$.data.teamId").value(teamId))
+                .andExpect(jsonPath("$.data.title").value("연습 일정"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/schedules")
+    inner class GetSchedules {
+        @Test
+        fun `should return all schedules for team`() {
+            // given
+            every { teamScheduleService.getByTeamId(teamId) } returns listOf(mockSchedule)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/$teamId/schedules"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(scheduleId))
+                .andExpect(jsonPath("$.data[0].title").value("연습 일정"))
+
+            verify { teamScheduleService.getByTeamId(teamId) }
+        }
+
+        @Test
+        fun `should return filtered schedules when date range provided`() {
+            // given
+            val from = LocalDateTime.of(2024, 6, 1, 0, 0)
+            val to = LocalDateTime.of(2024, 6, 30, 23, 59)
+
+            every {
+                teamScheduleService.getByTeamIdAndDateRange(teamId, from, to)
+            } returns listOf(mockSchedule)
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/v1/teams/$teamId/schedules")
+                        .param("from", "2024-06-01T00:00:00")
+                        .param("to", "2024-06-30T23:59:00"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(scheduleId))
+
+            verify {
+                teamScheduleService.getByTeamIdAndDateRange(teamId, from, to)
+            }
+        }
+
+        @Test
+        fun `should return empty list when no schedules exist`() {
+            // given
+            every { teamScheduleService.getByTeamId(teamId) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/$teamId/schedules"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/teams/{teamId}/schedules/{scheduleId}")
+    inner class GetSchedule {
+        @Test
+        fun `should return schedule detail`() {
+            // given
+            every { teamScheduleService.getById(scheduleId) } returns mockSchedule
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/teams/$teamId/schedules/$scheduleId"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(scheduleId))
+                .andExpect(jsonPath("$.data.title").value("연습 일정"))
+                .andExpect(jsonPath("$.data.location").value("서울 야구장"))
+
+            verify { teamScheduleService.getById(scheduleId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/v1/teams/{teamId}/schedules/{scheduleId}")
+    inner class UpdateSchedule {
+        @Test
+        fun `should update schedule successfully`() {
+            // given
+            val request =
+                UpdateTeamScheduleRequest(
+                    title = "수정된 연습 일정",
+                    location = "부산 야구장",
+                )
+
+            val updatedSchedule = mockk<TeamSchedule>(relaxed = true)
+            every { updatedSchedule.id } returns scheduleId
+            every { updatedSchedule.team } returns mockTeam
+            every { updatedSchedule.title } returns "수정된 연습 일정"
+            every { updatedSchedule.description } returns "정기 연습"
+            every { updatedSchedule.scheduleType } returns TeamScheduleType.PRACTICE
+            every { updatedSchedule.startAt } returns LocalDateTime.of(2024, 6, 1, 14, 0)
+            every { updatedSchedule.endAt } returns LocalDateTime.of(2024, 6, 1, 17, 0)
+            every { updatedSchedule.location } returns "부산 야구장"
+            every { updatedSchedule.createdAt } returns Instant.now()
+            every { updatedSchedule.updatedAt } returns Instant.now()
+
+            every {
+                teamScheduleService.update(
+                    id = scheduleId,
+                    title = request.title,
+                    description = request.description,
+                    scheduleType = request.scheduleType,
+                    startAt = request.startAt,
+                    endAt = request.endAt,
+                    location = request.location,
+                )
+            } returns updatedSchedule
+
+            // when & then
+            mockMvc
+                .perform(
+                    patch("/api/v1/teams/$teamId/schedules/$scheduleId")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.title").value("수정된 연습 일정"))
+                .andExpect(jsonPath("$.data.location").value("부산 야구장"))
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/teams/{teamId}/schedules/{scheduleId}")
+    inner class DeleteSchedule {
+        @Test
+        fun `should delete schedule successfully`() {
+            // given
+            every { teamScheduleService.delete(scheduleId) } returns Unit
+
+            // when & then
+            mockMvc
+                .perform(delete("/api/v1/teams/$teamId/schedules/$scheduleId"))
+                .andExpect(status().isNoContent)
+                .andExpect(jsonPath("$.success").value(true))
+
+            verify { teamScheduleService.delete(scheduleId) }
+        }
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/correction/CorrectionRequestAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/correction/CorrectionRequestAdminController.kt
@@ -1,0 +1,84 @@
+package com.nextup.backoffice.controller.correction
+
+import com.nextup.backoffice.dto.correction.ApproveCorrectionRequestDto
+import com.nextup.backoffice.dto.correction.CorrectionRequestAdminResponse
+import com.nextup.backoffice.dto.correction.RejectCorrectionRequestDto
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.game.correction.CorrectionRequestService
+import jakarta.validation.Valid
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 기록 정정 요청 관리자 Controller (Backoffice)
+ *
+ * 관리자가 기록원의 정정 요청을 승인/반려하는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/backoffice/corrections")
+class CorrectionRequestAdminController(
+    private val correctionRequestService: CorrectionRequestService,
+) {
+    /**
+     * 대기 중인 정정 요청 목록을 조회합니다.
+     */
+    @GetMapping("/pending")
+    fun getPendingRequests(): ApiResponse<List<CorrectionRequestAdminResponse>> {
+        val requests = correctionRequestService.getPendingRequests()
+        return ApiResponse.success(requests.map { CorrectionRequestAdminResponse.from(it) })
+    }
+
+    /**
+     * 정정 요청 상세를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    fun getCorrectionRequest(
+        @PathVariable id: Long,
+    ): ApiResponse<CorrectionRequestAdminResponse> {
+        val request = correctionRequestService.getById(id)
+        return ApiResponse.success(CorrectionRequestAdminResponse.from(request))
+    }
+
+    /**
+     * 정정 요청을 승인합니다.
+     *
+     * 승인 시 기존 RecordCorrectionService를 통해 실제 기록 정정이 수행됩니다.
+     */
+    @PatchMapping("/{id}/approve")
+    fun approveRequest(
+        @PathVariable id: Long,
+        @AuthenticationPrincipal adminUserId: Long,
+        @Valid @RequestBody request: ApproveCorrectionRequestDto,
+    ): ApiResponse<CorrectionRequestAdminResponse> {
+        val correctionRequest =
+            correctionRequestService.approve(
+                requestId = id,
+                reviewerUserId = adminUserId,
+                comment = request.comment,
+            )
+        return ApiResponse.success(CorrectionRequestAdminResponse.from(correctionRequest))
+    }
+
+    /**
+     * 정정 요청을 반려합니다.
+     */
+    @PatchMapping("/{id}/reject")
+    fun rejectRequest(
+        @PathVariable id: Long,
+        @AuthenticationPrincipal adminUserId: Long,
+        @Valid @RequestBody request: RejectCorrectionRequestDto,
+    ): ApiResponse<CorrectionRequestAdminResponse> {
+        val correctionRequest =
+            correctionRequestService.reject(
+                requestId = id,
+                reviewerUserId = adminUserId,
+                comment = request.comment,
+            )
+        return ApiResponse.success(CorrectionRequestAdminResponse.from(correctionRequest))
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/correction/CorrectionRequestAdminDto.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/correction/CorrectionRequestAdminDto.kt
@@ -1,0 +1,62 @@
+package com.nextup.backoffice.dto.correction
+
+import com.nextup.core.domain.game.CorrectionRequest
+import com.nextup.core.domain.game.CorrectionRequestStatus
+import com.nextup.core.domain.game.CorrectionType
+import java.time.Instant
+
+/**
+ * 기록 정정 요청 승인 요청 DTO (Backoffice)
+ */
+data class ApproveCorrectionRequestDto(
+    val comment: String? = null,
+)
+
+/**
+ * 기록 정정 요청 반려 요청 DTO (Backoffice)
+ */
+data class RejectCorrectionRequestDto(
+    val comment: String,
+)
+
+/**
+ * 기록 정정 요청 응답 DTO (Backoffice)
+ */
+data class CorrectionRequestAdminResponse(
+    val id: Long,
+    val gameId: Long,
+    val requesterUserId: Long,
+    val correctionType: CorrectionType,
+    val targetRecordId: Long,
+    val fieldName: String,
+    val newValue: String,
+    val reason: String,
+    val status: CorrectionRequestStatus,
+    val statusDisplayName: String,
+    val reviewerUserId: Long?,
+    val reviewComment: String?,
+    val reviewedAt: Instant?,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(request: CorrectionRequest): CorrectionRequestAdminResponse =
+            CorrectionRequestAdminResponse(
+                id = request.id,
+                gameId = request.gameId,
+                requesterUserId = request.requesterUserId,
+                correctionType = request.correctionType,
+                targetRecordId = request.targetRecordId,
+                fieldName = request.fieldName,
+                newValue = request.newValue,
+                reason = request.reason,
+                status = request.status,
+                statusDisplayName = request.status.displayName,
+                reviewerUserId = request.reviewerUserId,
+                reviewComment = request.reviewComment,
+                reviewedAt = request.reviewedAt,
+                createdAt = request.createdAt,
+                updatedAt = request.updatedAt,
+            )
+    }
+}

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/correction/CorrectionRequestAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/correction/CorrectionRequestAdminControllerTest.kt
@@ -1,0 +1,246 @@
+package com.nextup.backoffice.controller.correction
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.backoffice.dto.correction.ApproveCorrectionRequestDto
+import com.nextup.backoffice.dto.correction.RejectCorrectionRequestDto
+import com.nextup.core.domain.game.CorrectionRequest
+import com.nextup.core.domain.game.CorrectionRequestStatus
+import com.nextup.core.domain.game.CorrectionType
+import com.nextup.core.service.game.correction.CorrectionRequestService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+
+@DisplayName("CorrectionRequestAdminController 테스트")
+class CorrectionRequestAdminControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var correctionRequestService: CorrectionRequestService
+    private lateinit var objectMapper: ObjectMapper
+
+    private val adminUserId = 99L
+    private val mockRequest = mockk<CorrectionRequest>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        correctionRequestService = mockk()
+        objectMapper =
+            jacksonObjectMapper().registerModule(JavaTimeModule())
+
+        // @AuthenticationPrincipal adminUserId: Long 을 위한 보안 컨텍스트 설정
+        val authentication =
+            UsernamePasswordAuthenticationToken(
+                adminUserId,
+                null,
+                emptyList(),
+            )
+        SecurityContextHolder.getContext().authentication = authentication
+
+        val controller =
+            CorrectionRequestAdminController(correctionRequestService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(
+                    AuthenticationPrincipalArgumentResolver(),
+                )
+                .build()
+
+        every { mockRequest.id } returns 1L
+        every { mockRequest.gameId } returns 100L
+        every { mockRequest.requesterUserId } returns 10L
+        every { mockRequest.correctionType } returns CorrectionType.BATTING
+        every { mockRequest.targetRecordId } returns 50L
+        every { mockRequest.fieldName } returns "hits"
+        every { mockRequest.newValue } returns "3"
+        every { mockRequest.reason } returns "안타 수 오기록"
+        every { mockRequest.status } returns CorrectionRequestStatus.PENDING
+        every { mockRequest.reviewerUserId } returns null
+        every { mockRequest.reviewComment } returns null
+        every { mockRequest.reviewedAt } returns null
+        every { mockRequest.createdAt } returns Instant.now()
+        every { mockRequest.updatedAt } returns Instant.now()
+    }
+
+    @Nested
+    @DisplayName("GET /api/backoffice/corrections/pending")
+    inner class GetPendingRequests {
+        @Test
+        fun `should return pending correction requests`() {
+            // given
+            every {
+                correctionRequestService.getPendingRequests()
+            } returns listOf(mockRequest)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/backoffice/corrections/pending"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].gameId").value(100))
+                .andExpect(jsonPath("$.data[0].correctionType").value("BATTING"))
+                .andExpect(jsonPath("$.data[0].status").value("PENDING"))
+                .andExpect(jsonPath("$.data[0].statusDisplayName").value("대기"))
+
+            verify { correctionRequestService.getPendingRequests() }
+        }
+
+        @Test
+        fun `should return empty list when no pending requests`() {
+            // given
+            every {
+                correctionRequestService.getPendingRequests()
+            } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/backoffice/corrections/pending"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/backoffice/corrections/{id}")
+    inner class GetCorrectionRequest {
+        @Test
+        fun `should return correction request detail`() {
+            // given
+            every { correctionRequestService.getById(1L) } returns mockRequest
+
+            // when & then
+            mockMvc
+                .perform(get("/api/backoffice/corrections/1"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.fieldName").value("hits"))
+                .andExpect(jsonPath("$.data.newValue").value("3"))
+                .andExpect(jsonPath("$.data.reason").value("안타 수 오기록"))
+
+            verify { correctionRequestService.getById(1L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/backoffice/corrections/{id}/approve")
+    inner class ApproveRequest {
+        @Test
+        fun `should approve correction request successfully`() {
+            // given
+            val approvedRequest = mockk<CorrectionRequest>(relaxed = true)
+            every { approvedRequest.id } returns 1L
+            every { approvedRequest.gameId } returns 100L
+            every { approvedRequest.requesterUserId } returns 10L
+            every { approvedRequest.correctionType } returns CorrectionType.BATTING
+            every { approvedRequest.targetRecordId } returns 50L
+            every { approvedRequest.fieldName } returns "hits"
+            every { approvedRequest.newValue } returns "3"
+            every { approvedRequest.reason } returns "안타 수 오기록"
+            every { approvedRequest.status } returns CorrectionRequestStatus.APPROVED
+            every { approvedRequest.reviewerUserId } returns adminUserId
+            every { approvedRequest.reviewComment } returns "확인 완료"
+            every { approvedRequest.reviewedAt } returns Instant.now()
+            every { approvedRequest.createdAt } returns Instant.now()
+            every { approvedRequest.updatedAt } returns Instant.now()
+
+            val dto = ApproveCorrectionRequestDto(comment = "확인 완료")
+
+            every {
+                correctionRequestService.approve(
+                    requestId = 1L,
+                    reviewerUserId = adminUserId,
+                    comment = "확인 완료",
+                )
+            } returns approvedRequest
+
+            // when & then
+            mockMvc
+                .perform(
+                    patch("/api/backoffice/corrections/1/approve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.status").value("APPROVED"))
+                .andExpect(jsonPath("$.data.statusDisplayName").value("승인"))
+                .andExpect(jsonPath("$.data.reviewComment").value("확인 완료"))
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/backoffice/corrections/{id}/reject")
+    inner class RejectRequest {
+        @Test
+        fun `should reject correction request successfully`() {
+            // given
+            val rejectedRequest = mockk<CorrectionRequest>(relaxed = true)
+            every { rejectedRequest.id } returns 1L
+            every { rejectedRequest.gameId } returns 100L
+            every { rejectedRequest.requesterUserId } returns 10L
+            every { rejectedRequest.correctionType } returns CorrectionType.BATTING
+            every { rejectedRequest.targetRecordId } returns 50L
+            every { rejectedRequest.fieldName } returns "hits"
+            every { rejectedRequest.newValue } returns "3"
+            every { rejectedRequest.reason } returns "안타 수 오기록"
+            every { rejectedRequest.status } returns CorrectionRequestStatus.REJECTED
+            every { rejectedRequest.reviewerUserId } returns adminUserId
+            every { rejectedRequest.reviewComment } returns "영상 확인 결과 정확합니다"
+            every { rejectedRequest.reviewedAt } returns Instant.now()
+            every { rejectedRequest.createdAt } returns Instant.now()
+            every { rejectedRequest.updatedAt } returns Instant.now()
+
+            val dto =
+                RejectCorrectionRequestDto(
+                    comment = "영상 확인 결과 정확합니다",
+                )
+
+            every {
+                correctionRequestService.reject(
+                    requestId = 1L,
+                    reviewerUserId = adminUserId,
+                    comment = "영상 확인 결과 정확합니다",
+                )
+            } returns rejectedRequest
+
+            // when & then
+            mockMvc
+                .perform(
+                    patch("/api/backoffice/corrections/1/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.status").value("REJECTED"))
+                .andExpect(jsonPath("$.data.statusDisplayName").value("반려"))
+                .andExpect(
+                    jsonPath("$.data.reviewComment")
+                        .value("영상 확인 결과 정확합니다"),
+                )
+        }
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/CorrectionRequestNotFoundException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/CorrectionRequestNotFoundException.kt
@@ -1,0 +1,11 @@
+package com.nextup.common.exception
+
+/**
+ * 기록 정정 요청을 찾을 수 없을 때 발생하는 예외
+ */
+class CorrectionRequestNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "CORRECTION_REQUEST_NOT_FOUND",
+        message = "기록 정정 요청을 찾을 수 없습니다: $id",
+    )

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/TeamScheduleNotFoundException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/TeamScheduleNotFoundException.kt
@@ -1,0 +1,11 @@
+package com.nextup.common.exception
+
+/**
+ * 팀 일정을 찾을 수 없을 때 발생하는 예외
+ */
+class TeamScheduleNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "TEAM_SCHEDULE_NOT_FOUND",
+        message = "팀 일정을 찾을 수 없습니다: $id",
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/CorrectionRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/CorrectionRequest.kt
@@ -1,0 +1,135 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.Instant
+
+/**
+ * 기록 정정 요청 엔티티
+ *
+ * 기록원이 기록 정정을 요청하고, 관리자가 승인/반려하는 워크플로우를 관리합니다.
+ * PENDING → APPROVED / REJECTED
+ */
+@Entity
+@Table(
+    name = "correction_requests",
+    indexes = [
+        Index(name = "idx_correction_requests_game_id", columnList = "game_id"),
+        Index(name = "idx_correction_requests_status", columnList = "status"),
+        Index(name = "idx_correction_requests_requester", columnList = "requester_user_id"),
+    ],
+)
+class CorrectionRequest private constructor(
+    @Column(name = "game_id", nullable = false)
+    val gameId: Long,
+    @Column(name = "requester_user_id", nullable = false)
+    val requesterUserId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "correction_type", nullable = false, length = 20)
+    val correctionType: CorrectionType,
+    @Column(name = "target_record_id", nullable = false)
+    val targetRecordId: Long,
+    @Column(name = "field_name", nullable = false, length = 100)
+    val fieldName: String,
+    @Column(name = "new_value", nullable = false, length = 500)
+    val newValue: String,
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val reason: String,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: CorrectionRequestStatus = CorrectionRequestStatus.PENDING,
+    @Column(name = "reviewer_user_id")
+    var reviewerUserId: Long? = null,
+    @Column(name = "review_comment", columnDefinition = "TEXT")
+    var reviewComment: String? = null,
+    @Column(name = "reviewed_at")
+    var reviewedAt: Instant? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 정정 요청을 승인합니다.
+     */
+    fun approve(
+        reviewerUserId: Long,
+        comment: String? = null,
+    ) {
+        require(status == CorrectionRequestStatus.PENDING) {
+            "PENDING 상태의 요청만 승인할 수 있습니다"
+        }
+        this.status = CorrectionRequestStatus.APPROVED
+        this.reviewerUserId = reviewerUserId
+        this.reviewComment = comment
+        this.reviewedAt = Instant.now()
+    }
+
+    /**
+     * 정정 요청을 반려합니다.
+     */
+    fun reject(
+        reviewerUserId: Long,
+        comment: String,
+    ) {
+        require(status == CorrectionRequestStatus.PENDING) {
+            "PENDING 상태의 요청만 반려할 수 있습니다"
+        }
+        require(comment.isNotBlank()) {
+            "반려 사유는 필수입니다"
+        }
+        this.status = CorrectionRequestStatus.REJECTED
+        this.reviewerUserId = reviewerUserId
+        this.reviewComment = comment
+        this.reviewedAt = Instant.now()
+    }
+
+    companion object {
+        /**
+         * 기록 정정 요청을 생성합니다.
+         */
+        fun create(
+            gameId: Long,
+            requesterUserId: Long,
+            correctionType: CorrectionType,
+            targetRecordId: Long,
+            fieldName: String,
+            newValue: String,
+            reason: String,
+        ): CorrectionRequest {
+            require(gameId > 0) { "경기 ID는 필수입니다" }
+            require(requesterUserId > 0) { "요청자 ID는 필수입니다" }
+            require(fieldName.isNotBlank()) { "정정 필드명은 필수입니다" }
+            require(newValue.isNotBlank()) { "정정 값은 필수입니다" }
+            require(reason.isNotBlank()) { "정정 사유는 필수입니다" }
+
+            return CorrectionRequest(
+                gameId = gameId,
+                requesterUserId = requesterUserId,
+                correctionType = correctionType,
+                targetRecordId = targetRecordId,
+                fieldName = fieldName,
+                newValue = newValue,
+                reason = reason,
+            )
+        }
+    }
+}
+
+/**
+ * 기록 정정 요청 상태
+ */
+enum class CorrectionRequestStatus(
+    val displayName: String,
+) {
+    PENDING("대기"),
+    APPROVED("승인"),
+    REJECTED("반려"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/team/TeamSchedule.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/team/TeamSchedule.kt
@@ -1,0 +1,128 @@
+package com.nextup.core.domain.team
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+/**
+ * 팀 일정 엔티티
+ *
+ * 경기 일정 외에 연습, 이벤트, 모임 등 팀 자체 일정을 관리합니다.
+ */
+@Entity
+@Table(
+    name = "team_schedules",
+    indexes = [
+        Index(name = "idx_team_schedules_team_id", columnList = "team_id"),
+        Index(name = "idx_team_schedules_start_at", columnList = "start_at"),
+        Index(name = "idx_team_schedules_type", columnList = "schedule_type"),
+    ],
+)
+class TeamSchedule private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    val team: Team,
+    @Column(nullable = false, length = 200)
+    var title: String,
+    @Column(columnDefinition = "TEXT")
+    var description: String?,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "schedule_type", nullable = false, length = 30)
+    var scheduleType: TeamScheduleType,
+    @Column(name = "start_at", nullable = false)
+    var startAt: LocalDateTime,
+    @Column(name = "end_at")
+    var endAt: LocalDateTime?,
+    @Column(length = 500)
+    var location: String?,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 일정 정보를 수정합니다.
+     */
+    fun update(
+        title: String? = null,
+        description: String? = null,
+        scheduleType: TeamScheduleType? = null,
+        startAt: LocalDateTime? = null,
+        endAt: LocalDateTime? = null,
+        location: String? = null,
+    ) {
+        title?.let {
+            require(it.isNotBlank()) { "제목은 비어있을 수 없습니다" }
+            this.title = it
+        }
+        description?.let { this.description = it }
+        scheduleType?.let { this.scheduleType = it }
+        startAt?.let { this.startAt = it }
+        endAt?.let { this.endAt = it }
+        location?.let { this.location = it }
+
+        validateDateRange()
+    }
+
+    private fun validateDateRange() {
+        endAt?.let { end ->
+            require(!end.isBefore(startAt)) {
+                "종료 시간은 시작 시간 이후여야 합니다"
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * 팀 일정을 생성합니다.
+         */
+        fun create(
+            team: Team,
+            title: String,
+            description: String? = null,
+            scheduleType: TeamScheduleType,
+            startAt: LocalDateTime,
+            endAt: LocalDateTime? = null,
+            location: String? = null,
+        ): TeamSchedule {
+            require(title.isNotBlank()) { "제목은 필수입니다" }
+
+            val schedule =
+                TeamSchedule(
+                    team = team,
+                    title = title,
+                    description = description,
+                    scheduleType = scheduleType,
+                    startAt = startAt,
+                    endAt = endAt,
+                    location = location,
+                )
+
+            schedule.validateDateRange()
+
+            return schedule
+        }
+    }
+}
+
+/**
+ * 팀 일정 유형
+ */
+enum class TeamScheduleType(
+    val displayName: String,
+) {
+    PRACTICE("연습"),
+    MEETING("모임"),
+    EVENT("이벤트"),
+    OTHER("기타"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BattingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BattingRecordRepositoryPort.kt
@@ -101,4 +101,13 @@ interface BattingRecordRepositoryPort {
      * gamePlayer, gameTeam, game을 함께 로딩하여 커리어 통계 계산에 사용합니다.
      */
     fun findAllByPlayerIdWithGameInfo(playerId: Long): List<BattingRecord>
+
+    /**
+     * 선수 ID와 대회 ID로 타격 기록을 조회합니다.
+     * 대회별 스탯 필터에 사용됩니다.
+     */
+    fun findAllByPlayerIdAndCompetitionId(
+        playerId: Long,
+        competitionId: Long,
+    ): List<BattingRecord>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CorrectionRequestRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CorrectionRequestRepositoryPort.kt
@@ -1,0 +1,20 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.game.CorrectionRequest
+import com.nextup.core.domain.game.CorrectionRequestStatus
+
+/**
+ * CorrectionRequest Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface CorrectionRequestRepositoryPort {
+    fun save(correctionRequest: CorrectionRequest): CorrectionRequest
+
+    fun findByIdOrNull(id: Long): CorrectionRequest?
+
+    fun findByGameId(gameId: Long): List<CorrectionRequest>
+
+    fun findByStatus(status: CorrectionRequestStatus): List<CorrectionRequest>
+
+    fun findByRequesterUserId(requesterUserId: Long): List<CorrectionRequest>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MatchRequestRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MatchRequestRepositoryPort.kt
@@ -2,6 +2,8 @@ package com.nextup.core.port.repository
 
 import com.nextup.core.domain.match.MatchRequest
 import com.nextup.core.domain.match.MatchRequestStatus
+import com.nextup.core.domain.match.SkillLevel
+import java.time.LocalDate
 
 interface MatchRequestRepositoryPort {
     fun save(matchRequest: MatchRequest): MatchRequest
@@ -13,4 +15,17 @@ interface MatchRequestRepositoryPort {
     fun findAllOpen(): List<MatchRequest>
 
     fun findByStatus(status: MatchRequestStatus): List<MatchRequest>
+
+    /**
+     * OPEN 상태의 매칭 요청을 필터 조건으로 조회합니다.
+     *
+     * @param area 지역 필터 (선호 장소에 포함된 문자열, null이면 무시)
+     * @param date 날짜 필터 (null이면 무시)
+     * @param skillLevel 실력 수준 필터 (null이면 무시)
+     */
+    fun findAllOpenWithFilter(
+        area: String?,
+        date: LocalDate?,
+        skillLevel: SkillLevel?,
+    ): List<MatchRequest>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/NotificationRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/NotificationRepositoryPort.kt
@@ -20,4 +20,9 @@ interface NotificationRepositoryPort {
      * 사용자의 미읽은 알림 개수를 조회합니다.
      */
     fun countUnreadByUserId(userId: Long): Long
+
+    /**
+     * 사용자의 모든 미읽은 알림을 읽음 처리합니다.
+     */
+    fun markAllAsReadByUserId(userId: Long)
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchingRecordRepositoryPort.kt
@@ -129,4 +129,13 @@ interface PitchingRecordRepositoryPort {
      * gamePlayer, gameTeam, game을 함께 로딩하여 커리어 통계 계산에 사용합니다.
      */
     fun findAllByPlayerIdWithGameInfo(playerId: Long): List<PitchingRecord>
+
+    /**
+     * 선수 ID와 대회 ID로 투수 기록을 조회합니다.
+     * 대회별 스탯 필터에 사용됩니다.
+     */
+    fun findAllByPlayerIdAndCompetitionId(
+        playerId: Long,
+        competitionId: Long,
+    ): List<PitchingRecord>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamScheduleRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/TeamScheduleRepositoryPort.kt
@@ -1,0 +1,24 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.team.TeamSchedule
+import java.time.LocalDateTime
+
+/**
+ * TeamSchedule Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface TeamScheduleRepositoryPort {
+    fun save(teamSchedule: TeamSchedule): TeamSchedule
+
+    fun findByIdOrNull(id: Long): TeamSchedule?
+
+    fun findByTeamId(teamId: Long): List<TeamSchedule>
+
+    fun findByTeamIdAndDateRange(
+        teamId: Long,
+        from: LocalDateTime,
+        to: LocalDateTime,
+    ): List<TeamSchedule>
+
+    fun deleteById(id: Long)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
@@ -40,7 +40,7 @@ interface GameLifecycleService {
         gameId: Long,
         newScheduledAt: LocalDateTime,
     ): Game
-    
+
     /**
      * 기록원이 경기를 독점 잠금합니다.
      *

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/correction/CorrectionRequestService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/correction/CorrectionRequestService.kt
@@ -1,0 +1,142 @@
+package com.nextup.core.service.game.correction
+
+import com.nextup.common.exception.CorrectionRequestNotFoundException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.core.domain.game.CorrectionRequest
+import com.nextup.core.domain.game.CorrectionRequestStatus
+import com.nextup.core.domain.game.CorrectionType
+import com.nextup.core.port.repository.CorrectionRequestRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 기록 정정 요청 서비스
+ *
+ * 기록원이 기록 정정을 요청하고, 관리자가 승인/반려하는 워크플로우를 관리합니다.
+ * 승인 시 기존 RecordCorrectionService를 통해 실제 정정을 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class CorrectionRequestService(
+    private val correctionRequestRepository: CorrectionRequestRepositoryPort,
+    private val recordCorrectionService: RecordCorrectionService,
+) {
+    /**
+     * 기록 정정 요청을 생성합니다.
+     */
+    @Transactional
+    fun createRequest(
+        gameId: Long,
+        requesterUserId: Long,
+        correctionType: CorrectionType,
+        targetRecordId: Long,
+        fieldName: String,
+        newValue: String,
+        reason: String,
+    ): CorrectionRequest {
+        val request =
+            CorrectionRequest.create(
+                gameId = gameId,
+                requesterUserId = requesterUserId,
+                correctionType = correctionType,
+                targetRecordId = targetRecordId,
+                fieldName = fieldName,
+                newValue = newValue,
+                reason = reason,
+            )
+
+        return correctionRequestRepository.save(request)
+    }
+
+    /**
+     * 기록 정정 요청을 승인하고 실제 정정을 수행합니다.
+     */
+    @Transactional
+    fun approve(
+        requestId: Long,
+        reviewerUserId: Long,
+        comment: String?,
+    ): CorrectionRequest {
+        val request = getById(requestId)
+
+        try {
+            request.approve(reviewerUserId, comment)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidStateException(
+                "INVALID_CORRECTION_REQUEST_STATE",
+                e.message ?: "정정 요청을 승인할 수 없습니다",
+            )
+        }
+
+        // 실제 기록 정정 수행
+        when (request.correctionType) {
+            CorrectionType.BATTING ->
+                recordCorrectionService.correctBattingRecord(
+                    gameId = request.gameId,
+                    recordId = request.targetRecordId,
+                    request =
+                        BattingCorrectionRequest(
+                            adminUserId = reviewerUserId,
+                            fieldName = request.fieldName,
+                            newValue = request.newValue,
+                            reason = request.reason,
+                        ),
+                )
+            CorrectionType.PITCHING ->
+                recordCorrectionService.correctPitchingRecord(
+                    gameId = request.gameId,
+                    recordId = request.targetRecordId,
+                    request =
+                        PitchingCorrectionRequest(
+                            adminUserId = reviewerUserId,
+                            fieldName = request.fieldName,
+                            newValue = request.newValue,
+                            reason = request.reason,
+                        ),
+                )
+        }
+
+        return request
+    }
+
+    /**
+     * 기록 정정 요청을 반려합니다.
+     */
+    @Transactional
+    fun reject(
+        requestId: Long,
+        reviewerUserId: Long,
+        comment: String,
+    ): CorrectionRequest {
+        val request = getById(requestId)
+
+        try {
+            request.reject(reviewerUserId, comment)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidStateException(
+                "INVALID_CORRECTION_REQUEST_STATE",
+                e.message ?: "정정 요청을 반려할 수 없습니다",
+            )
+        }
+
+        return request
+    }
+
+    /**
+     * ID로 정정 요청을 조회합니다.
+     */
+    fun getById(id: Long): CorrectionRequest =
+        correctionRequestRepository.findByIdOrNull(id)
+            ?: throw CorrectionRequestNotFoundException(id)
+
+    /**
+     * 대기 중인 정정 요청 목록을 조회합니다.
+     */
+    fun getPendingRequests(): List<CorrectionRequest> =
+        correctionRequestRepository.findByStatus(CorrectionRequestStatus.PENDING)
+
+    /**
+     * 경기별 정정 요청 목록을 조회합니다.
+     */
+    fun getByGameId(gameId: Long): List<CorrectionRequest> = correctionRequestRepository.findByGameId(gameId)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/correction/CorrectionRequestService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/correction/CorrectionRequestService.kt
@@ -94,6 +94,18 @@ class CorrectionRequestService(
                             reason = request.reason,
                         ),
                 )
+            CorrectionType.FIELDING ->
+                recordCorrectionService.correctFieldingRecord(
+                    gameId = request.gameId,
+                    recordId = request.targetRecordId,
+                    request =
+                        FieldingCorrectionRequest(
+                            adminUserId = reviewerUserId,
+                            fieldName = request.fieldName,
+                            newValue = request.newValue,
+                            reason = request.reason,
+                        ),
+                )
         }
 
         return request

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/match/MatchingService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/match/MatchingService.kt
@@ -16,6 +16,7 @@ import com.nextup.core.port.repository.MatchResponseRepositoryPort
 import com.nextup.core.port.repository.TeamRepositoryPort
 import com.nextup.core.service.match.dto.CreateMatchRequestDto
 import com.nextup.core.service.match.dto.CreateMatchResponseDto
+import com.nextup.core.service.match.dto.MatchRequestFilterDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -61,6 +62,22 @@ class MatchingService(
      * OPEN 상태의 모든 매칭 요청을 조회합니다.
      */
     fun getOpenRequests(): List<MatchRequest> = matchRequestRepository.findAllOpen()
+
+    /**
+     * OPEN 상태의 매칭 요청을 필터링하여 조회합니다.
+     *
+     * @param filter 필터 조건 (지역, 날짜, 실력 수준)
+     */
+    fun getOpenRequests(filter: MatchRequestFilterDto): List<MatchRequest> {
+        if (!filter.hasAnyFilter()) {
+            return getOpenRequests()
+        }
+        return matchRequestRepository.findAllOpenWithFilter(
+            area = filter.area,
+            date = filter.date,
+            skillLevel = filter.skillLevel,
+        )
+    }
 
     /**
      * 매칭 요청에 응답합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/match/dto/MatchRequestFilterDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/match/dto/MatchRequestFilterDto.kt
@@ -1,0 +1,20 @@
+package com.nextup.core.service.match.dto
+
+import com.nextup.core.domain.match.SkillLevel
+import java.time.LocalDate
+
+/**
+ * 매칭 요청 필터 DTO
+ *
+ * 위치/날짜/실력 수준으로 매칭 요청을 필터링합니다.
+ */
+data class MatchRequestFilterDto(
+    val area: String? = null,
+    val date: LocalDate? = null,
+    val skillLevel: SkillLevel? = null,
+) {
+    /**
+     * 필터 조건이 하나라도 설정되어 있는지 확인합니다.
+     */
+    fun hasAnyFilter(): Boolean = area != null || date != null || skillLevel != null
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/notification/NotificationService.kt
@@ -212,6 +212,14 @@ class NotificationService(
     fun getUserPreferences(userId: Long): List<NotificationPreference> = preferenceRepository.findByUserId(userId)
 
     /**
+     * 사용자의 모든 미읽은 알림을 읽음 처리합니다.
+     */
+    @Transactional
+    fun markAllAsRead(userId: Long) {
+        notificationRepository.markAllAsReadByUserId(userId)
+    }
+
+    /**
      * 사용자의 미읽은 알림 개수를 조회합니다.
      */
     fun getUnreadCount(userId: Long): Long = notificationRepository.countUnreadByUserId(userId)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/CompetitionStatsDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/CompetitionStatsDto.kt
@@ -1,0 +1,47 @@
+package com.nextup.core.service.stats
+
+/**
+ * 대회별 타격 통계 DTO
+ */
+data class CompetitionBattingStatsDto(
+    val playerId: Long,
+    val competitionId: Long,
+    val gamesPlayed: Int,
+    val plateAppearances: Int,
+    val atBats: Int,
+    val hits: Int,
+    val doubles: Int,
+    val triples: Int,
+    val homeRuns: Int,
+    val runs: Int,
+    val runsBattedIn: Int,
+    val walks: Int,
+    val strikeouts: Int,
+    val stolenBases: Int,
+    val battingAverage: String,
+    val onBasePercentage: String,
+    val sluggingPercentage: String,
+    val ops: String,
+)
+
+/**
+ * 대회별 투수 통계 DTO
+ */
+data class CompetitionPitchingStatsDto(
+    val playerId: Long,
+    val competitionId: Long,
+    val gamesPlayed: Int,
+    val gamesStarted: Int,
+    val inningsPitchedDisplay: String,
+    val wins: Int,
+    val losses: Int,
+    val saves: Int,
+    val holds: Int,
+    val earnedRuns: Int,
+    val hitsAllowed: Int,
+    val walksAllowed: Int,
+    val strikeouts: Int,
+    val homeRunsAllowed: Int,
+    val earnedRunAverage: String?,
+    val whip: String,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/PlayerStatsService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/PlayerStatsService.kt
@@ -247,6 +247,187 @@ class PlayerStatsService(
         return careerPitchingStatsRepository.save(careerStats)
     }
 
+    // ========== 대회별 통계 조회 메서드 ==========
+
+    /**
+     * 선수의 대회별 타격 통계를 조회합니다.
+     */
+    fun getBattingStatsByCompetition(
+        playerId: Long,
+        competitionId: Long,
+    ): CompetitionBattingStatsDto {
+        val records = battingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+
+        var gamesPlayed = 0
+        var plateAppearances = 0
+        var atBats = 0
+        var hits = 0
+        var doubles = 0
+        var triples = 0
+        var homeRuns = 0
+        var runs = 0
+        var runsBattedIn = 0
+        var walks = 0
+        var strikeouts = 0
+        var stolenBases = 0
+
+        records.forEach { record ->
+            gamesPlayed++
+            plateAppearances += record.plateAppearances
+            atBats += record.atBats
+            hits += record.hits
+            doubles += record.doubles
+            triples += record.triples
+            homeRuns += record.homeRuns
+            runs += record.runs
+            runsBattedIn += record.runsBattedIn
+            walks += record.walks
+            strikeouts += record.strikeouts
+            stolenBases += record.stolenBases
+        }
+
+        val battingAverage =
+            if (atBats > 0) {
+                java.math.BigDecimal(hits).divide(
+                    java.math.BigDecimal(atBats),
+                    3,
+                    java.math.RoundingMode.HALF_UP,
+                )
+            } else {
+                java.math.BigDecimal.ZERO
+            }
+
+        val onBasePercentage =
+            if (atBats + walks > 0) {
+                java.math.BigDecimal(hits + walks).divide(
+                    java.math.BigDecimal(atBats + walks),
+                    3,
+                    java.math.RoundingMode.HALF_UP,
+                )
+            } else {
+                java.math.BigDecimal.ZERO
+            }
+
+        val totalBases = hits + doubles + triples * 2 + homeRuns * 3
+        val sluggingPercentage =
+            if (atBats > 0) {
+                java.math.BigDecimal(totalBases).divide(
+                    java.math.BigDecimal(atBats),
+                    3,
+                    java.math.RoundingMode.HALF_UP,
+                )
+            } else {
+                java.math.BigDecimal.ZERO
+            }
+
+        val ops = onBasePercentage.add(sluggingPercentage)
+
+        return CompetitionBattingStatsDto(
+            playerId = playerId,
+            competitionId = competitionId,
+            gamesPlayed = gamesPlayed,
+            plateAppearances = plateAppearances,
+            atBats = atBats,
+            hits = hits,
+            doubles = doubles,
+            triples = triples,
+            homeRuns = homeRuns,
+            runs = runs,
+            runsBattedIn = runsBattedIn,
+            walks = walks,
+            strikeouts = strikeouts,
+            stolenBases = stolenBases,
+            battingAverage = battingAverage.toPlainString(),
+            onBasePercentage = onBasePercentage.toPlainString(),
+            sluggingPercentage = sluggingPercentage.toPlainString(),
+            ops = ops.toPlainString(),
+        )
+    }
+
+    /**
+     * 선수의 대회별 투수 통계를 조회합니다.
+     */
+    fun getPitchingStatsByCompetition(
+        playerId: Long,
+        competitionId: Long,
+    ): CompetitionPitchingStatsDto {
+        val records = pitchingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+
+        var gamesPlayed = 0
+        var gamesStarted = 0
+        var inningsPitchedOuts = 0
+        var wins = 0
+        var losses = 0
+        var saves = 0
+        var holds = 0
+        var earnedRuns = 0
+        var hitsAllowed = 0
+        var walksAllowed = 0
+        var strikeouts = 0
+        var homeRunsAllowed = 0
+
+        records.forEach { record ->
+            gamesPlayed++
+            if (record.gamePlayer.isStarter) gamesStarted++
+            inningsPitchedOuts += record.inningsPitchedOuts
+            wins += if (record.decision == com.nextup.core.domain.game.PitchingDecision.WIN) 1 else 0
+            losses += if (record.decision == com.nextup.core.domain.game.PitchingDecision.LOSS) 1 else 0
+            saves += if (record.decision == com.nextup.core.domain.game.PitchingDecision.SAVE) 1 else 0
+            holds += if (record.decision == com.nextup.core.domain.game.PitchingDecision.HOLD) 1 else 0
+            earnedRuns += record.earnedRuns
+            hitsAllowed += record.hitsAllowed
+            walksAllowed += record.walksAllowed
+            strikeouts += record.strikeouts
+            homeRunsAllowed += record.homeRunsAllowed
+        }
+
+        val completeInnings = inningsPitchedOuts / 3
+        val remainingOuts = inningsPitchedOuts % 3
+        val inningsPitchedDisplay =
+            if (remainingOuts == 0) "$completeInnings" else "$completeInnings.$remainingOuts"
+
+        val era =
+            if (inningsPitchedOuts > 0) {
+                java.math.BigDecimal(earnedRuns * 27).divide(
+                    java.math.BigDecimal(inningsPitchedOuts),
+                    2,
+                    java.math.RoundingMode.HALF_UP,
+                ).toPlainString()
+            } else {
+                null
+            }
+
+        val whip =
+            if (inningsPitchedOuts > 0) {
+                java.math.BigDecimal((hitsAllowed + walksAllowed) * 3).divide(
+                    java.math.BigDecimal(inningsPitchedOuts),
+                    2,
+                    java.math.RoundingMode.HALF_UP,
+                )
+            } else {
+                java.math.BigDecimal.ZERO
+            }
+
+        return CompetitionPitchingStatsDto(
+            playerId = playerId,
+            competitionId = competitionId,
+            gamesPlayed = gamesPlayed,
+            gamesStarted = gamesStarted,
+            inningsPitchedDisplay = inningsPitchedDisplay,
+            wins = wins,
+            losses = losses,
+            saves = saves,
+            holds = holds,
+            earnedRuns = earnedRuns,
+            hitsAllowed = hitsAllowed,
+            walksAllowed = walksAllowed,
+            strikeouts = strikeouts,
+            homeRunsAllowed = homeRunsAllowed,
+            earnedRunAverage = era,
+            whip = whip.toPlainString(),
+        )
+    }
+
     // ========== 리더보드 조회 메서드 ==========
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamScheduleService.kt
@@ -1,0 +1,119 @@
+package com.nextup.core.service.team
+
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.common.exception.TeamScheduleNotFoundException
+import com.nextup.core.domain.team.TeamSchedule
+import com.nextup.core.domain.team.TeamScheduleType
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.port.repository.TeamScheduleRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * 팀 일정 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class TeamScheduleService(
+    private val teamScheduleRepository: TeamScheduleRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+) {
+    /**
+     * 팀 일정을 생성합니다.
+     */
+    @Transactional
+    fun create(
+        teamId: Long,
+        title: String,
+        description: String?,
+        scheduleType: TeamScheduleType,
+        startAt: LocalDateTime,
+        endAt: LocalDateTime?,
+        location: String?,
+    ): TeamSchedule {
+        val team =
+            teamRepository.findByIdOrNull(teamId)
+                ?: throw TeamNotFoundException(teamId)
+
+        val schedule =
+            TeamSchedule.create(
+                team = team,
+                title = title,
+                description = description,
+                scheduleType = scheduleType,
+                startAt = startAt,
+                endAt = endAt,
+                location = location,
+            )
+
+        return teamScheduleRepository.save(schedule)
+    }
+
+    /**
+     * 팀 일정 목록을 조회합니다.
+     */
+    fun getByTeamId(teamId: Long): List<TeamSchedule> {
+        teamRepository.findByIdOrNull(teamId)
+            ?: throw TeamNotFoundException(teamId)
+
+        return teamScheduleRepository.findByTeamId(teamId)
+    }
+
+    /**
+     * 팀 일정 목록을 기간으로 필터링하여 조회합니다.
+     */
+    fun getByTeamIdAndDateRange(
+        teamId: Long,
+        from: LocalDateTime,
+        to: LocalDateTime,
+    ): List<TeamSchedule> {
+        teamRepository.findByIdOrNull(teamId)
+            ?: throw TeamNotFoundException(teamId)
+
+        return teamScheduleRepository.findByTeamIdAndDateRange(teamId, from, to)
+    }
+
+    /**
+     * ID로 팀 일정을 조회합니다.
+     */
+    fun getById(id: Long): TeamSchedule =
+        teamScheduleRepository.findByIdOrNull(id)
+            ?: throw TeamScheduleNotFoundException(id)
+
+    /**
+     * 팀 일정을 수정합니다.
+     */
+    @Transactional
+    fun update(
+        id: Long,
+        title: String? = null,
+        description: String? = null,
+        scheduleType: TeamScheduleType? = null,
+        startAt: LocalDateTime? = null,
+        endAt: LocalDateTime? = null,
+        location: String? = null,
+    ): TeamSchedule {
+        val schedule = getById(id)
+        schedule.update(
+            title = title,
+            description = description,
+            scheduleType = scheduleType,
+            startAt = startAt,
+            endAt = endAt,
+            location = location,
+        )
+        return schedule
+    }
+
+    /**
+     * 팀 일정을 삭제합니다.
+     */
+    @Transactional
+    fun delete(id: Long) {
+        val schedule = getById(id)
+        teamScheduleRepository.deleteById(schedule.id)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/CorrectionRequestTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/CorrectionRequestTest.kt
@@ -1,0 +1,279 @@
+package com.nextup.core.domain.game
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("CorrectionRequest 엔티티 테스트")
+class CorrectionRequestTest {
+    private fun createValidRequest(): CorrectionRequest =
+        CorrectionRequest.create(
+            gameId = 1L,
+            requesterUserId = 10L,
+            correctionType = CorrectionType.BATTING,
+            targetRecordId = 100L,
+            fieldName = "hits",
+            newValue = "3",
+            reason = "기록원 입력 오류",
+        )
+
+    @Nested
+    @DisplayName("정정 요청 생성")
+    inner class Create {
+        @Test
+        fun `유효한 파라미터로 정정 요청을 생성할 수 있다`() {
+            // when
+            val request = createValidRequest()
+
+            // then
+            assertThat(request.gameId).isEqualTo(1L)
+            assertThat(request.requesterUserId).isEqualTo(10L)
+            assertThat(request.correctionType).isEqualTo(CorrectionType.BATTING)
+            assertThat(request.targetRecordId).isEqualTo(100L)
+            assertThat(request.fieldName).isEqualTo("hits")
+            assertThat(request.newValue).isEqualTo("3")
+            assertThat(request.reason).isEqualTo("기록원 입력 오류")
+            assertThat(request.status).isEqualTo(CorrectionRequestStatus.PENDING)
+            assertThat(request.reviewerUserId).isNull()
+            assertThat(request.reviewComment).isNull()
+            assertThat(request.reviewedAt).isNull()
+        }
+
+        @Test
+        fun `gameId가 0이면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                CorrectionRequest.create(
+                    gameId = 0L,
+                    requesterUserId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    targetRecordId = 100L,
+                    fieldName = "hits",
+                    newValue = "3",
+                    reason = "정정 사유",
+                )
+            }
+        }
+
+        @Test
+        fun `gameId가 음수이면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                CorrectionRequest.create(
+                    gameId = -1L,
+                    requesterUserId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    targetRecordId = 100L,
+                    fieldName = "hits",
+                    newValue = "3",
+                    reason = "정정 사유",
+                )
+            }
+        }
+
+        @Test
+        fun `requesterUserId가 0이면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                CorrectionRequest.create(
+                    gameId = 1L,
+                    requesterUserId = 0L,
+                    correctionType = CorrectionType.BATTING,
+                    targetRecordId = 100L,
+                    fieldName = "hits",
+                    newValue = "3",
+                    reason = "정정 사유",
+                )
+            }
+        }
+
+        @Test
+        fun `fieldName이 빈 문자열이면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                CorrectionRequest.create(
+                    gameId = 1L,
+                    requesterUserId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    targetRecordId = 100L,
+                    fieldName = "",
+                    newValue = "3",
+                    reason = "정정 사유",
+                )
+            }
+        }
+
+        @Test
+        fun `newValue가 빈 문자열이면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                CorrectionRequest.create(
+                    gameId = 1L,
+                    requesterUserId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    targetRecordId = 100L,
+                    fieldName = "hits",
+                    newValue = "",
+                    reason = "정정 사유",
+                )
+            }
+        }
+
+        @Test
+        fun `reason이 빈 문자열이면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                CorrectionRequest.create(
+                    gameId = 1L,
+                    requesterUserId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    targetRecordId = 100L,
+                    fieldName = "hits",
+                    newValue = "3",
+                    reason = "",
+                )
+            }
+        }
+
+        @Test
+        fun `reason이 공백만 있으면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                CorrectionRequest.create(
+                    gameId = 1L,
+                    requesterUserId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    targetRecordId = 100L,
+                    fieldName = "hits",
+                    newValue = "3",
+                    reason = "   ",
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("정정 요청 승인")
+    inner class Approve {
+        @Test
+        fun `PENDING 상태의 요청을 승인할 수 있다`() {
+            // given
+            val request = createValidRequest()
+            val reviewerUserId = 99L
+
+            // when
+            request.approve(reviewerUserId = reviewerUserId, comment = "승인합니다")
+
+            // then
+            assertThat(request.status).isEqualTo(CorrectionRequestStatus.APPROVED)
+            assertThat(request.reviewerUserId).isEqualTo(reviewerUserId)
+            assertThat(request.reviewComment).isEqualTo("승인합니다")
+            assertThat(request.reviewedAt).isNotNull()
+        }
+
+        @Test
+        fun `comment 없이도 승인할 수 있다`() {
+            // given
+            val request = createValidRequest()
+
+            // when
+            request.approve(reviewerUserId = 99L)
+
+            // then
+            assertThat(request.status).isEqualTo(CorrectionRequestStatus.APPROVED)
+            assertThat(request.reviewComment).isNull()
+        }
+
+        @Test
+        fun `이미 승인된 요청을 다시 승인하면 예외가 발생한다`() {
+            // given
+            val request = createValidRequest()
+            request.approve(reviewerUserId = 99L)
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                request.approve(reviewerUserId = 99L)
+            }
+        }
+
+        @Test
+        fun `반려된 요청을 승인하면 예외가 발생한다`() {
+            // given
+            val request = createValidRequest()
+            request.reject(reviewerUserId = 99L, comment = "반려 사유")
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                request.approve(reviewerUserId = 99L)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("정정 요청 반려")
+    inner class Reject {
+        @Test
+        fun `PENDING 상태의 요청을 반려할 수 있다`() {
+            // given
+            val request = createValidRequest()
+            val reviewerUserId = 99L
+
+            // when
+            request.reject(reviewerUserId = reviewerUserId, comment = "증거 불충분")
+
+            // then
+            assertThat(request.status).isEqualTo(CorrectionRequestStatus.REJECTED)
+            assertThat(request.reviewerUserId).isEqualTo(reviewerUserId)
+            assertThat(request.reviewComment).isEqualTo("증거 불충분")
+            assertThat(request.reviewedAt).isNotNull()
+        }
+
+        @Test
+        fun `반려 시 comment가 빈 문자열이면 예외가 발생한다`() {
+            // given
+            val request = createValidRequest()
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                request.reject(reviewerUserId = 99L, comment = "")
+            }
+        }
+
+        @Test
+        fun `반려 시 comment가 공백만 있으면 예외가 발생한다`() {
+            // given
+            val request = createValidRequest()
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                request.reject(reviewerUserId = 99L, comment = "   ")
+            }
+        }
+
+        @Test
+        fun `이미 승인된 요청을 반려하면 예외가 발생한다`() {
+            // given
+            val request = createValidRequest()
+            request.approve(reviewerUserId = 99L)
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                request.reject(reviewerUserId = 99L, comment = "반려 사유")
+            }
+        }
+
+        @Test
+        fun `이미 반려된 요청을 다시 반려하면 예외가 발생한다`() {
+            // given
+            val request = createValidRequest()
+            request.reject(reviewerUserId = 99L, comment = "반려 사유")
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                request.reject(reviewerUserId = 99L, comment = "재반려 사유")
+            }
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamScheduleTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamScheduleTest.kt
@@ -1,0 +1,236 @@
+package com.nextup.core.domain.team
+
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+@DisplayName("TeamSchedule 엔티티 테스트")
+class TeamScheduleTest {
+    private val team: Team = mockk(relaxed = true)
+    private val baseStartAt: LocalDateTime = LocalDateTime.of(2026, 3, 20, 10, 0)
+    private val baseEndAt: LocalDateTime = LocalDateTime.of(2026, 3, 20, 12, 0)
+
+    @Nested
+    @DisplayName("팀 일정 생성")
+    inner class Create {
+        @Test
+        fun `유효한 파라미터로 팀 일정을 생성할 수 있다`() {
+            // when
+            val schedule = TeamSchedule.create(
+                team = team,
+                title = "정기 연습",
+                description = "월요일 연습입니다",
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = baseStartAt,
+                endAt = baseEndAt,
+                location = "잠실 야구장",
+            )
+
+            // then
+            assertThat(schedule.team).isEqualTo(team)
+            assertThat(schedule.title).isEqualTo("정기 연습")
+            assertThat(schedule.description).isEqualTo("월요일 연습입니다")
+            assertThat(schedule.scheduleType).isEqualTo(TeamScheduleType.PRACTICE)
+            assertThat(schedule.startAt).isEqualTo(baseStartAt)
+            assertThat(schedule.endAt).isEqualTo(baseEndAt)
+            assertThat(schedule.location).isEqualTo("잠실 야구장")
+        }
+
+        @Test
+        fun `endAt 없이도 팀 일정을 생성할 수 있다`() {
+            // when
+            val schedule = TeamSchedule.create(
+                team = team,
+                title = "팀 모임",
+                scheduleType = TeamScheduleType.MEETING,
+                startAt = baseStartAt,
+            )
+
+            // then
+            assertThat(schedule.endAt).isNull()
+        }
+
+        @Test
+        fun `빈 title로 생성하면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                TeamSchedule.create(
+                    team = team,
+                    title = "",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = baseStartAt,
+                )
+            }
+        }
+
+        @Test
+        fun `공백만 있는 title로 생성하면 예외가 발생한다`() {
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                TeamSchedule.create(
+                    team = team,
+                    title = "   ",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = baseStartAt,
+                )
+            }
+        }
+
+        @Test
+        fun `endAt이 startAt보다 이전이면 예외가 발생한다`() {
+            // given
+            val invalidEndAt = baseStartAt.minusHours(1)
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                TeamSchedule.create(
+                    team = team,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = baseStartAt,
+                    endAt = invalidEndAt,
+                )
+            }
+        }
+
+        @Test
+        fun `endAt이 startAt과 같으면 생성에 성공한다`() {
+            // when
+            val schedule = TeamSchedule.create(
+                team = team,
+                title = "즉시 종료 이벤트",
+                scheduleType = TeamScheduleType.EVENT,
+                startAt = baseStartAt,
+                endAt = baseStartAt,
+            )
+
+            // then
+            assertThat(schedule.endAt).isEqualTo(baseStartAt)
+        }
+    }
+
+    @Nested
+    @DisplayName("팀 일정 수정")
+    inner class Update {
+        @Test
+        fun `모든 필드를 부분적으로 업데이트할 수 있다`() {
+            // given
+            val schedule = TeamSchedule.create(
+                team = team,
+                title = "원래 제목",
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = baseStartAt,
+            )
+
+            // when
+            schedule.update(
+                title = "수정된 제목",
+                scheduleType = TeamScheduleType.MEETING,
+            )
+
+            // then
+            assertThat(schedule.title).isEqualTo("수정된 제목")
+            assertThat(schedule.scheduleType).isEqualTo(TeamScheduleType.MEETING)
+            assertThat(schedule.startAt).isEqualTo(baseStartAt)
+        }
+
+        @Test
+        fun `null 파라미터는 기존 값을 유지한다`() {
+            // given
+            val schedule = TeamSchedule.create(
+                team = team,
+                title = "원래 제목",
+                description = "원래 설명",
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = baseStartAt,
+                endAt = baseEndAt,
+                location = "잠실 야구장",
+            )
+
+            // when
+            schedule.update(title = "수정된 제목")
+
+            // then
+            assertThat(schedule.description).isEqualTo("원래 설명")
+            assertThat(schedule.scheduleType).isEqualTo(TeamScheduleType.PRACTICE)
+            assertThat(schedule.startAt).isEqualTo(baseStartAt)
+            assertThat(schedule.endAt).isEqualTo(baseEndAt)
+            assertThat(schedule.location).isEqualTo("잠실 야구장")
+        }
+
+        @Test
+        fun `update 시 빈 title이면 예외가 발생한다`() {
+            // given
+            val schedule = TeamSchedule.create(
+                team = team,
+                title = "원래 제목",
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = baseStartAt,
+            )
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                schedule.update(title = "")
+            }
+        }
+
+        @Test
+        fun `update 시 공백만 있는 title이면 예외가 발생한다`() {
+            // given
+            val schedule = TeamSchedule.create(
+                team = team,
+                title = "원래 제목",
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = baseStartAt,
+            )
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                schedule.update(title = "   ")
+            }
+        }
+
+        @Test
+        fun `update 시 endAt이 startAt보다 이전이면 예외가 발생한다`() {
+            // given
+            val schedule = TeamSchedule.create(
+                team = team,
+                title = "연습",
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = baseStartAt,
+                endAt = baseEndAt,
+            )
+            val invalidEndAt = baseStartAt.minusMinutes(30)
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                schedule.update(endAt = invalidEndAt)
+            }
+        }
+
+        @Test
+        fun `startAt과 endAt을 함께 업데이트할 수 있다`() {
+            // given
+            val schedule = TeamSchedule.create(
+                team = team,
+                title = "연습",
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = baseStartAt,
+                endAt = baseEndAt,
+            )
+            val newStartAt = LocalDateTime.of(2026, 3, 21, 9, 0)
+            val newEndAt = LocalDateTime.of(2026, 3, 21, 11, 0)
+
+            // when
+            schedule.update(startAt = newStartAt, endAt = newEndAt)
+
+            // then
+            assertThat(schedule.startAt).isEqualTo(newStartAt)
+            assertThat(schedule.endAt).isEqualTo(newEndAt)
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamScheduleTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamScheduleTest.kt
@@ -20,15 +20,16 @@ class TeamScheduleTest {
         @Test
         fun `유효한 파라미터로 팀 일정을 생성할 수 있다`() {
             // when
-            val schedule = TeamSchedule.create(
-                team = team,
-                title = "정기 연습",
-                description = "월요일 연습입니다",
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = baseStartAt,
-                endAt = baseEndAt,
-                location = "잠실 야구장",
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = team,
+                    title = "정기 연습",
+                    description = "월요일 연습입니다",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = baseStartAt,
+                    endAt = baseEndAt,
+                    location = "잠실 야구장",
+                )
 
             // then
             assertThat(schedule.team).isEqualTo(team)
@@ -43,12 +44,13 @@ class TeamScheduleTest {
         @Test
         fun `endAt 없이도 팀 일정을 생성할 수 있다`() {
             // when
-            val schedule = TeamSchedule.create(
-                team = team,
-                title = "팀 모임",
-                scheduleType = TeamScheduleType.MEETING,
-                startAt = baseStartAt,
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = team,
+                    title = "팀 모임",
+                    scheduleType = TeamScheduleType.MEETING,
+                    startAt = baseStartAt,
+                )
 
             // then
             assertThat(schedule.endAt).isNull()
@@ -100,13 +102,14 @@ class TeamScheduleTest {
         @Test
         fun `endAt이 startAt과 같으면 생성에 성공한다`() {
             // when
-            val schedule = TeamSchedule.create(
-                team = team,
-                title = "즉시 종료 이벤트",
-                scheduleType = TeamScheduleType.EVENT,
-                startAt = baseStartAt,
-                endAt = baseStartAt,
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = team,
+                    title = "즉시 종료 이벤트",
+                    scheduleType = TeamScheduleType.EVENT,
+                    startAt = baseStartAt,
+                    endAt = baseStartAt,
+                )
 
             // then
             assertThat(schedule.endAt).isEqualTo(baseStartAt)
@@ -119,12 +122,13 @@ class TeamScheduleTest {
         @Test
         fun `모든 필드를 부분적으로 업데이트할 수 있다`() {
             // given
-            val schedule = TeamSchedule.create(
-                team = team,
-                title = "원래 제목",
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = baseStartAt,
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = team,
+                    title = "원래 제목",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = baseStartAt,
+                )
 
             // when
             schedule.update(
@@ -141,15 +145,16 @@ class TeamScheduleTest {
         @Test
         fun `null 파라미터는 기존 값을 유지한다`() {
             // given
-            val schedule = TeamSchedule.create(
-                team = team,
-                title = "원래 제목",
-                description = "원래 설명",
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = baseStartAt,
-                endAt = baseEndAt,
-                location = "잠실 야구장",
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = team,
+                    title = "원래 제목",
+                    description = "원래 설명",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = baseStartAt,
+                    endAt = baseEndAt,
+                    location = "잠실 야구장",
+                )
 
             // when
             schedule.update(title = "수정된 제목")
@@ -165,12 +170,13 @@ class TeamScheduleTest {
         @Test
         fun `update 시 빈 title이면 예외가 발생한다`() {
             // given
-            val schedule = TeamSchedule.create(
-                team = team,
-                title = "원래 제목",
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = baseStartAt,
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = team,
+                    title = "원래 제목",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = baseStartAt,
+                )
 
             // when & then
             assertThrows<IllegalArgumentException> {
@@ -181,12 +187,13 @@ class TeamScheduleTest {
         @Test
         fun `update 시 공백만 있는 title이면 예외가 발생한다`() {
             // given
-            val schedule = TeamSchedule.create(
-                team = team,
-                title = "원래 제목",
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = baseStartAt,
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = team,
+                    title = "원래 제목",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = baseStartAt,
+                )
 
             // when & then
             assertThrows<IllegalArgumentException> {
@@ -197,13 +204,14 @@ class TeamScheduleTest {
         @Test
         fun `update 시 endAt이 startAt보다 이전이면 예외가 발생한다`() {
             // given
-            val schedule = TeamSchedule.create(
-                team = team,
-                title = "연습",
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = baseStartAt,
-                endAt = baseEndAt,
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = team,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = baseStartAt,
+                    endAt = baseEndAt,
+                )
             val invalidEndAt = baseStartAt.minusMinutes(30)
 
             // when & then
@@ -215,13 +223,14 @@ class TeamScheduleTest {
         @Test
         fun `startAt과 endAt을 함께 업데이트할 수 있다`() {
             // given
-            val schedule = TeamSchedule.create(
-                team = team,
-                title = "연습",
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = baseStartAt,
-                endAt = baseEndAt,
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = team,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = baseStartAt,
+                    endAt = baseEndAt,
+                )
             val newStartAt = LocalDateTime.of(2026, 3, 21, 9, 0)
             val newEndAt = LocalDateTime.of(2026, 3, 21, 11, 0)
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/correction/CorrectionRequestServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/correction/CorrectionRequestServiceTest.kt
@@ -1,0 +1,218 @@
+package com.nextup.core.service.game.correction
+
+import com.nextup.common.exception.CorrectionRequestNotFoundException
+import com.nextup.core.domain.game.CorrectionRequest
+import com.nextup.core.domain.game.CorrectionRequestStatus
+import com.nextup.core.domain.game.CorrectionType
+import com.nextup.core.port.repository.CorrectionRequestRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("CorrectionRequestService")
+class CorrectionRequestServiceTest {
+    private lateinit var correctionRequestRepository: CorrectionRequestRepositoryPort
+    private lateinit var recordCorrectionService: RecordCorrectionService
+    private lateinit var service: CorrectionRequestService
+
+    @BeforeEach
+    fun setUp() {
+        correctionRequestRepository = mockk()
+        recordCorrectionService = mockk(relaxed = true)
+        service = CorrectionRequestService(
+            correctionRequestRepository = correctionRequestRepository,
+            recordCorrectionService = recordCorrectionService,
+        )
+    }
+
+    private fun createBattingRequest(): CorrectionRequest =
+        CorrectionRequest.create(
+            gameId = 1L,
+            requesterUserId = 1L,
+            correctionType = CorrectionType.BATTING,
+            targetRecordId = 1L,
+            fieldName = "hits",
+            newValue = "3",
+            reason = "기록 오류",
+        )
+
+    private fun createPitchingRequest(): CorrectionRequest =
+        CorrectionRequest.create(
+            gameId = 1L,
+            requesterUserId = 1L,
+            correctionType = CorrectionType.PITCHING,
+            targetRecordId = 2L,
+            fieldName = "strikeOuts",
+            newValue = "5",
+            reason = "기록 오류",
+        )
+
+    @Nested
+    @DisplayName("createRequest - 정정 요청 생성")
+    inner class CreateRequestTest {
+        @Test
+        fun `정정 요청을 생성하고 저장한다`() {
+            // given
+            val saved = createBattingRequest()
+            every { correctionRequestRepository.save(any()) } returns saved
+
+            // when
+            val result = service.createRequest(
+                gameId = 1L,
+                requesterUserId = 1L,
+                correctionType = CorrectionType.BATTING,
+                targetRecordId = 1L,
+                fieldName = "hits",
+                newValue = "3",
+                reason = "기록 오류",
+            )
+
+            // then
+            assertThat(result).isNotNull
+            assertThat(result.correctionType).isEqualTo(CorrectionType.BATTING)
+            assertThat(result.status).isEqualTo(CorrectionRequestStatus.PENDING)
+            verify(exactly = 1) { correctionRequestRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("approve - 정정 요청 승인")
+    inner class ApproveTest {
+        @Test
+        fun `BATTING 타입 정정 요청을 승인하고 타격 기록을 정정한다`() {
+            // given
+            val requestId = 1L
+            val reviewerUserId = 10L
+            val request = createBattingRequest()
+            every { correctionRequestRepository.findByIdOrNull(requestId) } returns request
+            every {
+                recordCorrectionService.correctBattingRecord(any(), any(), any())
+            } returns mockk(relaxed = true)
+
+            // when
+            val result = service.approve(
+                requestId = requestId,
+                reviewerUserId = reviewerUserId,
+                comment = "승인합니다",
+            )
+
+            // then
+            assertThat(result.status).isEqualTo(CorrectionRequestStatus.APPROVED)
+            assertThat(result.reviewerUserId).isEqualTo(reviewerUserId)
+            verify(exactly = 1) {
+                recordCorrectionService.correctBattingRecord(
+                    gameId = 1L,
+                    recordId = 1L,
+                    request = BattingCorrectionRequest(
+                        adminUserId = reviewerUserId,
+                        fieldName = "hits",
+                        newValue = "3",
+                        reason = "기록 오류",
+                    ),
+                )
+            }
+        }
+
+        @Test
+        fun `PITCHING 타입 정정 요청을 승인하고 투수 기록을 정정한다`() {
+            // given
+            val requestId = 2L
+            val reviewerUserId = 10L
+            val request = createPitchingRequest()
+            every { correctionRequestRepository.findByIdOrNull(requestId) } returns request
+            every {
+                recordCorrectionService.correctPitchingRecord(any(), any(), any())
+            } returns mockk(relaxed = true)
+
+            // when
+            val result = service.approve(
+                requestId = requestId,
+                reviewerUserId = reviewerUserId,
+                comment = "승인합니다",
+            )
+
+            // then
+            assertThat(result.status).isEqualTo(CorrectionRequestStatus.APPROVED)
+            assertThat(result.reviewerUserId).isEqualTo(reviewerUserId)
+            verify(exactly = 1) {
+                recordCorrectionService.correctPitchingRecord(
+                    gameId = 1L,
+                    recordId = 2L,
+                    request = PitchingCorrectionRequest(
+                        adminUserId = reviewerUserId,
+                        fieldName = "strikeOuts",
+                        newValue = "5",
+                        reason = "기록 오류",
+                    ),
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("reject - 정정 요청 반려")
+    inner class RejectTest {
+        @Test
+        fun `PENDING 상태의 정정 요청을 반려한다`() {
+            // given
+            val requestId = 1L
+            val reviewerUserId = 10L
+            val request = createBattingRequest()
+            every { correctionRequestRepository.findByIdOrNull(requestId) } returns request
+
+            // when
+            val result = service.reject(
+                requestId = requestId,
+                reviewerUserId = reviewerUserId,
+                comment = "근거가 부족합니다",
+            )
+
+            // then
+            assertThat(result.status).isEqualTo(CorrectionRequestStatus.REJECTED)
+            assertThat(result.reviewerUserId).isEqualTo(reviewerUserId)
+            assertThat(result.reviewComment).isEqualTo("근거가 부족합니다")
+        }
+    }
+
+    @Nested
+    @DisplayName("getById - ID로 정정 요청 조회")
+    inner class GetByIdTest {
+        @Test
+        fun `존재하지 않는 ID이면 CorrectionRequestNotFoundException을 던진다`() {
+            // given
+            val requestId = 999L
+            every { correctionRequestRepository.findByIdOrNull(requestId) } returns null
+
+            // when & then
+            assertThrows<CorrectionRequestNotFoundException> {
+                service.getById(requestId)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getPendingRequests - 대기 중인 정정 요청 목록 조회")
+    inner class GetPendingRequestsTest {
+        @Test
+        fun `PENDING 상태인 정정 요청 목록을 반환한다`() {
+            // given
+            val pending = listOf(createBattingRequest(), createPitchingRequest())
+            every {
+                correctionRequestRepository.findByStatus(CorrectionRequestStatus.PENDING)
+            } returns pending
+
+            // when
+            val result = service.getPendingRequests()
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result).allMatch { it.status == CorrectionRequestStatus.PENDING }
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/correction/CorrectionRequestServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/correction/CorrectionRequestServiceTest.kt
@@ -25,10 +25,11 @@ class CorrectionRequestServiceTest {
     fun setUp() {
         correctionRequestRepository = mockk()
         recordCorrectionService = mockk(relaxed = true)
-        service = CorrectionRequestService(
-            correctionRequestRepository = correctionRequestRepository,
-            recordCorrectionService = recordCorrectionService,
-        )
+        service =
+            CorrectionRequestService(
+                correctionRequestRepository = correctionRequestRepository,
+                recordCorrectionService = recordCorrectionService,
+            )
     }
 
     private fun createBattingRequest(): CorrectionRequest =
@@ -63,15 +64,16 @@ class CorrectionRequestServiceTest {
             every { correctionRequestRepository.save(any()) } returns saved
 
             // when
-            val result = service.createRequest(
-                gameId = 1L,
-                requesterUserId = 1L,
-                correctionType = CorrectionType.BATTING,
-                targetRecordId = 1L,
-                fieldName = "hits",
-                newValue = "3",
-                reason = "기록 오류",
-            )
+            val result =
+                service.createRequest(
+                    gameId = 1L,
+                    requesterUserId = 1L,
+                    correctionType = CorrectionType.BATTING,
+                    targetRecordId = 1L,
+                    fieldName = "hits",
+                    newValue = "3",
+                    reason = "기록 오류",
+                )
 
             // then
             assertThat(result).isNotNull
@@ -96,11 +98,12 @@ class CorrectionRequestServiceTest {
             } returns mockk(relaxed = true)
 
             // when
-            val result = service.approve(
-                requestId = requestId,
-                reviewerUserId = reviewerUserId,
-                comment = "승인합니다",
-            )
+            val result =
+                service.approve(
+                    requestId = requestId,
+                    reviewerUserId = reviewerUserId,
+                    comment = "승인합니다",
+                )
 
             // then
             assertThat(result.status).isEqualTo(CorrectionRequestStatus.APPROVED)
@@ -109,12 +112,13 @@ class CorrectionRequestServiceTest {
                 recordCorrectionService.correctBattingRecord(
                     gameId = 1L,
                     recordId = 1L,
-                    request = BattingCorrectionRequest(
-                        adminUserId = reviewerUserId,
-                        fieldName = "hits",
-                        newValue = "3",
-                        reason = "기록 오류",
-                    ),
+                    request =
+                        BattingCorrectionRequest(
+                            adminUserId = reviewerUserId,
+                            fieldName = "hits",
+                            newValue = "3",
+                            reason = "기록 오류",
+                        ),
                 )
             }
         }
@@ -131,11 +135,12 @@ class CorrectionRequestServiceTest {
             } returns mockk(relaxed = true)
 
             // when
-            val result = service.approve(
-                requestId = requestId,
-                reviewerUserId = reviewerUserId,
-                comment = "승인합니다",
-            )
+            val result =
+                service.approve(
+                    requestId = requestId,
+                    reviewerUserId = reviewerUserId,
+                    comment = "승인합니다",
+                )
 
             // then
             assertThat(result.status).isEqualTo(CorrectionRequestStatus.APPROVED)
@@ -144,12 +149,13 @@ class CorrectionRequestServiceTest {
                 recordCorrectionService.correctPitchingRecord(
                     gameId = 1L,
                     recordId = 2L,
-                    request = PitchingCorrectionRequest(
-                        adminUserId = reviewerUserId,
-                        fieldName = "strikeOuts",
-                        newValue = "5",
-                        reason = "기록 오류",
-                    ),
+                    request =
+                        PitchingCorrectionRequest(
+                            adminUserId = reviewerUserId,
+                            fieldName = "strikeOuts",
+                            newValue = "5",
+                            reason = "기록 오류",
+                        ),
                 )
             }
         }
@@ -167,11 +173,12 @@ class CorrectionRequestServiceTest {
             every { correctionRequestRepository.findByIdOrNull(requestId) } returns request
 
             // when
-            val result = service.reject(
-                requestId = requestId,
-                reviewerUserId = reviewerUserId,
-                comment = "근거가 부족합니다",
-            )
+            val result =
+                service.reject(
+                    requestId = requestId,
+                    reviewerUserId = reviewerUserId,
+                    comment = "근거가 부족합니다",
+                )
 
             // then
             assertThat(result.status).isEqualTo(CorrectionRequestStatus.REJECTED)

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stats/CompetitionStatsDtoTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stats/CompetitionStatsDtoTest.kt
@@ -1,0 +1,293 @@
+package com.nextup.core.service.stats
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("CompetitionStatsDto 테스트")
+class CompetitionStatsDtoTest {
+    @Nested
+    @DisplayName("CompetitionBattingStatsDto")
+    inner class CompetitionBattingStatsDtoTests {
+        @Test
+        fun `should create batting stats dto with all fields`() {
+            // given & when
+            val dto =
+                CompetitionBattingStatsDto(
+                    playerId = 1L,
+                    competitionId = 100L,
+                    gamesPlayed = 10,
+                    plateAppearances = 45,
+                    atBats = 40,
+                    hits = 12,
+                    doubles = 3,
+                    triples = 1,
+                    homeRuns = 2,
+                    runs = 7,
+                    runsBattedIn = 9,
+                    walks = 4,
+                    strikeouts = 8,
+                    stolenBases = 3,
+                    battingAverage = "0.300",
+                    onBasePercentage = "0.364",
+                    sluggingPercentage = "0.525",
+                    ops = "0.889",
+                )
+
+            // then
+            assertThat(dto.playerId).isEqualTo(1L)
+            assertThat(dto.competitionId).isEqualTo(100L)
+            assertThat(dto.gamesPlayed).isEqualTo(10)
+            assertThat(dto.plateAppearances).isEqualTo(45)
+            assertThat(dto.atBats).isEqualTo(40)
+            assertThat(dto.hits).isEqualTo(12)
+            assertThat(dto.doubles).isEqualTo(3)
+            assertThat(dto.triples).isEqualTo(1)
+            assertThat(dto.homeRuns).isEqualTo(2)
+            assertThat(dto.runs).isEqualTo(7)
+            assertThat(dto.runsBattedIn).isEqualTo(9)
+            assertThat(dto.walks).isEqualTo(4)
+            assertThat(dto.strikeouts).isEqualTo(8)
+            assertThat(dto.stolenBases).isEqualTo(3)
+            assertThat(dto.battingAverage).isEqualTo("0.300")
+            assertThat(dto.onBasePercentage).isEqualTo("0.364")
+            assertThat(dto.sluggingPercentage).isEqualTo("0.525")
+            assertThat(dto.ops).isEqualTo("0.889")
+        }
+
+        @Test
+        fun `should create batting stats dto with zero stats`() {
+            // given & when
+            val dto =
+                CompetitionBattingStatsDto(
+                    playerId = 1L,
+                    competitionId = 100L,
+                    gamesPlayed = 0,
+                    plateAppearances = 0,
+                    atBats = 0,
+                    hits = 0,
+                    doubles = 0,
+                    triples = 0,
+                    homeRuns = 0,
+                    runs = 0,
+                    runsBattedIn = 0,
+                    walks = 0,
+                    strikeouts = 0,
+                    stolenBases = 0,
+                    battingAverage = "0",
+                    onBasePercentage = "0",
+                    sluggingPercentage = "0",
+                    ops = "0",
+                )
+
+            // then
+            assertThat(dto.gamesPlayed).isZero
+            assertThat(dto.hits).isZero
+            assertThat(dto.battingAverage).isEqualTo("0")
+            assertThat(dto.ops).isEqualTo("0")
+        }
+
+        @Test
+        fun `should support equality check as data class`() {
+            // given
+            val dto1 =
+                CompetitionBattingStatsDto(
+                    playerId = 1L,
+                    competitionId = 100L,
+                    gamesPlayed = 5,
+                    plateAppearances = 20,
+                    atBats = 18,
+                    hits = 6,
+                    doubles = 1,
+                    triples = 0,
+                    homeRuns = 1,
+                    runs = 3,
+                    runsBattedIn = 4,
+                    walks = 2,
+                    strikeouts = 3,
+                    stolenBases = 1,
+                    battingAverage = "0.333",
+                    onBasePercentage = "0.400",
+                    sluggingPercentage = "0.556",
+                    ops = "0.956",
+                )
+            val dto2 = dto1.copy()
+
+            // then
+            assertThat(dto1).isEqualTo(dto2)
+            assertThat(dto1.hashCode()).isEqualTo(dto2.hashCode())
+        }
+
+        @Test
+        fun `should support copy with modified fields`() {
+            // given
+            val original =
+                CompetitionBattingStatsDto(
+                    playerId = 1L,
+                    competitionId = 100L,
+                    gamesPlayed = 5,
+                    plateAppearances = 20,
+                    atBats = 18,
+                    hits = 6,
+                    doubles = 1,
+                    triples = 0,
+                    homeRuns = 1,
+                    runs = 3,
+                    runsBattedIn = 4,
+                    walks = 2,
+                    strikeouts = 3,
+                    stolenBases = 1,
+                    battingAverage = "0.333",
+                    onBasePercentage = "0.400",
+                    sluggingPercentage = "0.556",
+                    ops = "0.956",
+                )
+
+            // when
+            val modified = original.copy(hits = 8, battingAverage = "0.444")
+
+            // then
+            assertThat(modified.hits).isEqualTo(8)
+            assertThat(modified.battingAverage).isEqualTo("0.444")
+            assertThat(modified.playerId).isEqualTo(original.playerId)
+            assertThat(modified.competitionId).isEqualTo(original.competitionId)
+        }
+    }
+
+    @Nested
+    @DisplayName("CompetitionPitchingStatsDto")
+    inner class CompetitionPitchingStatsDtoTests {
+        @Test
+        fun `should create pitching stats dto with all fields`() {
+            // given & when
+            val dto =
+                CompetitionPitchingStatsDto(
+                    playerId = 1L,
+                    competitionId = 100L,
+                    gamesPlayed = 5,
+                    gamesStarted = 4,
+                    inningsPitchedDisplay = "25.2",
+                    wins = 3,
+                    losses = 1,
+                    saves = 0,
+                    holds = 1,
+                    earnedRuns = 10,
+                    hitsAllowed = 20,
+                    walksAllowed = 8,
+                    strikeouts = 25,
+                    homeRunsAllowed = 3,
+                    earnedRunAverage = "3.51",
+                    whip = "1.09",
+                )
+
+            // then
+            assertThat(dto.playerId).isEqualTo(1L)
+            assertThat(dto.competitionId).isEqualTo(100L)
+            assertThat(dto.gamesPlayed).isEqualTo(5)
+            assertThat(dto.gamesStarted).isEqualTo(4)
+            assertThat(dto.inningsPitchedDisplay).isEqualTo("25.2")
+            assertThat(dto.wins).isEqualTo(3)
+            assertThat(dto.losses).isEqualTo(1)
+            assertThat(dto.saves).isEqualTo(0)
+            assertThat(dto.holds).isEqualTo(1)
+            assertThat(dto.earnedRuns).isEqualTo(10)
+            assertThat(dto.hitsAllowed).isEqualTo(20)
+            assertThat(dto.walksAllowed).isEqualTo(8)
+            assertThat(dto.strikeouts).isEqualTo(25)
+            assertThat(dto.homeRunsAllowed).isEqualTo(3)
+            assertThat(dto.earnedRunAverage).isEqualTo("3.51")
+            assertThat(dto.whip).isEqualTo("1.09")
+        }
+
+        @Test
+        fun `should allow null ERA`() {
+            // given & when
+            val dto =
+                CompetitionPitchingStatsDto(
+                    playerId = 1L,
+                    competitionId = 100L,
+                    gamesPlayed = 0,
+                    gamesStarted = 0,
+                    inningsPitchedDisplay = "0",
+                    wins = 0,
+                    losses = 0,
+                    saves = 0,
+                    holds = 0,
+                    earnedRuns = 0,
+                    hitsAllowed = 0,
+                    walksAllowed = 0,
+                    strikeouts = 0,
+                    homeRunsAllowed = 0,
+                    earnedRunAverage = null,
+                    whip = "0",
+                )
+
+            // then
+            assertThat(dto.earnedRunAverage).isNull()
+            assertThat(dto.gamesPlayed).isZero
+        }
+
+        @Test
+        fun `should support equality check as data class`() {
+            // given
+            val dto1 =
+                CompetitionPitchingStatsDto(
+                    playerId = 1L,
+                    competitionId = 100L,
+                    gamesPlayed = 3,
+                    gamesStarted = 2,
+                    inningsPitchedDisplay = "15.0",
+                    wins = 2,
+                    losses = 1,
+                    saves = 0,
+                    holds = 0,
+                    earnedRuns = 5,
+                    hitsAllowed = 12,
+                    walksAllowed = 4,
+                    strikeouts = 15,
+                    homeRunsAllowed = 2,
+                    earnedRunAverage = "3.00",
+                    whip = "1.07",
+                )
+            val dto2 = dto1.copy()
+
+            // then
+            assertThat(dto1).isEqualTo(dto2)
+            assertThat(dto1.hashCode()).isEqualTo(dto2.hashCode())
+        }
+
+        @Test
+        fun `should support copy with modified fields`() {
+            // given
+            val original =
+                CompetitionPitchingStatsDto(
+                    playerId = 1L,
+                    competitionId = 100L,
+                    gamesPlayed = 3,
+                    gamesStarted = 2,
+                    inningsPitchedDisplay = "15.0",
+                    wins = 2,
+                    losses = 1,
+                    saves = 0,
+                    holds = 0,
+                    earnedRuns = 5,
+                    hitsAllowed = 12,
+                    walksAllowed = 4,
+                    strikeouts = 15,
+                    homeRunsAllowed = 2,
+                    earnedRunAverage = "3.00",
+                    whip = "1.07",
+                )
+
+            // when
+            val modified =
+                original.copy(wins = 3, earnedRunAverage = "2.50")
+
+            // then
+            assertThat(modified.wins).isEqualTo(3)
+            assertThat(modified.earnedRunAverage).isEqualTo("2.50")
+            assertThat(modified.playerId).isEqualTo(original.playerId)
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stats/PlayerStatsServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stats/PlayerStatsServiceTest.kt
@@ -458,6 +458,298 @@ class PlayerStatsServiceTest {
     }
 
     @Nested
+    @DisplayName("대회별 타격 통계 조회")
+    inner class GetBattingStatsByCompetition {
+        private val competitionId = 100L
+
+        @Test
+        fun `should return competition batting stats with calculated averages`() {
+            // given
+            val gamePlayer = mockk<GamePlayer>()
+            val record1 =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 4, ab = 4, h = 2)
+                    setExtraStats(
+                        doubles = 1,
+                        triples = 0,
+                        homeRuns = 0,
+                        runs = 1,
+                        rbi = 2,
+                        walks = 0,
+                        strikeouts = 1,
+                        stolenBases = 0,
+                    )
+                }
+            val record2 =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 5, ab = 4, h = 1)
+                    setExtraStats(
+                        doubles = 0,
+                        triples = 1,
+                        homeRuns = 0,
+                        runs = 0,
+                        rbi = 1,
+                        walks = 1,
+                        strikeouts = 2,
+                        stolenBases = 1,
+                    )
+                }
+
+            every {
+                battingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns listOf(record1, record2)
+
+            // when
+            val result = playerStatsService.getBattingStatsByCompetition(playerId, competitionId)
+
+            // then
+            assertThat(result.playerId).isEqualTo(playerId)
+            assertThat(result.competitionId).isEqualTo(competitionId)
+            assertThat(result.gamesPlayed).isEqualTo(2)
+            assertThat(result.plateAppearances).isEqualTo(9)
+            assertThat(result.atBats).isEqualTo(8)
+            assertThat(result.hits).isEqualTo(3)
+            assertThat(result.doubles).isEqualTo(1)
+            assertThat(result.triples).isEqualTo(1)
+            assertThat(result.homeRuns).isEqualTo(0)
+            assertThat(result.runs).isEqualTo(1)
+            assertThat(result.runsBattedIn).isEqualTo(3)
+            assertThat(result.walks).isEqualTo(1)
+            assertThat(result.strikeouts).isEqualTo(3)
+            assertThat(result.stolenBases).isEqualTo(1)
+            assertThat(result.battingAverage).isEqualTo("0.375")
+            verify {
+                battingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+            }
+        }
+
+        @Test
+        fun `should return zero averages when no at-bats`() {
+            // given
+            every {
+                battingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns emptyList()
+
+            // when
+            val result = playerStatsService.getBattingStatsByCompetition(playerId, competitionId)
+
+            // then
+            assertThat(result.gamesPlayed).isZero
+            assertThat(result.atBats).isZero
+            assertThat(result.battingAverage).isEqualTo("0")
+            assertThat(result.onBasePercentage).isEqualTo("0")
+            assertThat(result.sluggingPercentage).isEqualTo("0")
+            assertThat(result.ops).isEqualTo("0")
+        }
+
+        @Test
+        fun `should calculate OPS correctly with home runs`() {
+            // given
+            val gamePlayer = mockk<GamePlayer>()
+            val record =
+                BattingRecord.create(gamePlayer).apply {
+                    setStats(pa = 5, ab = 4, h = 2)
+                    setExtraStats(
+                        doubles = 0,
+                        triples = 0,
+                        homeRuns = 1,
+                        runs = 2,
+                        rbi = 3,
+                        walks = 1,
+                        strikeouts = 1,
+                        stolenBases = 0,
+                    )
+                }
+
+            every {
+                battingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns listOf(record)
+
+            // when
+            val result = playerStatsService.getBattingStatsByCompetition(playerId, competitionId)
+
+            // then
+            assertThat(result.homeRuns).isEqualTo(1)
+            // totalBases = hits(2) + doubles(0) + triples(0)*2 + homeRuns(1)*3 = 5
+            // slugging = 5/4 = 1.250
+            assertThat(result.sluggingPercentage).isEqualTo("1.250")
+            // OBP = (hits(2) + walks(1)) / (atBats(4) + walks(1)) = 3/5 = 0.600
+            assertThat(result.onBasePercentage).isEqualTo("0.600")
+        }
+    }
+
+    @Nested
+    @DisplayName("대회별 투수 통계 조회")
+    inner class GetPitchingStatsByCompetition {
+        private val competitionId = 100L
+
+        @Test
+        fun `should return competition pitching stats with calculated ERA`() {
+            // given
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { isStarter } returns true
+                }
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 2,
+                        runsAllowed = 2,
+                        strikeouts = 6,
+                        decision = PitchingDecision.WIN,
+                    )
+                    setPitchingExtraStats(
+                        hitsAllowed = 5,
+                        walksAllowed = 2,
+                        homeRunsAllowed = 1,
+                    )
+                }
+
+            every {
+                pitchingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns listOf(record)
+
+            // when
+            val result = playerStatsService.getPitchingStatsByCompetition(playerId, competitionId)
+
+            // then
+            assertThat(result.playerId).isEqualTo(playerId)
+            assertThat(result.competitionId).isEqualTo(competitionId)
+            assertThat(result.gamesPlayed).isEqualTo(1)
+            assertThat(result.gamesStarted).isEqualTo(1)
+            assertThat(result.wins).isEqualTo(1)
+            assertThat(result.losses).isEqualTo(0)
+            assertThat(result.earnedRuns).isEqualTo(2)
+            assertThat(result.strikeouts).isEqualTo(6)
+            assertThat(result.hitsAllowed).isEqualTo(5)
+            assertThat(result.walksAllowed).isEqualTo(2)
+            assertThat(result.homeRunsAllowed).isEqualTo(1)
+            // ERA = (earnedRuns * 27) / inningsPitchedOuts = 54 / 18 = 3.00
+            assertThat(result.earnedRunAverage).isEqualTo("3.00")
+            assertThat(result.inningsPitchedDisplay).isEqualTo("6")
+            verify {
+                pitchingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+            }
+        }
+
+        @Test
+        fun `should return null ERA when no innings pitched`() {
+            // given
+            every {
+                pitchingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns emptyList()
+
+            // when
+            val result = playerStatsService.getPitchingStatsByCompetition(playerId, competitionId)
+
+            // then
+            assertThat(result.gamesPlayed).isZero
+            assertThat(result.earnedRunAverage).isNull()
+            assertThat(result.whip).isEqualTo("0")
+            assertThat(result.inningsPitchedDisplay).isEqualTo("0")
+        }
+
+        @Test
+        fun `should display partial innings correctly`() {
+            // given
+            val gamePlayer =
+                mockk<GamePlayer> {
+                    every { isStarter } returns false
+                }
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
+                    setStats(
+                        inningsPitchedOuts = 7,
+                        earnedRuns = 1,
+                        runsAllowed = 1,
+                        strikeouts = 3,
+                        decision = PitchingDecision.HOLD,
+                    )
+                    setPitchingExtraStats(
+                        hitsAllowed = 2,
+                        walksAllowed = 1,
+                        homeRunsAllowed = 0,
+                    )
+                }
+
+            every {
+                pitchingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns listOf(record)
+
+            // when
+            val result = playerStatsService.getPitchingStatsByCompetition(playerId, competitionId)
+
+            // then
+            assertThat(result.inningsPitchedDisplay).isEqualTo("2.1")
+            assertThat(result.gamesStarted).isEqualTo(0)
+            assertThat(result.holds).isEqualTo(1)
+        }
+
+        @Test
+        fun `should aggregate multiple records with different decisions`() {
+            // given
+            val starterPlayer =
+                mockk<GamePlayer> {
+                    every { isStarter } returns true
+                }
+            val reliefPlayer =
+                mockk<GamePlayer> {
+                    every { isStarter } returns false
+                }
+
+            val record1 =
+                PitchingRecord.create(starterPlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 3,
+                        runsAllowed = 3,
+                        strikeouts = 5,
+                        decision = PitchingDecision.WIN,
+                    )
+                    setPitchingExtraStats(
+                        hitsAllowed = 6,
+                        walksAllowed = 2,
+                        homeRunsAllowed = 1,
+                    )
+                }
+            val record2 =
+                PitchingRecord.create(reliefPlayer, isStartingPitcher = false).apply {
+                    setStats(
+                        inningsPitchedOuts = 9,
+                        earnedRuns = 0,
+                        runsAllowed = 0,
+                        strikeouts = 4,
+                        decision = PitchingDecision.SAVE,
+                    )
+                    setPitchingExtraStats(
+                        hitsAllowed = 1,
+                        walksAllowed = 0,
+                        homeRunsAllowed = 0,
+                    )
+                }
+
+            every {
+                pitchingRecordRepository.findAllByPlayerIdAndCompetitionId(playerId, competitionId)
+            } returns listOf(record1, record2)
+
+            // when
+            val result = playerStatsService.getPitchingStatsByCompetition(playerId, competitionId)
+
+            // then
+            assertThat(result.gamesPlayed).isEqualTo(2)
+            assertThat(result.gamesStarted).isEqualTo(1)
+            assertThat(result.wins).isEqualTo(1)
+            assertThat(result.saves).isEqualTo(1)
+            assertThat(result.earnedRuns).isEqualTo(3)
+            assertThat(result.strikeouts).isEqualTo(9)
+            assertThat(result.hitsAllowed).isEqualTo(7)
+            assertThat(result.walksAllowed).isEqualTo(2)
+            assertThat(result.inningsPitchedDisplay).isEqualTo("9")
+        }
+    }
+
+    @Nested
     @DisplayName("시즌 타격 리더보드")
     inner class GetSeasonBattingLeaders {
         @Test
@@ -661,6 +953,36 @@ class PlayerStatsServiceTest {
         val field = PitchingRecord::class.java.getDeclaredField(fieldName)
         field.isAccessible = true
         field.set(this, value)
+    }
+
+    private fun BattingRecord.setExtraStats(
+        doubles: Int = 0,
+        triples: Int = 0,
+        homeRuns: Int = 0,
+        runs: Int = 0,
+        rbi: Int = 0,
+        walks: Int = 0,
+        strikeouts: Int = 0,
+        stolenBases: Int = 0,
+    ) {
+        setField("doubles", doubles)
+        setField("triples", triples)
+        setField("homeRuns", homeRuns)
+        setField("runs", runs)
+        setField("runsBattedIn", rbi)
+        setField("walks", walks)
+        setField("strikeouts", strikeouts)
+        setField("stolenBases", stolenBases)
+    }
+
+    private fun PitchingRecord.setPitchingExtraStats(
+        hitsAllowed: Int = 0,
+        walksAllowed: Int = 0,
+        homeRunsAllowed: Int = 0,
+    ) {
+        setField("hitsAllowed", hitsAllowed)
+        setField("walksAllowed", walksAllowed)
+        setField("homeRunsAllowed", homeRunsAllowed)
     }
 
     private fun createMockGame(year: Int): Game =

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/team/TeamScheduleServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/team/TeamScheduleServiceTest.kt
@@ -30,10 +30,11 @@ class TeamScheduleServiceTest {
     fun setUp() {
         teamScheduleRepository = mockk()
         teamRepository = mockk()
-        service = TeamScheduleService(
-            teamScheduleRepository = teamScheduleRepository,
-            teamRepository = teamRepository,
-        )
+        service =
+            TeamScheduleService(
+                teamScheduleRepository = teamScheduleRepository,
+                teamRepository = teamRepository,
+            )
 
         mockTeam = mockk(relaxed = true)
     }
@@ -46,25 +47,27 @@ class TeamScheduleServiceTest {
             // given
             val teamId = 1L
             val startAt = LocalDateTime.now().plusDays(1)
-            val schedule = TeamSchedule.create(
-                team = mockTeam,
-                title = "연습",
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = startAt,
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = mockTeam,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = startAt,
+                )
             every { teamRepository.findByIdOrNull(teamId) } returns mockTeam
             every { teamScheduleRepository.save(any()) } returns schedule
 
             // when
-            val result = service.create(
-                teamId = teamId,
-                title = "연습",
-                description = null,
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = startAt,
-                endAt = null,
-                location = null,
-            )
+            val result =
+                service.create(
+                    teamId = teamId,
+                    title = "연습",
+                    description = null,
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = startAt,
+                    endAt = null,
+                    location = null,
+                )
 
             // then
             assertThat(result).isNotNull
@@ -102,20 +105,21 @@ class TeamScheduleServiceTest {
             // given
             val teamId = 1L
             val startAt = LocalDateTime.now().plusDays(1)
-            val schedules = listOf(
-                TeamSchedule.create(
-                    team = mockTeam,
-                    title = "연습",
-                    scheduleType = TeamScheduleType.PRACTICE,
-                    startAt = startAt,
-                ),
-                TeamSchedule.create(
-                    team = mockTeam,
-                    title = "모임",
-                    scheduleType = TeamScheduleType.MEETING,
-                    startAt = startAt.plusDays(1),
-                ),
-            )
+            val schedules =
+                listOf(
+                    TeamSchedule.create(
+                        team = mockTeam,
+                        title = "연습",
+                        scheduleType = TeamScheduleType.PRACTICE,
+                        startAt = startAt,
+                    ),
+                    TeamSchedule.create(
+                        team = mockTeam,
+                        title = "모임",
+                        scheduleType = TeamScheduleType.MEETING,
+                        startAt = startAt.plusDays(1),
+                    ),
+                )
             every { teamRepository.findByIdOrNull(teamId) } returns mockTeam
             every { teamScheduleRepository.findByTeamId(teamId) } returns schedules
 
@@ -165,20 +169,22 @@ class TeamScheduleServiceTest {
             // given
             val scheduleId = 1L
             val startAt = LocalDateTime.now().plusDays(1)
-            val schedule = TeamSchedule.create(
-                team = mockTeam,
-                title = "연습",
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = startAt,
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = mockTeam,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = startAt,
+                )
             every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns schedule
 
             // when
-            val result = service.update(
-                id = scheduleId,
-                title = "정기 연습",
-                scheduleType = TeamScheduleType.PRACTICE,
-            )
+            val result =
+                service.update(
+                    id = scheduleId,
+                    title = "정기 연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                )
 
             // then
             assertThat(result.title).isEqualTo("정기 연습")
@@ -193,12 +199,13 @@ class TeamScheduleServiceTest {
             // given
             val scheduleId = 1L
             val startAt = LocalDateTime.now().plusDays(1)
-            val schedule = TeamSchedule.create(
-                team = mockTeam,
-                title = "연습",
-                scheduleType = TeamScheduleType.PRACTICE,
-                startAt = startAt,
-            )
+            val schedule =
+                TeamSchedule.create(
+                    team = mockTeam,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = startAt,
+                )
             every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns schedule
             every { teamScheduleRepository.deleteById(schedule.id) } returns Unit
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/team/TeamScheduleServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/team/TeamScheduleServiceTest.kt
@@ -1,0 +1,212 @@
+package com.nextup.core.service.team
+
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.common.exception.TeamScheduleNotFoundException
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamSchedule
+import com.nextup.core.domain.team.TeamScheduleType
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.port.repository.TeamScheduleRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+@DisplayName("TeamScheduleService")
+class TeamScheduleServiceTest {
+    private lateinit var teamScheduleRepository: TeamScheduleRepositoryPort
+    private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var service: TeamScheduleService
+
+    private lateinit var mockTeam: Team
+
+    @BeforeEach
+    fun setUp() {
+        teamScheduleRepository = mockk()
+        teamRepository = mockk()
+        service = TeamScheduleService(
+            teamScheduleRepository = teamScheduleRepository,
+            teamRepository = teamRepository,
+        )
+
+        mockTeam = mockk(relaxed = true)
+    }
+
+    @Nested
+    @DisplayName("create - 팀 일정 생성")
+    inner class CreateTest {
+        @Test
+        fun `팀이 존재하면 일정을 생성하고 저장한다`() {
+            // given
+            val teamId = 1L
+            val startAt = LocalDateTime.now().plusDays(1)
+            val schedule = TeamSchedule.create(
+                team = mockTeam,
+                title = "연습",
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = startAt,
+            )
+            every { teamRepository.findByIdOrNull(teamId) } returns mockTeam
+            every { teamScheduleRepository.save(any()) } returns schedule
+
+            // when
+            val result = service.create(
+                teamId = teamId,
+                title = "연습",
+                description = null,
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = startAt,
+                endAt = null,
+                location = null,
+            )
+
+            // then
+            assertThat(result).isNotNull
+            assertThat(result.title).isEqualTo("연습")
+            verify(exactly = 1) { teamScheduleRepository.save(any()) }
+        }
+
+        @Test
+        fun `팀이 존재하지 않으면 TeamNotFoundException을 던진다`() {
+            // given
+            val teamId = 999L
+            every { teamRepository.findByIdOrNull(teamId) } returns null
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                service.create(
+                    teamId = teamId,
+                    title = "연습",
+                    description = null,
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = LocalDateTime.now().plusDays(1),
+                    endAt = null,
+                    location = null,
+                )
+            }
+            verify(exactly = 0) { teamScheduleRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("getByTeamId - 팀 일정 목록 조회")
+    inner class GetByTeamIdTest {
+        @Test
+        fun `팀이 존재하면 해당 팀의 일정 목록을 반환한다`() {
+            // given
+            val teamId = 1L
+            val startAt = LocalDateTime.now().plusDays(1)
+            val schedules = listOf(
+                TeamSchedule.create(
+                    team = mockTeam,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = startAt,
+                ),
+                TeamSchedule.create(
+                    team = mockTeam,
+                    title = "모임",
+                    scheduleType = TeamScheduleType.MEETING,
+                    startAt = startAt.plusDays(1),
+                ),
+            )
+            every { teamRepository.findByIdOrNull(teamId) } returns mockTeam
+            every { teamScheduleRepository.findByTeamId(teamId) } returns schedules
+
+            // when
+            val result = service.getByTeamId(teamId)
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result[0].title).isEqualTo("연습")
+            assertThat(result[1].title).isEqualTo("모임")
+        }
+
+        @Test
+        fun `팀이 존재하지 않으면 TeamNotFoundException을 던진다`() {
+            // given
+            val teamId = 999L
+            every { teamRepository.findByIdOrNull(teamId) } returns null
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                service.getByTeamId(teamId)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getById - ID로 팀 일정 조회")
+    inner class GetByIdTest {
+        @Test
+        fun `존재하지 않는 ID이면 TeamScheduleNotFoundException을 던진다`() {
+            // given
+            val scheduleId = 999L
+            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns null
+
+            // when & then
+            assertThrows<TeamScheduleNotFoundException> {
+                service.getById(scheduleId)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("update - 팀 일정 수정")
+    inner class UpdateTest {
+        @Test
+        fun `존재하는 일정을 수정한다`() {
+            // given
+            val scheduleId = 1L
+            val startAt = LocalDateTime.now().plusDays(1)
+            val schedule = TeamSchedule.create(
+                team = mockTeam,
+                title = "연습",
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = startAt,
+            )
+            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns schedule
+
+            // when
+            val result = service.update(
+                id = scheduleId,
+                title = "정기 연습",
+                scheduleType = TeamScheduleType.PRACTICE,
+            )
+
+            // then
+            assertThat(result.title).isEqualTo("정기 연습")
+        }
+    }
+
+    @Nested
+    @DisplayName("delete - 팀 일정 삭제")
+    inner class DeleteTest {
+        @Test
+        fun `존재하는 일정을 삭제한다`() {
+            // given
+            val scheduleId = 1L
+            val startAt = LocalDateTime.now().plusDays(1)
+            val schedule = TeamSchedule.create(
+                team = mockTeam,
+                title = "연습",
+                scheduleType = TeamScheduleType.PRACTICE,
+                startAt = startAt,
+            )
+            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns schedule
+            every { teamScheduleRepository.deleteById(schedule.id) } returns Unit
+
+            // when
+            service.delete(scheduleId)
+
+            // then
+            verify(exactly = 1) { teamScheduleRepository.deleteById(schedule.id) }
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchRequestJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchRequestJpaRepository.kt
@@ -2,8 +2,11 @@ package com.nextup.infrastructure.persistence.match
 
 import com.nextup.core.domain.match.MatchRequest
 import com.nextup.core.domain.match.MatchRequestStatus
+import com.nextup.core.domain.match.SkillLevel
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDate
 
 interface MatchRequestJpaRepository : JpaRepository<MatchRequest, Long> {
     @Query("SELECT mr FROM MatchRequest mr WHERE mr.team.id = :teamId")
@@ -13,4 +16,16 @@ interface MatchRequestJpaRepository : JpaRepository<MatchRequest, Long> {
     fun findAllOpen(): List<MatchRequest>
 
     fun findByStatus(status: MatchRequestStatus): List<MatchRequest>
+
+    @Query(
+        "SELECT mr FROM MatchRequest mr WHERE mr.status = 'OPEN' " +
+            "AND (:area IS NULL OR mr.preferredLocation LIKE CONCAT('%', :area, '%')) " +
+            "AND (:date IS NULL OR mr.preferredDate = :date) " +
+            "AND (:skillLevel IS NULL OR mr.skillLevel = :skillLevel)",
+    )
+    fun findAllOpenWithFilter(
+        @Param("area") area: String?,
+        @Param("date") date: LocalDate?,
+        @Param("skillLevel") skillLevel: SkillLevel?,
+    ): List<MatchRequest>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchRequestRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/match/MatchRequestRepositoryAdapter.kt
@@ -2,9 +2,11 @@ package com.nextup.infrastructure.persistence.match
 
 import com.nextup.core.domain.match.MatchRequest
 import com.nextup.core.domain.match.MatchRequestStatus
+import com.nextup.core.domain.match.SkillLevel
 import com.nextup.core.port.repository.MatchRequestRepositoryPort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 class MatchRequestRepositoryAdapter(
@@ -19,4 +21,10 @@ class MatchRequestRepositoryAdapter(
     override fun findAllOpen(): List<MatchRequest> = jpaRepository.findAllOpen()
 
     override fun findByStatus(status: MatchRequestStatus): List<MatchRequest> = jpaRepository.findByStatus(status)
+
+    override fun findAllOpenWithFilter(
+        area: String?,
+        date: LocalDate?,
+        skillLevel: SkillLevel?,
+    ): List<MatchRequest> = jpaRepository.findAllOpenWithFilter(area, date, skillLevel)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
@@ -202,4 +202,23 @@ interface BattingRecordRepository :
     override fun findAllByPlayerIdWithGameInfo(
         @Param("playerId") playerId: Long,
     ): List<BattingRecord>
+
+    /**
+     * 선수 ID와 대회 ID로 타격 기록을 조회합니다.
+     */
+    @Query(
+        """
+        SELECT br FROM BattingRecord br
+        JOIN FETCH br.gamePlayer gp
+        JOIN FETCH gp.gameTeam gt
+        JOIN FETCH gt.game g
+        WHERE gp.player.id = :playerId
+        AND g.competition.id = :competitionId
+        ORDER BY g.scheduledAt DESC
+    """,
+    )
+    override fun findAllByPlayerIdAndCompetitionId(
+        @Param("playerId") playerId: Long,
+        @Param("competitionId") competitionId: Long,
+    ): List<BattingRecord>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/CorrectionRequestRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/CorrectionRequestRepository.kt
@@ -1,0 +1,18 @@
+package com.nextup.infrastructure.repository.game
+
+import com.nextup.core.domain.game.CorrectionRequest
+import com.nextup.core.domain.game.CorrectionRequestStatus
+import com.nextup.core.port.repository.CorrectionRequestRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CorrectionRequestRepository :
+    JpaRepository<CorrectionRequest, Long>,
+    CorrectionRequestRepositoryPort {
+    override fun findByIdOrNull(id: Long): CorrectionRequest? = findById(id).orElse(null)
+
+    override fun findByGameId(gameId: Long): List<CorrectionRequest>
+
+    override fun findByStatus(status: CorrectionRequestStatus): List<CorrectionRequest>
+
+    override fun findByRequesterUserId(requesterUserId: Long): List<CorrectionRequest>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
@@ -291,4 +291,23 @@ interface PitchingRecordRepository :
     override fun findAllByPlayerIdWithGameInfo(
         @Param("playerId") playerId: Long,
     ): List<PitchingRecord>
+
+    /**
+     * 선수 ID와 대회 ID로 투수 기록을 조회합니다.
+     */
+    @Query(
+        """
+        SELECT pr FROM PitchingRecord pr
+        JOIN FETCH pr.gamePlayer gp
+        JOIN FETCH gp.gameTeam gt
+        JOIN FETCH gt.game g
+        WHERE gp.player.id = :playerId
+        AND g.competition.id = :competitionId
+        ORDER BY g.scheduledAt DESC
+    """,
+    )
+    override fun findAllByPlayerIdAndCompetitionId(
+        @Param("playerId") playerId: Long,
+        @Param("competitionId") competitionId: Long,
+    ): List<PitchingRecord>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/notification/NotificationRepository.kt
@@ -9,6 +9,7 @@ import com.nextup.infrastructure.common.toPageable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
@@ -38,4 +39,15 @@ interface NotificationRepository :
     ): Long
 
     override fun countUnreadByUserId(userId: Long): Long = countUnreadNotificationsByUserId(userId)
+
+    @Modifying
+    @Query(
+        "UPDATE Notification n SET n.readAt = CURRENT_TIMESTAMP " +
+            "WHERE n.userId = :userId AND n.readAt IS NULL",
+    )
+    fun markAllAsReadForUser(
+        @Param("userId") userId: Long,
+    )
+
+    override fun markAllAsReadByUserId(userId: Long) = markAllAsReadForUser(userId)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/team/TeamScheduleRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/team/TeamScheduleRepository.kt
@@ -1,0 +1,29 @@
+package com.nextup.infrastructure.repository.team
+
+import com.nextup.core.domain.team.TeamSchedule
+import com.nextup.core.port.repository.TeamScheduleRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
+
+interface TeamScheduleRepository :
+    JpaRepository<TeamSchedule, Long>,
+    TeamScheduleRepositoryPort {
+    override fun findByIdOrNull(id: Long): TeamSchedule? = findById(id).orElse(null)
+
+    @Query("SELECT ts FROM TeamSchedule ts WHERE ts.team.id = :teamId ORDER BY ts.startAt")
+    override fun findByTeamId(
+        @Param("teamId") teamId: Long,
+    ): List<TeamSchedule>
+
+    @Query(
+        "SELECT ts FROM TeamSchedule ts WHERE ts.team.id = :teamId " +
+            "AND ts.startAt >= :from AND ts.startAt <= :to ORDER BY ts.startAt",
+    )
+    override fun findByTeamIdAndDateRange(
+        @Param("teamId") teamId: Long,
+        @Param("from") from: LocalDateTime,
+        @Param("to") to: LocalDateTime,
+    ): List<TeamSchedule>
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V037__create_team_schedules_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V037__create_team_schedules_table.sql
@@ -1,0 +1,17 @@
+-- M-16: 팀 일정 관리 테이블
+CREATE TABLE team_schedules (
+    id BIGSERIAL PRIMARY KEY,
+    team_id BIGINT NOT NULL REFERENCES teams(id),
+    title VARCHAR(200) NOT NULL,
+    description TEXT,
+    schedule_type VARCHAR(30) NOT NULL,
+    start_at TIMESTAMP NOT NULL,
+    end_at TIMESTAMP,
+    location VARCHAR(500),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_team_schedules_team_id ON team_schedules(team_id);
+CREATE INDEX idx_team_schedules_start_at ON team_schedules(start_at);
+CREATE INDEX idx_team_schedules_type ON team_schedules(schedule_type);

--- a/nextup-infrastructure/src/main/resources/db/migration/V038__create_correction_requests_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V038__create_correction_requests_table.sql
@@ -1,0 +1,21 @@
+-- M-17: 기록 정정 요청 승인 워크플로우 테이블
+CREATE TABLE correction_requests (
+    id BIGSERIAL PRIMARY KEY,
+    game_id BIGINT NOT NULL,
+    requester_user_id BIGINT NOT NULL,
+    correction_type VARCHAR(20) NOT NULL,
+    target_record_id BIGINT NOT NULL,
+    field_name VARCHAR(100) NOT NULL,
+    new_value VARCHAR(500) NOT NULL,
+    reason TEXT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    reviewer_user_id BIGINT,
+    review_comment TEXT,
+    reviewed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_correction_requests_game_id ON correction_requests(game_id);
+CREATE INDEX idx_correction_requests_status ON correction_requests(status);
+CREATE INDEX idx_correction_requests_requester ON correction_requests(requester_user_id);

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/correction/CorrectionRequestScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/correction/CorrectionRequestScorerController.kt
@@ -1,0 +1,60 @@
+package com.nextup.scorer.controller.correction
+
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.game.correction.CorrectionRequestService
+import com.nextup.scorer.dto.correction.CorrectionRequestResponse
+import com.nextup.scorer.dto.correction.CreateCorrectionRequestDto
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 기록 정정 요청 Controller (기록원 전용)
+ *
+ * 기록원이 기록 정정을 요청하는 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/scorer/corrections/requests")
+class CorrectionRequestScorerController(
+    private val correctionRequestService: CorrectionRequestService,
+) {
+    /**
+     * 기록 정정 요청을 생성합니다.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createCorrectionRequest(
+        @AuthenticationPrincipal userId: Long,
+        @Valid @RequestBody request: CreateCorrectionRequestDto,
+    ): ApiResponse<CorrectionRequestResponse> {
+        val correctionRequest =
+            correctionRequestService.createRequest(
+                gameId = request.gameId,
+                requesterUserId = userId,
+                correctionType = request.correctionType,
+                targetRecordId = request.targetRecordId,
+                fieldName = request.fieldName,
+                newValue = request.newValue,
+                reason = request.reason,
+            )
+        return ApiResponse.success(CorrectionRequestResponse.from(correctionRequest))
+    }
+
+    /**
+     * 경기별 정정 요청 목록을 조회합니다.
+     */
+    @GetMapping("/games/{gameId}")
+    fun getCorrectionRequestsByGame(
+        @PathVariable gameId: Long,
+    ): ApiResponse<List<CorrectionRequestResponse>> {
+        val requests = correctionRequestService.getByGameId(gameId)
+        return ApiResponse.success(requests.map { CorrectionRequestResponse.from(it) })
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/correction/CorrectionRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/correction/CorrectionRequestDto.kt
@@ -1,0 +1,66 @@
+package com.nextup.scorer.dto.correction
+
+import com.nextup.core.domain.game.CorrectionRequest
+import com.nextup.core.domain.game.CorrectionRequestStatus
+import com.nextup.core.domain.game.CorrectionType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.Instant
+
+/**
+ * 기록 정정 요청 생성 DTO (Scorer)
+ */
+data class CreateCorrectionRequestDto(
+    @field:NotNull(message = "경기 ID는 필수입니다")
+    val gameId: Long,
+    @field:NotNull(message = "정정 유형은 필수입니다")
+    val correctionType: CorrectionType,
+    @field:NotNull(message = "대상 기록 ID는 필수입니다")
+    val targetRecordId: Long,
+    @field:NotBlank(message = "정정 필드명은 필수입니다")
+    val fieldName: String,
+    @field:NotBlank(message = "정정 값은 필수입니다")
+    val newValue: String,
+    @field:NotBlank(message = "정정 사유는 필수입니다")
+    val reason: String,
+)
+
+/**
+ * 기록 정정 요청 응답 DTO (Scorer)
+ */
+data class CorrectionRequestResponse(
+    val id: Long,
+    val gameId: Long,
+    val requesterUserId: Long,
+    val correctionType: CorrectionType,
+    val targetRecordId: Long,
+    val fieldName: String,
+    val newValue: String,
+    val reason: String,
+    val status: CorrectionRequestStatus,
+    val statusDisplayName: String,
+    val reviewerUserId: Long?,
+    val reviewComment: String?,
+    val reviewedAt: Instant?,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(request: CorrectionRequest): CorrectionRequestResponse =
+            CorrectionRequestResponse(
+                id = request.id,
+                gameId = request.gameId,
+                requesterUserId = request.requesterUserId,
+                correctionType = request.correctionType,
+                targetRecordId = request.targetRecordId,
+                fieldName = request.fieldName,
+                newValue = request.newValue,
+                reason = request.reason,
+                status = request.status,
+                statusDisplayName = request.status.displayName,
+                reviewerUserId = request.reviewerUserId,
+                reviewComment = request.reviewComment,
+                reviewedAt = request.reviewedAt,
+                createdAt = request.createdAt,
+            )
+    }
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/correction/CorrectionRequestScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/correction/CorrectionRequestScorerControllerTest.kt
@@ -1,0 +1,172 @@
+package com.nextup.scorer.controller.correction
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.core.domain.game.CorrectionRequest
+import com.nextup.core.domain.game.CorrectionRequestStatus
+import com.nextup.core.domain.game.CorrectionType
+import com.nextup.core.service.game.correction.CorrectionRequestService
+import com.nextup.scorer.dto.correction.CreateCorrectionRequestDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+
+@DisplayName("CorrectionRequestScorerController 테스트")
+class CorrectionRequestScorerControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var correctionRequestService: CorrectionRequestService
+    private lateinit var objectMapper: ObjectMapper
+
+    private val scorerUserId = 10L
+    private val mockRequest = mockk<CorrectionRequest>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        correctionRequestService = mockk()
+        objectMapper =
+            jacksonObjectMapper().registerModule(JavaTimeModule())
+
+        // @AuthenticationPrincipal userId: Long 을 위한 보안 컨텍스트 설정
+        val authentication =
+            UsernamePasswordAuthenticationToken(
+                scorerUserId,
+                null,
+                emptyList(),
+            )
+        SecurityContextHolder.getContext().authentication = authentication
+
+        val controller =
+            CorrectionRequestScorerController(correctionRequestService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(
+                    AuthenticationPrincipalArgumentResolver(),
+                )
+                .build()
+
+        every { mockRequest.id } returns 1L
+        every { mockRequest.gameId } returns 100L
+        every { mockRequest.requesterUserId } returns scorerUserId
+        every { mockRequest.correctionType } returns CorrectionType.BATTING
+        every { mockRequest.targetRecordId } returns 50L
+        every { mockRequest.fieldName } returns "hits"
+        every { mockRequest.newValue } returns "3"
+        every { mockRequest.reason } returns "안타 수 오기록"
+        every { mockRequest.status } returns CorrectionRequestStatus.PENDING
+        every { mockRequest.reviewerUserId } returns null
+        every { mockRequest.reviewComment } returns null
+        every { mockRequest.reviewedAt } returns null
+        every { mockRequest.createdAt } returns Instant.now()
+        every { mockRequest.updatedAt } returns Instant.now()
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/corrections/requests")
+    inner class CreateCorrectionRequest {
+        @Test
+        fun `should create correction request successfully`() {
+            // given
+            val dto =
+                CreateCorrectionRequestDto(
+                    gameId = 100L,
+                    correctionType = CorrectionType.BATTING,
+                    targetRecordId = 50L,
+                    fieldName = "hits",
+                    newValue = "3",
+                    reason = "안타 수 오기록",
+                )
+
+            every {
+                correctionRequestService.createRequest(
+                    gameId = 100L,
+                    requesterUserId = scorerUserId,
+                    correctionType = CorrectionType.BATTING,
+                    targetRecordId = 50L,
+                    fieldName = "hits",
+                    newValue = "3",
+                    reason = "안타 수 오기록",
+                )
+            } returns mockRequest
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/scorer/corrections/requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)),
+                )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.gameId").value(100))
+                .andExpect(jsonPath("$.data.correctionType").value("BATTING"))
+                .andExpect(jsonPath("$.data.fieldName").value("hits"))
+                .andExpect(jsonPath("$.data.newValue").value("3"))
+                .andExpect(jsonPath("$.data.status").value("PENDING"))
+                .andExpect(jsonPath("$.data.statusDisplayName").value("대기"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/scorer/corrections/requests/games/{gameId}")
+    inner class GetCorrectionRequestsByGame {
+        @Test
+        fun `should return correction requests for game`() {
+            // given
+            val gameId = 100L
+            every {
+                correctionRequestService.getByGameId(gameId)
+            } returns listOf(mockRequest)
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/scorer/corrections/requests/games/$gameId"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].gameId").value(100))
+                .andExpect(jsonPath("$.data[0].reason").value("안타 수 오기록"))
+
+            verify { correctionRequestService.getByGameId(gameId) }
+        }
+
+        @Test
+        fun `should return empty list when no requests for game`() {
+            // given
+            val gameId = 999L
+            every {
+                correctionRequestService.getByGameId(gameId)
+            } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(
+                    get("/api/scorer/corrections/requests/games/$gameId"),
+                )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #346

M-13부터 M-19까지 7개 API 추가 기능을 구현합니다.

## Tasks

- **M-13**: 대회 목록 조회에 `status` 필터 파라미터 추가 (CompetitionController)
- **M-14**: 알림 일괄 읽음 처리 API 추가 (`PATCH /api/v1/notifications/read-all`)
- **M-15**: 매칭 요청 조회에 `area`/`date`/`skillLevel` 필터 추가 (MatchRequestController)
- **M-16**: 팀 일정(TeamSchedule) CRUD API 신규 구현 (Entity, Service, Repository, Controller, Migration)
- **M-17**: 기록 정정 요청 승인 워크플로우 구현 (scorer에서 요청 생성, backoffice에서 승인/반려)
- **M-18**: 라인업 상세 조회 API 추가 (`GET /api/v1/lineups/games/{gameId}/detail`, 선수 상세 정보 포함)
- **M-19**: 대회별 선수 통계 조회 API 추가 (`GET /api/v1/stats/batting/competition`, `GET /api/v1/stats/pitching/competition`)

## To Reviewer

### 신규 Entity (2개)
- `TeamSchedule`: 팀 일정 관리 (연습, 회의, 이벤트 등)
- `CorrectionRequest`: 기록 정정 요청 승인 워크플로우 (PENDING -> APPROVED/REJECTED)

### DB Migration
- `V037`: `team_schedules` 테이블 생성
- `V038`: `correction_requests` 테이블 생성

### 모듈별 변경사항
- **nextup-api**: CompetitionController, NotificationController, MatchRequestController, LineupController, PlayerStatsController 수정 + TeamScheduleController 신규
- **nextup-backoffice**: CorrectionRequestAdminController 신규 (관리자 승인/반려)
- **nextup-scorer**: CorrectionRequestScorerController 신규 (기록원 정정 요청)
- **nextup-core**: TeamSchedule, CorrectionRequest Entity + Service + RepositoryPort + DTO
- **nextup-infrastructure**: Repository 구현체 + Migration SQL
- **nextup-common**: TeamScheduleNotFoundException, CorrectionRequestNotFoundException 추가