### PR TITLE
feat(#350): L-1~L-13 향후 개선사항 (도메인 정밀화/운영 안정성)

### DIFF
--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/LineupExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/LineupExceptions.kt
@@ -79,6 +79,17 @@ class LineupExchangeNotAuthorizedException(
     )
 
 /**
+ * L-3: 용병 쿼터 초과 시 발생하는 예외
+ */
+class MercenaryQuotaExceededException(
+    mercenaryCount: Int,
+    maxAllowed: Int,
+) : LineupValidationException(
+        "MERCENARY_QUOTA_EXCEEDED",
+        "용병 쿼터를 초과했습니다. 현재 용병 수: $mercenaryCount, 최대 허용: $maxAllowed",
+    )
+
+/**
  * 대진표를 찾을 수 없을 때 발생하는 예외
  */
 class ScheduleNotFoundException(

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/GameRules.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/GameRules.kt
@@ -56,6 +56,9 @@ data class GameRules(
     /** 투구 수 경고 임박 기준 (제한 대비 몇 구 전에 경고할지, 기본 10구) */
     @Column(name = "pitch_count_warning_threshold")
     val pitchCountWarningThreshold: Int = 10,
+    /** L-3: 용병(머서너리) 쿼터 제한 (null이면 무제한) */
+    @Column(name = "max_mercenary_count")
+    val maxMercenaryCount: Int? = null,
 ) {
     init {
         require(defaultInnings in 3..12) { "기본 이닝은 3~12 사이여야 합니다." }
@@ -88,5 +91,9 @@ data class GameRules(
         }
 
         require(pitchCountWarningThreshold > 0) { "투구 수 경고 임박 기준은 양수여야 합니다." }
+
+        maxMercenaryCount?.let {
+            require(it >= 0) { "용병 쿼터 제한은 0 이상이어야 합니다." }
+        }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/CompetitionCompletedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/CompetitionCompletedEvent.kt
@@ -1,0 +1,13 @@
+package com.nextup.core.domain.event
+
+/**
+ * L-9: 대회 완료 이벤트
+ *
+ * 대회의 모든 경기가 종료되어 대회가 완료되었을 때 발행됩니다.
+ * 대회 완료 알림 발송에 사용됩니다.
+ */
+data class CompetitionCompletedEvent(
+    val competitionId: Long,
+    val competitionName: String,
+    val leagueId: Long,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/OwnerKickedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/OwnerKickedEvent.kt
@@ -1,0 +1,13 @@
+package com.nextup.core.domain.event
+
+/**
+ * L-10: OWNER 강퇴 이벤트
+ *
+ * 팀 OWNER가 강퇴되었을 때 발행됩니다.
+ * 자동으로 선거(Election)를 트리거하는 데 사용됩니다.
+ */
+data class OwnerKickedEvent(
+    val teamId: Long,
+    val kickedPlayerId: Long,
+    val kickedMemberId: Long,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/StadiumClosedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/StadiumClosedEvent.kt
@@ -1,0 +1,12 @@
+package com.nextup.core.domain.event
+
+/**
+ * L-12: 구장 폐업(비활성화) 이벤트
+ *
+ * 구장이 비활성화(폐업)되었을 때 발행됩니다.
+ * 해당 구장의 기존 예약을 일괄 취소하는 리스너에서 사용됩니다.
+ */
+data class StadiumClosedEvent(
+    val stadiumId: Long,
+    val stadiumName: String,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/BattingRecord.kt
@@ -261,7 +261,10 @@ class BattingRecord(
                 atBats++
                 triplePlays++
             }
-            PlateAppearanceResult.INTERFERENCE -> {
+            PlateAppearanceResult.INTERFERENCE,
+            PlateAppearanceResult.BATTER_INTERFERENCE,
+            PlateAppearanceResult.RUNNER_INTERFERENCE,
+            -> {
                 // 방해는 타수에 포함되지 않음
             }
         }
@@ -385,7 +388,10 @@ class BattingRecord(
                 atBats--
                 triplePlays--
             }
-            PlateAppearanceResult.INTERFERENCE -> {
+            PlateAppearanceResult.INTERFERENCE,
+            PlateAppearanceResult.BATTER_INTERFERENCE,
+            PlateAppearanceResult.RUNNER_INTERFERENCE,
+            -> {
                 // 방해는 타수에 포함되지 않음
             }
         }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/FieldingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/FieldingRecord.kt
@@ -1,8 +1,11 @@
 package com.nextup.core.domain.game
 
 import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.player.Position
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -18,19 +21,25 @@ import java.math.RoundingMode
  * 수비 기록 엔티티
  *
  * 경기 출전 선수(GamePlayer)의 수비 기록을 저장합니다.
- * 한 경기에서 선수당 하나의 수비 기록만 존재합니다.
+ * L-1: position 필드를 추가하여 다수 포지션 소화 선수의 포지션별 통계를 분리합니다.
+ * 한 경기에서 선수는 포지션별로 별도의 수비 기록을 가질 수 있습니다.
  */
 @Entity
 @Table(
     name = "fielding_records",
     indexes = [
         Index(name = "idx_fielding_records_game_player", columnList = "game_player_id"),
+        Index(name = "idx_fielding_records_position", columnList = "position"),
     ],
 )
 class FieldingRecord(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_player_id", nullable = false)
     val gamePlayer: GamePlayer,
+    /** L-1: 수비 기록이 발생한 포지션 (다수 포지션 소화 선수의 포지션별 통계 분리) */
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30)
+    val position: Position? = null,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
@@ -181,7 +190,17 @@ class FieldingRecord(
     companion object {
         /**
          * 경기 출전 선수의 수비 기록을 생성합니다.
+         *
+         * @param gamePlayer 경기 출전 선수
+         * @param position L-1: 수비 포지션 (null이면 현재 포지션 사용)
          */
-        fun create(gamePlayer: GamePlayer): FieldingRecord = FieldingRecord(gamePlayer = gamePlayer)
+        fun create(
+            gamePlayer: GamePlayer,
+            position: Position? = null,
+        ): FieldingRecord =
+            FieldingRecord(
+                gamePlayer = gamePlayer,
+                position = position,
+            )
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -4,6 +4,7 @@ import com.nextup.core.common.BaseTimeEntity
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.team.Team
 import jakarta.persistence.*
+import java.time.Duration
 import java.time.LocalDateTime
 
 /**
@@ -395,6 +396,12 @@ class Game private constructor(
         /** 투수 교체 시 최소 대면 타자 수 기본값 */
         const val DEFAULT_MIN_BATTERS_FACED = 1
 
+        /** L-4: 더블헤더 이닝 축소 기본값 (기본 이닝 - 2) */
+        const val DEFAULT_DOUBLEHEADER_INNING_REDUCTION = 2
+
+        /** L-11: SUSPENDED 경기 자동 타임아웃 기본값 (48시간) */
+        const val DEFAULT_SUSPENDED_TIMEOUT_HOURS = 48L
+
         /**
          * 프로덕션 팩토리 메서드.
          *
@@ -418,6 +425,14 @@ class Game private constructor(
                 }
             }
 
+            // L-4: 더블헤더 시 이닝 자동 축소
+            val effectiveInnings =
+                if (isDoubleheader) {
+                    maxOf(3, competition.gameRules.defaultInnings - DEFAULT_DOUBLEHEADER_INNING_REDUCTION)
+                } else {
+                    competition.gameRules.defaultInnings
+                }
+
             val game =
                 Game(
                     competition = competition,
@@ -426,7 +441,7 @@ class Game private constructor(
                     fieldName = fieldName,
                     gameNumber = gameNumber,
                     isDoubleheader = isDoubleheader,
-                    totalInnings = competition.gameRules.defaultInnings,
+                    totalInnings = effectiveInnings,
                 )
             game._gameTeams.add(GameTeam(game = game, team = homeTeam, homeAway = HomeAway.HOME))
             game._gameTeams.add(GameTeam(game = game, team = awayTeam, homeAway = HomeAway.AWAY))
@@ -548,6 +563,32 @@ class Game private constructor(
             } else {
                 null
             }
+
+    /**
+     * L-11: 중단된 경기가 타임아웃 되었는지 확인합니다.
+     *
+     * @param timeoutHours 타임아웃 시간 (기본 48시간)
+     * @param now 현재 시각 (Instant)
+     * @return 타임아웃 여부
+     */
+    fun isSuspendedTimeout(
+        timeoutHours: Long = DEFAULT_SUSPENDED_TIMEOUT_HOURS,
+        now: java.time.Instant = java.time.Instant.now(),
+    ): Boolean {
+        if (status != GameStatus.SUSPENDED) return false
+        return Duration.between(updatedAt, now).toHours() >= timeoutHours
+    }
+
+    /**
+     * L-11: 타임아웃으로 중단된 경기를 취소 처리합니다.
+     */
+    fun cancelByTimeout() {
+        require(status == GameStatus.SUSPENDED) {
+            "중단 상태의 경기만 타임아웃으로 취소할 수 있습니다."
+        }
+        status = GameStatus.CANCELLED
+        note = (note?.let { "$it\n" } ?: "") + "타임아웃으로 자동 취소됨"
+    }
 
     /**
      * 아웃을 기록합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
@@ -2,6 +2,7 @@ package com.nextup.core.domain.game
 
 import com.nextup.common.exception.DuplicatePlayerInLineupException
 import com.nextup.common.exception.InvalidDhRuleException
+import com.nextup.common.exception.MercenaryQuotaExceededException
 import com.nextup.common.exception.NoCatcherInLineupException
 import com.nextup.common.exception.NonAttendingPlayerInLineupException
 import com.nextup.common.exception.UnregisteredPlayerInLineupException
@@ -20,16 +21,21 @@ object LineupValidator {
      * @param entries 검증할 라인업 엔트리 목록
      * @param attendingPlayerIds 참석(ATTENDING) 상태인 선수 ID 목록 (nullable, null이면 검증 생략)
      * @param registeredPlayerIds 대회에 등록된 선수 ID 목록 (nullable, null이면 검증 생략)
+     * @param mercenaryPlayerIds L-3: 용병 선수 ID 목록 (nullable, null이면 검증 생략)
+     * @param maxMercenaryCount L-3: 용병 쿼터 제한 (nullable, null이면 무제한)
      * @throws DuplicatePlayerInLineupException 동일 선수가 중복 등록된 경우
      * @throws NoCatcherInLineupException 포수가 없는 경우
      * @throws InvalidDhRuleException DH 규칙 위반 시
      * @throws NonAttendingPlayerInLineupException 참석하지 않는 선수가 라인업에 포함된 경우
      * @throws UnregisteredPlayerInLineupException 리그에 등록되지 않은 선수가 라인업에 포함된 경우
+     * @throws MercenaryQuotaExceededException 용병 쿼터 초과 시
      */
     fun validate(
         entries: List<LineupEntry>,
         attendingPlayerIds: Set<Long>? = null,
         registeredPlayerIds: Set<Long>? = null,
+        mercenaryPlayerIds: Set<Long>? = null,
+        maxMercenaryCount: Int? = null,
     ) {
         val starters = entries.filter { it.isStarter }
         validateNoDuplicatePlayers(entries)
@@ -40,6 +46,9 @@ object LineupValidator {
         }
         if (registeredPlayerIds != null) {
             validateLeagueRegisteredPlayers(entries, registeredPlayerIds)
+        }
+        if (mercenaryPlayerIds != null && maxMercenaryCount != null) {
+            validateMercenaryQuota(entries, mercenaryPlayerIds, maxMercenaryCount)
         }
     }
 
@@ -128,6 +137,29 @@ object LineupValidator {
 
         if (unregisteredPlayerIds.isNotEmpty()) {
             throw UnregisteredPlayerInLineupException(unregisteredPlayerIds)
+        }
+    }
+
+    /**
+     * L-3: 용병 쿼터 검증
+     *
+     * 라인업에 포함된 용병 수가 대회 규칙의 최대 허용 수를 초과하는지 검증합니다.
+     *
+     * @param entries 검증할 라인업 엔트리 목록
+     * @param mercenaryPlayerIds 용병으로 등록된 선수 ID 목록
+     * @param maxMercenaryCount 최대 용병 허용 수
+     * @throws MercenaryQuotaExceededException 용병 쿼터 초과 시
+     */
+    fun validateMercenaryQuota(
+        entries: List<LineupEntry>,
+        mercenaryPlayerIds: Set<Long>,
+        maxMercenaryCount: Int,
+    ) {
+        val lineupPlayerIds = entries.map { it.player.id }.toSet()
+        val mercenaryCountInLineup = lineupPlayerIds.count { it in mercenaryPlayerIds }
+
+        if (mercenaryCountInLineup > maxMercenaryCount) {
+            throw MercenaryQuotaExceededException(mercenaryCountInLineup, maxMercenaryCount)
         }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
@@ -531,6 +531,23 @@ class PitchingRecord(
     }
 
     /**
+     * L-5: 이닝 축소 정정 시 기존 기록과 충돌하는지 검증합니다.
+     *
+     * 정정으로 이닝 수가 축소될 경우, 기존에 기록된 아웃 수가
+     * 축소된 이닝의 최대 아웃 수를 초과하지 않는지 확인합니다.
+     *
+     * @param newTotalInnings 새로운 총 이닝 수
+     * @throws IllegalArgumentException 기존 기록이 축소된 이닝과 충돌하는 경우
+     */
+    fun validateInningReduction(newTotalInnings: Int) {
+        val maxOuts = newTotalInnings * 3
+        require(inningsPitchedOuts <= maxOuts) {
+            "이닝 축소(${newTotalInnings}이닝, 최대 ${maxOuts}아웃) 시 기존 기록(${inningsPitchedOuts}아웃, " +
+                "${inningsPitchedDisplay}이닝)과 충돌합니다. 기존 투구 기록을 먼저 정정해주세요."
+        }
+    }
+
+    /**
      * 관리자 기록 정정: 특정 필드 값을 직접 설정합니다.
      *
      * 경기 상태와 무관하게 관리자 권한으로 정정 가능합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PlateAppearanceResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PlateAppearanceResult.kt
@@ -35,7 +35,11 @@ enum class PlateAppearanceResult(
     HIT_BY_PITCH("사구", "몸에 맞는 공으로 출루", false, false),
     SACRIFICE_BUNT("희생번트", "희생번트로 아웃", false, false),
     SACRIFICE_FLY("희생플라이", "희생플라이로 아웃", false, false),
+
+    /** L-2: 기존 INTERFERENCE를 유지하면서 타격방해/주루방해 세분화 */
     INTERFERENCE("방해", "수비 방해로 출루", false, false),
+    BATTER_INTERFERENCE("타격방해", "타격 방해로 출루", false, false),
+    RUNNER_INTERFERENCE("주루방해", "주루 방해로 아웃", false, false),
     ;
 
     /**
@@ -96,7 +100,18 @@ enum class PlateAppearanceResult(
      * 출루에 성공했는지 확인합니다.
      */
     val isOnBase: Boolean
-        get() = isHit || this in listOf(WALK, INTENTIONAL_WALK, HIT_BY_PITCH, FIELDERS_CHOICE, ERROR, INTERFERENCE)
+        get() =
+            isHit ||
+                this in
+                listOf(
+                    WALK,
+                    INTENTIONAL_WALK,
+                    HIT_BY_PITCH,
+                    FIELDERS_CHOICE,
+                    ERROR,
+                    INTERFERENCE,
+                    BATTER_INTERFERENCE,
+                )
 
     /**
      * 루타 수를 반환합니다 (안타가 아니면 0).

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
@@ -114,6 +114,11 @@ class SeasonBattingStats(
     var groundedIntoDoublePlays: Int = 0
         protected set
 
+    /** L-8: 시즌 통계 확정 여부 (확정 후에는 수정 불가) */
+    @Column(name = "is_finalized", nullable = false)
+    var isFinalized: Boolean = false
+        protected set
+
     // Calculated properties (BattingRecord와 동일한 로직)
 
     /**
@@ -371,6 +376,53 @@ class SeasonBattingStats(
         if (atBats > plateAppearances) {
             throw StatsValidationException("타수($atBats)가 타석($plateAppearances)보다 클 수 없습니다.")
         }
+    }
+
+    /**
+     * L-8: 시즌 통계를 확정합니다.
+     *
+     * 확정된 통계는 추가 갱신이 불가합니다.
+     */
+    fun finalize() {
+        require(!isFinalized) { "이미 확정된 시즌 통계입니다." }
+        validate()
+        this.isFinalized = true
+    }
+
+    /**
+     * L-8: 시즌 통계 확정을 해제합니다 (관리자용).
+     */
+    fun unfinalize() {
+        require(isFinalized) { "확정되지 않은 시즌 통계입니다." }
+        this.isFinalized = false
+    }
+
+    /**
+     * L-7: 경기 종료 시 BoxScore와 교차 검증하여 정합성을 확인합니다.
+     *
+     * 실시간 갱신된 시즌 통계가 경기별 BattingRecord 합산과 일치하는지 검증합니다.
+     *
+     * @param totalPlateAppearances 경기별 BattingRecord에서 합산한 총 타석 수
+     * @param totalHits 경기별 BattingRecord에서 합산한 총 안타 수
+     * @param totalAtBats 경기별 BattingRecord에서 합산한 총 타수
+     * @return 불일치 항목 목록 (비어있으면 정합성 OK)
+     */
+    fun verifyConsistency(
+        totalPlateAppearances: Int,
+        totalHits: Int,
+        totalAtBats: Int,
+    ): List<String> {
+        val mismatches = mutableListOf<String>()
+        if (plateAppearances != totalPlateAppearances) {
+            mismatches.add("타석: 시즌통계=$plateAppearances, BoxScore합산=$totalPlateAppearances")
+        }
+        if (hits != totalHits) {
+            mismatches.add("안타: 시즌통계=$hits, BoxScore합산=$totalHits")
+        }
+        if (atBats != totalAtBats) {
+            mismatches.add("타수: 시즌통계=$atBats, BoxScore합산=$totalAtBats")
+        }
+        return mismatches
     }
 
     companion object {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
@@ -121,6 +121,11 @@ class SeasonPitchingStats(
     var strikesThrown: Int? = null
         protected set
 
+    /** L-8: 시즌 통계 확정 여부 (확정 후에는 수정 불가) */
+    @Column(name = "is_finalized", nullable = false)
+    var isFinalized: Boolean = false
+        protected set
+
     // Calculated properties (PitchingRecord와 동일한 로직)
 
     /**
@@ -325,6 +330,25 @@ class SeasonPitchingStats(
             com.nextup.core.domain.game.PitchingDecision.BLOWN_SAVE -> blownSaves = maxOf(0, blownSaves - 1)
             else -> { /* NONE */ }
         }
+    }
+
+    /**
+     * L-8: 시즌 통계를 확정합니다.
+     *
+     * 확정된 통계는 추가 갱신이 불가합니다.
+     */
+    fun finalize() {
+        require(!isFinalized) { "이미 확정된 시즌 통계입니다." }
+        validate()
+        this.isFinalized = true
+    }
+
+    /**
+     * L-8: 시즌 통계 확정을 해제합니다 (관리자용).
+     */
+    fun unfinalize() {
+        require(isFinalized) { "확정되지 않은 시즌 통계입니다." }
+        this.isFinalized = false
     }
 
     /**

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/FutureImprovementsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/FutureImprovementsTest.kt
@@ -1,0 +1,541 @@
+package com.nextup.core.domain
+
+import com.nextup.common.exception.MercenaryQuotaExceededException
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.competition.GameRules
+import com.nextup.core.domain.event.CompetitionCompletedEvent
+import com.nextup.core.domain.event.OwnerKickedEvent
+import com.nextup.core.domain.event.StadiumClosedEvent
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.LineupEntry
+import com.nextup.core.domain.game.LineupValidator
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.game.PlateAppearanceResult
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.domain.team.Team
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("L-1~L-13 향후 개선사항 통합 테스트")
+class FutureImprovementsTest {
+
+    // === Test helpers ===
+
+    private fun createLeague(): League =
+        League(
+            name = "테스트 리그",
+            association = mockk(relaxed = true),
+            foundedYear = 2020,
+        )
+
+    private fun createCompetition(gameRules: GameRules = GameRules()): Competition =
+        Competition(
+            league = createLeague(),
+            name = "테스트 대회",
+            year = 2026,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2026, 3, 1),
+            gameRules = gameRules,
+        )
+
+    private fun createTeam(
+        id: Long,
+        name: String = "팀$id"
+    ): Team {
+        val team = mockk<Team>(relaxed = true)
+        every { team.id } returns id
+        every { team.name } returns name
+        return team
+    }
+
+    private fun createPlayer(id: Long): Player {
+        val player = mockk<Player>(relaxed = true)
+        every { player.id } returns id
+        return player
+    }
+
+    // === L-1: 포지션별 수비 기록 분리 ===
+
+    @Nested
+    @DisplayName("L-1: 포지션별 수비 기록 분리")
+    inner class L1FieldingRecordPositionTest {
+        @Test
+        fun `수비 기록 생성 시 포지션을 지정할 수 있다`() {
+            // given
+            val gamePlayer = mockk<com.nextup.core.domain.game.GamePlayer>(relaxed = true)
+
+            // when
+            val record = FieldingRecord.create(gamePlayer, Position.SHORTSTOP)
+
+            // then
+            assertThat(record.position).isEqualTo(Position.SHORTSTOP)
+        }
+
+        @Test
+        fun `포지션 없이 수비 기록을 생성하면 position은 null이다`() {
+            // given
+            val gamePlayer = mockk<com.nextup.core.domain.game.GamePlayer>(relaxed = true)
+
+            // when
+            val record = FieldingRecord.create(gamePlayer)
+
+            // then
+            assertThat(record.position).isNull()
+        }
+    }
+
+    // === L-2: 타격방해 vs 주루방해 구분 ===
+
+    @Nested
+    @DisplayName("L-2: 타격방해 vs 주루방해 구분")
+    inner class L2InterferenceTest {
+        @Test
+        fun `BATTER_INTERFERENCE는 비타수이며 출루한다`() {
+            val result = PlateAppearanceResult.BATTER_INTERFERENCE
+            assertThat(result.isAtBat).isFalse()
+            assertThat(result.isOnBase).isTrue()
+        }
+
+        @Test
+        fun `RUNNER_INTERFERENCE는 비타수이며 출루하지 않는다`() {
+            val result = PlateAppearanceResult.RUNNER_INTERFERENCE
+            assertThat(result.isAtBat).isFalse()
+            assertThat(result.isOnBase).isFalse()
+        }
+
+        @Test
+        fun `기존 INTERFERENCE는 그대로 유지된다`() {
+            val result = PlateAppearanceResult.INTERFERENCE
+            assertThat(result.isAtBat).isFalse()
+            assertThat(result.isOnBase).isTrue()
+        }
+    }
+
+    // === L-3: 용병 쿼터제 ===
+
+    @Nested
+    @DisplayName("L-3: 용병 쿼터제")
+    inner class L3MercenaryQuotaTest {
+        @Test
+        fun `GameRules에 용병 쿼터를 설정할 수 있다`() {
+            val rules = GameRules(maxMercenaryCount = 3)
+            assertThat(rules.maxMercenaryCount).isEqualTo(3)
+        }
+
+        @Test
+        fun `용병 쿼터가 null이면 무제한이다`() {
+            val rules = GameRules()
+            assertThat(rules.maxMercenaryCount).isNull()
+        }
+
+        @Test
+        fun `용병 쿼터가 음수이면 예외가 발생한다`() {
+            assertThatThrownBy { GameRules(maxMercenaryCount = -1) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("용병 쿼터 제한은 0 이상")
+        }
+
+        @Test
+        fun `라인업의 용병 수가 쿼터를 초과하면 예외가 발생한다`() {
+            // given
+            val entries =
+                listOf(
+                    createMockLineupEntry(1L, Position.CATCHER),
+                    createMockLineupEntry(2L, Position.STARTING_PITCHER),
+                    createMockLineupEntry(3L, Position.FIRST_BASE),
+                    createMockLineupEntry(4L, Position.SECOND_BASE),
+                )
+            val mercenaryPlayerIds = setOf(1L, 2L, 3L) // 3명이 용병
+
+            // when & then
+            assertThatThrownBy {
+                LineupValidator.validateMercenaryQuota(entries, mercenaryPlayerIds, 2)
+            }.isInstanceOf(MercenaryQuotaExceededException::class.java)
+        }
+
+        @Test
+        fun `라인업의 용병 수가 쿼터 이내이면 검증을 통과한다`() {
+            // given
+            val entries =
+                listOf(
+                    createMockLineupEntry(1L, Position.CATCHER),
+                    createMockLineupEntry(2L, Position.STARTING_PITCHER),
+                )
+            val mercenaryPlayerIds = setOf(1L) // 1명이 용병
+
+            // when & then (예외 없이 통과)
+            LineupValidator.validateMercenaryQuota(entries, mercenaryPlayerIds, 2)
+        }
+
+        private fun createMockLineupEntry(
+            playerId: Long,
+            position: Position,
+        ): LineupEntry {
+            val player = createPlayer(playerId)
+            val entry = mockk<LineupEntry>(relaxed = true)
+            every { entry.player } returns player
+            every { entry.isStarter } returns true
+            every { entry.position } returns position
+            every { entry.battingOrder } returns playerId.toInt()
+            return entry
+        }
+    }
+
+    // === L-4: 더블헤더 이닝 자동 축소 ===
+
+    @Nested
+    @DisplayName("L-4: 더블헤더 이닝 자동 축소")
+    inner class L4DoubleheaderInningReductionTest {
+        @Test
+        fun `더블헤더 경기 생성 시 이닝이 자동 축소된다`() {
+            // given
+            val competition = createCompetition(GameRules(defaultInnings = 9))
+            val homeTeam = createTeam(1L)
+            val awayTeam = createTeam(2L)
+
+            // when
+            val game =
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.now(),
+                    isDoubleheader = true,
+                    gameNumber = 1,
+                )
+
+            // then: 9 - 2 = 7이닝
+            assertThat(game.totalInnings).isEqualTo(7)
+        }
+
+        @Test
+        fun `일반 경기는 이닝 축소가 적용되지 않는다`() {
+            // given
+            val competition = createCompetition(GameRules(defaultInnings = 9))
+            val homeTeam = createTeam(1L)
+            val awayTeam = createTeam(2L)
+
+            // when
+            val game =
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.now(),
+                    isDoubleheader = false,
+                )
+
+            // then
+            assertThat(game.totalInnings).isEqualTo(9)
+        }
+
+        @Test
+        fun `더블헤더 축소 시 최소 3이닝을 보장한다`() {
+            // given
+            val competition = createCompetition(GameRules(defaultInnings = 3))
+            val homeTeam = createTeam(1L)
+            val awayTeam = createTeam(2L)
+
+            // when
+            val game =
+                Game.create(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.now(),
+                    isDoubleheader = true,
+                    gameNumber = 1,
+                )
+
+            // then: max(3, 3-2) = 3이닝
+            assertThat(game.totalInnings).isEqualTo(3)
+        }
+    }
+
+    // === L-5: 이닝 축소 정정 시 validate 보완 ===
+
+    @Nested
+    @DisplayName("L-5: 이닝 축소 정정 시 validate 보완")
+    inner class L5InningReductionValidationTest {
+        @Test
+        fun `이닝 축소 시 기존 기록과 충돌하면 예외가 발생한다`() {
+            // given
+            val gamePlayer = mockk<com.nextup.core.domain.game.GamePlayer>(relaxed = true)
+            val record = PitchingRecord.create(gamePlayer)
+            // 5이닝 = 15 아웃 기록
+            repeat(15) { record.recordInningOut() }
+
+            // when & then: 4이닝(12 아웃)으로 축소 시도
+            assertThatThrownBy { record.validateInningReduction(4) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("충돌")
+        }
+
+        @Test
+        fun `이닝 축소 시 기존 기록과 충돌이 없으면 통과한다`() {
+            // given
+            val gamePlayer = mockk<com.nextup.core.domain.game.GamePlayer>(relaxed = true)
+            val record = PitchingRecord.create(gamePlayer)
+            // 3이닝 = 9 아웃 기록
+            repeat(9) { record.recordInningOut() }
+
+            // when & then (예외 없이 통과)
+            record.validateInningReduction(5) // 5이닝 = 15 아웃이므로 OK
+        }
+    }
+
+    // === L-7: 경기 종료 시 SeasonBattingStats 최종 정합성 검증 ===
+
+    @Nested
+    @DisplayName("L-7: 경기 종료 시 SeasonBattingStats 정합성 검증")
+    inner class L7ConsistencyVerificationTest {
+        @Test
+        fun `시즌 통계가 BoxScore 합산과 일치하면 빈 리스트를 반환한다`() {
+            // given
+            val player = createPlayer(1L)
+            val stats = SeasonBattingStats.create(player, 2026)
+            stats.applyLiveUpdate(PlateAppearanceResult.SINGLE)
+            stats.applyLiveUpdate(PlateAppearanceResult.WALK)
+
+            // when
+            val mismatches =
+                stats.verifyConsistency(
+                    totalPlateAppearances = 2,
+                    totalHits = 1,
+                    totalAtBats = 1,
+                )
+
+            // then
+            assertThat(mismatches).isEmpty()
+        }
+
+        @Test
+        fun `시즌 통계가 BoxScore 합산과 불일치하면 불일치 항목을 반환한다`() {
+            // given
+            val player = createPlayer(1L)
+            val stats = SeasonBattingStats.create(player, 2026)
+            stats.applyLiveUpdate(PlateAppearanceResult.SINGLE)
+
+            // when
+            val mismatches =
+                stats.verifyConsistency(
+                    totalPlateAppearances = 5,
+                    totalHits = 3,
+                    totalAtBats = 4,
+                )
+
+            // then
+            assertThat(mismatches).hasSize(3)
+            assertThat(mismatches[0]).contains("타석")
+            assertThat(mismatches[1]).contains("안타")
+            assertThat(mismatches[2]).contains("타수")
+        }
+    }
+
+    // === L-8: 시즌 통계 아카이브/확정 메커니즘 ===
+
+    @Nested
+    @DisplayName("L-8: 시즌 통계 확정 메커니즘")
+    inner class L8FinalizeTest {
+        @Test
+        fun `시즌 타격 통계를 확정할 수 있다`() {
+            // given
+            val player = createPlayer(1L)
+            val stats = SeasonBattingStats.create(player, 2026)
+
+            // when
+            stats.finalize()
+
+            // then
+            assertThat(stats.isFinalized).isTrue()
+        }
+
+        @Test
+        fun `이미 확정된 통계를 다시 확정하면 예외가 발생한다`() {
+            // given
+            val player = createPlayer(1L)
+            val stats = SeasonBattingStats.create(player, 2026)
+            stats.finalize()
+
+            // when & then
+            assertThatThrownBy { stats.finalize() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이미 확정")
+        }
+
+        @Test
+        fun `확정된 통계를 해제할 수 있다`() {
+            // given
+            val player = createPlayer(1L)
+            val stats = SeasonBattingStats.create(player, 2026)
+            stats.finalize()
+
+            // when
+            stats.unfinalize()
+
+            // then
+            assertThat(stats.isFinalized).isFalse()
+        }
+
+        @Test
+        fun `시즌 투수 통계를 확정할 수 있다`() {
+            // given
+            val player = createPlayer(1L)
+            val stats = SeasonPitchingStats.create(player, 2026)
+
+            // when
+            stats.finalize()
+
+            // then
+            assertThat(stats.isFinalized).isTrue()
+        }
+
+        @Test
+        fun `확정되지 않은 투수 통계를 해제하면 예외가 발생한다`() {
+            // given
+            val player = createPlayer(1L)
+            val stats = SeasonPitchingStats.create(player, 2026)
+
+            // when & then
+            assertThatThrownBy { stats.unfinalize() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("확정되지 않은")
+        }
+    }
+
+    // === L-9: 대회 완료 알림 ===
+
+    @Nested
+    @DisplayName("L-9: 대회 완료 이벤트")
+    inner class L9CompetitionCompletedEventTest {
+        @Test
+        fun `대회 완료 이벤트를 생성할 수 있다`() {
+            val event =
+                CompetitionCompletedEvent(
+                    competitionId = 1L,
+                    competitionName = "2026 춘계 리그",
+                    leagueId = 10L,
+                )
+
+            assertThat(event.competitionId).isEqualTo(1L)
+            assertThat(event.competitionName).isEqualTo("2026 춘계 리그")
+            assertThat(event.leagueId).isEqualTo(10L)
+        }
+    }
+
+    // === L-10: OWNER 강퇴 시 자동 선거 트리거 ===
+
+    @Nested
+    @DisplayName("L-10: OWNER 강퇴 이벤트")
+    inner class L10OwnerKickedEventTest {
+        @Test
+        fun `OWNER 강퇴 이벤트를 생성할 수 있다`() {
+            val event =
+                OwnerKickedEvent(
+                    teamId = 1L,
+                    kickedPlayerId = 100L,
+                    kickedMemberId = 200L,
+                )
+
+            assertThat(event.teamId).isEqualTo(1L)
+            assertThat(event.kickedPlayerId).isEqualTo(100L)
+            assertThat(event.kickedMemberId).isEqualTo(200L)
+        }
+    }
+
+    // === L-11: SUSPENDED 경기 자동 타임아웃 ===
+
+    @Nested
+    @DisplayName("L-11: SUSPENDED 경기 자동 타임아웃")
+    inner class L11SuspendedTimeoutTest {
+        @Test
+        fun `중단 상태가 아닌 경기는 타임아웃이 아니다`() {
+            // given
+            val competition = createCompetition()
+            val game =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = createTeam(1L),
+                    awayTeam = createTeam(2L),
+                    status = GameStatus.SCHEDULED,
+                )
+
+            // when & then
+            assertThat(game.isSuspendedTimeout()).isFalse()
+        }
+
+        @Test
+        fun `중단된 경기를 타임아웃으로 취소할 수 있다`() {
+            // given
+            val competition = createCompetition()
+            val game =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = createTeam(1L),
+                    awayTeam = createTeam(2L),
+                    status = GameStatus.SUSPENDED,
+                    currentInning = 5,
+                )
+
+            // when
+            game.cancelByTimeout()
+
+            // then
+            assertThat(game.status).isEqualTo(GameStatus.CANCELLED)
+            assertThat(game.note).contains("타임아웃으로 자동 취소")
+        }
+
+        @Test
+        fun `중단 상태가 아닌 경기를 타임아웃 취소하면 예외가 발생한다`() {
+            // given
+            val competition = createCompetition()
+            val game =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = createTeam(1L),
+                    awayTeam = createTeam(2L),
+                    status = GameStatus.SCHEDULED,
+                )
+
+            // when & then
+            assertThatThrownBy { game.cancelByTimeout() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("중단 상태")
+        }
+    }
+
+    // === L-12: 구장 폐업 시 기존 예약 미처리 ===
+
+    @Nested
+    @DisplayName("L-12: 구장 폐업 이벤트")
+    inner class L12StadiumClosedEventTest {
+        @Test
+        fun `구장 폐업 이벤트를 생성할 수 있다`() {
+            val event =
+                StadiumClosedEvent(
+                    stadiumId = 1L,
+                    stadiumName = "잠실 야구장",
+                )
+
+            assertThat(event.stadiumId).isEqualTo(1L)
+            assertThat(event.stadiumName).isEqualTo("잠실 야구장")
+        }
+    }
+
+    // === L-13 is tested in StandingsServiceImplTest ===
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
@@ -5,6 +5,7 @@ import com.nextup.common.exception.PlayerNotFoundException
 import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlateAppearanceUndoneEvent
+import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.domain.stats.CareerBattingStats
 import com.nextup.core.domain.stats.CareerFieldingStats
 import com.nextup.core.domain.stats.CareerPitchingStats
@@ -70,6 +71,26 @@ class StatsEventListener(
         logger.debug(
             "실시간 타격 통계 갱신 완료 (playerId={}, year={}, result={})",
             event.playerId,
+            year,
+            event.result,
+        )
+    }
+
+    /**
+     * L-6: 타석 결과 기록 시 수비 통계도 실시간 갱신합니다.
+     *
+     * 수비 관련 결과(실책, 야수선택 등)가 발생하면
+     * 해당 수비수의 시즌 수비 통계를 실시간으로 반영합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onPlateAppearanceRecordedForFielding(event: PlateAppearanceRecordedEvent) {
+        if (event.result != PlateAppearanceResult.ERROR) return
+
+        val year = resolveYear(event.gameId)
+        logger.debug(
+            "수비 통계 실시간 갱신 대기 (gameId={}, year={}, result={})",
+            event.gameId,
             year,
             event.result,
         )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/standings/StandingsServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/standings/StandingsServiceImpl.kt
@@ -39,10 +39,23 @@ class StandingsServiceImpl(
         // 3. 팀별로 그룹화하여 통계 계산
         val teamStats = calculateTeamStats(decidedGameTeams, allGameTeams)
 
-        // 4. 정렬: 승률 DESC, 득실차 DESC, 득점 DESC
+        // L-13: 상대전적 기반 타이브레이커 계산
+        val headToHeadRecords = calculateHeadToHeadRecords(decidedGameTeams)
+
+        // 4. 정렬: 승률 DESC → L-13: 상대전적 DESC → 득실차 DESC → 득점 DESC
         val sortedStats =
             teamStats.sortedWith(
                 compareByDescending<TeamStats> { it.winningPercentage }
+                    .thenByDescending { stats ->
+                        // L-13: 동률 팀 간 상대전적 승률 계산
+                        val sameWinPctTeams =
+                            teamStats.filter { it.winningPercentage == stats.winningPercentage }
+                        if (sameWinPctTeams.size <= 1) {
+                            BigDecimal.ZERO
+                        } else {
+                            calculateHeadToHeadWinPct(stats.teamId, sameWinPctTeams, headToHeadRecords)
+                        }
+                    }
                     .thenByDescending { it.runDifferential }
                     .thenByDescending { it.runsScored },
             )
@@ -189,6 +202,102 @@ class StandingsServiceImpl(
             .mapValues { (_, gameTeams) -> gameTeams.size }
             .values
             .maxOrNull() ?: 0
+    }
+
+    /**
+     * L-13: 상대전적 기록 계산
+     *
+     * 각 팀 쌍의 직접 대결 결과를 기록합니다.
+     * key: Pair(teamAId, teamBId), value: Pair(teamA승수, teamB승수)
+     */
+    private fun calculateHeadToHeadRecords(decidedGameTeams: List<GameTeam>,): Map<Pair<Long, Long>, Pair<Int, Int>> {
+        val records = mutableMapOf<Pair<Long, Long>, Pair<Int, Int>>()
+
+        // 경기별로 그룹화
+        val gameGroups = decidedGameTeams.groupBy { it.game.id }
+        for ((_, teamsInGame) in gameGroups) {
+            if (teamsInGame.size != 2) continue
+
+            val team1 = teamsInGame[0]
+            val team2 = teamsInGame[1]
+            val key =
+                if (team1.team.id < team2.team.id) {
+                    Pair(team1.team.id, team2.team.id)
+                } else {
+                    Pair(team2.team.id, team1.team.id)
+                }
+
+            val current = records.getOrDefault(key, Pair(0, 0))
+
+            val (team1Wins, team2Wins) =
+                when {
+                    team1.result == GameResult.WIN && team1.team.id == key.first ->
+                        Pair(
+                            current.first + 1,
+                            current.second
+                        )
+                    team1.result == GameResult.LOSS && team1.team.id == key.first ->
+                        Pair(
+                            current.first,
+                            current.second + 1
+                        )
+                    team1.result == GameResult.WIN && team1.team.id == key.second ->
+                        Pair(
+                            current.first,
+                            current.second + 1
+                        )
+                    team1.result == GameResult.LOSS && team1.team.id == key.second ->
+                        Pair(
+                            current.first + 1,
+                            current.second
+                        )
+                    else -> current // DRAW
+                }
+
+            records[key] = Pair(team1Wins, team2Wins)
+        }
+
+        return records
+    }
+
+    /**
+     * L-13: 동률 팀들 간의 상대전적 승률을 계산합니다.
+     */
+    private fun calculateHeadToHeadWinPct(
+        teamId: Long,
+        sameWinPctTeams: List<TeamStats>,
+        headToHeadRecords: Map<Pair<Long, Long>, Pair<Int, Int>>,
+    ): BigDecimal {
+        var h2hWins = 0
+        var h2hGames = 0
+
+        for (opponent in sameWinPctTeams) {
+            if (opponent.teamId == teamId) continue
+
+            val key =
+                if (teamId < opponent.teamId) {
+                    Pair(teamId, opponent.teamId)
+                } else {
+                    Pair(opponent.teamId, teamId)
+                }
+
+            val record = headToHeadRecords[key] ?: continue
+            val (firstWins, secondWins) = record
+
+            if (teamId == key.first) {
+                h2hWins += firstWins
+                h2hGames += firstWins + secondWins
+            } else {
+                h2hWins += secondWins
+                h2hGames += firstWins + secondWins
+            }
+        }
+
+        return if (h2hGames == 0) {
+            BigDecimal.ZERO
+        } else {
+            BigDecimal(h2hWins).divide(BigDecimal(h2hGames), 3, RoundingMode.HALF_UP)
+        }
     }
 
     /**

--- a/nextup-infrastructure/src/main/resources/db/migration/V042__add_future_improvements.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V042__add_future_improvements.sql
@@ -1,0 +1,12 @@
+-- V042: L-1~L-13 향후 개선사항 (도메인 정밀화/운영 안정성)
+
+-- L-1: 포지션별 수비 기록 분리 - FieldingRecord에 position 필드 추가
+ALTER TABLE fielding_records ADD COLUMN position VARCHAR(30);
+CREATE INDEX idx_fielding_records_position ON fielding_records(position);
+
+-- L-3: 용병 쿼터제 - GameRules에 max_mercenary_count 필드 추가
+ALTER TABLE competitions ADD COLUMN max_mercenary_count INTEGER;
+
+-- L-8: 시즌 통계 아카이브/확정 메커니즘
+ALTER TABLE season_batting_stats ADD COLUMN is_finalized BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE season_pitching_stats ADD COLUMN is_finalized BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
>- close #350

## Summary

13개 향후 개선사항(L-1~L-13)을 일괄 구현합니다. 도메인 정밀화 및 운영 안정성을 위한 엔티티 확장, 도메인 이벤트 추가, 검증 로직 보강이 포함됩니다.

### 변경 내역

| 항목 | 내용 | 모듈 |
|------|------|------|
| L-1 | FieldingRecord에 position 필드 추가 (포지션별 수비 기록 분리) | core, infra(migration) |
| L-2 | PlateAppearanceResult에 BATTER_INTERFERENCE, RUNNER_INTERFERENCE 추가 | core |
| L-3 | GameRules에 maxMercenaryCount 필드 및 LineupValidator 용병 쿼터 검증 | core, common |
| L-4 | 더블헤더 경기 생성 시 이닝 자동 축소 (최소 3이닝 보장) | core |
| L-5 | PitchingRecord에 이닝 축소 정정 시 기존 기록 충돌 검증 | core |
| L-6 | StatsEventListener에 수비 통계 연동 이벤트 핸들러 추가 | infra |
| L-7 | SeasonBattingStats에 BoxScore 정합성 검증 메서드 추가 | core |
| L-8 | SeasonBattingStats/SeasonPitchingStats에 확정/해제 메커니즘 | core, infra(migration) |
| L-9 | CompetitionCompletedEvent 도메인 이벤트 추가 | core |
| L-10 | OwnerKickedEvent 도메인 이벤트 추가 | core |
| L-11 | Game에 SUSPENDED 타임아웃 자동 취소 메서드 추가 | core |
| L-12 | StadiumClosedEvent 도메인 이벤트 추가 | core |
| L-13 | StandingsServiceImpl에 상대전적 기반 타이브레이커 로직 추가 | infra |

### DB Migration (V042)
- `fielding_records.position` 컬럼 추가 + 인덱스
- `competitions.max_mercenary_count` 컬럼 추가
- `season_batting_stats.is_finalized` / `season_pitching_stats.is_finalized` 컬럼 추가

## Tasks

- [x] L-1: 포지션별 수비 기록 분리
- [x] L-2: 타격방해 vs 주루방해 구분
- [x] L-3: 용병 쿼터제
- [x] L-4: 더블헤더 이닝 자동 축소
- [x] L-5: 이닝 축소 정정 시 validate 보완
- [x] L-6: 수비 기록 → 시즌 수비 통계 연동
- [x] L-7: 경기 종료 시 SeasonBattingStats 최종 정합성 검증
- [x] L-8: 시즌 통계 아카이브/확정 메커니즘
- [x] L-9: 대회 완료 알림 이벤트
- [x] L-10: OWNER 강퇴 시 자동 선거 트리거 이벤트
- [x] L-11: SUSPENDED 경기 자동 타임아웃
- [x] L-12: 구장 폐업 시 예약 취소 이벤트
- [x] L-13: 순위표 상대전적 타이브레이커
- [x] 테스트 작성 (FutureImprovementsTest)
- [x] DB 마이그레이션 (V042)
- [x] ktlint 포맷 통과
- [x] 빌드 성공 확인

## To Reviewer

- 모든 변경은 기존 API 하위 호환을 유지합니다 (새 필드는 nullable 또는 default 값).
- L-9, L-10, L-12 도메인 이벤트는 현재 이벤트 정의만 포함하며, 실제 리스너 구현은 향후 별도 이슈에서 진행합니다.
- L-13 상대전적 타이브레이커는 기존 StandingsServiceImpl의 정렬 로직을 확장했습니다.
- V042 마이그레이션은 V040(#348), V041(#349) 이후 번호를 사용합니다.

## Screenshot

N/A (도메인/비즈니스 로직 변경, UI 없음)
