### PR TITLE
feat(#348): 용병 시스템 신규 구현 (도메인 모델 + API)

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/mercenary/MercenaryRequestController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/mercenary/MercenaryRequestController.kt
@@ -1,0 +1,125 @@
+package com.nextup.api.controller.mercenary
+
+import com.nextup.api.dto.mercenary.ApplyMercenaryApiRequest
+import com.nextup.api.dto.mercenary.CreateMercenaryRequestApiRequest
+import com.nextup.api.dto.mercenary.MercenaryApplicationResponse
+import com.nextup.api.dto.mercenary.MercenaryParticipationResponse
+import com.nextup.api.dto.mercenary.MercenaryRequestResponse
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.mercenary.MercenaryService
+import com.nextup.core.service.mercenary.dto.ApplyMercenaryDto
+import com.nextup.core.service.mercenary.dto.CreateMercenaryRequestDto
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 용병 요청 API Controller (공개 API)
+ *
+ * 팀의 용병 모집 및 지원을 위한 API
+ */
+@RestController
+@RequestMapping("/api/v1/mercenary-requests")
+class MercenaryRequestController(
+    private val mercenaryService: MercenaryService,
+) {
+    /**
+     * 용병 요청을 생성합니다.
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createRequest(
+        @Valid @RequestBody request: CreateMercenaryRequestApiRequest,
+    ): ApiResponse<MercenaryRequestResponse> {
+        val mercenaryRequest =
+            mercenaryService.createRequest(
+                CreateMercenaryRequestDto(
+                    requestingTeamId = request.teamId,
+                    gameId = request.gameId,
+                    positions = request.positions,
+                    maxCount = request.maxCount,
+                    deadline = request.deadline,
+                    description = request.description,
+                ),
+            )
+
+        return ApiResponse.success(MercenaryRequestResponse.from(mercenaryRequest))
+    }
+
+    /**
+     * OPEN 상태의 용병 요청 목록을 조회합니다.
+     */
+    @GetMapping
+    fun getOpenRequests(): ApiResponse<List<MercenaryRequestResponse>> {
+        val requests = mercenaryService.getOpenRequests()
+        return ApiResponse.success(requests.map { MercenaryRequestResponse.from(it) })
+    }
+
+    /**
+     * 용병 요청에 지원합니다.
+     */
+    @PostMapping("/{id}/apply")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun apply(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: ApplyMercenaryApiRequest,
+    ): ApiResponse<MercenaryApplicationResponse> {
+        val application =
+            mercenaryService.apply(
+                ApplyMercenaryDto(
+                    requestId = id,
+                    playerId = request.playerId,
+                    preferredPositions = request.preferredPositions,
+                    message = request.message,
+                ),
+            )
+
+        return ApiResponse.success(MercenaryApplicationResponse.from(application))
+    }
+
+    /**
+     * 용병 지원을 수락합니다.
+     */
+    @PatchMapping("/{id}/applications/{appId}/accept")
+    fun acceptApplication(
+        @PathVariable id: Long,
+        @PathVariable appId: Long,
+    ): ApiResponse<MercenaryApplicationResponse> {
+        val application = mercenaryService.acceptApplication(id, appId)
+        return ApiResponse.success(MercenaryApplicationResponse.from(application))
+    }
+
+    /**
+     * 용병 지원을 거절합니다.
+     */
+    @PatchMapping("/{id}/applications/{appId}/reject")
+    fun rejectApplication(
+        @PathVariable id: Long,
+        @PathVariable appId: Long,
+    ): ApiResponse<MercenaryApplicationResponse> {
+        val application = mercenaryService.rejectApplication(id, appId)
+        return ApiResponse.success(MercenaryApplicationResponse.from(application))
+    }
+
+    /**
+     * 용병 요청에 대한 지원 목록을 조회합니다.
+     */
+    @GetMapping("/{id}/applications")
+    fun getApplications(
+        @PathVariable id: Long,
+    ): ApiResponse<List<MercenaryApplicationResponse>> {
+        val applications = mercenaryService.getApplicationsByRequest(id)
+        return ApiResponse.success(applications.map { MercenaryApplicationResponse.from(it) })
+    }
+
+    /**
+     * 내 용병 참가 이력을 조회합니다.
+     */
+    @GetMapping("/me/history")
+    fun getMyHistory(
+        @RequestParam playerId: Long,
+    ): ApiResponse<List<MercenaryParticipationResponse>> {
+        val participations = mercenaryService.getParticipationsByPlayer(playerId)
+        return ApiResponse.success(participations.map { MercenaryParticipationResponse.from(it) })
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/mercenary/ApplyMercenaryApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/mercenary/ApplyMercenaryApiRequest.kt
@@ -1,0 +1,13 @@
+package com.nextup.api.dto.mercenary
+
+import com.nextup.core.domain.player.Position
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+
+data class ApplyMercenaryApiRequest(
+    @field:NotNull(message = "선수 ID는 필수입니다")
+    val playerId: Long,
+    @field:NotEmpty(message = "선호 포지션을 최소 1개 이상 지정해야 합니다")
+    val preferredPositions: Set<Position>,
+    val message: String? = null,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/mercenary/CreateMercenaryRequestApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/mercenary/CreateMercenaryRequestApiRequest.kt
@@ -1,0 +1,21 @@
+package com.nextup.api.dto.mercenary
+
+import com.nextup.core.domain.player.Position
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import java.time.Instant
+
+data class CreateMercenaryRequestApiRequest(
+    @field:NotNull(message = "팀 ID는 필수입니다")
+    val teamId: Long,
+    @field:NotNull(message = "경기 ID는 필수입니다")
+    val gameId: Long,
+    @field:NotEmpty(message = "필요 포지션을 최소 1개 이상 지정해야 합니다")
+    val positions: Set<Position>,
+    @field:Min(value = 1, message = "최대 모집 인원은 1명 이상이어야 합니다")
+    val maxCount: Int,
+    @field:NotNull(message = "마감 시한은 필수입니다")
+    val deadline: Instant,
+    val description: String? = null,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/mercenary/MercenaryApplicationResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/mercenary/MercenaryApplicationResponse.kt
@@ -1,0 +1,29 @@
+package com.nextup.api.dto.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryApplication
+import com.nextup.core.domain.mercenary.MercenaryApplicationStatus
+import com.nextup.core.domain.player.Position
+import java.time.Instant
+
+data class MercenaryApplicationResponse(
+    val id: Long,
+    val requestId: Long,
+    val playerId: Long,
+    val preferredPositions: Set<Position>,
+    val status: MercenaryApplicationStatus,
+    val message: String?,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(application: MercenaryApplication): MercenaryApplicationResponse =
+            MercenaryApplicationResponse(
+                id = application.id,
+                requestId = application.requestId,
+                playerId = application.playerId,
+                preferredPositions = application.preferredPositions.toSet(),
+                status = application.status,
+                message = application.message,
+                createdAt = application.createdAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/mercenary/MercenaryParticipationResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/mercenary/MercenaryParticipationResponse.kt
@@ -1,0 +1,23 @@
+package com.nextup.api.dto.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryParticipation
+import java.time.Instant
+
+data class MercenaryParticipationResponse(
+    val id: Long,
+    val gameId: Long,
+    val playerId: Long,
+    val teamId: Long,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(participation: MercenaryParticipation): MercenaryParticipationResponse =
+            MercenaryParticipationResponse(
+                id = participation.id,
+                gameId = participation.gameId,
+                playerId = participation.playerId,
+                teamId = participation.teamId,
+                createdAt = participation.createdAt,
+            )
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/mercenary/MercenaryRequestResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/mercenary/MercenaryRequestResponse.kt
@@ -1,0 +1,33 @@
+package com.nextup.api.dto.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryRequest
+import com.nextup.core.domain.mercenary.MercenaryRequestStatus
+import com.nextup.core.domain.player.Position
+import java.time.Instant
+
+data class MercenaryRequestResponse(
+    val id: Long,
+    val requestingTeamId: Long,
+    val gameId: Long,
+    val positions: Set<Position>,
+    val maxCount: Int,
+    val status: MercenaryRequestStatus,
+    val deadline: Instant,
+    val description: String?,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(request: MercenaryRequest): MercenaryRequestResponse =
+            MercenaryRequestResponse(
+                id = request.id,
+                requestingTeamId = request.requestingTeamId,
+                gameId = request.gameId,
+                positions = request.positions.toSet(),
+                maxCount = request.maxCount,
+                status = request.status,
+                deadline = request.deadline,
+                description = request.description,
+                createdAt = request.createdAt,
+            )
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/mercenary/MercenaryRequestControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/mercenary/MercenaryRequestControllerTest.kt
@@ -1,0 +1,451 @@
+package com.nextup.api.controller.mercenary
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.mercenary.ApplyMercenaryApiRequest
+import com.nextup.api.dto.mercenary.CreateMercenaryRequestApiRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.MercenaryApplicationNotFoundException
+import com.nextup.common.exception.MercenaryRequestNotFoundException
+import com.nextup.core.domain.mercenary.MercenaryApplication
+import com.nextup.core.domain.mercenary.MercenaryApplicationStatus
+import com.nextup.core.domain.mercenary.MercenaryParticipation
+import com.nextup.core.domain.mercenary.MercenaryRequest
+import com.nextup.core.domain.mercenary.MercenaryRequestStatus
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.mercenary.MercenaryService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+
+@DisplayName("MercenaryRequestController 테스트")
+class MercenaryRequestControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var mercenaryService: MercenaryService
+    private lateinit var objectMapper: ObjectMapper
+
+    private val mockRequest = mockk<MercenaryRequest>(relaxed = true)
+    private val mockApplication = mockk<MercenaryApplication>(relaxed = true)
+    private val mockParticipation = mockk<MercenaryParticipation>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        mercenaryService = mockk()
+        objectMapper =
+            jacksonObjectMapper()
+                .registerModule(JavaTimeModule())
+
+        val controller = MercenaryRequestController(mercenaryService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        every { mockRequest.id } returns 1L
+        every { mockRequest.requestingTeamId } returns 10L
+        every { mockRequest.gameId } returns 100L
+        every { mockRequest.positions } returns mutableSetOf(Position.STARTING_PITCHER, Position.CATCHER)
+        every { mockRequest.maxCount } returns 2
+        every { mockRequest.status } returns MercenaryRequestStatus.OPEN
+        every { mockRequest.deadline } returns Instant.now().plusSeconds(86400)
+        every { mockRequest.description } returns "투수 1명, 포수 1명 구합니다"
+        every { mockRequest.createdAt } returns Instant.now()
+
+        every { mockApplication.id } returns 1L
+        every { mockApplication.requestId } returns 1L
+        every { mockApplication.playerId } returns 50L
+        every { mockApplication.preferredPositions } returns mutableSetOf(Position.STARTING_PITCHER)
+        every { mockApplication.status } returns MercenaryApplicationStatus.PENDING
+        every { mockApplication.message } returns "열심히 하겠습니다"
+        every { mockApplication.createdAt } returns Instant.now()
+
+        every { mockParticipation.id } returns 1L
+        every { mockParticipation.gameId } returns 100L
+        every { mockParticipation.playerId } returns 50L
+        every { mockParticipation.teamId } returns 10L
+        every { mockParticipation.createdAt } returns Instant.now()
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/mercenary-requests - 용병 요청 생성")
+    inner class CreateRequest {
+        @Test
+        fun `용병 요청 생성에 성공한다`() {
+            // given
+            val request =
+                CreateMercenaryRequestApiRequest(
+                    teamId = 10L,
+                    gameId = 100L,
+                    positions = setOf(Position.STARTING_PITCHER, Position.CATCHER),
+                    maxCount = 2,
+                    deadline = Instant.now().plusSeconds(86400),
+                    description = "투수 1명, 포수 1명 구합니다",
+                )
+
+            every { mercenaryService.createRequest(any()) } returns mockRequest
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/mercenary-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.requestingTeamId").value(10))
+                .andExpect(jsonPath("$.data.gameId").value(100))
+                .andExpect(jsonPath("$.data.maxCount").value(2))
+                .andExpect(jsonPath("$.data.status").value("OPEN"))
+
+            verify(exactly = 1) { mercenaryService.createRequest(any()) }
+        }
+
+        @Test
+        fun `필수 필드가 없으면 400을 반환한다`() {
+            // given - teamId, gameId, positions, deadline 모두 null
+            val invalidRequest =
+                mapOf(
+                    "teamId" to null,
+                    "gameId" to null,
+                    "positions" to emptyList<String>(),
+                    "maxCount" to 0,
+                    "deadline" to null,
+                )
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/mercenary-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)),
+                )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+
+            verify(exactly = 0) { mercenaryService.createRequest(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/mercenary-requests - OPEN 용병 요청 목록 조회")
+    inner class GetOpenRequests {
+        @Test
+        fun `OPEN 상태 용병 요청 목록을 반환한다`() {
+            // given
+            every { mercenaryService.getOpenRequests() } returns listOf(mockRequest)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/mercenary-requests"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].status").value("OPEN"))
+                .andExpect(jsonPath("$.data[0].requestingTeamId").value(10))
+
+            verify(exactly = 1) { mercenaryService.getOpenRequests() }
+        }
+
+        @Test
+        fun `용병 요청이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { mercenaryService.getOpenRequests() } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/mercenary-requests"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+
+            verify(exactly = 1) { mercenaryService.getOpenRequests() }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/mercenary-requests/{id}/apply - 용병 지원")
+    inner class Apply {
+        @Test
+        fun `용병 지원에 성공한다`() {
+            // given
+            val request =
+                ApplyMercenaryApiRequest(
+                    playerId = 50L,
+                    preferredPositions = setOf(Position.STARTING_PITCHER),
+                    message = "열심히 하겠습니다",
+                )
+
+            every { mercenaryService.apply(any()) } returns mockApplication
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/mercenary-requests/1/apply")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.requestId").value(1))
+                .andExpect(jsonPath("$.data.playerId").value(50))
+                .andExpect(jsonPath("$.data.status").value("PENDING"))
+
+            verify(exactly = 1) { mercenaryService.apply(any()) }
+        }
+
+        @Test
+        fun `존재하지 않는 용병 요청에 지원하면 404를 반환한다`() {
+            // given
+            val request =
+                ApplyMercenaryApiRequest(
+                    playerId = 50L,
+                    preferredPositions = setOf(Position.STARTING_PITCHER),
+                    message = null,
+                )
+
+            every { mercenaryService.apply(any()) } throws MercenaryRequestNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/mercenary-requests/999/apply")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)),
+                )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+
+            verify(exactly = 1) { mercenaryService.apply(any()) }
+        }
+
+        @Test
+        fun `필수 필드가 없으면 400을 반환한다`() {
+            // given - playerId null, preferredPositions empty
+            val invalidRequest =
+                mapOf(
+                    "playerId" to null,
+                    "preferredPositions" to emptyList<String>(),
+                )
+
+            // when & then
+            mockMvc
+                .perform(
+                    post("/api/v1/mercenary-requests/1/apply")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)),
+                )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+
+            verify(exactly = 0) { mercenaryService.apply(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/v1/mercenary-requests/{id}/applications/{appId}/accept - 지원 수락")
+    inner class AcceptApplication {
+        @Test
+        fun `용병 지원 수락에 성공한다`() {
+            // given
+            val acceptedApplication = mockk<MercenaryApplication>(relaxed = true)
+            every { acceptedApplication.id } returns 1L
+            every { acceptedApplication.requestId } returns 1L
+            every { acceptedApplication.playerId } returns 50L
+            every { acceptedApplication.preferredPositions } returns mutableSetOf(Position.STARTING_PITCHER)
+            every { acceptedApplication.status } returns MercenaryApplicationStatus.ACCEPTED
+            every { acceptedApplication.message } returns null
+            every { acceptedApplication.createdAt } returns Instant.now()
+
+            every { mercenaryService.acceptApplication(1L, 1L) } returns acceptedApplication
+
+            // when & then
+            mockMvc
+                .perform(patch("/api/v1/mercenary-requests/1/applications/1/accept"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+
+            verify(exactly = 1) { mercenaryService.acceptApplication(1L, 1L) }
+        }
+
+        @Test
+        fun `존재하지 않는 지원을 수락하면 404를 반환한다`() {
+            // given
+            every { mercenaryService.acceptApplication(1L, 999L) } throws MercenaryApplicationNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(patch("/api/v1/mercenary-requests/1/applications/999/accept"))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+
+            verify(exactly = 1) { mercenaryService.acceptApplication(1L, 999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/v1/mercenary-requests/{id}/applications/{appId}/reject - 지원 거절")
+    inner class RejectApplication {
+        @Test
+        fun `용병 지원 거절에 성공한다`() {
+            // given
+            val rejectedApplication = mockk<MercenaryApplication>(relaxed = true)
+            every { rejectedApplication.id } returns 1L
+            every { rejectedApplication.requestId } returns 1L
+            every { rejectedApplication.playerId } returns 50L
+            every { rejectedApplication.preferredPositions } returns mutableSetOf(Position.STARTING_PITCHER)
+            every { rejectedApplication.status } returns MercenaryApplicationStatus.REJECTED
+            every { rejectedApplication.message } returns null
+            every { rejectedApplication.createdAt } returns Instant.now()
+
+            every { mercenaryService.rejectApplication(1L, 1L) } returns rejectedApplication
+
+            // when & then
+            mockMvc
+                .perform(patch("/api/v1/mercenary-requests/1/applications/1/reject"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.status").value("REJECTED"))
+
+            verify(exactly = 1) { mercenaryService.rejectApplication(1L, 1L) }
+        }
+
+        @Test
+        fun `존재하지 않는 지원을 거절하면 404를 반환한다`() {
+            // given
+            every { mercenaryService.rejectApplication(1L, 999L) } throws MercenaryApplicationNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(patch("/api/v1/mercenary-requests/1/applications/999/reject"))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+
+            verify(exactly = 1) { mercenaryService.rejectApplication(1L, 999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/mercenary-requests/{id}/applications - 지원 목록 조회")
+    inner class GetApplications {
+        @Test
+        fun `용병 요청에 대한 지원 목록을 반환한다`() {
+            // given
+            every { mercenaryService.getApplicationsByRequest(1L) } returns listOf(mockApplication)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/mercenary-requests/1/applications"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].playerId").value(50))
+                .andExpect(jsonPath("$.data[0].status").value("PENDING"))
+
+            verify(exactly = 1) { mercenaryService.getApplicationsByRequest(1L) }
+        }
+
+        @Test
+        fun `지원이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { mercenaryService.getApplicationsByRequest(1L) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/mercenary-requests/1/applications"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+
+            verify(exactly = 1) { mercenaryService.getApplicationsByRequest(1L) }
+        }
+
+        @Test
+        fun `존재하지 않는 요청의 지원 목록 조회 시 404를 반환한다`() {
+            // given
+            every { mercenaryService.getApplicationsByRequest(999L) } throws MercenaryRequestNotFoundException(999L)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/mercenary-requests/999/applications"))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.success").value(false))
+
+            verify(exactly = 1) { mercenaryService.getApplicationsByRequest(999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/mercenary-requests/me/history - 내 참가 이력 조회")
+    inner class GetMyHistory {
+        @Test
+        fun `선수의 용병 참가 이력을 반환한다`() {
+            // given
+            every { mercenaryService.getParticipationsByPlayer(50L) } returns listOf(mockParticipation)
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/mercenary-requests/me/history").param("playerId", "50"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].gameId").value(100))
+                .andExpect(jsonPath("$.data[0].playerId").value(50))
+                .andExpect(jsonPath("$.data[0].teamId").value(10))
+
+            verify(exactly = 1) { mercenaryService.getParticipationsByPlayer(50L) }
+        }
+
+        @Test
+        fun `참가 이력이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { mercenaryService.getParticipationsByPlayer(50L) } returns emptyList()
+
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/mercenary-requests/me/history").param("playerId", "50"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray)
+                .andExpect(jsonPath("$.data").isEmpty)
+
+            verify(exactly = 1) { mercenaryService.getParticipationsByPlayer(50L) }
+        }
+
+        @Test
+        fun `playerId 파라미터가 없으면 400을 반환한다`() {
+            // when & then
+            mockMvc
+                .perform(get("/api/v1/mercenary-requests/me/history"))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.success").value(false))
+
+            verify(exactly = 0) { mercenaryService.getParticipationsByPlayer(any()) }
+        }
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/MercenaryExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/MercenaryExceptions.kt
@@ -1,0 +1,37 @@
+package com.nextup.common.exception
+
+class MercenaryRequestNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "MERCENARY_REQUEST_NOT_FOUND",
+        message = "용병 요청을 찾을 수 없습니다: $id",
+    )
+
+class MercenaryApplicationNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "MERCENARY_APPLICATION_NOT_FOUND",
+        message = "용병 지원을 찾을 수 없습니다: $id",
+    )
+
+class MercenaryAlreadyAppliedException(
+    requestId: Long,
+    playerId: Long,
+) : InvalidInputException(
+        code = "MERCENARY_ALREADY_APPLIED",
+        message = "이미 해당 용병 요청에 지원했습니다: requestId=$requestId, playerId=$playerId",
+    )
+
+class MercenaryRequestClosedException(
+    id: Long,
+) : InvalidStateException(
+        code = "MERCENARY_REQUEST_CLOSED",
+        message = "마감된 용병 요청입니다: $id",
+    )
+
+class MercenaryMaxCountReachedException(
+    requestId: Long,
+) : InvalidStateException(
+        code = "MERCENARY_MAX_COUNT_REACHED",
+        message = "최대 모집 인원에 도달했습니다: requestId=$requestId",
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/mercenary/MercenaryApplication.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/mercenary/MercenaryApplication.kt
@@ -1,0 +1,98 @@
+package com.nextup.core.domain.mercenary
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.player.Position
+import jakarta.persistence.*
+
+/**
+ * 용병 지원 엔티티
+ *
+ * 선수가 용병 요청에 지원하는 것을 나타냅니다.
+ * Rich Domain Model 원칙에 따라 비즈니스 로직을 Entity 내부에 캡슐화합니다.
+ */
+@Entity
+@Table(
+    name = "mercenary_applications",
+    indexes = [
+        Index(name = "idx_ma_request_id", columnList = "request_id"),
+        Index(name = "idx_ma_player_id", columnList = "player_id"),
+        Index(name = "idx_ma_status", columnList = "status"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_ma_request_player",
+            columnNames = ["request_id", "player_id"],
+        ),
+    ],
+)
+class MercenaryApplication private constructor(
+    @Column(name = "request_id", nullable = false)
+    val requestId: Long,
+    @Column(name = "player_id", nullable = false)
+    val playerId: Long,
+    @ElementCollection(targetClass = Position::class)
+    @CollectionTable(
+        name = "mercenary_application_positions",
+        joinColumns = [JoinColumn(name = "mercenary_application_id")],
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "position", nullable = false, length = 30)
+    val preferredPositions: MutableSet<Position> = mutableSetOf(),
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: MercenaryApplicationStatus = MercenaryApplicationStatus.PENDING,
+    @Column(columnDefinition = "TEXT")
+    val message: String? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 지원을 수락합니다.
+     */
+    fun accept() {
+        check(status == MercenaryApplicationStatus.PENDING) {
+            "PENDING 상태의 지원만 수락할 수 있습니다"
+        }
+        this.status = MercenaryApplicationStatus.ACCEPTED
+    }
+
+    /**
+     * 지원을 거절합니다.
+     */
+    fun reject() {
+        check(status == MercenaryApplicationStatus.PENDING) {
+            "PENDING 상태의 지원만 거절할 수 있습니다"
+        }
+        this.status = MercenaryApplicationStatus.REJECTED
+    }
+
+    companion object {
+        /**
+         * 용병 지원을 생성합니다.
+         *
+         * @param requestId 용병 요청 ID
+         * @param playerId 지원 선수 ID
+         * @param preferredPositions 선호 포지션 목록
+         * @param message 지원 메시지
+         * @return 생성된 MercenaryApplication
+         */
+        fun create(
+            requestId: Long,
+            playerId: Long,
+            preferredPositions: Set<Position>,
+            message: String? = null,
+        ): MercenaryApplication {
+            require(preferredPositions.isNotEmpty()) {
+                "선호 포지션을 최소 1개 이상 지정해야 합니다"
+            }
+
+            return MercenaryApplication(
+                requestId = requestId,
+                playerId = playerId,
+                preferredPositions = preferredPositions.toMutableSet(),
+                message = message,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/mercenary/MercenaryApplicationStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/mercenary/MercenaryApplicationStatus.kt
@@ -1,0 +1,9 @@
+package com.nextup.core.domain.mercenary
+
+enum class MercenaryApplicationStatus(
+    val displayName: String,
+) {
+    PENDING("대기중"),
+    ACCEPTED("수락"),
+    REJECTED("거절"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/mercenary/MercenaryParticipation.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/mercenary/MercenaryParticipation.kt
@@ -1,0 +1,58 @@
+package com.nextup.core.domain.mercenary
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+
+/**
+ * 용병 참가 엔티티
+ *
+ * 용병으로 실제 경기에 참가한 기록을 나타냅니다.
+ * 지원이 수락되면 자동으로 생성됩니다.
+ */
+@Entity
+@Table(
+    name = "mercenary_participations",
+    indexes = [
+        Index(name = "idx_mp_game_id", columnList = "game_id"),
+        Index(name = "idx_mp_player_id", columnList = "player_id"),
+        Index(name = "idx_mp_team_id", columnList = "team_id"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_mp_game_player",
+            columnNames = ["game_id", "player_id"],
+        ),
+    ],
+)
+class MercenaryParticipation private constructor(
+    @Column(name = "game_id", nullable = false)
+    val gameId: Long,
+    @Column(name = "player_id", nullable = false)
+    val playerId: Long,
+    @Column(name = "team_id", nullable = false)
+    val teamId: Long,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    companion object {
+        /**
+         * 용병 참가 기록을 생성합니다.
+         *
+         * @param gameId 경기 ID
+         * @param playerId 선수 ID
+         * @param teamId 팀 ID
+         * @return 생성된 MercenaryParticipation
+         */
+        fun create(
+            gameId: Long,
+            playerId: Long,
+            teamId: Long,
+        ): MercenaryParticipation =
+            MercenaryParticipation(
+                gameId = gameId,
+                playerId = playerId,
+                teamId = teamId,
+            )
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/mercenary/MercenaryRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/mercenary/MercenaryRequest.kt
@@ -1,0 +1,120 @@
+package com.nextup.core.domain.mercenary
+
+import com.nextup.core.common.BaseTimeEntity
+import com.nextup.core.domain.player.Position
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * 용병 요청 엔티티
+ *
+ * 팀이 특정 경기에 용병을 구하기 위해 생성하는 요청입니다.
+ * Rich Domain Model 원칙에 따라 비즈니스 로직을 Entity 내부에 캡슐화합니다.
+ */
+@Entity
+@Table(
+    name = "mercenary_requests",
+    indexes = [
+        Index(name = "idx_mr_requesting_team_id", columnList = "requesting_team_id"),
+        Index(name = "idx_mr_game_id", columnList = "game_id"),
+        Index(name = "idx_mr_status", columnList = "status"),
+        Index(name = "idx_mr_deadline", columnList = "deadline"),
+    ],
+)
+class MercenaryRequest private constructor(
+    @Column(name = "requesting_team_id", nullable = false)
+    val requestingTeamId: Long,
+    @Column(name = "game_id", nullable = false)
+    val gameId: Long,
+    @ElementCollection(targetClass = Position::class)
+    @CollectionTable(
+        name = "mercenary_request_positions",
+        joinColumns = [JoinColumn(name = "mercenary_request_id")],
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "position", nullable = false, length = 30)
+    val positions: MutableSet<Position> = mutableSetOf(),
+    @Column(name = "max_count", nullable = false)
+    val maxCount: Int,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: MercenaryRequestStatus = MercenaryRequestStatus.OPEN,
+    @Column(nullable = false)
+    val deadline: Instant,
+    @Column(columnDefinition = "TEXT")
+    val description: String? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 마감 시한이 지났는지 확인합니다.
+     */
+    fun isExpired(): Boolean = Instant.now().isAfter(deadline)
+
+    /**
+     * 지원을 받을 수 있는 상태인지 확인합니다.
+     */
+    fun canAcceptApplication(): Boolean = status == MercenaryRequestStatus.OPEN && !isExpired()
+
+    /**
+     * 용병 요청을 마감합니다.
+     */
+    fun close() {
+        check(status == MercenaryRequestStatus.OPEN) {
+            "OPEN 상태의 요청만 마감할 수 있습니다"
+        }
+        this.status = MercenaryRequestStatus.CLOSED
+    }
+
+    /**
+     * 용병 요청을 취소합니다.
+     */
+    fun cancel() {
+        check(status == MercenaryRequestStatus.OPEN) {
+            "OPEN 상태의 요청만 취소할 수 있습니다"
+        }
+        this.status = MercenaryRequestStatus.CANCELLED
+    }
+
+    companion object {
+        /**
+         * 용병 요청을 생성합니다.
+         *
+         * @param requestingTeamId 요청 팀 ID
+         * @param gameId 경기 ID
+         * @param positions 필요 포지션 목록
+         * @param maxCount 최대 모집 인원
+         * @param deadline 마감 시한
+         * @param description 설명
+         * @return 생성된 MercenaryRequest
+         */
+        fun create(
+            requestingTeamId: Long,
+            gameId: Long,
+            positions: Set<Position>,
+            maxCount: Int,
+            deadline: Instant,
+            description: String? = null,
+        ): MercenaryRequest {
+            require(positions.isNotEmpty()) {
+                "필요 포지션을 최소 1개 이상 지정해야 합니다"
+            }
+            require(maxCount > 0) {
+                "최대 모집 인원은 1명 이상이어야 합니다"
+            }
+            require(deadline.isAfter(Instant.now())) {
+                "마감 시한은 현재 시간 이후여야 합니다"
+            }
+
+            return MercenaryRequest(
+                requestingTeamId = requestingTeamId,
+                gameId = gameId,
+                positions = positions.toMutableSet(),
+                maxCount = maxCount,
+                deadline = deadline,
+                description = description,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/mercenary/MercenaryRequestStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/mercenary/MercenaryRequestStatus.kt
@@ -1,0 +1,9 @@
+package com.nextup.core.domain.mercenary
+
+enum class MercenaryRequestStatus(
+    val displayName: String,
+) {
+    OPEN("모집중"),
+    CLOSED("모집완료"),
+    CANCELLED("취소"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MercenaryApplicationRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MercenaryApplicationRepositoryPort.kt
@@ -1,0 +1,24 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.mercenary.MercenaryApplication
+
+/**
+ * MercenaryApplication Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface MercenaryApplicationRepositoryPort {
+    fun save(application: MercenaryApplication): MercenaryApplication
+
+    fun findByIdOrNull(id: Long): MercenaryApplication?
+
+    fun findByRequestId(requestId: Long): List<MercenaryApplication>
+
+    fun findByPlayerId(playerId: Long): List<MercenaryApplication>
+
+    fun existsByRequestIdAndPlayerId(
+        requestId: Long,
+        playerId: Long,
+    ): Boolean
+
+    fun countAcceptedByRequestId(requestId: Long): Long
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MercenaryParticipationRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MercenaryParticipationRepositoryPort.kt
@@ -1,0 +1,22 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.mercenary.MercenaryParticipation
+
+/**
+ * MercenaryParticipation Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface MercenaryParticipationRepositoryPort {
+    fun save(participation: MercenaryParticipation): MercenaryParticipation
+
+    fun findByGameId(gameId: Long): List<MercenaryParticipation>
+
+    fun findByPlayerId(playerId: Long): List<MercenaryParticipation>
+
+    fun findByTeamId(teamId: Long): List<MercenaryParticipation>
+
+    fun existsByGameIdAndPlayerId(
+        gameId: Long,
+        playerId: Long,
+    ): Boolean
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MercenaryRequestRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/MercenaryRequestRepositoryPort.kt
@@ -1,0 +1,20 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.mercenary.MercenaryRequest
+import com.nextup.core.domain.mercenary.MercenaryRequestStatus
+
+/**
+ * MercenaryRequest Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface MercenaryRequestRepositoryPort {
+    fun save(mercenaryRequest: MercenaryRequest): MercenaryRequest
+
+    fun findByIdOrNull(id: Long): MercenaryRequest?
+
+    fun findByStatus(status: MercenaryRequestStatus): List<MercenaryRequest>
+
+    fun findByRequestingTeamId(teamId: Long): List<MercenaryRequest>
+
+    fun findByGameId(gameId: Long): List<MercenaryRequest>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/mercenary/MercenaryService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/mercenary/MercenaryService.kt
@@ -1,0 +1,186 @@
+package com.nextup.core.service.mercenary
+
+import com.nextup.common.exception.MercenaryAlreadyAppliedException
+import com.nextup.common.exception.MercenaryApplicationNotFoundException
+import com.nextup.common.exception.MercenaryMaxCountReachedException
+import com.nextup.common.exception.MercenaryRequestClosedException
+import com.nextup.common.exception.MercenaryRequestNotFoundException
+import com.nextup.core.domain.mercenary.MercenaryApplication
+import com.nextup.core.domain.mercenary.MercenaryParticipation
+import com.nextup.core.domain.mercenary.MercenaryRequest
+import com.nextup.core.domain.mercenary.MercenaryRequestStatus
+import com.nextup.core.port.repository.MercenaryApplicationRepositoryPort
+import com.nextup.core.port.repository.MercenaryParticipationRepositoryPort
+import com.nextup.core.port.repository.MercenaryRequestRepositoryPort
+import com.nextup.core.service.mercenary.dto.ApplyMercenaryDto
+import com.nextup.core.service.mercenary.dto.CreateMercenaryRequestDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 용병 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class MercenaryService(
+    private val mercenaryRequestRepository: MercenaryRequestRepositoryPort,
+    private val mercenaryApplicationRepository: MercenaryApplicationRepositoryPort,
+    private val mercenaryParticipationRepository: MercenaryParticipationRepositoryPort,
+) {
+    /**
+     * 용병 요청을 생성합니다.
+     */
+    @Transactional
+    fun createRequest(dto: CreateMercenaryRequestDto): MercenaryRequest {
+        val mercenaryRequest =
+            MercenaryRequest.create(
+                requestingTeamId = dto.requestingTeamId,
+                gameId = dto.gameId,
+                positions = dto.positions,
+                maxCount = dto.maxCount,
+                deadline = dto.deadline,
+                description = dto.description,
+            )
+
+        return mercenaryRequestRepository.save(mercenaryRequest)
+    }
+
+    /**
+     * OPEN 상태의 용병 요청 목록을 조회합니다.
+     */
+    fun getOpenRequests(): List<MercenaryRequest> = mercenaryRequestRepository.findByStatus(MercenaryRequestStatus.OPEN)
+
+    /**
+     * 용병 요청을 ID로 조회합니다.
+     */
+    fun getRequestById(id: Long): MercenaryRequest =
+        mercenaryRequestRepository.findByIdOrNull(id)
+            ?: throw MercenaryRequestNotFoundException(id)
+
+    /**
+     * 용병 요청에 지원합니다.
+     */
+    @Transactional
+    fun apply(dto: ApplyMercenaryDto): MercenaryApplication {
+        val request =
+            mercenaryRequestRepository.findByIdOrNull(dto.requestId)
+                ?: throw MercenaryRequestNotFoundException(dto.requestId)
+
+        if (!request.canAcceptApplication()) {
+            throw MercenaryRequestClosedException(dto.requestId)
+        }
+
+        if (mercenaryApplicationRepository.existsByRequestIdAndPlayerId(dto.requestId, dto.playerId)) {
+            throw MercenaryAlreadyAppliedException(dto.requestId, dto.playerId)
+        }
+
+        val application =
+            MercenaryApplication.create(
+                requestId = dto.requestId,
+                playerId = dto.playerId,
+                preferredPositions = dto.preferredPositions,
+                message = dto.message,
+            )
+
+        return mercenaryApplicationRepository.save(application)
+    }
+
+    /**
+     * 용병 지원을 수락합니다.
+     */
+    @Transactional
+    fun acceptApplication(
+        requestId: Long,
+        applicationId: Long,
+    ): MercenaryApplication {
+        val request =
+            mercenaryRequestRepository.findByIdOrNull(requestId)
+                ?: throw MercenaryRequestNotFoundException(requestId)
+
+        val application =
+            mercenaryApplicationRepository.findByIdOrNull(applicationId)
+                ?: throw MercenaryApplicationNotFoundException(applicationId)
+
+        val acceptedCount = mercenaryApplicationRepository.countAcceptedByRequestId(requestId)
+        if (acceptedCount >= request.maxCount) {
+            throw MercenaryMaxCountReachedException(requestId)
+        }
+
+        application.accept()
+
+        // 참가 기록 생성
+        val participation =
+            MercenaryParticipation.create(
+                gameId = request.gameId,
+                playerId = application.playerId,
+                teamId = request.requestingTeamId,
+            )
+        mercenaryParticipationRepository.save(participation)
+
+        // 최대 인원 도달 시 자동 마감
+        if (acceptedCount + 1 >= request.maxCount) {
+            request.close()
+        }
+
+        return application
+    }
+
+    /**
+     * 용병 지원을 거절합니다.
+     */
+    @Transactional
+    fun rejectApplication(
+        requestId: Long,
+        applicationId: Long,
+    ): MercenaryApplication {
+        mercenaryRequestRepository.findByIdOrNull(requestId)
+            ?: throw MercenaryRequestNotFoundException(requestId)
+
+        val application =
+            mercenaryApplicationRepository.findByIdOrNull(applicationId)
+                ?: throw MercenaryApplicationNotFoundException(applicationId)
+
+        application.reject()
+
+        return application
+    }
+
+    /**
+     * 용병 요청에 대한 지원 목록을 조회합니다.
+     */
+    fun getApplicationsByRequest(requestId: Long): List<MercenaryApplication> {
+        mercenaryRequestRepository.findByIdOrNull(requestId)
+            ?: throw MercenaryRequestNotFoundException(requestId)
+
+        return mercenaryApplicationRepository.findByRequestId(requestId)
+    }
+
+    /**
+     * 선수의 용병 참가 이력을 조회합니다.
+     */
+    fun getParticipationsByPlayer(playerId: Long): List<MercenaryParticipation> =
+        mercenaryParticipationRepository.findByPlayerId(playerId)
+
+    /**
+     * 용병 요청을 취소합니다.
+     */
+    @Transactional
+    fun cancelRequest(requestId: Long): MercenaryRequest {
+        val request =
+            mercenaryRequestRepository.findByIdOrNull(requestId)
+                ?: throw MercenaryRequestNotFoundException(requestId)
+
+        try {
+            request.cancel()
+        } catch (e: IllegalStateException) {
+            throw com.nextup.common.exception.InvalidStateException(
+                "INVALID_MERCENARY_REQUEST_STATE",
+                e.message ?: "용병 요청을 취소할 수 없습니다",
+            )
+        }
+
+        return request
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/mercenary/dto/ApplyMercenaryDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/mercenary/dto/ApplyMercenaryDto.kt
@@ -1,0 +1,10 @@
+package com.nextup.core.service.mercenary.dto
+
+import com.nextup.core.domain.player.Position
+
+data class ApplyMercenaryDto(
+    val requestId: Long,
+    val playerId: Long,
+    val preferredPositions: Set<Position>,
+    val message: String? = null,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/mercenary/dto/CreateMercenaryRequestDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/mercenary/dto/CreateMercenaryRequestDto.kt
@@ -1,0 +1,13 @@
+package com.nextup.core.service.mercenary.dto
+
+import com.nextup.core.domain.player.Position
+import java.time.Instant
+
+data class CreateMercenaryRequestDto(
+    val requestingTeamId: Long,
+    val gameId: Long,
+    val positions: Set<Position>,
+    val maxCount: Int,
+    val deadline: Instant,
+    val description: String? = null,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/mercenary/MercenaryApplicationTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/mercenary/MercenaryApplicationTest.kt
@@ -1,0 +1,124 @@
+package com.nextup.core.domain.mercenary
+
+import com.nextup.core.domain.player.Position
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MercenaryApplicationTest {
+    @Test
+    fun `용병 지원을 생성할 수 있다`() {
+        // when
+        val application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER, Position.FIRST_BASE),
+                message = "포수 경력 5년입니다",
+            )
+
+        // then
+        assertThat(application.requestId).isEqualTo(1L)
+        assertThat(application.playerId).isEqualTo(100L)
+        assertThat(application.preferredPositions).containsExactlyInAnyOrder(
+            Position.CATCHER,
+            Position.FIRST_BASE,
+        )
+        assertThat(application.status).isEqualTo(MercenaryApplicationStatus.PENDING)
+        assertThat(application.message).isEqualTo("포수 경력 5년입니다")
+    }
+
+    @Test
+    fun `선호 포지션이 비어있으면 생성 시 예외가 발생한다`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = emptySet(),
+            )
+        }
+    }
+
+    @Test
+    fun `PENDING 상태의 지원을 수락할 수 있다`() {
+        // given
+        val application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+
+        // when
+        application.accept()
+
+        // then
+        assertThat(application.status).isEqualTo(MercenaryApplicationStatus.ACCEPTED)
+    }
+
+    @Test
+    fun `PENDING 상태가 아닌 지원을 수락하면 예외가 발생한다`() {
+        // given
+        val application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+        application.reject()
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            application.accept()
+        }
+    }
+
+    @Test
+    fun `PENDING 상태의 지원을 거절할 수 있다`() {
+        // given
+        val application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+
+        // when
+        application.reject()
+
+        // then
+        assertThat(application.status).isEqualTo(MercenaryApplicationStatus.REJECTED)
+    }
+
+    @Test
+    fun `PENDING 상태가 아닌 지원을 거절하면 예외가 발생한다`() {
+        // given
+        val application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+        application.accept()
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            application.reject()
+        }
+    }
+
+    @Test
+    fun `메시지 없이 지원을 생성할 수 있다`() {
+        // when
+        val application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.SHORTSTOP),
+            )
+
+        // then
+        assertThat(application.message).isNull()
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/mercenary/MercenaryParticipationTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/mercenary/MercenaryParticipationTest.kt
@@ -1,0 +1,22 @@
+package com.nextup.core.domain.mercenary
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MercenaryParticipationTest {
+    @Test
+    fun `용병 참가 기록을 생성할 수 있다`() {
+        // when
+        val participation =
+            MercenaryParticipation.create(
+                gameId = 10L,
+                playerId = 100L,
+                teamId = 1L,
+            )
+
+        // then
+        assertThat(participation.gameId).isEqualTo(10L)
+        assertThat(participation.playerId).isEqualTo(100L)
+        assertThat(participation.teamId).isEqualTo(1L)
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/mercenary/MercenaryRequestTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/mercenary/MercenaryRequestTest.kt
@@ -1,0 +1,186 @@
+package com.nextup.core.domain.mercenary
+
+import com.nextup.core.domain.player.Position
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class MercenaryRequestTest {
+    private val futureDeadline = Instant.now().plus(7, ChronoUnit.DAYS)
+
+    @Test
+    fun `용병 요청을 생성할 수 있다`() {
+        // when
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER, Position.SHORTSTOP),
+                maxCount = 2,
+                deadline = futureDeadline,
+                description = "포수, 유격수 구합니다",
+            )
+
+        // then
+        assertThat(request.requestingTeamId).isEqualTo(1L)
+        assertThat(request.gameId).isEqualTo(10L)
+        assertThat(request.positions).containsExactlyInAnyOrder(Position.CATCHER, Position.SHORTSTOP)
+        assertThat(request.maxCount).isEqualTo(2)
+        assertThat(request.status).isEqualTo(MercenaryRequestStatus.OPEN)
+        assertThat(request.deadline).isEqualTo(futureDeadline)
+        assertThat(request.description).isEqualTo("포수, 유격수 구합니다")
+    }
+
+    @Test
+    fun `포지션이 비어있으면 생성 시 예외가 발생한다`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = emptySet(),
+                maxCount = 2,
+                deadline = futureDeadline,
+            )
+        }
+    }
+
+    @Test
+    fun `최대 모집 인원이 0 이하이면 생성 시 예외가 발생한다`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 0,
+                deadline = futureDeadline,
+            )
+        }
+    }
+
+    @Test
+    fun `마감 시한이 과거이면 생성 시 예외가 발생한다`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 2,
+                deadline = Instant.now().minus(1, ChronoUnit.DAYS),
+            )
+        }
+    }
+
+    @Test
+    fun `OPEN 상태의 요청을 마감할 수 있다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        // when
+        request.close()
+
+        // then
+        assertThat(request.status).isEqualTo(MercenaryRequestStatus.CLOSED)
+    }
+
+    @Test
+    fun `OPEN 상태가 아닌 요청을 마감하면 예외가 발생한다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+        request.cancel()
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            request.close()
+        }
+    }
+
+    @Test
+    fun `OPEN 상태의 요청을 취소할 수 있다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        // when
+        request.cancel()
+
+        // then
+        assertThat(request.status).isEqualTo(MercenaryRequestStatus.CANCELLED)
+    }
+
+    @Test
+    fun `OPEN 상태가 아닌 요청을 취소하면 예외가 발생한다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+        request.close()
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            request.cancel()
+        }
+    }
+
+    @Test
+    fun `지원을 받을 수 있는 상태인지 확인한다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        // when & then
+        assertThat(request.canAcceptApplication()).isTrue()
+    }
+
+    @Test
+    fun `마감된 요청은 지원을 받을 수 없다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+        request.close()
+
+        // when & then
+        assertThat(request.canAcceptApplication()).isFalse()
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/mercenary/MercenaryServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/mercenary/MercenaryServiceTest.kt
@@ -1,0 +1,637 @@
+package com.nextup.core.service.mercenary
+
+import com.nextup.common.exception.MercenaryAlreadyAppliedException
+import com.nextup.common.exception.MercenaryApplicationNotFoundException
+import com.nextup.common.exception.MercenaryMaxCountReachedException
+import com.nextup.common.exception.MercenaryRequestClosedException
+import com.nextup.common.exception.MercenaryRequestNotFoundException
+import com.nextup.core.domain.mercenary.MercenaryApplication
+import com.nextup.core.domain.mercenary.MercenaryApplicationStatus
+import com.nextup.core.domain.mercenary.MercenaryParticipation
+import com.nextup.core.domain.mercenary.MercenaryRequest
+import com.nextup.core.domain.mercenary.MercenaryRequestStatus
+import com.nextup.core.domain.player.Position
+import com.nextup.core.port.repository.MercenaryApplicationRepositoryPort
+import com.nextup.core.port.repository.MercenaryParticipationRepositoryPort
+import com.nextup.core.port.repository.MercenaryRequestRepositoryPort
+import com.nextup.core.service.mercenary.dto.ApplyMercenaryDto
+import com.nextup.core.service.mercenary.dto.CreateMercenaryRequestDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class MercenaryServiceTest {
+    private lateinit var mercenaryRequestRepository: MercenaryRequestRepositoryPort
+    private lateinit var mercenaryApplicationRepository: MercenaryApplicationRepositoryPort
+    private lateinit var mercenaryParticipationRepository: MercenaryParticipationRepositoryPort
+    private lateinit var mercenaryService: MercenaryService
+
+    private val futureDeadline = Instant.now().plus(7, ChronoUnit.DAYS)
+
+    @BeforeEach
+    fun setUp() {
+        mercenaryRequestRepository = mockk()
+        mercenaryApplicationRepository = mockk()
+        mercenaryParticipationRepository = mockk()
+        mercenaryService =
+            MercenaryService(
+                mercenaryRequestRepository = mercenaryRequestRepository,
+                mercenaryApplicationRepository = mercenaryApplicationRepository,
+                mercenaryParticipationRepository = mercenaryParticipationRepository,
+            )
+    }
+
+    // ========== createRequest 테스트 ==========
+
+    @Test
+    fun `용병 요청을 생성할 수 있다`() {
+        // given
+        val dto =
+            CreateMercenaryRequestDto(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER, Position.SHORTSTOP),
+                maxCount = 2,
+                deadline = futureDeadline,
+                description = "포수, 유격수 구합니다",
+            )
+
+        every { mercenaryRequestRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result = mercenaryService.createRequest(dto)
+
+        // then
+        assertThat(result.requestingTeamId).isEqualTo(1L)
+        assertThat(result.gameId).isEqualTo(10L)
+        assertThat(result.positions).containsExactlyInAnyOrder(Position.CATCHER, Position.SHORTSTOP)
+        assertThat(result.maxCount).isEqualTo(2)
+        assertThat(result.status).isEqualTo(MercenaryRequestStatus.OPEN)
+
+        verify { mercenaryRequestRepository.save(any()) }
+    }
+
+    // ========== getOpenRequests 테스트 ==========
+
+    @Test
+    fun `OPEN 상태의 용병 요청 목록을 조회할 수 있다`() {
+        // given
+        val request1 =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+        val request2 =
+            MercenaryRequest.create(
+                requestingTeamId = 2L,
+                gameId = 20L,
+                positions = setOf(Position.SHORTSTOP),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        every {
+            mercenaryRequestRepository.findByStatus(MercenaryRequestStatus.OPEN)
+        } returns listOf(request1, request2)
+
+        // when
+        val result = mercenaryService.getOpenRequests()
+
+        // then
+        assertThat(result).hasSize(2)
+
+        verify { mercenaryRequestRepository.findByStatus(MercenaryRequestStatus.OPEN) }
+    }
+
+    @Test
+    fun `OPEN 상태의 용병 요청이 없으면 빈 리스트를 반환한다`() {
+        // given
+        every {
+            mercenaryRequestRepository.findByStatus(MercenaryRequestStatus.OPEN)
+        } returns emptyList()
+
+        // when
+        val result = mercenaryService.getOpenRequests()
+
+        // then
+        assertThat(result).isEmpty()
+    }
+
+    // ========== getRequestById 테스트 ==========
+
+    @Test
+    fun `ID로 용병 요청을 조회할 수 있다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+
+        // when
+        val result = mercenaryService.getRequestById(1L)
+
+        // then
+        assertThat(result).isEqualTo(request)
+
+        verify { mercenaryRequestRepository.findByIdOrNull(1L) }
+    }
+
+    @Test
+    fun `존재하지 않는 ID로 용병 요청 조회 시 예외가 발생한다`() {
+        // given
+        every { mercenaryRequestRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<MercenaryRequestNotFoundException> {
+            mercenaryService.getRequestById(999L)
+        }
+
+        verify { mercenaryRequestRepository.findByIdOrNull(999L) }
+    }
+
+    // ========== apply 테스트 ==========
+
+    @Test
+    fun `용병 요청에 지원할 수 있다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 2,
+                deadline = futureDeadline,
+            )
+
+        val dto =
+            ApplyMercenaryDto(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+                message = "포수 가능합니다",
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+        every {
+            mercenaryApplicationRepository.existsByRequestIdAndPlayerId(1L, 100L)
+        } returns false
+        every { mercenaryApplicationRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result = mercenaryService.apply(dto)
+
+        // then
+        assertThat(result.requestId).isEqualTo(1L)
+        assertThat(result.playerId).isEqualTo(100L)
+        assertThat(result.preferredPositions).containsExactly(Position.CATCHER)
+        assertThat(result.status).isEqualTo(MercenaryApplicationStatus.PENDING)
+        assertThat(result.message).isEqualTo("포수 가능합니다")
+
+        verify { mercenaryRequestRepository.findByIdOrNull(1L) }
+        verify { mercenaryApplicationRepository.existsByRequestIdAndPlayerId(1L, 100L) }
+        verify { mercenaryApplicationRepository.save(any()) }
+    }
+
+    @Test
+    fun `존재하지 않는 용병 요청에 지원 시 예외가 발생한다`() {
+        // given
+        val dto =
+            ApplyMercenaryDto(
+                requestId = 999L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<MercenaryRequestNotFoundException> {
+            mercenaryService.apply(dto)
+        }
+
+        verify { mercenaryRequestRepository.findByIdOrNull(999L) }
+    }
+
+    @Test
+    fun `마감된 용병 요청에 지원 시 예외가 발생한다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+        request.close()
+
+        val dto =
+            ApplyMercenaryDto(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+
+        // when & then
+        assertThrows<MercenaryRequestClosedException> {
+            mercenaryService.apply(dto)
+        }
+
+        verify { mercenaryRequestRepository.findByIdOrNull(1L) }
+    }
+
+    @Test
+    fun `이미 지원한 요청에 재지원 시 예외가 발생한다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 2,
+                deadline = futureDeadline,
+            )
+
+        val dto =
+            ApplyMercenaryDto(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+        every {
+            mercenaryApplicationRepository.existsByRequestIdAndPlayerId(1L, 100L)
+        } returns true
+
+        // when & then
+        assertThrows<MercenaryAlreadyAppliedException> {
+            mercenaryService.apply(dto)
+        }
+
+        verify { mercenaryRequestRepository.findByIdOrNull(1L) }
+        verify { mercenaryApplicationRepository.existsByRequestIdAndPlayerId(1L, 100L) }
+    }
+
+    // ========== acceptApplication 테스트 ==========
+
+    @Test
+    fun `용병 지원을 수락할 수 있다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 2,
+                deadline = futureDeadline,
+            )
+
+        val application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+        every { mercenaryApplicationRepository.findByIdOrNull(1L) } returns application
+        every { mercenaryApplicationRepository.countAcceptedByRequestId(1L) } returns 0L
+        every { mercenaryParticipationRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result = mercenaryService.acceptApplication(1L, 1L)
+
+        // then
+        assertThat(result.status).isEqualTo(MercenaryApplicationStatus.ACCEPTED)
+
+        verify { mercenaryParticipationRepository.save(any()) }
+    }
+
+    @Test
+    fun `최대 인원 도달 시 수락하면 요청이 자동 마감된다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        val application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+        every { mercenaryApplicationRepository.findByIdOrNull(1L) } returns application
+        every { mercenaryApplicationRepository.countAcceptedByRequestId(1L) } returns 0L
+        every { mercenaryParticipationRepository.save(any()) } answers { firstArg() }
+
+        // when
+        mercenaryService.acceptApplication(1L, 1L)
+
+        // then
+        assertThat(request.status).isEqualTo(MercenaryRequestStatus.CLOSED)
+    }
+
+    @Test
+    fun `존재하지 않는 용병 요청에 대한 수락 시 예외가 발생한다`() {
+        // given
+        every { mercenaryRequestRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<MercenaryRequestNotFoundException> {
+            mercenaryService.acceptApplication(999L, 1L)
+        }
+
+        verify { mercenaryRequestRepository.findByIdOrNull(999L) }
+    }
+
+    @Test
+    fun `존재하지 않는 지원에 대한 수락 시 예외가 발생한다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+        every { mercenaryApplicationRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<MercenaryApplicationNotFoundException> {
+            mercenaryService.acceptApplication(1L, 999L)
+        }
+
+        verify { mercenaryRequestRepository.findByIdOrNull(1L) }
+        verify { mercenaryApplicationRepository.findByIdOrNull(999L) }
+    }
+
+    @Test
+    fun `최대 인원이 이미 도달한 경우 수락 시 예외가 발생한다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        val application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 200L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+        every { mercenaryApplicationRepository.findByIdOrNull(2L) } returns application
+        every { mercenaryApplicationRepository.countAcceptedByRequestId(1L) } returns 1L
+
+        // when & then
+        assertThrows<MercenaryMaxCountReachedException> {
+            mercenaryService.acceptApplication(1L, 2L)
+        }
+
+        verify { mercenaryRequestRepository.findByIdOrNull(1L) }
+        verify { mercenaryApplicationRepository.findByIdOrNull(2L) }
+        verify { mercenaryApplicationRepository.countAcceptedByRequestId(1L) }
+    }
+
+    // ========== rejectApplication 테스트 ==========
+
+    @Test
+    fun `용병 지원을 거절할 수 있다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        val application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+        every { mercenaryApplicationRepository.findByIdOrNull(1L) } returns application
+
+        // when
+        val result = mercenaryService.rejectApplication(1L, 1L)
+
+        // then
+        assertThat(result.status).isEqualTo(MercenaryApplicationStatus.REJECTED)
+
+        verify { mercenaryRequestRepository.findByIdOrNull(1L) }
+        verify { mercenaryApplicationRepository.findByIdOrNull(1L) }
+    }
+
+    @Test
+    fun `존재하지 않는 용병 요청에 대한 거절 시 예외가 발생한다`() {
+        // given
+        every { mercenaryRequestRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<MercenaryRequestNotFoundException> {
+            mercenaryService.rejectApplication(999L, 1L)
+        }
+    }
+
+    @Test
+    fun `존재하지 않는 지원에 대한 거절 시 예외가 발생한다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+        every { mercenaryApplicationRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<MercenaryApplicationNotFoundException> {
+            mercenaryService.rejectApplication(1L, 999L)
+        }
+    }
+
+    // ========== getApplicationsByRequest 테스트 ==========
+
+    @Test
+    fun `용병 요청에 대한 지원 목록을 조회할 수 있다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 2,
+                deadline = futureDeadline,
+            )
+
+        val app1 =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 100L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+        val app2 =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 200L,
+                preferredPositions = setOf(Position.CATCHER),
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+        every { mercenaryApplicationRepository.findByRequestId(1L) } returns listOf(app1, app2)
+
+        // when
+        val result = mercenaryService.getApplicationsByRequest(1L)
+
+        // then
+        assertThat(result).hasSize(2)
+
+        verify { mercenaryRequestRepository.findByIdOrNull(1L) }
+        verify { mercenaryApplicationRepository.findByRequestId(1L) }
+    }
+
+    @Test
+    fun `존재하지 않는 용병 요청의 지원 목록 조회 시 예외가 발생한다`() {
+        // given
+        every { mercenaryRequestRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<MercenaryRequestNotFoundException> {
+            mercenaryService.getApplicationsByRequest(999L)
+        }
+    }
+
+    // ========== getParticipationsByPlayer 테스트 ==========
+
+    @Test
+    fun `선수의 용병 참가 이력을 조회할 수 있다`() {
+        // given
+        val p1 = MercenaryParticipation.create(gameId = 10L, playerId = 100L, teamId = 1L)
+        val p2 = MercenaryParticipation.create(gameId = 20L, playerId = 100L, teamId = 2L)
+
+        every { mercenaryParticipationRepository.findByPlayerId(100L) } returns listOf(p1, p2)
+
+        // when
+        val result = mercenaryService.getParticipationsByPlayer(100L)
+
+        // then
+        assertThat(result).hasSize(2)
+
+        verify { mercenaryParticipationRepository.findByPlayerId(100L) }
+    }
+
+    @Test
+    fun `용병 참가 이력이 없으면 빈 리스트를 반환한다`() {
+        // given
+        every { mercenaryParticipationRepository.findByPlayerId(100L) } returns emptyList()
+
+        // when
+        val result = mercenaryService.getParticipationsByPlayer(100L)
+
+        // then
+        assertThat(result).isEmpty()
+    }
+
+    // ========== cancelRequest 테스트 ==========
+
+    @Test
+    fun `용병 요청을 취소할 수 있다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+
+        // when
+        val result = mercenaryService.cancelRequest(1L)
+
+        // then
+        assertThat(result.status).isEqualTo(MercenaryRequestStatus.CANCELLED)
+
+        verify { mercenaryRequestRepository.findByIdOrNull(1L) }
+    }
+
+    @Test
+    fun `존재하지 않는 용병 요청 취소 시 예외가 발생한다`() {
+        // given
+        every { mercenaryRequestRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThrows<MercenaryRequestNotFoundException> {
+            mercenaryService.cancelRequest(999L)
+        }
+
+        verify { mercenaryRequestRepository.findByIdOrNull(999L) }
+    }
+
+    @Test
+    fun `OPEN 상태가 아닌 용병 요청 취소 시 예외가 발생한다`() {
+        // given
+        val request =
+            MercenaryRequest.create(
+                requestingTeamId = 1L,
+                gameId = 10L,
+                positions = setOf(Position.CATCHER),
+                maxCount = 1,
+                deadline = futureDeadline,
+            )
+        request.close()
+
+        every { mercenaryRequestRepository.findByIdOrNull(1L) } returns request
+
+        // when & then
+        assertThrows<com.nextup.common.exception.InvalidStateException> {
+            mercenaryService.cancelRequest(1L)
+        }
+
+        verify { mercenaryRequestRepository.findByIdOrNull(1L) }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryApplicationJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryApplicationJpaRepository.kt
@@ -1,0 +1,26 @@
+package com.nextup.infrastructure.persistence.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryApplication
+import com.nextup.core.domain.mercenary.MercenaryApplicationStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface MercenaryApplicationJpaRepository : JpaRepository<MercenaryApplication, Long> {
+    fun findByRequestId(requestId: Long): List<MercenaryApplication>
+
+    fun findByPlayerId(playerId: Long): List<MercenaryApplication>
+
+    fun existsByRequestIdAndPlayerId(
+        requestId: Long,
+        playerId: Long,
+    ): Boolean
+
+    @Query(
+        "SELECT COUNT(ma) FROM MercenaryApplication ma " +
+            "WHERE ma.requestId = :requestId AND ma.status = :status",
+    )
+    fun countByRequestIdAndStatus(
+        requestId: Long,
+        status: MercenaryApplicationStatus,
+    ): Long
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryApplicationRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryApplicationRepositoryAdapter.kt
@@ -1,0 +1,28 @@
+package com.nextup.infrastructure.persistence.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryApplication
+import com.nextup.core.domain.mercenary.MercenaryApplicationStatus
+import com.nextup.core.port.repository.MercenaryApplicationRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class MercenaryApplicationRepositoryAdapter(
+    private val jpaRepository: MercenaryApplicationJpaRepository,
+) : MercenaryApplicationRepositoryPort {
+    override fun save(application: MercenaryApplication): MercenaryApplication = jpaRepository.save(application)
+
+    override fun findByIdOrNull(id: Long): MercenaryApplication? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByRequestId(requestId: Long): List<MercenaryApplication> = jpaRepository.findByRequestId(requestId)
+
+    override fun findByPlayerId(playerId: Long): List<MercenaryApplication> = jpaRepository.findByPlayerId(playerId)
+
+    override fun existsByRequestIdAndPlayerId(
+        requestId: Long,
+        playerId: Long,
+    ): Boolean = jpaRepository.existsByRequestIdAndPlayerId(requestId, playerId)
+
+    override fun countAcceptedByRequestId(requestId: Long): Long =
+        jpaRepository.countByRequestIdAndStatus(requestId, MercenaryApplicationStatus.ACCEPTED)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryParticipationJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryParticipationJpaRepository.kt
@@ -1,0 +1,17 @@
+package com.nextup.infrastructure.persistence.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryParticipation
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MercenaryParticipationJpaRepository : JpaRepository<MercenaryParticipation, Long> {
+    fun findByGameId(gameId: Long): List<MercenaryParticipation>
+
+    fun findByPlayerId(playerId: Long): List<MercenaryParticipation>
+
+    fun findByTeamId(teamId: Long): List<MercenaryParticipation>
+
+    fun existsByGameIdAndPlayerId(
+        gameId: Long,
+        playerId: Long,
+    ): Boolean
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryParticipationRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryParticipationRepositoryAdapter.kt
@@ -1,0 +1,23 @@
+package com.nextup.infrastructure.persistence.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryParticipation
+import com.nextup.core.port.repository.MercenaryParticipationRepositoryPort
+import org.springframework.stereotype.Repository
+
+@Repository
+class MercenaryParticipationRepositoryAdapter(
+    private val jpaRepository: MercenaryParticipationJpaRepository,
+) : MercenaryParticipationRepositoryPort {
+    override fun save(participation: MercenaryParticipation): MercenaryParticipation = jpaRepository.save(participation)
+
+    override fun findByGameId(gameId: Long): List<MercenaryParticipation> = jpaRepository.findByGameId(gameId)
+
+    override fun findByPlayerId(playerId: Long): List<MercenaryParticipation> = jpaRepository.findByPlayerId(playerId)
+
+    override fun findByTeamId(teamId: Long): List<MercenaryParticipation> = jpaRepository.findByTeamId(teamId)
+
+    override fun existsByGameIdAndPlayerId(
+        gameId: Long,
+        playerId: Long,
+    ): Boolean = jpaRepository.existsByGameIdAndPlayerId(gameId, playerId)
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryRequestJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryRequestJpaRepository.kt
@@ -1,0 +1,13 @@
+package com.nextup.infrastructure.persistence.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryRequest
+import com.nextup.core.domain.mercenary.MercenaryRequestStatus
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MercenaryRequestJpaRepository : JpaRepository<MercenaryRequest, Long> {
+    fun findByStatus(status: MercenaryRequestStatus): List<MercenaryRequest>
+
+    fun findByRequestingTeamId(teamId: Long): List<MercenaryRequest>
+
+    fun findByGameId(gameId: Long): List<MercenaryRequest>
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryRequestRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryRequestRepositoryAdapter.kt
@@ -1,0 +1,24 @@
+package com.nextup.infrastructure.persistence.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryRequest
+import com.nextup.core.domain.mercenary.MercenaryRequestStatus
+import com.nextup.core.port.repository.MercenaryRequestRepositoryPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class MercenaryRequestRepositoryAdapter(
+    private val jpaRepository: MercenaryRequestJpaRepository,
+) : MercenaryRequestRepositoryPort {
+    override fun save(mercenaryRequest: MercenaryRequest): MercenaryRequest = jpaRepository.save(mercenaryRequest)
+
+    override fun findByIdOrNull(id: Long): MercenaryRequest? = jpaRepository.findByIdOrNull(id)
+
+    override fun findByStatus(status: MercenaryRequestStatus): List<MercenaryRequest> =
+        jpaRepository.findByStatus(status)
+
+    override fun findByRequestingTeamId(teamId: Long): List<MercenaryRequest> =
+        jpaRepository.findByRequestingTeamId(teamId)
+
+    override fun findByGameId(gameId: Long): List<MercenaryRequest> = jpaRepository.findByGameId(gameId)
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V040__create_mercenary_tables.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V040__create_mercenary_tables.sql
@@ -1,0 +1,73 @@
+-- 용병 요청 테이블
+CREATE TABLE mercenary_requests (
+    id BIGSERIAL PRIMARY KEY,
+    requesting_team_id BIGINT NOT NULL,
+    game_id BIGINT NOT NULL,
+    max_count INTEGER NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',
+    deadline TIMESTAMP WITH TIME ZONE NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_mr_team FOREIGN KEY (requesting_team_id) REFERENCES teams(id),
+    CONSTRAINT fk_mr_game FOREIGN KEY (game_id) REFERENCES games(id)
+);
+
+CREATE INDEX idx_mr_requesting_team_id ON mercenary_requests(requesting_team_id);
+CREATE INDEX idx_mr_game_id ON mercenary_requests(game_id);
+CREATE INDEX idx_mr_status ON mercenary_requests(status);
+CREATE INDEX idx_mr_deadline ON mercenary_requests(deadline);
+
+-- 용병 요청 포지션 (ElementCollection)
+CREATE TABLE mercenary_request_positions (
+    mercenary_request_id BIGINT NOT NULL,
+    position VARCHAR(30) NOT NULL,
+    CONSTRAINT fk_mrp_request FOREIGN KEY (mercenary_request_id)
+        REFERENCES mercenary_requests(id) ON DELETE CASCADE,
+    PRIMARY KEY (mercenary_request_id, position)
+);
+
+-- 용병 지원 테이블
+CREATE TABLE mercenary_applications (
+    id BIGSERIAL PRIMARY KEY,
+    request_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    message TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_ma_request FOREIGN KEY (request_id) REFERENCES mercenary_requests(id),
+    CONSTRAINT fk_ma_player FOREIGN KEY (player_id) REFERENCES players(id),
+    CONSTRAINT uk_ma_request_player UNIQUE (request_id, player_id)
+);
+
+CREATE INDEX idx_ma_request_id ON mercenary_applications(request_id);
+CREATE INDEX idx_ma_player_id ON mercenary_applications(player_id);
+CREATE INDEX idx_ma_status ON mercenary_applications(status);
+
+-- 용병 지원 선호 포지션 (ElementCollection)
+CREATE TABLE mercenary_application_positions (
+    mercenary_application_id BIGINT NOT NULL,
+    position VARCHAR(30) NOT NULL,
+    CONSTRAINT fk_map_application FOREIGN KEY (mercenary_application_id)
+        REFERENCES mercenary_applications(id) ON DELETE CASCADE,
+    PRIMARY KEY (mercenary_application_id, position)
+);
+
+-- 용병 참가 테이블
+CREATE TABLE mercenary_participations (
+    id BIGSERIAL PRIMARY KEY,
+    game_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    team_id BIGINT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_mp_game FOREIGN KEY (game_id) REFERENCES games(id),
+    CONSTRAINT fk_mp_player FOREIGN KEY (player_id) REFERENCES players(id),
+    CONSTRAINT fk_mp_team FOREIGN KEY (team_id) REFERENCES teams(id),
+    CONSTRAINT uk_mp_game_player UNIQUE (game_id, player_id)
+);
+
+CREATE INDEX idx_mp_game_id ON mercenary_participations(game_id);
+CREATE INDEX idx_mp_player_id ON mercenary_participations(player_id);
+CREATE INDEX idx_mp_team_id ON mercenary_participations(team_id);

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryApplicationRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryApplicationRepositoryAdapterTest.kt
@@ -1,0 +1,209 @@
+package com.nextup.infrastructure.persistence.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryApplication
+import com.nextup.core.domain.mercenary.MercenaryApplicationStatus
+import com.nextup.core.domain.player.Position
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+
+@DisplayName("MercenaryApplicationRepositoryAdapter 테스트")
+class MercenaryApplicationRepositoryAdapterTest {
+    private lateinit var jpaRepository: MercenaryApplicationJpaRepository
+    private lateinit var adapter: MercenaryApplicationRepositoryAdapter
+
+    private lateinit var application: MercenaryApplication
+
+    @BeforeEach
+    fun setUp() {
+        jpaRepository = mockk()
+        adapter = MercenaryApplicationRepositoryAdapter(jpaRepository)
+
+        application =
+            MercenaryApplication.create(
+                requestId = 1L,
+                playerId = 50L,
+                preferredPositions = setOf(Position.STARTING_PITCHER),
+                message = "열심히 하겠습니다",
+            )
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+        @Test
+        fun `용병 지원을 저장한다`() {
+            // given
+            every { jpaRepository.save(application) } returns application
+
+            // when
+            val result = adapter.save(application)
+
+            // then
+            assertThat(result).isEqualTo(application)
+            verify { jpaRepository.save(application) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdOrNull")
+    inner class FindByIdOrNull {
+        @Test
+        fun `ID로 용병 지원을 조회한다`() {
+            // given
+            every { jpaRepository.findByIdOrNull(1L) } returns application
+
+            // when
+            val result = adapter.findByIdOrNull(1L)
+
+            // then
+            assertThat(result).isEqualTo(application)
+            verify { jpaRepository.findByIdOrNull(1L) }
+        }
+
+        @Test
+        fun `존재하지 않는 ID로 조회하면 null을 반환한다`() {
+            // given
+            every { jpaRepository.findByIdOrNull(999L) } returns null
+
+            // when
+            val result = adapter.findByIdOrNull(999L)
+
+            // then
+            assertThat(result).isNull()
+            verify { jpaRepository.findByIdOrNull(999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByRequestId")
+    inner class FindByRequestId {
+        @Test
+        fun `용병 요청 ID로 지원 목록을 조회한다`() {
+            // given
+            every { jpaRepository.findByRequestId(1L) } returns listOf(application)
+
+            // when
+            val result = adapter.findByRequestId(1L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0]).isEqualTo(application)
+            verify { jpaRepository.findByRequestId(1L) }
+        }
+
+        @Test
+        fun `지원이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { jpaRepository.findByRequestId(999L) } returns emptyList()
+
+            // when
+            val result = adapter.findByRequestId(999L)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findByRequestId(999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByPlayerId")
+    inner class FindByPlayerId {
+        @Test
+        fun `선수 ID로 지원 목록을 조회한다`() {
+            // given
+            every { jpaRepository.findByPlayerId(50L) } returns listOf(application)
+
+            // when
+            val result = adapter.findByPlayerId(50L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0]).isEqualTo(application)
+            verify { jpaRepository.findByPlayerId(50L) }
+        }
+
+        @Test
+        fun `지원이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { jpaRepository.findByPlayerId(999L) } returns emptyList()
+
+            // when
+            val result = adapter.findByPlayerId(999L)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findByPlayerId(999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByRequestIdAndPlayerId")
+    inner class ExistsByRequestIdAndPlayerId {
+        @Test
+        fun `이미 지원한 경우 true를 반환한다`() {
+            // given
+            every { jpaRepository.existsByRequestIdAndPlayerId(1L, 50L) } returns true
+
+            // when
+            val result = adapter.existsByRequestIdAndPlayerId(1L, 50L)
+
+            // then
+            assertThat(result).isTrue()
+            verify { jpaRepository.existsByRequestIdAndPlayerId(1L, 50L) }
+        }
+
+        @Test
+        fun `지원하지 않은 경우 false를 반환한다`() {
+            // given
+            every { jpaRepository.existsByRequestIdAndPlayerId(1L, 999L) } returns false
+
+            // when
+            val result = adapter.existsByRequestIdAndPlayerId(1L, 999L)
+
+            // then
+            assertThat(result).isFalse()
+            verify { jpaRepository.existsByRequestIdAndPlayerId(1L, 999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("countAcceptedByRequestId")
+    inner class CountAcceptedByRequestId {
+        @Test
+        fun `용병 요청의 수락된 지원 수를 반환한다`() {
+            // given
+            every {
+                jpaRepository.countByRequestIdAndStatus(1L, MercenaryApplicationStatus.ACCEPTED)
+            } returns 2L
+
+            // when
+            val result = adapter.countAcceptedByRequestId(1L)
+
+            // then
+            assertThat(result).isEqualTo(2L)
+            verify { jpaRepository.countByRequestIdAndStatus(1L, MercenaryApplicationStatus.ACCEPTED) }
+        }
+
+        @Test
+        fun `수락된 지원이 없으면 0을 반환한다`() {
+            // given
+            every {
+                jpaRepository.countByRequestIdAndStatus(1L, MercenaryApplicationStatus.ACCEPTED)
+            } returns 0L
+
+            // when
+            val result = adapter.countAcceptedByRequestId(1L)
+
+            // then
+            assertThat(result).isEqualTo(0L)
+            verify { jpaRepository.countByRequestIdAndStatus(1L, MercenaryApplicationStatus.ACCEPTED) }
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryParticipationRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryParticipationRepositoryAdapterTest.kt
@@ -1,0 +1,172 @@
+package com.nextup.infrastructure.persistence.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryParticipation
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("MercenaryParticipationRepositoryAdapter 테스트")
+class MercenaryParticipationRepositoryAdapterTest {
+    private lateinit var jpaRepository: MercenaryParticipationJpaRepository
+    private lateinit var adapter: MercenaryParticipationRepositoryAdapter
+
+    private lateinit var participation: MercenaryParticipation
+
+    @BeforeEach
+    fun setUp() {
+        jpaRepository = mockk()
+        adapter = MercenaryParticipationRepositoryAdapter(jpaRepository)
+
+        participation =
+            MercenaryParticipation.create(
+                gameId = 100L,
+                playerId = 50L,
+                teamId = 10L,
+            )
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+        @Test
+        fun `용병 참가 기록을 저장한다`() {
+            // given
+            every { jpaRepository.save(participation) } returns participation
+
+            // when
+            val result = adapter.save(participation)
+
+            // then
+            assertThat(result).isEqualTo(participation)
+            verify { jpaRepository.save(participation) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByGameId")
+    inner class FindByGameId {
+        @Test
+        fun `경기 ID로 참가 목록을 조회한다`() {
+            // given
+            every { jpaRepository.findByGameId(100L) } returns listOf(participation)
+
+            // when
+            val result = adapter.findByGameId(100L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0]).isEqualTo(participation)
+            verify { jpaRepository.findByGameId(100L) }
+        }
+
+        @Test
+        fun `참가 기록이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { jpaRepository.findByGameId(999L) } returns emptyList()
+
+            // when
+            val result = adapter.findByGameId(999L)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findByGameId(999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByPlayerId")
+    inner class FindByPlayerId {
+        @Test
+        fun `선수 ID로 참가 이력을 조회한다`() {
+            // given
+            every { jpaRepository.findByPlayerId(50L) } returns listOf(participation)
+
+            // when
+            val result = adapter.findByPlayerId(50L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0]).isEqualTo(participation)
+            verify { jpaRepository.findByPlayerId(50L) }
+        }
+
+        @Test
+        fun `참가 이력이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { jpaRepository.findByPlayerId(999L) } returns emptyList()
+
+            // when
+            val result = adapter.findByPlayerId(999L)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findByPlayerId(999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByTeamId")
+    inner class FindByTeamId {
+        @Test
+        fun `팀 ID로 참가 목록을 조회한다`() {
+            // given
+            every { jpaRepository.findByTeamId(10L) } returns listOf(participation)
+
+            // when
+            val result = adapter.findByTeamId(10L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0]).isEqualTo(participation)
+            verify { jpaRepository.findByTeamId(10L) }
+        }
+
+        @Test
+        fun `참가 기록이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { jpaRepository.findByTeamId(999L) } returns emptyList()
+
+            // when
+            val result = adapter.findByTeamId(999L)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findByTeamId(999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByGameIdAndPlayerId")
+    inner class ExistsByGameIdAndPlayerId {
+        @Test
+        fun `해당 경기에 선수가 이미 참가한 경우 true를 반환한다`() {
+            // given
+            every { jpaRepository.existsByGameIdAndPlayerId(100L, 50L) } returns true
+
+            // when
+            val result = adapter.existsByGameIdAndPlayerId(100L, 50L)
+
+            // then
+            assertThat(result).isTrue()
+            verify { jpaRepository.existsByGameIdAndPlayerId(100L, 50L) }
+        }
+
+        @Test
+        fun `해당 경기에 선수가 참가하지 않은 경우 false를 반환한다`() {
+            // given
+            every { jpaRepository.existsByGameIdAndPlayerId(100L, 999L) } returns false
+
+            // when
+            val result = adapter.existsByGameIdAndPlayerId(100L, 999L)
+
+            // then
+            assertThat(result).isFalse()
+            verify { jpaRepository.existsByGameIdAndPlayerId(100L, 999L) }
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryRequestRepositoryAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/persistence/mercenary/MercenaryRequestRepositoryAdapterTest.kt
@@ -1,0 +1,192 @@
+package com.nextup.infrastructure.persistence.mercenary
+
+import com.nextup.core.domain.mercenary.MercenaryRequest
+import com.nextup.core.domain.mercenary.MercenaryRequestStatus
+import com.nextup.core.domain.player.Position
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import java.time.Instant
+
+@DisplayName("MercenaryRequestRepositoryAdapter 테스트")
+class MercenaryRequestRepositoryAdapterTest {
+    private lateinit var jpaRepository: MercenaryRequestJpaRepository
+    private lateinit var adapter: MercenaryRequestRepositoryAdapter
+
+    private lateinit var mercenaryRequest: MercenaryRequest
+
+    @BeforeEach
+    fun setUp() {
+        jpaRepository = mockk()
+        adapter = MercenaryRequestRepositoryAdapter(jpaRepository)
+
+        mercenaryRequest =
+            MercenaryRequest.create(
+                requestingTeamId = 10L,
+                gameId = 100L,
+                positions = setOf(Position.STARTING_PITCHER, Position.CATCHER),
+                maxCount = 2,
+                deadline = Instant.now().plusSeconds(86400),
+                description = "투수 1명, 포수 1명 구합니다",
+            )
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+        @Test
+        fun `용병 요청을 저장한다`() {
+            // given
+            every { jpaRepository.save(mercenaryRequest) } returns mercenaryRequest
+
+            // when
+            val result = adapter.save(mercenaryRequest)
+
+            // then
+            assertThat(result).isEqualTo(mercenaryRequest)
+            verify { jpaRepository.save(mercenaryRequest) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdOrNull")
+    inner class FindByIdOrNull {
+        @Test
+        fun `ID로 용병 요청을 조회한다`() {
+            // given
+            every { jpaRepository.findByIdOrNull(1L) } returns mercenaryRequest
+
+            // when
+            val result = adapter.findByIdOrNull(1L)
+
+            // then
+            assertThat(result).isEqualTo(mercenaryRequest)
+            verify { jpaRepository.findByIdOrNull(1L) }
+        }
+
+        @Test
+        fun `존재하지 않는 ID로 조회하면 null을 반환한다`() {
+            // given
+            every { jpaRepository.findByIdOrNull(999L) } returns null
+
+            // when
+            val result = adapter.findByIdOrNull(999L)
+
+            // then
+            assertThat(result).isNull()
+            verify { jpaRepository.findByIdOrNull(999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByStatus")
+    inner class FindByStatus {
+        @Test
+        fun `OPEN 상태의 용병 요청 목록을 조회한다`() {
+            // given
+            every { jpaRepository.findByStatus(MercenaryRequestStatus.OPEN) } returns listOf(mercenaryRequest)
+
+            // when
+            val result = adapter.findByStatus(MercenaryRequestStatus.OPEN)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0]).isEqualTo(mercenaryRequest)
+            verify { jpaRepository.findByStatus(MercenaryRequestStatus.OPEN) }
+        }
+
+        @Test
+        fun `해당 상태의 요청이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { jpaRepository.findByStatus(MercenaryRequestStatus.CLOSED) } returns emptyList()
+
+            // when
+            val result = adapter.findByStatus(MercenaryRequestStatus.CLOSED)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findByStatus(MercenaryRequestStatus.CLOSED) }
+        }
+
+        @Test
+        fun `CANCELLED 상태의 용병 요청 목록을 조회한다`() {
+            // given
+            every { jpaRepository.findByStatus(MercenaryRequestStatus.CANCELLED) } returns emptyList()
+
+            // when
+            val result = adapter.findByStatus(MercenaryRequestStatus.CANCELLED)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findByStatus(MercenaryRequestStatus.CANCELLED) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByRequestingTeamId")
+    inner class FindByRequestingTeamId {
+        @Test
+        fun `요청 팀 ID로 용병 요청 목록을 조회한다`() {
+            // given
+            every { jpaRepository.findByRequestingTeamId(10L) } returns listOf(mercenaryRequest)
+
+            // when
+            val result = adapter.findByRequestingTeamId(10L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0]).isEqualTo(mercenaryRequest)
+            verify { jpaRepository.findByRequestingTeamId(10L) }
+        }
+
+        @Test
+        fun `해당 팀의 요청이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { jpaRepository.findByRequestingTeamId(999L) } returns emptyList()
+
+            // when
+            val result = adapter.findByRequestingTeamId(999L)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findByRequestingTeamId(999L) }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByGameId")
+    inner class FindByGameId {
+        @Test
+        fun `경기 ID로 용병 요청 목록을 조회한다`() {
+            // given
+            every { jpaRepository.findByGameId(100L) } returns listOf(mercenaryRequest)
+
+            // when
+            val result = adapter.findByGameId(100L)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0]).isEqualTo(mercenaryRequest)
+            verify { jpaRepository.findByGameId(100L) }
+        }
+
+        @Test
+        fun `해당 경기의 요청이 없으면 빈 목록을 반환한다`() {
+            // given
+            every { jpaRepository.findByGameId(999L) } returns emptyList()
+
+            // when
+            val result = adapter.findByGameId(999L)
+
+            // then
+            assertThat(result).isEmpty()
+            verify { jpaRepository.findByGameId(999L) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- close #348

용병(Mercenary) 시스템을 신규 구현합니다. 팀이 경기에 필요한 용병을 모집하고, 선수가 지원하며, 수락/거절을 통해 실제 참가 기록을 생성하는 전체 플로우를 포함합니다.

## Tasks

- **Domain (nextup-core)**
  - `MercenaryRequest` 엔티티: 용병 모집 요청 (positions, maxCount, deadline, status 관리)
  - `MercenaryApplication` 엔티티: 용병 지원 (preferredPositions, status 관리)
  - `MercenaryParticipation` 엔티티: 용병 참가 기록 (gameId, playerId, teamId)
  - `MercenaryRequestStatus` / `MercenaryApplicationStatus` 열거형
  - Repository Port 인터페이스 3개
  - `MercenaryService`: 생성, 조회, 지원, 수락/거절, 취소, 자동 마감 비즈니스 로직
- **Exception (nextup-common)**
  - `MercenaryRequestNotFoundException`, `MercenaryApplicationNotFoundException`
  - `MercenaryAlreadyAppliedException`, `MercenaryRequestClosedException`, `MercenaryMaxCountReachedException`
- **Infrastructure (nextup-infrastructure)**
  - JPA Repository 3개 + Adapter 3개 (Hexagonal Architecture)
  - Flyway `V040__create_mercenary_tables.sql` (5개 테이블)
- **API (nextup-api)**
  - `MercenaryRequestController`: 6개 REST 엔드포인트
  - Request/Response DTO 5개 (Zero Entity Leak 준수)
- **Tests (nextup-core)**
  - Entity 단위 테스트 16개 (MercenaryRequest 8 + MercenaryApplication 7 + MercenaryParticipation 1)
  - Service 단위 테스트 19개 (mockk 기반)

## To Reviewer

- Rich Domain Model 패턴을 적용하여 비즈니스 로직(close, cancel, accept, reject 등)을 엔티티 내부에 캡슐화했습니다.
- `acceptApplication` 시 수락 인원이 maxCount에 도달하면 자동으로 요청을 마감(CLOSED) 처리합니다.
- `@ElementCollection`으로 Position 목록을 별도 조인 테이블로 관리합니다.
- 모든 Controller 반환은 `ApiResponse.success()`로 래핑되어 있습니다.