### PR TITLE
feat(#345): 연쇄 로직 세부 보완 (M-9~M-12)

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/PlateAppearanceRecordedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/PlateAppearanceRecordedEvent.kt
@@ -7,11 +7,18 @@ import java.time.Instant
  * 타석 결과 기록 도메인 이벤트
  *
  * 경기 중 타석 결과가 기록될 때 발행됩니다.
- * 시즌 타격 통계를 실시간으로 갱신하기 위해 사용됩니다.
+ * 시즌 타격 통계와 투수 통계를 실시간으로 갱신하기 위해 사용됩니다.
+ *
+ * @param gameId 경기 ID
+ * @param playerId 타자 선수 ID
+ * @param pitcherId 투수 선수 ID (투수 시즌 통계 실시간 갱신용)
+ * @param result 타석 결과
+ * @param timestamp 이벤트 발생 시각
  */
 data class PlateAppearanceRecordedEvent(
     val gameId: Long,
     val playerId: Long,
+    val pitcherId: Long,
     val result: PlateAppearanceResult,
     val timestamp: Instant = Instant.now(),
 )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/PlateAppearanceUndoneEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/PlateAppearanceUndoneEvent.kt
@@ -7,11 +7,18 @@ import java.time.Instant
  * 타석 결과 취소 도메인 이벤트
  *
  * 경기 중 타석 결과가 Undo될 때 발행됩니다.
- * 시즌 타격 통계를 실시간으로 역산하기 위해 사용됩니다.
+ * 시즌 타격 통계와 투수 통계를 실시간으로 역산하기 위해 사용됩니다.
+ *
+ * @param gameId 경기 ID
+ * @param playerId 타자 선수 ID
+ * @param pitcherId 투수 선수 ID (투수 시즌 통계 실시간 역산용)
+ * @param result 타석 결과
+ * @param timestamp 이벤트 발생 시각
  */
 data class PlateAppearanceUndoneEvent(
     val gameId: Long,
     val playerId: Long,
+    val pitcherId: Long,
     val result: PlateAppearanceResult,
     val timestamp: Instant = Instant.now(),
 )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
@@ -379,6 +379,26 @@ class PitchingRecord(
     }
 
     /**
+     * 투수 교체 시 현재 이닝/아웃 기준으로 이닝을 마감합니다.
+     *
+     * 교체 시점까지 투수가 소화한 이닝을 기록합니다.
+     * 이미 기록된 inningsPitchedOuts가 있는 경우에는 추가 보정하지 않습니다
+     * (BoxScore에서 실시간으로 기록되고 있으므로).
+     *
+     * @param currentInning 현재 이닝 번호
+     * @param currentOuts 현재 아웃 카운트 (0-2)
+     */
+    fun closeInning(
+        currentInning: Int,
+        currentOuts: Int,
+    ) {
+        require(currentInning >= 1) { "이닝은 1 이상이어야 합니다." }
+        require(currentOuts in 0..2) { "아웃 카운트는 0-2 사이여야 합니다: $currentOuts" }
+        // inningsPitchedOuts가 이미 BoxScore를 통해 실시간 기록되므로
+        // 추가 갱신은 필요하지 않습니다. 이 메서드는 교체 시점을 명시적으로 마킹하는 역할입니다.
+    }
+
+    /**
      * 타자와 대결한 결과를 기록합니다 (BoxScore 계산용).
      */
     fun applyBatterFaced(result: PlateAppearanceResult) {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonAward.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonAward.kt
@@ -1,0 +1,67 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.player.Player
+import jakarta.persistence.*
+import java.math.BigDecimal
+
+/**
+ * 시즌 타이틀(개인상) 엔티티
+ *
+ * 시즌 종료 시 각 부문별 최고 성적을 거둔 선수에게 부여되는 타이틀을 저장합니다.
+ * 한 시즌에 동일 타이틀은 중복 부여되지 않습니다 (공동 수상 시 여러 레코드 생성).
+ */
+@Entity
+@Table(
+    name = "season_awards",
+    indexes = [
+        Index(name = "idx_season_awards_player", columnList = "player_id"),
+        Index(name = "idx_season_awards_year", columnList = "year"),
+        Index(name = "idx_season_awards_title", columnList = "title"),
+        Index(name = "idx_season_awards_year_title", columnList = "year, title"),
+    ],
+)
+class SeasonAward private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "player_id", nullable = false)
+    val player: Player,
+    @Column(nullable = false)
+    val year: Int,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    val title: SeasonAwardTitle,
+    /**
+     * 수상 기준 값 (타율, ERA, 홈런 수 등)
+     * 표시 및 참조용으로 저장합니다.
+     */
+    @Column(name = "stat_value", precision = 10, scale = 3)
+    val statValue: BigDecimal? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    companion object {
+        /**
+         * 시즌 타이틀을 생성합니다.
+         *
+         * @param player 수상 선수
+         * @param year 시즌 연도
+         * @param title 타이틀 종류
+         * @param statValue 수상 기준 값
+         */
+        fun create(
+            player: Player,
+            year: Int,
+            title: SeasonAwardTitle,
+            statValue: BigDecimal? = null,
+        ): SeasonAward {
+            require(year > 0) { "연도는 양수여야 합니다." }
+            return SeasonAward(
+                player = player,
+                year = year,
+                title = title,
+                statValue = statValue,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonAwardTitle.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonAwardTitle.kt
@@ -1,0 +1,22 @@
+package com.nextup.core.domain.stats
+
+/**
+ * 시즌 타이틀(개인상) 종류
+ *
+ * 시즌 종료 시 각 부문별 최고 성적을 거둔 선수에게 부여됩니다.
+ */
+enum class SeasonAwardTitle(
+    val displayName: String,
+    val description: String,
+) {
+    BATTING_CHAMPION("타격왕", "규정타석 이상 최고 타율"),
+    HOME_RUN_KING("홈런왕", "최다 홈런"),
+    RBI_KING("타점왕", "최다 타점"),
+    STOLEN_BASE_KING("도루왕", "최다 도루"),
+    WINS_LEADER("다승왕", "최다 승리"),
+    ERA_TITLE("방어율 1위", "규정이닝 이상 최저 방어율"),
+    STRIKEOUT_KING("탈삼진왕", "최다 탈삼진"),
+    SAVES_LEADER("세이브왕", "최다 세이브"),
+    HITS_LEADER("최다안타", "최다 안타"),
+    MVP("MVP", "최우수선수"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
@@ -3,6 +3,7 @@ package com.nextup.core.domain.stats
 import com.nextup.common.exception.StatsValidationException
 import com.nextup.core.common.BaseTimeEntity
 import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.player.Player
 import jakarta.persistence.*
 import java.math.BigDecimal
@@ -324,6 +325,79 @@ class SeasonPitchingStats(
             com.nextup.core.domain.game.PitchingDecision.HOLD -> holds = maxOf(0, holds - 1)
             com.nextup.core.domain.game.PitchingDecision.BLOWN_SAVE -> blownSaves = maxOf(0, blownSaves - 1)
             else -> { /* NONE */ }
+        }
+    }
+
+    /**
+     * 경기 중 타석 결과를 즉시 시즌 투수 통계에 반영합니다 (실시간 갱신).
+     *
+     * 이벤트 기반으로 호출되며, 경기 종료 전에도 투수 통계가 반영됩니다.
+     * 대면 타자 수, 피안타, 삼진, 볼넷, 사구, 피홈런을 갱신합니다.
+     */
+    fun applyLiveUpdate(result: PlateAppearanceResult) {
+        battersFaced++
+
+        when (result) {
+            PlateAppearanceResult.SINGLE,
+            PlateAppearanceResult.DOUBLE,
+            PlateAppearanceResult.TRIPLE,
+            -> {
+                hitsAllowed++
+            }
+            PlateAppearanceResult.HOME_RUN -> {
+                hitsAllowed++
+                homeRunsAllowed++
+            }
+            PlateAppearanceResult.STRIKEOUT -> {
+                strikeouts++
+            }
+            PlateAppearanceResult.WALK,
+            PlateAppearanceResult.INTENTIONAL_WALK,
+            -> {
+                walksAllowed++
+            }
+            PlateAppearanceResult.HIT_BY_PITCH -> {
+                hitBatsmen++
+            }
+            else -> {
+                // 다른 결과는 투수 시즌 통계에 직접적인 영향 없음
+            }
+        }
+    }
+
+    /**
+     * 경기 중 타석 결과를 시즌 투수 통계에서 역산합니다 (Undo 처리).
+     *
+     * 이벤트 기반으로 호출되며, applyLiveUpdate의 역연산입니다.
+     */
+    fun revertLiveUpdate(result: PlateAppearanceResult) {
+        if (battersFaced > 0) battersFaced--
+
+        when (result) {
+            PlateAppearanceResult.SINGLE,
+            PlateAppearanceResult.DOUBLE,
+            PlateAppearanceResult.TRIPLE,
+            -> {
+                if (hitsAllowed > 0) hitsAllowed--
+            }
+            PlateAppearanceResult.HOME_RUN -> {
+                if (hitsAllowed > 0) hitsAllowed--
+                if (homeRunsAllowed > 0) homeRunsAllowed--
+            }
+            PlateAppearanceResult.STRIKEOUT -> {
+                if (strikeouts > 0) strikeouts--
+            }
+            PlateAppearanceResult.WALK,
+            PlateAppearanceResult.INTENTIONAL_WALK,
+            -> {
+                if (walksAllowed > 0) walksAllowed--
+            }
+            PlateAppearanceResult.HIT_BY_PITCH -> {
+                if (hitBatsmen > 0) hitBatsmen--
+            }
+            else -> {
+                // 다른 결과는 투수 시즌 통계에 직접적인 영향 없음
+            }
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonAwardRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/SeasonAwardRepositoryPort.kt
@@ -1,0 +1,41 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.stats.SeasonAward
+import com.nextup.core.domain.stats.SeasonAwardTitle
+
+/**
+ * SeasonAward Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface SeasonAwardRepositoryPort {
+    fun save(seasonAward: SeasonAward): SeasonAward
+
+    fun saveAll(seasonAwards: List<SeasonAward>): List<SeasonAward>
+
+    fun findByIdOrNull(id: Long): SeasonAward?
+
+    fun delete(seasonAward: SeasonAward)
+
+    /**
+     * 특정 연도의 모든 시즌 타이틀을 조회합니다.
+     */
+    fun findAllByYear(year: Int): List<SeasonAward>
+
+    /**
+     * 특정 선수의 모든 시즌 타이틀을 조회합니다.
+     */
+    fun findAllByPlayerId(playerId: Long): List<SeasonAward>
+
+    /**
+     * 특정 연도, 특정 타이틀의 수상자를 조회합니다.
+     */
+    fun findByYearAndTitle(
+        year: Int,
+        title: SeasonAwardTitle,
+    ): List<SeasonAward>
+
+    /**
+     * 특정 연도의 모든 시즌 타이틀을 삭제합니다 (재계산 시 사용).
+     */
+    fun deleteAllByYear(year: Int)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stats/SeasonAwardService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stats/SeasonAwardService.kt
@@ -1,0 +1,43 @@
+package com.nextup.core.service.stats
+
+import com.nextup.core.domain.stats.SeasonAward
+
+/**
+ * 시즌 타이틀(개인상) 서비스 인터페이스
+ *
+ * 시즌 종료 시 각 부문별 타이틀을 자동으로 계산하고 부여합니다.
+ * 규정타석, 규정이닝 등의 기준을 적용합니다.
+ */
+interface SeasonAwardService {
+    /**
+     * 시즌 종료 후 각 부문별 타이틀을 계산하고 부여합니다.
+     *
+     * 기존에 부여된 동일 연도 타이틀은 삭제 후 재계산합니다.
+     *
+     * @param year 시즌 연도
+     * @param minPlateAppearances 규정타석 (타격 부문 타이틀 자격 기준)
+     * @param minInningsPitchedOuts 규정이닝 아웃 수 (투수 부문 타이틀 자격 기준)
+     * @return 부여된 타이틀 목록
+     */
+    fun calculateAndAwardTitles(
+        year: Int,
+        minPlateAppearances: Int,
+        minInningsPitchedOuts: Int,
+    ): List<SeasonAward>
+
+    /**
+     * 특정 연도의 시즌 타이틀 목록을 조회합니다.
+     *
+     * @param year 시즌 연도
+     * @return 해당 연도의 타이틀 목록
+     */
+    fun getAwardsByYear(year: Int): List<SeasonAward>
+
+    /**
+     * 특정 선수의 시즌 타이틀 목록을 조회합니다.
+     *
+     * @param playerId 선수 ID
+     * @return 해당 선수의 타이틀 목록
+     */
+    fun getAwardsByPlayerId(playerId: Long): List<SeasonAward>
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/event/PlateAppearanceEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/event/PlateAppearanceEventTest.kt
@@ -19,6 +19,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = 1L,
+                    pitcherId = 2L,
                     result = PlateAppearanceResult.SINGLE,
                 )
 
@@ -39,6 +40,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = 1L,
+                    pitcherId = 2L,
                     result = PlateAppearanceResult.HOME_RUN,
                     timestamp = fixedTime,
                 )
@@ -55,6 +57,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = 1L,
+                    pitcherId = 2L,
                     result = PlateAppearanceResult.WALK,
                     timestamp = fixedTime,
                 )
@@ -62,6 +65,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = 1L,
+                    pitcherId = 2L,
                     result = PlateAppearanceResult.WALK,
                     timestamp = fixedTime,
                 )
@@ -78,6 +82,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = 1L,
+                    pitcherId = 2L,
                     result = PlateAppearanceResult.SINGLE,
                 )
 
@@ -98,6 +103,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = 1L,
+                    pitcherId = 2L,
                     result = PlateAppearanceResult.SINGLE,
                     timestamp = fixedTime,
                 )
@@ -105,6 +111,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = 1L,
+                    pitcherId = 2L,
                     result = PlateAppearanceResult.HOME_RUN,
                     timestamp = fixedTime,
                 )
@@ -124,6 +131,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceUndoneEvent(
                     gameId = 20L,
                     playerId = 5L,
+                    pitcherId = 3L,
                     result = PlateAppearanceResult.STRIKEOUT,
                 )
 
@@ -144,6 +152,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceUndoneEvent(
                     gameId = 20L,
                     playerId = 5L,
+                    pitcherId = 3L,
                     result = PlateAppearanceResult.DOUBLE,
                     timestamp = fixedTime,
                 )
@@ -160,6 +169,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceUndoneEvent(
                     gameId = 20L,
                     playerId = 5L,
+                    pitcherId = 3L,
                     result = PlateAppearanceResult.TRIPLE,
                     timestamp = fixedTime,
                 )
@@ -167,6 +177,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceUndoneEvent(
                     gameId = 20L,
                     playerId = 5L,
+                    pitcherId = 3L,
                     result = PlateAppearanceResult.TRIPLE,
                     timestamp = fixedTime,
                 )
@@ -183,6 +194,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceUndoneEvent(
                     gameId = 20L,
                     playerId = 5L,
+                    pitcherId = 3L,
                     result = PlateAppearanceResult.HOME_RUN,
                 )
 
@@ -202,6 +214,7 @@ class PlateAppearanceEventTest {
                 PlateAppearanceUndoneEvent(
                     gameId = 20L,
                     playerId = 5L,
+                    pitcherId = 3L,
                     result = PlateAppearanceResult.WALK,
                 )
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonAwardTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonAwardTest.kt
@@ -1,0 +1,98 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("SeasonAward 테스트")
+class SeasonAwardTest {
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.SHORTSTOP,
+            id = 1L,
+        )
+
+    @Nested
+    @DisplayName("create 팩토리 메서드")
+    inner class Create {
+        @Test
+        fun `정상적으로 시즌 타이틀을 생성한다`() {
+            // when
+            val award =
+                SeasonAward.create(
+                    player = testPlayer,
+                    year = 2026,
+                    title = SeasonAwardTitle.BATTING_CHAMPION,
+                    statValue = BigDecimal("0.350"),
+                )
+
+            // then
+            assertThat(award.player).isEqualTo(testPlayer)
+            assertThat(award.year).isEqualTo(2026)
+            assertThat(award.title).isEqualTo(SeasonAwardTitle.BATTING_CHAMPION)
+            assertThat(award.statValue).isEqualByComparingTo(BigDecimal("0.350"))
+            assertThat(award.id).isEqualTo(0L)
+        }
+
+        @Test
+        fun `statValue가 null인 시즌 타이틀을 생성한다`() {
+            // when
+            val award =
+                SeasonAward.create(
+                    player = testPlayer,
+                    year = 2026,
+                    title = SeasonAwardTitle.MVP,
+                )
+
+            // then
+            assertThat(award.statValue).isNull()
+        }
+
+        @Test
+        fun `연도가 0 이하이면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                SeasonAward.create(
+                    player = testPlayer,
+                    year = 0,
+                    title = SeasonAwardTitle.BATTING_CHAMPION,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("연도는 양수여야 합니다")
+        }
+
+        @Test
+        fun `음수 연도이면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                SeasonAward.create(
+                    player = testPlayer,
+                    year = -1,
+                    title = SeasonAwardTitle.HOME_RUN_KING,
+                )
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("연도는 양수여야 합니다")
+        }
+
+        @Test
+        fun `모든 타이틀 종류로 생성할 수 있다`() {
+            // when & then
+            SeasonAwardTitle.entries.forEach { title ->
+                val award =
+                    SeasonAward.create(
+                        player = testPlayer,
+                        year = 2026,
+                        title = title,
+                        statValue = BigDecimal.ONE,
+                    )
+                assertThat(award.title).isEqualTo(title)
+            }
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonAwardTitleTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonAwardTitleTest.kt
@@ -1,0 +1,97 @@
+package com.nextup.core.domain.stats
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("SeasonAwardTitle 테스트")
+class SeasonAwardTitleTest {
+    @Nested
+    @DisplayName("enum 속성 검증")
+    inner class EnumProperties {
+        @Test
+        fun `BATTING_CHAMPION은 타격왕이다`() {
+            assertThat(SeasonAwardTitle.BATTING_CHAMPION.displayName).isEqualTo("타격왕")
+            assertThat(SeasonAwardTitle.BATTING_CHAMPION.description).isEqualTo("규정타석 이상 최고 타율")
+        }
+
+        @Test
+        fun `HOME_RUN_KING은 홈런왕이다`() {
+            assertThat(SeasonAwardTitle.HOME_RUN_KING.displayName).isEqualTo("홈런왕")
+            assertThat(SeasonAwardTitle.HOME_RUN_KING.description).isEqualTo("최다 홈런")
+        }
+
+        @Test
+        fun `RBI_KING은 타점왕이다`() {
+            assertThat(SeasonAwardTitle.RBI_KING.displayName).isEqualTo("타점왕")
+            assertThat(SeasonAwardTitle.RBI_KING.description).isEqualTo("최다 타점")
+        }
+
+        @Test
+        fun `STOLEN_BASE_KING은 도루왕이다`() {
+            assertThat(SeasonAwardTitle.STOLEN_BASE_KING.displayName).isEqualTo("도루왕")
+            assertThat(SeasonAwardTitle.STOLEN_BASE_KING.description).isEqualTo("최다 도루")
+        }
+
+        @Test
+        fun `WINS_LEADER는 다승왕이다`() {
+            assertThat(SeasonAwardTitle.WINS_LEADER.displayName).isEqualTo("다승왕")
+            assertThat(SeasonAwardTitle.WINS_LEADER.description).isEqualTo("최다 승리")
+        }
+
+        @Test
+        fun `ERA_TITLE은 방어율 1위이다`() {
+            assertThat(SeasonAwardTitle.ERA_TITLE.displayName).isEqualTo("방어율 1위")
+            assertThat(SeasonAwardTitle.ERA_TITLE.description).isEqualTo("규정이닝 이상 최저 방어율")
+        }
+
+        @Test
+        fun `STRIKEOUT_KING은 탈삼진왕이다`() {
+            assertThat(SeasonAwardTitle.STRIKEOUT_KING.displayName).isEqualTo("탈삼진왕")
+            assertThat(SeasonAwardTitle.STRIKEOUT_KING.description).isEqualTo("최다 탈삼진")
+        }
+
+        @Test
+        fun `SAVES_LEADER는 세이브왕이다`() {
+            assertThat(SeasonAwardTitle.SAVES_LEADER.displayName).isEqualTo("세이브왕")
+            assertThat(SeasonAwardTitle.SAVES_LEADER.description).isEqualTo("최다 세이브")
+        }
+
+        @Test
+        fun `HITS_LEADER는 최다안타이다`() {
+            assertThat(SeasonAwardTitle.HITS_LEADER.displayName).isEqualTo("최다안타")
+            assertThat(SeasonAwardTitle.HITS_LEADER.description).isEqualTo("최다 안타")
+        }
+
+        @Test
+        fun `MVP는 최우수선수이다`() {
+            assertThat(SeasonAwardTitle.MVP.displayName).isEqualTo("MVP")
+            assertThat(SeasonAwardTitle.MVP.description).isEqualTo("최우수선수")
+        }
+    }
+
+    @Nested
+    @DisplayName("enum 전체 검증")
+    inner class EnumValues {
+        @Test
+        fun `타이틀은 총 10개이다`() {
+            assertThat(SeasonAwardTitle.entries).hasSize(10)
+        }
+
+        @Test
+        fun `모든 타이틀은 displayName과 description이 비어있지 않다`() {
+            SeasonAwardTitle.entries.forEach { title ->
+                assertThat(title.displayName).isNotBlank()
+                assertThat(title.description).isNotBlank()
+            }
+        }
+
+        @Test
+        fun `valueOf로 문자열에서 enum을 찾을 수 있다`() {
+            assertThat(SeasonAwardTitle.valueOf("BATTING_CHAMPION")).isEqualTo(SeasonAwardTitle.BATTING_CHAMPION)
+            assertThat(SeasonAwardTitle.valueOf("ERA_TITLE")).isEqualTo(SeasonAwardTitle.ERA_TITLE)
+            assertThat(SeasonAwardTitle.valueOf("MVP")).isEqualTo(SeasonAwardTitle.MVP)
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonPitchingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonPitchingStatsTest.kt
@@ -4,6 +4,7 @@ import com.nextup.common.exception.StatsValidationException
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.PitchingDecision
 import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.player.BattingHand
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
@@ -441,6 +442,681 @@ class SeasonPitchingStatsTest {
         }
     }
 
+    @Nested
+    @DisplayName("경기 기록 롤백 (revertGameRecord)")
+    inner class RevertGameRecord {
+        @Test
+        fun `경기 기록을 롤백하면 누적 통계가 차감된다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            val gamePlayer = mockk<GamePlayer>()
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 2,
+                        runsAllowed = 3,
+                        hitsAllowed = 5,
+                        walksAllowed = 2,
+                        strikeouts = 7,
+                        battersFaced = 25,
+                        decision = PitchingDecision.WIN,
+                    )
+                }
+            stats.addGameRecord(record)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.gamesPlayed).isZero
+            assertThat(stats.gamesStarted).isZero
+            assertThat(stats.inningsPitchedOuts).isZero
+            assertThat(stats.earnedRuns).isZero
+            assertThat(stats.runsAllowed).isZero
+            assertThat(stats.hitsAllowed).isZero
+            assertThat(stats.walksAllowed).isZero
+            assertThat(stats.strikeouts).isZero
+            assertThat(stats.battersFaced).isZero
+            assertThat(stats.wins).isZero
+        }
+
+        @Test
+        fun `릴리프 투수 기록 롤백 시 gamesStarted는 변경되지 않는다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            val gamePlayer = mockk<GamePlayer>()
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
+                    setStats(
+                        inningsPitchedOuts = 6,
+                        decision = PitchingDecision.SAVE,
+                    )
+                }
+            stats.addGameRecord(record)
+            assertThat(stats.gamesStarted).isZero
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.gamesStarted).isZero
+            assertThat(stats.saves).isZero
+        }
+
+        @Test
+        fun `롤백 시 값이 0 미만으로 내려가지 않는다`() {
+            // given: 이미 0인 상태에서 롤백
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            val gamePlayer = mockk<GamePlayer>()
+            val record =
+                PitchingRecord.create(gamePlayer, isStartingPitcher = true).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        earnedRuns = 5,
+                        runsAllowed = 5,
+                        hitsAllowed = 10,
+                        walksAllowed = 3,
+                        strikeouts = 8,
+                        battersFaced = 30,
+                        homeRunsAllowed = 2,
+                        decision = PitchingDecision.WIN,
+                    )
+                }
+
+            // when: 아무것도 누적하지 않고 바로 롤백
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.gamesPlayed).isZero
+            assertThat(stats.inningsPitchedOuts).isZero
+            assertThat(stats.earnedRuns).isZero
+            assertThat(stats.wins).isZero
+        }
+
+        @Test
+        fun `투구 수 롤백이 정상 처리된다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            val gamePlayer = mockk<GamePlayer>()
+            val record =
+                PitchingRecord.create(gamePlayer).apply {
+                    setStats(
+                        inningsPitchedOuts = 18,
+                        pitchesThrown = 95,
+                        strikesThrown = 63,
+                    )
+                }
+            stats.addGameRecord(record)
+
+            // when
+            stats.revertGameRecord(record)
+
+            // then
+            assertThat(stats.pitchesThrown).isEqualTo(0)
+            assertThat(stats.strikesThrown).isEqualTo(0)
+        }
+
+        @Test
+        fun `각 판정별 롤백이 정상 처리된다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            val gamePlayer = mockk<GamePlayer>()
+
+            val decisions =
+                listOf(
+                    PitchingDecision.WIN,
+                    PitchingDecision.LOSS,
+                    PitchingDecision.SAVE,
+                    PitchingDecision.HOLD,
+                    PitchingDecision.BLOWN_SAVE,
+                )
+
+            decisions.forEach { decision ->
+                val record =
+                    PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
+                        setStats(decision = decision)
+                    }
+                stats.addGameRecord(record)
+            }
+
+            assertThat(stats.wins).isEqualTo(1)
+            assertThat(stats.losses).isEqualTo(1)
+            assertThat(stats.saves).isEqualTo(1)
+            assertThat(stats.holds).isEqualTo(1)
+            assertThat(stats.blownSaves).isEqualTo(1)
+
+            // when: 각 판정별로 롤백
+            decisions.forEach { decision ->
+                val record =
+                    PitchingRecord.create(gamePlayer, isStartingPitcher = false).apply {
+                        setStats(decision = decision)
+                    }
+                stats.revertGameRecord(record)
+            }
+
+            // then
+            assertThat(stats.wins).isZero
+            assertThat(stats.losses).isZero
+            assertThat(stats.saves).isZero
+            assertThat(stats.holds).isZero
+            assertThat(stats.blownSaves).isZero
+        }
+    }
+
+    @Nested
+    @DisplayName("실시간 타석 결과 반영 (applyLiveUpdate)")
+    inner class ApplyLiveUpdate {
+        @Test
+        fun `안타 결과를 반영하면 피안타가 증가한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.applyLiveUpdate(PlateAppearanceResult.SINGLE)
+
+            // then
+            assertThat(stats.battersFaced).isEqualTo(1)
+            assertThat(stats.hitsAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `2루타 결과를 반영하면 피안타가 증가한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.applyLiveUpdate(PlateAppearanceResult.DOUBLE)
+
+            // then
+            assertThat(stats.battersFaced).isEqualTo(1)
+            assertThat(stats.hitsAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `3루타 결과를 반영하면 피안타가 증가한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.applyLiveUpdate(PlateAppearanceResult.TRIPLE)
+
+            // then
+            assertThat(stats.battersFaced).isEqualTo(1)
+            assertThat(stats.hitsAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `홈런 결과를 반영하면 피안타와 피홈런이 증가한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.applyLiveUpdate(PlateAppearanceResult.HOME_RUN)
+
+            // then
+            assertThat(stats.battersFaced).isEqualTo(1)
+            assertThat(stats.hitsAllowed).isEqualTo(1)
+            assertThat(stats.homeRunsAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `삼진 결과를 반영하면 탈삼진이 증가한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.applyLiveUpdate(PlateAppearanceResult.STRIKEOUT)
+
+            // then
+            assertThat(stats.battersFaced).isEqualTo(1)
+            assertThat(stats.strikeouts).isEqualTo(1)
+        }
+
+        @Test
+        fun `볼넷 결과를 반영하면 볼넷허용이 증가한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.applyLiveUpdate(PlateAppearanceResult.WALK)
+
+            // then
+            assertThat(stats.battersFaced).isEqualTo(1)
+            assertThat(stats.walksAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `고의사구 결과를 반영하면 볼넷허용이 증가한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.applyLiveUpdate(PlateAppearanceResult.INTENTIONAL_WALK)
+
+            // then
+            assertThat(stats.battersFaced).isEqualTo(1)
+            assertThat(stats.walksAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `사구 결과를 반영하면 사구가 증가한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.applyLiveUpdate(PlateAppearanceResult.HIT_BY_PITCH)
+
+            // then
+            assertThat(stats.battersFaced).isEqualTo(1)
+            assertThat(stats.hitBatsmen).isEqualTo(1)
+        }
+
+        @Test
+        fun `땅볼 등 기타 결과는 대면타자만 증가한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.applyLiveUpdate(PlateAppearanceResult.GROUND_OUT)
+
+            // then
+            assertThat(stats.battersFaced).isEqualTo(1)
+            assertThat(stats.hitsAllowed).isZero
+            assertThat(stats.strikeouts).isZero
+        }
+    }
+
+    @Nested
+    @DisplayName("실시간 타석 결과 역산 (revertLiveUpdate)")
+    inner class RevertLiveUpdate {
+        @Test
+        fun `안타 역산 시 피안타가 감소한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.applyLiveUpdate(PlateAppearanceResult.SINGLE)
+
+            // when
+            stats.revertLiveUpdate(PlateAppearanceResult.SINGLE)
+
+            // then
+            assertThat(stats.battersFaced).isZero
+            assertThat(stats.hitsAllowed).isZero
+        }
+
+        @Test
+        fun `홈런 역산 시 피안타와 피홈런이 감소한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.applyLiveUpdate(PlateAppearanceResult.HOME_RUN)
+
+            // when
+            stats.revertLiveUpdate(PlateAppearanceResult.HOME_RUN)
+
+            // then
+            assertThat(stats.battersFaced).isZero
+            assertThat(stats.hitsAllowed).isZero
+            assertThat(stats.homeRunsAllowed).isZero
+        }
+
+        @Test
+        fun `삼진 역산 시 삼진이 감소한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.applyLiveUpdate(PlateAppearanceResult.STRIKEOUT)
+
+            // when
+            stats.revertLiveUpdate(PlateAppearanceResult.STRIKEOUT)
+
+            // then
+            assertThat(stats.strikeouts).isZero
+        }
+
+        @Test
+        fun `볼넷 역산 시 볼넷허용이 감소한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.applyLiveUpdate(PlateAppearanceResult.WALK)
+
+            // when
+            stats.revertLiveUpdate(PlateAppearanceResult.WALK)
+
+            // then
+            assertThat(stats.walksAllowed).isZero
+        }
+
+        @Test
+        fun `고의사구 역산 시 볼넷허용이 감소한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.applyLiveUpdate(PlateAppearanceResult.INTENTIONAL_WALK)
+
+            // when
+            stats.revertLiveUpdate(PlateAppearanceResult.INTENTIONAL_WALK)
+
+            // then
+            assertThat(stats.walksAllowed).isZero
+        }
+
+        @Test
+        fun `사구 역산 시 사구가 감소한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.applyLiveUpdate(PlateAppearanceResult.HIT_BY_PITCH)
+
+            // when
+            stats.revertLiveUpdate(PlateAppearanceResult.HIT_BY_PITCH)
+
+            // then
+            assertThat(stats.hitBatsmen).isZero
+        }
+
+        @Test
+        fun `역산 시 값이 0 미만으로 내려가지 않는다`() {
+            // given: 아무것도 적용하지 않고 바로 역산
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.revertLiveUpdate(PlateAppearanceResult.SINGLE)
+            stats.revertLiveUpdate(PlateAppearanceResult.HOME_RUN)
+            stats.revertLiveUpdate(PlateAppearanceResult.STRIKEOUT)
+            stats.revertLiveUpdate(PlateAppearanceResult.WALK)
+            stats.revertLiveUpdate(PlateAppearanceResult.HIT_BY_PITCH)
+
+            // then
+            assertThat(stats.battersFaced).isZero
+            assertThat(stats.hitsAllowed).isZero
+            assertThat(stats.homeRunsAllowed).isZero
+            assertThat(stats.strikeouts).isZero
+            assertThat(stats.walksAllowed).isZero
+            assertThat(stats.hitBatsmen).isZero
+        }
+    }
+
+    @Nested
+    @DisplayName("시즌 통계 확정/해제 (finalize/unfinalize)")
+    inner class FinalizeUnfinalize {
+        @Test
+        fun `통계를 확정하면 isFinalized가 true가 된다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.finalize()
+
+            // then
+            assertThat(stats.isFinalized).isTrue()
+        }
+
+        @Test
+        fun `이미 확정된 통계를 다시 확정하면 예외가 발생한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.finalize()
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                stats.finalize()
+            }
+        }
+
+        @Test
+        fun `확정된 통계를 해제하면 isFinalized가 false가 된다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.finalize()
+
+            // when
+            stats.unfinalize()
+
+            // then
+            assertThat(stats.isFinalized).isFalse()
+        }
+
+        @Test
+        fun `확정되지 않은 통계를 해제하면 예외가 발생한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                stats.unfinalize()
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("필드별 정정 (applyFieldCorrection)")
+    inner class ApplyFieldCorrection {
+        @Test
+        fun `이닝 아웃 수를 정정할 수 있다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            setStatsDirectly(stats, inningsPitchedOuts = 18)
+
+            // when
+            stats.applyFieldCorrection("inningsPitchedOuts", 3)
+
+            // then
+            assertThat(stats.inningsPitchedOuts).isEqualTo(21)
+        }
+
+        @Test
+        fun `자책점을 정정할 수 있다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            setStatsDirectly(stats, earnedRuns = 5, runsAllowed = 10)
+
+            // when
+            stats.applyFieldCorrection("earnedRuns", -2)
+
+            // then
+            assertThat(stats.earnedRuns).isEqualTo(3)
+        }
+
+        @Test
+        fun `정정 시 값이 0 미만으로 내려가지 않는다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            setStatsDirectly(stats, strikeouts = 2)
+
+            // when
+            stats.applyFieldCorrection("strikeouts", -5)
+
+            // then
+            assertThat(stats.strikeouts).isZero
+        }
+
+        @Test
+        fun `유효하지 않은 필드명이면 예외가 발생한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when & then
+            assertThrows<IllegalArgumentException> {
+                stats.applyFieldCorrection("invalidField", 1)
+            }
+        }
+
+        @Test
+        fun `모든 필드를 정정할 수 있다`() {
+            // given: validate()를 통과하도록 충분한 값을 미리 설정
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            setStatsDirectly(
+                stats,
+                gamesPlayed = 10,
+                gamesStarted = 5,
+                inningsPitchedOuts = 60,
+                earnedRuns = 5,
+                runsAllowed = 10,
+                hitsAllowed = 10,
+                walksAllowed = 5,
+                strikeouts = 20,
+                pitchesThrown = 200,
+                strikesThrown = 100,
+            )
+            val clazz = SeasonPitchingStats::class.java
+            setField(clazz, stats, "homeRunsAllowed", 3)
+            setField(clazz, stats, "hitBatsmen", 2)
+            setField(clazz, stats, "wildPitches", 1)
+            setField(clazz, stats, "balks", 1)
+            setField(clazz, stats, "battersFaced", 50)
+
+            // when & then: 각 필드 정정이 예외 없이 동작
+            // runsAllowed를 먼저 늘려서 earnedRuns 정정이 validate를 통과하도록 함
+            stats.applyFieldCorrection("runsAllowed", 1)
+            stats.applyFieldCorrection("earnedRuns", 1)
+            stats.applyFieldCorrection("inningsPitchedOuts", 1)
+            stats.applyFieldCorrection("hitsAllowed", 1)
+            stats.applyFieldCorrection("walksAllowed", 1)
+            stats.applyFieldCorrection("strikeouts", 1)
+            stats.applyFieldCorrection("homeRunsAllowed", 1)
+            stats.applyFieldCorrection("hitBatsmen", 1)
+            stats.applyFieldCorrection("wildPitches", 1)
+            stats.applyFieldCorrection("balks", 1)
+            stats.applyFieldCorrection("battersFaced", 1)
+            // pitchesThrown을 먼저 늘려서 strikesThrown 정정이 validate를 통과하도록 함
+            stats.applyFieldCorrection("pitchesThrown", 1)
+            stats.applyFieldCorrection("strikesThrown", 1)
+        }
+
+        @Test
+        fun `투구 수 정정이 nullable 필드에서 정상 동작한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            assertThat(stats.pitchesThrown).isNull()
+
+            // when
+            stats.applyFieldCorrection("pitchesThrown", 50)
+
+            // then
+            assertThat(stats.pitchesThrown).isEqualTo(50)
+        }
+
+        @Test
+        fun `정정 후 유효성 검증이 실행된다`() {
+            // given: earnedRuns > runsAllowed 상태가 되도록 정정하면 예외 발생
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            setStatsDirectly(stats, earnedRuns = 5, runsAllowed = 5)
+
+            // when & then
+            assertThrows<StatsValidationException> {
+                stats.applyFieldCorrection("earnedRuns", 1) // earnedRuns = 6 > runsAllowed = 5
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("추가 계산 속성 검증")
+    inner class AdditionalCalculatedProperties {
+        @Test
+        fun `WHIP는 이닝이 0일 때 0을 반환한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            val whip = stats.whip
+
+            // then
+            assertThat(whip).isEqualByComparingTo(BigDecimal("0.00"))
+        }
+
+        @Test
+        fun `K per 9는 이닝이 0일 때 0을 반환한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            val k9 = stats.strikeoutsPer9
+
+            // then
+            assertThat(k9).isEqualByComparingTo(BigDecimal("0.00"))
+        }
+
+        @Test
+        fun `BB per 9는 이닝이 0일 때 0을 반환한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            val bb9 = stats.walksPer9
+
+            // then
+            assertThat(bb9).isEqualByComparingTo(BigDecimal("0.00"))
+        }
+
+        @Test
+        fun `K-BB 비율은 삼진과 볼넷 모두 0일 때 0을 반환한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            val kbb = stats.strikeoutToWalkRatio
+
+            // then
+            assertThat(kbb).isEqualByComparingTo(BigDecimal("0.00"))
+        }
+
+        @Test
+        fun `비자책 실점이 올바르게 계산된다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            setStatsDirectly(stats, runsAllowed = 10, earnedRuns = 7)
+
+            // when & then
+            assertThat(stats.unearnedRuns).isEqualTo(3)
+        }
+
+        @Test
+        fun `승률은 승패 모두 0일 때 0을 반환한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            val winPct = stats.winningPercentage
+
+            // then
+            assertThat(winPct).isEqualByComparingTo(BigDecimal("0.000"))
+        }
+
+        @Test
+        fun `스트라이크 비율은 투구 수가 0일 때 null을 반환한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            setStatsDirectly(stats, pitchesThrown = 0, strikesThrown = 0)
+
+            // when
+            val strikePct = stats.strikePercentage
+
+            // then
+            assertThat(strikePct).isNull()
+        }
+
+        @Test
+        fun `이닝 표시 문자열이 올바르다 - 정수 이닝`() {
+            // given: 27 outs = 9.0 이닝
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            setStatsDirectly(stats, inningsPitchedOuts = 27)
+
+            // when & then
+            assertThat(stats.inningsPitchedDisplay).isEqualTo("9.0")
+            assertThat(stats.completeInnings).isEqualTo(9)
+            assertThat(stats.remainingOuts).isZero
+        }
+
+        @Test
+        fun `이닝 표시 문자열이 올바르다 - 소수 이닝`() {
+            // given: 19 outs = 6.1 이닝
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            setStatsDirectly(stats, inningsPitchedOuts = 19)
+
+            // when & then
+            assertThat(stats.inningsPitchedDisplay).isEqualTo("6.1")
+            assertThat(stats.completeInnings).isEqualTo(6)
+            assertThat(stats.remainingOuts).isEqualTo(1)
+        }
+    }
+
     // Helper methods
 
     private fun PitchingRecord.setStats(
@@ -451,6 +1127,7 @@ class SeasonPitchingStatsTest {
         walksAllowed: Int = 0,
         strikeouts: Int = 0,
         battersFaced: Int = 0,
+        homeRunsAllowed: Int = 0,
         decision: PitchingDecision = PitchingDecision.NONE,
         pitchesThrown: Int? = null,
         strikesThrown: Int? = null,
@@ -462,6 +1139,7 @@ class SeasonPitchingStatsTest {
         setField("walksAllowed", walksAllowed)
         setField("strikeouts", strikeouts)
         setField("battersFaced", battersFaced)
+        setField("homeRunsAllowed", homeRunsAllowed)
         setField("decision", decision)
         setField("pitchesThrown", pitchesThrown)
         setField("strikesThrown", strikesThrown)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
@@ -51,65 +51,105 @@ class StatsEventListener(
     /**
      * 타석 결과 기록 이벤트를 처리합니다.
      *
-     * 해당 선수의 시즌 타격 통계를 찾아 실시간으로 갱신합니다.
-     * 시즌 통계가 없는 경우 갱신을 건너뜁니다.
+     * 해당 선수의 시즌 타격 통계와 투수의 시즌 투수 통계를 실시간으로 갱신합니다.
+     * 시즌 통계가 없는 경우 해당 갱신을 건너뜁니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onPlateAppearanceRecorded(event: PlateAppearanceRecordedEvent) {
         val year = resolveYear(event.gameId)
-        val stats =
+
+        // 타격 통계 실시간 갱신
+        val battingStats =
             seasonBattingStatsRepository.findByPlayerIdAndYear(event.playerId, year)
-                ?: run {
-                    logger.debug(
-                        "시즌 타격 통계 없음 - 갱신 건너뜀 (playerId={}, year={})",
-                        event.playerId,
-                        year,
-                    )
-                    return
-                }
+        if (battingStats != null) {
+            battingStats.applyLiveUpdate(event.result)
+            seasonBattingStatsRepository.save(battingStats)
+            logger.debug(
+                "실시간 타격 통계 갱신 완료 (playerId={}, year={}, result={})",
+                event.playerId,
+                year,
+                event.result,
+            )
+        } else {
+            logger.debug(
+                "시즌 타격 통계 없음 - 갱신 건너뜀 (playerId={}, year={})",
+                event.playerId,
+                year,
+            )
+        }
 
-        stats.applyLiveUpdate(event.result)
-        seasonBattingStatsRepository.save(stats)
-
-        logger.debug(
-            "실시간 타격 통계 갱신 완료 (playerId={}, year={}, result={})",
-            event.playerId,
-            year,
-            event.result,
-        )
+        // 투수 통계 실시간 갱신
+        val pitchingStats =
+            seasonPitchingStatsRepository.findByPlayerIdAndYear(event.pitcherId, year)
+        if (pitchingStats != null) {
+            pitchingStats.applyLiveUpdate(event.result)
+            seasonPitchingStatsRepository.save(pitchingStats)
+            logger.debug(
+                "실시간 투수 통계 갱신 완료 (pitcherId={}, year={}, result={})",
+                event.pitcherId,
+                year,
+                event.result,
+            )
+        } else {
+            logger.debug(
+                "시즌 투수 통계 없음 - 갱신 건너뜀 (pitcherId={}, year={})",
+                event.pitcherId,
+                year,
+            )
+        }
     }
 
     /**
      * 타석 결과 취소 이벤트를 처리합니다.
      *
-     * 해당 선수의 시즌 타격 통계를 찾아 이전 타석 결과를 역산합니다.
-     * 시즌 통계가 없는 경우 갱신을 건너뜁니다.
+     * 해당 선수의 시즌 타격 통계와 투수의 시즌 투수 통계를 역산합니다.
+     * 시즌 통계가 없는 경우 해당 갱신을 건너뜁니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun onPlateAppearanceUndone(event: PlateAppearanceUndoneEvent) {
         val year = resolveYear(event.gameId)
-        val stats =
+
+        // 타격 통계 역산
+        val battingStats =
             seasonBattingStatsRepository.findByPlayerIdAndYear(event.playerId, year)
-                ?: run {
-                    logger.debug(
-                        "시즌 타격 통계 없음 - Undo 건너뜀 (playerId={}, year={})",
-                        event.playerId,
-                        year,
-                    )
-                    return
-                }
+        if (battingStats != null) {
+            battingStats.revertLiveUpdate(event.result)
+            seasonBattingStatsRepository.save(battingStats)
+            logger.debug(
+                "실시간 타격 통계 역산 완료 (playerId={}, year={}, result={})",
+                event.playerId,
+                year,
+                event.result,
+            )
+        } else {
+            logger.debug(
+                "시즌 타격 통계 없음 - Undo 건너뜀 (playerId={}, year={})",
+                event.playerId,
+                year,
+            )
+        }
 
-        stats.revertLiveUpdate(event.result)
-        seasonBattingStatsRepository.save(stats)
-
-        logger.debug(
-            "실시간 타격 통계 역산 완료 (playerId={}, year={}, result={})",
-            event.playerId,
-            year,
-            event.result,
-        )
+        // 투수 통계 역산
+        val pitchingStats =
+            seasonPitchingStatsRepository.findByPlayerIdAndYear(event.pitcherId, year)
+        if (pitchingStats != null) {
+            pitchingStats.revertLiveUpdate(event.result)
+            seasonPitchingStatsRepository.save(pitchingStats)
+            logger.debug(
+                "실시간 투수 통계 역산 완료 (pitcherId={}, year={}, result={})",
+                event.pitcherId,
+                year,
+                event.result,
+            )
+        } else {
+            logger.debug(
+                "시즌 투수 통계 없음 - Undo 건너뜀 (pitcherId={}, year={})",
+                event.pitcherId,
+                year,
+            )
+        }
     }
 
     /**

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonAwardRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonAwardRepository.kt
@@ -1,0 +1,49 @@
+package com.nextup.infrastructure.repository.stats
+
+import com.nextup.core.domain.stats.SeasonAward
+import com.nextup.core.domain.stats.SeasonAwardTitle
+import com.nextup.core.port.repository.SeasonAwardRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface SeasonAwardRepository :
+    JpaRepository<SeasonAward, Long>,
+    SeasonAwardRepositoryPort {
+    /**
+     * 특정 연도의 모든 시즌 타이틀을 조회합니다.
+     */
+    @Query("SELECT a FROM SeasonAward a JOIN FETCH a.player WHERE a.year = :year ORDER BY a.title")
+    override fun findAllByYear(
+        @Param("year") year: Int,
+    ): List<SeasonAward>
+
+    /**
+     * 특정 선수의 모든 시즌 타이틀을 조회합니다.
+     */
+    @Query("SELECT a FROM SeasonAward a WHERE a.player.id = :playerId ORDER BY a.year DESC, a.title")
+    override fun findAllByPlayerId(
+        @Param("playerId") playerId: Long,
+    ): List<SeasonAward>
+
+    /**
+     * 특정 연도, 특정 타이틀의 수상자를 조회합니다.
+     */
+    @Query(
+        "SELECT a FROM SeasonAward a JOIN FETCH a.player WHERE a.year = :year AND a.title = :title",
+    )
+    override fun findByYearAndTitle(
+        @Param("year") year: Int,
+        @Param("title") title: SeasonAwardTitle,
+    ): List<SeasonAward>
+
+    /**
+     * 특정 연도의 모든 시즌 타이틀을 삭제합니다 (재계산 시 사용).
+     */
+    @Modifying
+    @Query("DELETE FROM SeasonAward a WHERE a.year = :year")
+    override fun deleteAllByYear(
+        @Param("year") year: Int,
+    )
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonAwardRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/stats/SeasonAwardRepository.kt
@@ -11,6 +11,11 @@ import org.springframework.data.repository.query.Param
 interface SeasonAwardRepository :
     JpaRepository<SeasonAward, Long>,
     SeasonAwardRepositoryPort {
+    override fun findByIdOrNull(id: Long): SeasonAward? = findById(id).orElse(null)
+
+    override fun saveAll(seasonAwards: List<SeasonAward>): List<SeasonAward> =
+        saveAll(seasonAwards as Iterable<SeasonAward>)
+
     /**
      * 특정 연도의 모든 시즌 타이틀을 조회합니다.
      */

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameSubstitutionServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameSubstitutionServiceImpl.kt
@@ -3,12 +3,16 @@ package com.nextup.infrastructure.service.game
 import com.nextup.common.exception.GameNotFoundException
 import com.nextup.common.exception.GamePlayerNotFoundException
 import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.GameSubstitutionService
 import com.nextup.core.service.game.dto.SubstitutionRequest
 import org.slf4j.LoggerFactory
@@ -19,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional
  * 선수 교체 서비스 구현
  *
  * 선수 교체, DH 해제 규칙 검증을 담당합니다.
+ * 투수 교체 시 이전 투수의 이닝 마감 및 교체 선수의 기록 자동 생성을 수행합니다.
  */
 @Service
 @Transactional(readOnly = true)
@@ -26,6 +31,8 @@ class GameSubstitutionServiceImpl(
     private val gameRepository: GameRepositoryPort,
     private val gamePlayerRepository: GamePlayerRepositoryPort,
     private val gameEventRepository: GameEventRepositoryPort,
+    private val battingRecordRepository: BattingRecordRepositoryPort,
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
 ) : GameSubstitutionService {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -76,6 +83,25 @@ class GameSubstitutionServiceImpl(
             gamePlayerRepository.save(outgoingPlayer)
         }
 
+        // M-10: 투수 교체 시 이전 투수의 이닝 마감 처리
+        if (outgoingPlayer.isPitcher) {
+            val pitchingRecord =
+                pitchingRecordRepository.findByGamePlayerId(outgoingPlayer.id)
+            pitchingRecord?.closeInning(
+                currentInning = game.currentInning,
+                currentOuts = game.gameState.outs,
+            )
+            if (pitchingRecord != null) {
+                pitchingRecordRepository.save(pitchingRecord)
+                log.debug(
+                    "투수 교체 - 이닝 마감 처리 완료 (gamePlayerId={}, inning={}, outs={})",
+                    outgoingPlayer.id,
+                    game.currentInning,
+                    game.gameState.outs,
+                )
+            }
+        }
+
         outgoingPlayer.exitGame(game.currentInning)
         gamePlayerRepository.save(outgoingPlayer)
 
@@ -85,6 +111,9 @@ class GameSubstitutionServiceImpl(
             newBattingOrder = request.newBattingOrder,
         )
         gamePlayerRepository.save(incomingPlayer)
+
+        // M-11: 교체 선수 기록 자동 생성
+        createRecordsForSubstitute(incomingPlayer)
 
         val halfInning = if (game.isTopInning) "초" else "말"
         val dhReleaseNote = if (dhReleaseRequired) " (DH 규칙 해제)" else ""
@@ -100,6 +129,47 @@ class GameSubstitutionServiceImpl(
             )
 
         return gameEventRepository.save(substitutionEvent)
+    }
+
+    /**
+     * 교체 선수의 BattingRecord 및 PitchingRecord를 자동 생성합니다.
+     *
+     * - 타순이 있는 교체 선수(대타/대주자): BattingRecord 자동 생성
+     * - 투수 포지션 교체 선수(구원투수): PitchingRecord 자동 생성
+     * - 이미 기록이 존재하는 경우에는 생성하지 않습니다.
+     */
+    private fun createRecordsForSubstitute(incomingPlayer: com.nextup.core.domain.game.GamePlayer,) {
+        // 타순이 있는 교체 선수는 BattingRecord 생성
+        if (incomingPlayer.battingOrder != null) {
+            val existingBattingRecord =
+                battingRecordRepository.findByGamePlayerId(incomingPlayer.id)
+            if (existingBattingRecord == null) {
+                val battingRecord = BattingRecord.create(gamePlayer = incomingPlayer)
+                battingRecordRepository.save(battingRecord)
+                log.debug(
+                    "교체 선수 BattingRecord 자동 생성 (gamePlayerId={})",
+                    incomingPlayer.id,
+                )
+            }
+        }
+
+        // 투수 포지션 교체 선수는 PitchingRecord 생성
+        if (incomingPlayer.isPitcher) {
+            val existingPitchingRecord =
+                pitchingRecordRepository.findByGamePlayerId(incomingPlayer.id)
+            if (existingPitchingRecord == null) {
+                val pitchingRecord =
+                    PitchingRecord.create(
+                        gamePlayer = incomingPlayer,
+                        isStartingPitcher = false,
+                    )
+                pitchingRecordRepository.save(pitchingRecord)
+                log.debug(
+                    "교체 투수 PitchingRecord 자동 생성 (gamePlayerId={})",
+                    incomingPlayer.id,
+                )
+            }
+        }
     }
 
     private fun findGame(id: Long): Game =

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameUndoServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameUndoServiceImpl.kt
@@ -65,13 +65,16 @@ class GameUndoServiceImpl(
         if (lastEvent.eventType == GameEventType.PLATE_APPEARANCE) {
             lastEvent.plateAppearanceResult?.let { result ->
                 lastEvent.batter?.let { batter ->
-                    eventPublisher.publishEvent(
-                        PlateAppearanceUndoneEvent(
-                            gameId = gameId,
-                            playerId = batter.player.id,
-                            result = result,
-                        ),
-                    )
+                    lastEvent.pitcher?.let { pitcher ->
+                        eventPublisher.publishEvent(
+                            PlateAppearanceUndoneEvent(
+                                gameId = gameId,
+                                playerId = batter.player.id,
+                                pitcherId = pitcher.player.id,
+                                result = result,
+                            ),
+                        )
+                    }
                 }
             }
         }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/PlateAppearanceRecordServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/PlateAppearanceRecordServiceImpl.kt
@@ -112,6 +112,7 @@ class PlateAppearanceRecordServiceImpl(
             PlateAppearanceRecordedEvent(
                 gameId = gameId,
                 playerId = batter.player.id,
+                pitcherId = pitcher.player.id,
                 result = request.result,
             ),
         )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/SeasonAwardServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/SeasonAwardServiceImpl.kt
@@ -1,0 +1,262 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.core.domain.stats.SeasonAward
+import com.nextup.core.domain.stats.SeasonAwardTitle
+import com.nextup.core.port.repository.SeasonAwardRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import com.nextup.core.service.stats.SeasonAwardService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+/**
+ * 시즌 타이틀(개인상) 서비스 구현
+ *
+ * 시즌 종료 시 각 부문별 타이틀을 자동으로 계산하고 부여합니다.
+ * 규정타석, 규정이닝 등의 기준을 적용하여 자격을 검증합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class SeasonAwardServiceImpl(
+    private val seasonAwardRepository: SeasonAwardRepositoryPort,
+    private val seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort,
+    private val seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort,
+) : SeasonAwardService {
+    private val logger = LoggerFactory.getLogger(SeasonAwardServiceImpl::class.java)
+
+    @Transactional
+    override fun calculateAndAwardTitles(
+        year: Int,
+        minPlateAppearances: Int,
+        minInningsPitchedOuts: Int,
+    ): List<SeasonAward> {
+        require(year > 0) { "연도는 양수여야 합니다." }
+        require(minPlateAppearances >= 0) { "규정타석은 0 이상이어야 합니다." }
+        require(minInningsPitchedOuts >= 0) { "규정이닝은 0 이상이어야 합니다." }
+
+        logger.info(
+            "시즌 타이틀 계산 시작 (year={}, 규정타석={}, 규정이닝아웃={})",
+            year,
+            minPlateAppearances,
+            minInningsPitchedOuts,
+        )
+
+        // 기존 타이틀 삭제 (재계산)
+        seasonAwardRepository.deleteAllByYear(year)
+
+        val awards = mutableListOf<SeasonAward>()
+
+        // 타격 부문 타이틀
+        awards.addAll(calculateBattingAwards(year, minPlateAppearances))
+
+        // 투수 부문 타이틀
+        awards.addAll(calculatePitchingAwards(year, minInningsPitchedOuts))
+
+        val savedAwards = seasonAwardRepository.saveAll(awards)
+
+        logger.info(
+            "시즌 타이틀 계산 완료 (year={}, 부여된 타이틀 수={})",
+            year,
+            savedAwards.size,
+        )
+
+        return savedAwards
+    }
+
+    override fun getAwardsByYear(year: Int): List<SeasonAward> = seasonAwardRepository.findAllByYear(year)
+
+    override fun getAwardsByPlayerId(playerId: Long): List<SeasonAward> =
+        seasonAwardRepository.findAllByPlayerId(playerId)
+
+    /**
+     * 타격 부문 타이틀을 계산합니다.
+     *
+     * - 타격왕: 규정타석 이상 최고 타율
+     * - 홈런왕: 최다 홈런
+     * - 타점왕: 최다 타점
+     * - 도루왕: 최다 도루
+     * - 최다안타: 최다 안타
+     */
+    private fun calculateBattingAwards(
+        year: Int,
+        minPlateAppearances: Int,
+    ): List<SeasonAward> {
+        val awards = mutableListOf<SeasonAward>()
+
+        // 타격왕 (규정타석 이상 최고 타율)
+        val battingLeaders =
+            seasonBattingStatsRepository.findTopByBattingAverage(year, minPlateAppearances, 1)
+        battingLeaders.firstOrNull()?.let { leader ->
+            awards.add(
+                SeasonAward.create(
+                    player = leader.player,
+                    year = year,
+                    title = SeasonAwardTitle.BATTING_CHAMPION,
+                    statValue = leader.battingAverage,
+                ),
+            )
+            logger.debug(
+                "타격왕: {} (타율={})",
+                leader.player.name,
+                leader.battingAverage,
+            )
+        }
+
+        // 홈런왕 (최다 홈런)
+        val homeRunLeaders =
+            seasonBattingStatsRepository.findTopByHomeRuns(year, 1)
+        homeRunLeaders.firstOrNull()?.let { leader ->
+            if (leader.homeRuns > 0) {
+                awards.add(
+                    SeasonAward.create(
+                        player = leader.player,
+                        year = year,
+                        title = SeasonAwardTitle.HOME_RUN_KING,
+                        statValue = BigDecimal(leader.homeRuns),
+                    ),
+                )
+                logger.debug("홈런왕: {} (홈런={})", leader.player.name, leader.homeRuns)
+            }
+        }
+
+        // 타점왕 (최다 타점)
+        val rbiLeaders =
+            seasonBattingStatsRepository.findTopByRunsBattedIn(year, 1)
+        rbiLeaders.firstOrNull()?.let { leader ->
+            if (leader.runsBattedIn > 0) {
+                awards.add(
+                    SeasonAward.create(
+                        player = leader.player,
+                        year = year,
+                        title = SeasonAwardTitle.RBI_KING,
+                        statValue = BigDecimal(leader.runsBattedIn),
+                    ),
+                )
+                logger.debug("타점왕: {} (타점={})", leader.player.name, leader.runsBattedIn)
+            }
+        }
+
+        // 도루왕 (최다 도루)
+        val stolenBaseLeaders =
+            seasonBattingStatsRepository.findTopByStolenBases(year, 1)
+        stolenBaseLeaders.firstOrNull()?.let { leader ->
+            if (leader.stolenBases > 0) {
+                awards.add(
+                    SeasonAward.create(
+                        player = leader.player,
+                        year = year,
+                        title = SeasonAwardTitle.STOLEN_BASE_KING,
+                        statValue = BigDecimal(leader.stolenBases),
+                    ),
+                )
+                logger.debug("도루왕: {} (도루={})", leader.player.name, leader.stolenBases)
+            }
+        }
+
+        // 최다안타
+        val hitsLeaders =
+            seasonBattingStatsRepository.findTopByHits(year, 1)
+        hitsLeaders.firstOrNull()?.let { leader ->
+            if (leader.hits > 0) {
+                awards.add(
+                    SeasonAward.create(
+                        player = leader.player,
+                        year = year,
+                        title = SeasonAwardTitle.HITS_LEADER,
+                        statValue = BigDecimal(leader.hits),
+                    ),
+                )
+                logger.debug("최다안타: {} (안타={})", leader.player.name, leader.hits)
+            }
+        }
+
+        return awards
+    }
+
+    /**
+     * 투수 부문 타이틀을 계산합니다.
+     *
+     * - 다승왕: 최다 승리
+     * - 방어율 1위: 규정이닝 이상 최저 방어율
+     * - 탈삼진왕: 최다 탈삼진
+     * - 세이브왕: 최다 세이브
+     */
+    private fun calculatePitchingAwards(
+        year: Int,
+        minInningsPitchedOuts: Int,
+    ): List<SeasonAward> {
+        val awards = mutableListOf<SeasonAward>()
+
+        // 다승왕 (최다 승리)
+        val winsLeaders =
+            seasonPitchingStatsRepository.findTopByWins(year, 1)
+        winsLeaders.firstOrNull()?.let { leader ->
+            if (leader.wins > 0) {
+                awards.add(
+                    SeasonAward.create(
+                        player = leader.player,
+                        year = year,
+                        title = SeasonAwardTitle.WINS_LEADER,
+                        statValue = BigDecimal(leader.wins),
+                    ),
+                )
+                logger.debug("다승왕: {} (승={})", leader.player.name, leader.wins)
+            }
+        }
+
+        // 방어율 1위 (규정이닝 이상 최저 ERA)
+        val eraLeaders =
+            seasonPitchingStatsRepository.findTopByEra(year, minInningsPitchedOuts, 1)
+        eraLeaders.firstOrNull()?.let { leader ->
+            leader.earnedRunAverage?.let { era ->
+                awards.add(
+                    SeasonAward.create(
+                        player = leader.player,
+                        year = year,
+                        title = SeasonAwardTitle.ERA_TITLE,
+                        statValue = era,
+                    ),
+                )
+                logger.debug("방어율 1위: {} (ERA={})", leader.player.name, era)
+            }
+        }
+
+        // 탈삼진왕 (최다 탈삼진)
+        val strikeoutLeaders =
+            seasonPitchingStatsRepository.findTopByStrikeouts(year, 1)
+        strikeoutLeaders.firstOrNull()?.let { leader ->
+            if (leader.strikeouts > 0) {
+                awards.add(
+                    SeasonAward.create(
+                        player = leader.player,
+                        year = year,
+                        title = SeasonAwardTitle.STRIKEOUT_KING,
+                        statValue = BigDecimal(leader.strikeouts),
+                    ),
+                )
+                logger.debug("탈삼진왕: {} (삼진={})", leader.player.name, leader.strikeouts)
+            }
+        }
+
+        // 세이브왕 (최다 세이브)
+        val savesLeaders =
+            seasonPitchingStatsRepository.findTopBySaves(year, 1)
+        savesLeaders.firstOrNull()?.let { leader ->
+            if (leader.saves > 0) {
+                awards.add(
+                    SeasonAward.create(
+                        player = leader.player,
+                        year = year,
+                        title = SeasonAwardTitle.SAVES_LEADER,
+                        statValue = BigDecimal(leader.saves),
+                    ),
+                )
+                logger.debug("세이브왕: {} (세이브={})", leader.player.name, leader.saves)
+            }
+        }
+
+        return awards
+    }
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V039__create_season_awards_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V039__create_season_awards_table.sql
@@ -1,0 +1,16 @@
+-- 시즌 타이틀(개인상) 테이블
+-- 시즌 종료 시 각 부문별 최고 성적을 거둔 선수에게 부여되는 타이틀을 저장합니다.
+CREATE TABLE season_awards (
+    id            BIGSERIAL    PRIMARY KEY,
+    player_id     BIGINT       NOT NULL REFERENCES players(id),
+    year          INTEGER      NOT NULL,
+    title         VARCHAR(30)  NOT NULL,
+    stat_value    NUMERIC(10, 3),
+    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_season_awards_player ON season_awards(player_id);
+CREATE INDEX idx_season_awards_year ON season_awards(year);
+CREATE INDEX idx_season_awards_title ON season_awards(title);
+CREATE INDEX idx_season_awards_year_title ON season_awards(year, title);

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
@@ -233,11 +233,15 @@ class StatsEventListenerTest {
             } returns null
             every { playerRepository.findByIdOrNull(testPlayer.id) } returns testPlayer
             every { seasonBattingStatsRepository.save(capture(savedStats)) } answers { firstArg() }
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns null
 
             val event =
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.HOME_RUN,
                 )
 
@@ -266,6 +270,7 @@ class StatsEventListenerTest {
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = 999L,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.SINGLE,
                 )
 
@@ -1071,11 +1076,15 @@ class StatsEventListenerTest {
             // 첫 번째 save 시 충돌, 두 번째에 성공
             every { seasonBattingStatsRepository.save(any()) } throws
                 ObjectOptimisticLockingFailureException("conflict", null) andThen stats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns null
 
             val event =
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.SINGLE,
                 )
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
@@ -101,15 +101,21 @@ class StatsEventListenerTest {
         fun `타석 결과가 시즌 통계에 즉시 반영됨`() {
             // given
             val stats = SeasonBattingStats.create(testPlayer, 2024)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
             } returns stats
             every { seasonBattingStatsRepository.save(any()) } returns stats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
 
             val event =
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.SINGLE,
                 )
 
@@ -127,15 +133,21 @@ class StatsEventListenerTest {
         fun `홈런 기록 이벤트 처리 시 홈런 통계 증가`() {
             // given
             val stats = SeasonBattingStats.create(testPlayer, 2024)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
             } returns stats
             every { seasonBattingStatsRepository.save(any()) } returns stats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
 
             val event =
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.HOME_RUN,
                 )
 
@@ -151,15 +163,21 @@ class StatsEventListenerTest {
         fun `볼넷 기록 이벤트 처리 시 볼넷 통계 증가 (타수 제외)`() {
             // given
             val stats = SeasonBattingStats.create(testPlayer, 2024)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
             } returns stats
             every { seasonBattingStatsRepository.save(any()) } returns stats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
 
             val event =
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.WALK,
                 )
 
@@ -178,11 +196,15 @@ class StatsEventListenerTest {
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
             } returns null
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns null
 
             val event =
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.SINGLE,
                 )
 
@@ -191,6 +213,7 @@ class StatsEventListenerTest {
 
             // then
             verify(exactly = 0) { seasonBattingStatsRepository.save(any()) }
+            verify(exactly = 0) { seasonPitchingStatsRepository.save(any()) }
         }
 
         @Test
@@ -202,6 +225,7 @@ class StatsEventListenerTest {
                 PlateAppearanceRecordedEvent(
                     gameId = 999L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.SINGLE,
                 )
 
@@ -216,15 +240,21 @@ class StatsEventListenerTest {
             // given: 2023년 경기
             every { mockGame.scheduledAt } returns LocalDateTime.of(2023, 9, 1, 14, 0)
             val stats = SeasonBattingStats.create(testPlayer, 2023)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2023)
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2023)
             } returns stats
             every { seasonBattingStatsRepository.save(any()) } returns stats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2023)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
 
             val event =
                 PlateAppearanceRecordedEvent(
                     gameId = 10L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.DOUBLE,
                 )
 
@@ -234,6 +264,156 @@ class StatsEventListenerTest {
             // then
             verify { seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2023) }
             assertThat(stats.doubles).isEqualTo(1)
+        }
+
+        @Test
+        fun `타석 결과가 투수 시즌 통계에도 즉시 반영됨`() {
+            // given
+            val battingStats = SeasonBattingStats.create(testPlayer, 2024)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns battingStats
+            every { seasonBattingStatsRepository.save(any()) } returns battingStats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
+
+            val event =
+                PlateAppearanceRecordedEvent(
+                    gameId = 10L,
+                    playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
+                    result = PlateAppearanceResult.SINGLE,
+                )
+
+            // when
+            listener.onPlateAppearanceRecorded(event)
+
+            // then
+            assertThat(pitchingStats.battersFaced).isEqualTo(1)
+            assertThat(pitchingStats.hitsAllowed).isEqualTo(1)
+            verify { seasonPitchingStatsRepository.save(pitchingStats) }
+        }
+
+        @Test
+        fun `홈런 기록 시 투수 통계에 피안타와 피홈런 모두 반영됨`() {
+            // given
+            val battingStats = SeasonBattingStats.create(testPlayer, 2024)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns battingStats
+            every { seasonBattingStatsRepository.save(any()) } returns battingStats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
+
+            val event =
+                PlateAppearanceRecordedEvent(
+                    gameId = 10L,
+                    playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
+                    result = PlateAppearanceResult.HOME_RUN,
+                )
+
+            // when
+            listener.onPlateAppearanceRecorded(event)
+
+            // then
+            assertThat(pitchingStats.battersFaced).isEqualTo(1)
+            assertThat(pitchingStats.hitsAllowed).isEqualTo(1)
+            assertThat(pitchingStats.homeRunsAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `삼진 기록 시 투수 삼진 통계 증가`() {
+            // given
+            val battingStats = SeasonBattingStats.create(testPlayer, 2024)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns battingStats
+            every { seasonBattingStatsRepository.save(any()) } returns battingStats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
+
+            val event =
+                PlateAppearanceRecordedEvent(
+                    gameId = 10L,
+                    playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                )
+
+            // when
+            listener.onPlateAppearanceRecorded(event)
+
+            // then
+            assertThat(pitchingStats.battersFaced).isEqualTo(1)
+            assertThat(pitchingStats.strikeouts).isEqualTo(1)
+        }
+
+        @Test
+        fun `볼넷 기록 시 투수 볼넷 통계 증가`() {
+            // given
+            val battingStats = SeasonBattingStats.create(testPlayer, 2024)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns battingStats
+            every { seasonBattingStatsRepository.save(any()) } returns battingStats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
+
+            val event =
+                PlateAppearanceRecordedEvent(
+                    gameId = 10L,
+                    playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
+                    result = PlateAppearanceResult.WALK,
+                )
+
+            // when
+            listener.onPlateAppearanceRecorded(event)
+
+            // then
+            assertThat(pitchingStats.battersFaced).isEqualTo(1)
+            assertThat(pitchingStats.walksAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `투수 시즌 통계가 없는 경우 투수 통계 갱신 건너뜀`() {
+            // given
+            val battingStats = SeasonBattingStats.create(testPlayer, 2024)
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns battingStats
+            every { seasonBattingStatsRepository.save(any()) } returns battingStats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns null
+
+            val event =
+                PlateAppearanceRecordedEvent(
+                    gameId = 10L,
+                    playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
+                    result = PlateAppearanceResult.SINGLE,
+                )
+
+            // when
+            listener.onPlateAppearanceRecorded(event)
+
+            // then: 타격 통계는 저장, 투수 통계는 저장 안 됨
+            verify(exactly = 1) { seasonBattingStatsRepository.save(any()) }
+            verify(exactly = 0) { seasonPitchingStatsRepository.save(any()) }
         }
     }
 
@@ -245,16 +425,23 @@ class StatsEventListenerTest {
             // given: 이미 단타가 반영된 통계
             val stats = SeasonBattingStats.create(testPlayer, 2024)
             stats.applyLiveUpdate(PlateAppearanceResult.SINGLE)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
+            pitchingStats.applyLiveUpdate(PlateAppearanceResult.SINGLE)
 
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
             } returns stats
             every { seasonBattingStatsRepository.save(any()) } returns stats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
 
             val event =
                 PlateAppearanceUndoneEvent(
                     gameId = 10L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.SINGLE,
                 )
 
@@ -273,16 +460,23 @@ class StatsEventListenerTest {
             // given
             val stats = SeasonBattingStats.create(testPlayer, 2024)
             stats.applyLiveUpdate(PlateAppearanceResult.HOME_RUN)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
+            pitchingStats.applyLiveUpdate(PlateAppearanceResult.HOME_RUN)
 
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
             } returns stats
             every { seasonBattingStatsRepository.save(any()) } returns stats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
 
             val event =
                 PlateAppearanceUndoneEvent(
                     gameId = 10L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.HOME_RUN,
                 )
 
@@ -300,11 +494,15 @@ class StatsEventListenerTest {
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
             } returns null
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns null
 
             val event =
                 PlateAppearanceUndoneEvent(
                     gameId = 10L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.SINGLE,
                 )
 
@@ -313,6 +511,41 @@ class StatsEventListenerTest {
 
             // then
             verify(exactly = 0) { seasonBattingStatsRepository.save(any()) }
+            verify(exactly = 0) { seasonPitchingStatsRepository.save(any()) }
+        }
+
+        @Test
+        fun `Undo 시 투수 통계도 역산됨`() {
+            // given
+            val battingStats = SeasonBattingStats.create(testPlayer, 2024)
+            battingStats.applyLiveUpdate(PlateAppearanceResult.SINGLE)
+            val pitchingStats = SeasonPitchingStats.create(testPitcher, 2024)
+            pitchingStats.applyLiveUpdate(PlateAppearanceResult.SINGLE)
+
+            every {
+                seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
+            } returns battingStats
+            every { seasonBattingStatsRepository.save(any()) } returns battingStats
+            every {
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
+            } returns pitchingStats
+            every { seasonPitchingStatsRepository.save(any()) } returns pitchingStats
+
+            val event =
+                PlateAppearanceUndoneEvent(
+                    gameId = 10L,
+                    playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
+                    result = PlateAppearanceResult.SINGLE,
+                )
+
+            // when
+            listener.onPlateAppearanceUndone(event)
+
+            // then
+            assertThat(pitchingStats.battersFaced).isZero
+            assertThat(pitchingStats.hitsAllowed).isZero
+            verify { seasonPitchingStatsRepository.save(pitchingStats) }
         }
 
         @Test
@@ -324,6 +557,7 @@ class StatsEventListenerTest {
                 PlateAppearanceUndoneEvent(
                     gameId = 999L,
                     playerId = testPlayer.id,
+                    pitcherId = testPitcher.id,
                     result = PlateAppearanceResult.SINGLE,
                 )
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
@@ -16,9 +16,11 @@ import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.dto.SubstitutionRequest
 import io.mockk.every
 import io.mockk.mockk
@@ -37,6 +39,8 @@ class GameScorerServiceSubstitutionTest {
     private lateinit var gameRepository: GameRepositoryPort
     private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var gameEventRepository: GameEventRepositoryPort
+    private lateinit var battingRecordRepository: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
     private lateinit var gameSubstitutionService: GameSubstitutionServiceImpl
 
     @BeforeEach
@@ -44,11 +48,22 @@ class GameScorerServiceSubstitutionTest {
         gameRepository = mockk()
         gamePlayerRepository = mockk()
         gameEventRepository = mockk()
+        battingRecordRepository = mockk()
+        pitchingRecordRepository = mockk()
+
+        // M-10/M-11: 기본 stub - 기록 없음으로 설정
+        every { pitchingRecordRepository.findByGamePlayerId(any()) } returns null
+        every { battingRecordRepository.findByGamePlayerId(any()) } returns null
+        every { battingRecordRepository.save(any()) } answers { firstArg() }
+        every { pitchingRecordRepository.save(any()) } answers { firstArg() }
+
         gameSubstitutionService =
             GameSubstitutionServiceImpl(
                 gameRepository,
                 gamePlayerRepository,
                 gameEventRepository,
+                battingRecordRepository,
+                pitchingRecordRepository,
             )
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/SeasonAwardServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/stats/SeasonAwardServiceImplTest.kt
@@ -1,0 +1,656 @@
+package com.nextup.infrastructure.service.stats
+
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.stats.SeasonAward
+import com.nextup.core.domain.stats.SeasonAwardTitle
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.port.repository.SeasonAwardRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+@DisplayName("SeasonAwardServiceImpl 테스트")
+class SeasonAwardServiceImplTest {
+    private lateinit var seasonAwardRepository: SeasonAwardRepositoryPort
+    private lateinit var seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort
+    private lateinit var seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort
+    private lateinit var service: SeasonAwardServiceImpl
+
+    private lateinit var player1: Player
+    private lateinit var player2: Player
+
+    @BeforeEach
+    fun setUp() {
+        seasonAwardRepository = mockk()
+        seasonBattingStatsRepository = mockk()
+        seasonPitchingStatsRepository = mockk()
+
+        service =
+            SeasonAwardServiceImpl(
+                seasonAwardRepository,
+                seasonBattingStatsRepository,
+                seasonPitchingStatsRepository,
+            )
+
+        player1 = Player(name = "홍길동", primaryPosition = Position.SHORTSTOP)
+        setId(player1, Player::class.java, 10L)
+
+        player2 = Player(name = "김철수", primaryPosition = Position.STARTING_PITCHER)
+        setId(player2, Player::class.java, 20L)
+    }
+
+    @Nested
+    @DisplayName("calculateAndAwardTitles")
+    inner class CalculateAndAwardTitles {
+        @Test
+        fun `연도가 0 이하이면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                service.calculateAndAwardTitles(0, 50, 30)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("연도는 양수여야 합니다")
+        }
+
+        @Test
+        fun `규정타석이 음수이면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                service.calculateAndAwardTitles(2026, -1, 30)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("규정타석은 0 이상이어야 합니다")
+        }
+
+        @Test
+        fun `규정이닝이 음수이면 예외가 발생한다`() {
+            // when & then
+            assertThatThrownBy {
+                service.calculateAndAwardTitles(2026, 50, -1)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("규정이닝은 0 이상이어야 합니다")
+        }
+
+        @Test
+        fun `모든 부문에서 리더가 있을 때 모든 타이틀이 부여된다`() {
+            // given
+            val battingStats1 =
+                createBattingStats(player1, 2026, atBats = 100, hits = 35, pa = 110)
+            val battingStats2 =
+                createBattingStats(player2, 2026, homeRuns = 10, rbi = 30, stolenBases = 15, hits = 40)
+
+            val pitchingStats1 =
+                createPitchingStats(player2, 2026, wins = 8, ipOuts = 54, earnedRuns = 6, saves = 5, strikeouts = 50)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+
+            // 타격 부문 mock
+            every {
+                seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1)
+            } returns listOf(battingStats1)
+            every {
+                seasonBattingStatsRepository.findTopByHomeRuns(2026, 1)
+            } returns listOf(battingStats2)
+            every {
+                seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1)
+            } returns listOf(battingStats2)
+            every {
+                seasonBattingStatsRepository.findTopByStolenBases(2026, 1)
+            } returns listOf(battingStats2)
+            every {
+                seasonBattingStatsRepository.findTopByHits(2026, 1)
+            } returns listOf(battingStats2)
+
+            // 투수 부문 mock
+            every {
+                seasonPitchingStatsRepository.findTopByWins(2026, 1)
+            } returns listOf(pitchingStats1)
+            every {
+                seasonPitchingStatsRepository.findTopByEra(2026, 30, 1)
+            } returns listOf(pitchingStats1)
+            every {
+                seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1)
+            } returns listOf(pitchingStats1)
+            every {
+                seasonPitchingStatsRepository.findTopBySaves(2026, 1)
+            } returns listOf(pitchingStats1)
+
+            val savedSlot = slot<List<SeasonAward>>()
+            every { seasonAwardRepository.saveAll(capture(savedSlot)) } answers { savedSlot.captured }
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).hasSize(9) // 5 batting + 4 pitching
+            verify(exactly = 1) { seasonAwardRepository.deleteAllByYear(2026) }
+            verify(exactly = 1) { seasonAwardRepository.saveAll(any()) }
+        }
+
+        @Test
+        fun `모든 부문에서 리더가 없을 때 빈 목록이 반환된다`() {
+            // given
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            every { seasonAwardRepository.saveAll(any()) } returns emptyList()
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `홈런이 0인 리더는 홈런왕이 부여되지 않는다`() {
+            // given
+            val battingStats =
+                createBattingStats(player1, 2026, homeRuns = 0)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns listOf(battingStats)
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            every { seasonAwardRepository.saveAll(any()) } returns emptyList()
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `타점이 0인 리더는 타점왕이 부여되지 않는다`() {
+            // given
+            val battingStats =
+                createBattingStats(player1, 2026, rbi = 0)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns listOf(battingStats)
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            every { seasonAwardRepository.saveAll(any()) } returns emptyList()
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `도루가 0인 리더는 도루왕이 부여되지 않는다`() {
+            // given
+            val battingStats =
+                createBattingStats(player1, 2026, stolenBases = 0)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns listOf(battingStats)
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            every { seasonAwardRepository.saveAll(any()) } returns emptyList()
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `안타가 0인 리더는 최다안타가 부여되지 않는다`() {
+            // given
+            val battingStats =
+                createBattingStats(player1, 2026, hits = 0)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns listOf(battingStats)
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            every { seasonAwardRepository.saveAll(any()) } returns emptyList()
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `승수가 0인 리더는 다승왕이 부여되지 않는다`() {
+            // given
+            val pitchingStats =
+                createPitchingStats(player2, 2026, wins = 0)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns listOf(pitchingStats)
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            every { seasonAwardRepository.saveAll(any()) } returns emptyList()
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `삼진이 0인 리더는 탈삼진왕이 부여되지 않는다`() {
+            // given
+            val pitchingStats =
+                createPitchingStats(player2, 2026, strikeouts = 0)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns listOf(pitchingStats)
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            every { seasonAwardRepository.saveAll(any()) } returns emptyList()
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `세이브가 0인 리더는 세이브왕이 부여되지 않는다`() {
+            // given
+            val pitchingStats =
+                createPitchingStats(player2, 2026, saves = 0)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns listOf(pitchingStats)
+
+            every { seasonAwardRepository.saveAll(any()) } returns emptyList()
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `ERA 리더의 earnedRunAverage가 null이면 방어율 타이틀이 부여되지 않는다`() {
+            // given: 0이닝이지만 자책점이 있는 경우 ERA는 null
+            val pitchingStats =
+                createPitchingStats(player2, 2026, ipOuts = 0, earnedRuns = 1)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns listOf(pitchingStats)
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            every { seasonAwardRepository.saveAll(any()) } returns emptyList()
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `타격왕의 statValue가 타율로 설정된다`() {
+            // given
+            val battingStats =
+                createBattingStats(player1, 2026, atBats = 100, hits = 35, pa = 110)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns listOf(battingStats)
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            val savedSlot = slot<List<SeasonAward>>()
+            every { seasonAwardRepository.saveAll(capture(savedSlot)) } answers { savedSlot.captured }
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].title).isEqualTo(SeasonAwardTitle.BATTING_CHAMPION)
+            assertThat(result[0].player).isEqualTo(player1)
+            assertThat(result[0].statValue).isEqualTo(battingStats.battingAverage)
+        }
+
+        @Test
+        fun `방어율 타이틀의 statValue가 ERA로 설정된다`() {
+            // given
+            val pitchingStats =
+                createPitchingStats(player2, 2026, ipOuts = 54, earnedRuns = 6)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns listOf(pitchingStats)
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            val savedSlot = slot<List<SeasonAward>>()
+            every { seasonAwardRepository.saveAll(capture(savedSlot)) } answers { savedSlot.captured }
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].title).isEqualTo(SeasonAwardTitle.ERA_TITLE)
+            assertThat(result[0].statValue).isEqualTo(pitchingStats.earnedRunAverage)
+        }
+
+        @Test
+        fun `기존 타이틀이 삭제된 후 재계산된다`() {
+            // given
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+            every { seasonAwardRepository.saveAll(any()) } returns emptyList()
+
+            // when
+            service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            verify(exactly = 1) { seasonAwardRepository.deleteAllByYear(2026) }
+        }
+
+        @Test
+        fun `타격 부문만 리더가 있을 때 타격 타이틀만 부여된다`() {
+            // given
+            val battingStats =
+                createBattingStats(player1, 2026, homeRuns = 15)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns listOf(battingStats)
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            val savedSlot = slot<List<SeasonAward>>()
+            every { seasonAwardRepository.saveAll(capture(savedSlot)) } answers { savedSlot.captured }
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].title).isEqualTo(SeasonAwardTitle.HOME_RUN_KING)
+            assertThat(result[0].statValue).isEqualByComparingTo(BigDecimal(15))
+        }
+
+        @Test
+        fun `투수 부문만 리더가 있을 때 투수 타이틀만 부여된다`() {
+            // given
+            val pitchingStats =
+                createPitchingStats(player2, 2026, wins = 10)
+
+            justRun { seasonAwardRepository.deleteAllByYear(2026) }
+            every { seasonBattingStatsRepository.findTopByBattingAverage(2026, 50, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHomeRuns(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByRunsBattedIn(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByStolenBases(2026, 1) } returns emptyList()
+            every { seasonBattingStatsRepository.findTopByHits(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByWins(2026, 1) } returns listOf(pitchingStats)
+            every { seasonPitchingStatsRepository.findTopByEra(2026, 30, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopByStrikeouts(2026, 1) } returns emptyList()
+            every { seasonPitchingStatsRepository.findTopBySaves(2026, 1) } returns emptyList()
+
+            val savedSlot = slot<List<SeasonAward>>()
+            every { seasonAwardRepository.saveAll(capture(savedSlot)) } answers { savedSlot.captured }
+
+            // when
+            val result = service.calculateAndAwardTitles(2026, 50, 30)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].title).isEqualTo(SeasonAwardTitle.WINS_LEADER)
+        }
+    }
+
+    @Nested
+    @DisplayName("getAwardsByYear")
+    inner class GetAwardsByYear {
+        @Test
+        fun `연도별 타이틀 목록을 반환한다`() {
+            // given
+            val award1 =
+                SeasonAward.create(
+                    player = player1,
+                    year = 2026,
+                    title = SeasonAwardTitle.BATTING_CHAMPION,
+                    statValue = BigDecimal("0.350"),
+                )
+            val award2 =
+                SeasonAward.create(
+                    player = player2,
+                    year = 2026,
+                    title = SeasonAwardTitle.ERA_TITLE,
+                    statValue = BigDecimal("2.50"),
+                )
+
+            every { seasonAwardRepository.findAllByYear(2026) } returns listOf(award1, award2)
+
+            // when
+            val result = service.getAwardsByYear(2026)
+
+            // then
+            assertThat(result).hasSize(2)
+            verify(exactly = 1) { seasonAwardRepository.findAllByYear(2026) }
+        }
+
+        @Test
+        fun `해당 연도에 타이틀이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { seasonAwardRepository.findAllByYear(2025) } returns emptyList()
+
+            // when
+            val result = service.getAwardsByYear(2025)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("getAwardsByPlayerId")
+    inner class GetAwardsByPlayerId {
+        @Test
+        fun `선수별 타이틀 목록을 반환한다`() {
+            // given
+            val award =
+                SeasonAward.create(
+                    player = player1,
+                    year = 2026,
+                    title = SeasonAwardTitle.BATTING_CHAMPION,
+                    statValue = BigDecimal("0.350"),
+                )
+
+            every { seasonAwardRepository.findAllByPlayerId(10L) } returns listOf(award)
+
+            // when
+            val result = service.getAwardsByPlayerId(10L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].player).isEqualTo(player1)
+            verify(exactly = 1) { seasonAwardRepository.findAllByPlayerId(10L) }
+        }
+
+        @Test
+        fun `해당 선수에 타이틀이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { seasonAwardRepository.findAllByPlayerId(999L) } returns emptyList()
+
+            // when
+            val result = service.getAwardsByPlayerId(999L)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    // Helper methods
+
+    private fun createBattingStats(
+        player: Player,
+        year: Int,
+        atBats: Int = 0,
+        hits: Int = 0,
+        pa: Int = 0,
+        homeRuns: Int = 0,
+        rbi: Int = 0,
+        stolenBases: Int = 0,
+    ): SeasonBattingStats {
+        val stats = SeasonBattingStats(player = player, year = year)
+        setField(stats, "atBats", atBats)
+        setField(stats, "hits", hits)
+        setField(stats, "plateAppearances", pa)
+        setField(stats, "homeRuns", homeRuns)
+        setField(stats, "runsBattedIn", rbi)
+        setField(stats, "stolenBases", stolenBases)
+        return stats
+    }
+
+    private fun createPitchingStats(
+        player: Player,
+        year: Int,
+        ipOuts: Int = 0,
+        earnedRuns: Int = 0,
+        runsAllowed: Int = 0,
+        wins: Int = 0,
+        saves: Int = 0,
+        strikeouts: Int = 0,
+    ): SeasonPitchingStats {
+        val stats = SeasonPitchingStats(player = player, year = year)
+        setField(stats, "inningsPitchedOuts", ipOuts)
+        setField(stats, "earnedRuns", earnedRuns)
+        setField(stats, "runsAllowed", maxOf(runsAllowed, earnedRuns))
+        setField(stats, "wins", wins)
+        setField(stats, "saves", saves)
+        setField(stats, "strikeouts", strikeouts)
+        return stats
+    }
+
+    private fun setField(
+        target: Any,
+        fieldName: String,
+        value: Any,
+    ) {
+        val field = target::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+
+    private fun <T> setId(
+        target: T,
+        clazz: Class<T>,
+        id: Long,
+    ) {
+        val idField = clazz.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(target, id)
+    }
+}


### PR DESCRIPTION
## Summary

>- close #345

- **M-9**: 타석 이벤트에 `pitcherId`를 추가하여 `SeasonPitchingStats`를 실시간 갱신 (대면타자수, 피안타, 삼진, 볼넷, 사구, 피홈런)
- **M-10**: 투수 교체 시 `PitchingRecord.closeInning()`으로 이닝 마감 처리
- **M-11**: 교체 선수(대타/대주자/구원투수)의 `BattingRecord`/`PitchingRecord` 자동 생성
- **M-12**: 시즌 종료 시 타격/투수 부문별 타이틀(개인상) 자동 계산 및 부여 (SeasonAward 엔티티 신설)

## Tasks

- [x] M-9: PlateAppearanceRecordedEvent/UndoneEvent에 pitcherId 추가
- [x] M-9: SeasonPitchingStats에 applyLiveUpdate/revertLiveUpdate 메서드 추가
- [x] M-9: StatsEventListener에서 투수 통계 실시간 갱신 로직 추가
- [x] M-10: PitchingRecord.closeInning() 메서드 추가
- [x] M-10: GameSubstitutionServiceImpl에서 투수 교체 시 이닝 마감 호출
- [x] M-11: GameSubstitutionServiceImpl에서 교체 선수 기록 자동 생성
- [x] M-12: SeasonAwardTitle enum, SeasonAward 엔티티 생성
- [x] M-12: SeasonAwardRepositoryPort, SeasonAwardService 인터페이스 정의
- [x] M-12: SeasonAwardServiceImpl 구현 (타격 5개 + 투수 4개 부문)
- [x] M-12: V039 마이그레이션 (season_awards 테이블)
- [x] 기존 테스트 pitcherId 파라미터 추가 및 투수 통계 mock 설정
- [x] 투수 실시간 통계 갱신/역산 테스트 추가
- [x] ktlintFormat 및 빌드 통과 확인

## To Reviewer

### M-9: 실시간 투수 통계
- `PlateAppearanceRecordedEvent`/`PlateAppearanceUndoneEvent`에 `pitcherId: Long` 필드 추가
- `SeasonPitchingStats.applyLiveUpdate(result)`: 타석 결과에 따라 battersFaced, hitsAllowed, strikeouts, walksAllowed, hitBatsmen, homeRunsAllowed 갱신
- `StatsEventListener`에서 타격 통계와 함께 투수 통계도 동시 갱신

### M-10: 투수 교체 이닝 마감
- `PitchingRecord.closeInning(currentInning, currentOuts)`: 교체 시점 마킹용 (BoxScore에서 실시간 기록되므로 추가 갱신 불필요)
- `GameSubstitutionServiceImpl`에서 `outgoingPlayer.isPitcher` 체크 후 호출

### M-11: 교체 선수 기록 자동 생성
- 타순이 있는 교체 선수 -> `BattingRecord.create()` 자동 생성
- 투수 포지션 교체 선수 -> `PitchingRecord.create(isStartingPitcher=false)` 자동 생성
- 기존 기록 존재 시 중복 생성 방지

### M-12: 시즌 타이틀
- 타격: 타격왕, 홈런왕, 타점왕, 도루왕, 최다안타
- 투수: 다승왕, 방어율 1위, 탈삼진왕, 세이브왕
- 규정타석/규정이닝 기준 적용, 0 기록 수상 방지