### PR TITLE
feat(#349): 모집 공고 지원(Apply) 흐름 구현

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/recruitment/RecruitmentApplicationController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/recruitment/RecruitmentApplicationController.kt
@@ -1,0 +1,104 @@
+package com.nextup.api.controller.recruitment
+
+import com.nextup.api.dto.recruitment.ApplyRecruitmentApiRequest
+import com.nextup.api.dto.recruitment.RecruitmentApplicationResponse
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.recruitment.RecruitmentApplicationService
+import com.nextup.core.service.recruitment.dto.ApplyRecruitmentRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+/**
+ * 모집 공고 지원 API Controller (공개 API)
+ *
+ * 모집 공고 지원 관련 엔드포인트를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1")
+class RecruitmentApplicationController(
+    private val applicationService: RecruitmentApplicationService,
+) {
+    /**
+     * 모집 공고에 지원합니다.
+     */
+    @PostMapping("/recruitments/{recruitmentId}/apply")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun apply(
+        @PathVariable recruitmentId: Long,
+        @RequestParam applicantId: Long,
+        @Valid @RequestBody request: ApplyRecruitmentApiRequest,
+    ): ApiResponse<RecruitmentApplicationResponse> {
+        val application =
+            applicationService.apply(
+                ApplyRecruitmentRequest(
+                    recruitmentId = recruitmentId,
+                    applicantId = applicantId,
+                    message = request.message,
+                    preferredPositions = request.preferredPositions,
+                ),
+            )
+        return ApiResponse.success(RecruitmentApplicationResponse.from(application))
+    }
+
+    /**
+     * 내 지원 현황을 조회합니다.
+     */
+    @GetMapping("/me/applications")
+    fun getMyApplications(
+        @RequestParam applicantId: Long,
+    ): ApiResponse<List<RecruitmentApplicationResponse>> {
+        val applications = applicationService.getApplicationsByApplicant(applicantId)
+        return ApiResponse.success(applications.map { RecruitmentApplicationResponse.from(it) })
+    }
+
+    /**
+     * 지원을 취소합니다. (지원자 본인)
+     */
+    @DeleteMapping("/me/applications/{applicationId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun withdrawApplication(
+        @PathVariable applicationId: Long,
+        @RequestParam applicantId: Long,
+    ): ApiResponse<Unit> {
+        applicationService.withdrawApplication(applicationId, applicantId)
+        return ApiResponse.success(Unit)
+    }
+
+    /**
+     * 모집 공고별 지원자 목록을 조회합니다. (팀 관리자)
+     */
+    @GetMapping("/recruitments/{recruitmentId}/applications")
+    fun getApplications(
+        @PathVariable recruitmentId: Long,
+    ): ApiResponse<List<RecruitmentApplicationResponse>> {
+        val applications = applicationService.getApplicationsByRecruitment(recruitmentId)
+        return ApiResponse.success(applications.map { RecruitmentApplicationResponse.from(it) })
+    }
+
+    /**
+     * 지원을 수락합니다. (팀 관리자)
+     */
+    @PatchMapping("/recruitments/{recruitmentId}/applications/{applicationId}/accept")
+    fun acceptApplication(
+        @PathVariable recruitmentId: Long,
+        @PathVariable applicationId: Long,
+        @RequestParam processorId: Long,
+    ): ApiResponse<RecruitmentApplicationResponse> {
+        val application = applicationService.acceptApplication(applicationId, processorId)
+        return ApiResponse.success(RecruitmentApplicationResponse.from(application))
+    }
+
+    /**
+     * 지원을 거절합니다. (팀 관리자)
+     */
+    @PatchMapping("/recruitments/{recruitmentId}/applications/{applicationId}/reject")
+    fun rejectApplication(
+        @PathVariable recruitmentId: Long,
+        @PathVariable applicationId: Long,
+        @RequestParam processorId: Long,
+    ): ApiResponse<RecruitmentApplicationResponse> {
+        val application = applicationService.rejectApplication(applicationId, processorId)
+        return ApiResponse.success(RecruitmentApplicationResponse.from(application))
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/recruitment/ApplyRecruitmentApiRequest.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/recruitment/ApplyRecruitmentApiRequest.kt
@@ -1,0 +1,13 @@
+package com.nextup.api.dto.recruitment
+
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * 모집 공고 지원 요청 DTO (API)
+ */
+data class ApplyRecruitmentApiRequest(
+    @field:NotBlank(message = "지원 메시지는 필수입니다")
+    val message: String,
+    @field:NotBlank(message = "선호 포지션은 필수입니다")
+    val preferredPositions: String,
+)

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/recruitment/RecruitmentApplicationResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/recruitment/RecruitmentApplicationResponse.kt
@@ -1,0 +1,41 @@
+package com.nextup.api.dto.recruitment
+
+import com.nextup.core.domain.recruitment.ApplicationStatus
+import com.nextup.core.domain.recruitment.RecruitmentApplication
+import java.time.Instant
+
+/**
+ * 모집 공고 지원 응답 DTO (공개 API용)
+ */
+data class RecruitmentApplicationResponse(
+    val id: Long,
+    val recruitmentId: Long,
+    val recruitmentTitle: String,
+    val applicantId: Long,
+    val message: String,
+    val preferredPositions: String,
+    val status: ApplicationStatus,
+    val appliedAt: Instant,
+    val processedAt: Instant?,
+    val processedBy: Long?,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(application: RecruitmentApplication): RecruitmentApplicationResponse =
+            RecruitmentApplicationResponse(
+                id = application.id,
+                recruitmentId = application.recruitment.id,
+                recruitmentTitle = application.recruitment.title,
+                applicantId = application.applicantId,
+                message = application.message,
+                preferredPositions = application.preferredPositions,
+                status = application.status,
+                appliedAt = application.appliedAt,
+                processedAt = application.processedAt,
+                processedBy = application.processedBy,
+                createdAt = application.createdAt,
+                updatedAt = application.updatedAt,
+            )
+    }
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/recruitment/RecruitmentApplicationControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/recruitment/RecruitmentApplicationControllerTest.kt
@@ -1,0 +1,332 @@
+package com.nextup.api.controller.recruitment
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.api.dto.recruitment.ApplyRecruitmentApiRequest
+import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.DuplicateApplicationException
+import com.nextup.common.exception.RecruitmentApplicationNotFoundException
+import com.nextup.common.exception.RecruitmentNotOpenException
+import com.nextup.core.domain.recruitment.ApplicationStatus
+import com.nextup.core.domain.recruitment.RecruitmentApplication
+import com.nextup.core.domain.recruitment.TeamRecruitment
+import com.nextup.core.service.recruitment.RecruitmentApplicationService
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+
+@DisplayName("RecruitmentApplicationController")
+class RecruitmentApplicationControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private lateinit var applicationService: RecruitmentApplicationService
+    private lateinit var objectMapper: ObjectMapper
+
+    private val mockRecruitment = mockk<TeamRecruitment>(relaxed = true)
+    private val mockApplication = mockk<RecruitmentApplication>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        applicationService = mockk()
+        objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+        val controller = RecruitmentApplicationController(applicationService)
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
+
+        every { mockRecruitment.id } returns 1L
+        every { mockRecruitment.title } returns "투수 모집"
+
+        every { mockApplication.id } returns 1L
+        every { mockApplication.recruitment } returns mockRecruitment
+        every { mockApplication.applicantId } returns 10L
+        every { mockApplication.message } returns "열심히 하겠습니다"
+        every { mockApplication.preferredPositions } returns "투수,포수"
+        every { mockApplication.status } returns ApplicationStatus.PENDING
+        every { mockApplication.appliedAt } returns Instant.now()
+        every { mockApplication.processedAt } returns null
+        every { mockApplication.processedBy } returns null
+        every { mockApplication.createdAt } returns Instant.now()
+        every { mockApplication.updatedAt } returns Instant.now()
+    }
+
+    @Test
+    fun `should apply to recruitment`() {
+        // given
+        val request =
+            ApplyRecruitmentApiRequest(
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수,포수",
+            )
+
+        every { applicationService.apply(any()) } returns mockApplication
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/recruitments/1/apply")
+                    .param("applicantId", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.applicantId").value(10))
+            .andExpect(jsonPath("$.data.message").value("열심히 하겠습니다"))
+            .andExpect(jsonPath("$.data.status").value("PENDING"))
+
+        verify(exactly = 1) { applicationService.apply(any()) }
+    }
+
+    @Test
+    fun `should return 400 when applying with blank message`() {
+        // given
+        val invalidRequest =
+            mapOf(
+                "message" to "",
+                "preferredPositions" to "투수",
+            )
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/recruitments/1/apply")
+                    .param("applicantId", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidRequest)),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+
+        verify(exactly = 0) { applicationService.apply(any()) }
+    }
+
+    @Test
+    fun `should return error when recruitment is not open`() {
+        // given
+        val request =
+            ApplyRecruitmentApiRequest(
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { applicationService.apply(any()) } throws RecruitmentNotOpenException(1L)
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/recruitments/1/apply")
+                    .param("applicantId", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should return error when duplicate application`() {
+        // given
+        val request =
+            ApplyRecruitmentApiRequest(
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { applicationService.apply(any()) } throws DuplicateApplicationException(1L, 10L)
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/api/v1/recruitments/1/apply")
+                    .param("applicantId", "10")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should get my applications`() {
+        // given
+        every { applicationService.getApplicationsByApplicant(10L) } returns listOf(mockApplication)
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/me/applications")
+                    .param("applicantId", "10"),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].applicantId").value(10))
+
+        verify(exactly = 1) { applicationService.getApplicationsByApplicant(10L) }
+    }
+
+    @Test
+    fun `should get empty list when no applications`() {
+        // given
+        every { applicationService.getApplicationsByApplicant(10L) } returns emptyList()
+
+        // when & then
+        mockMvc
+            .perform(
+                get("/api/v1/me/applications")
+                    .param("applicantId", "10"),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data").isEmpty)
+    }
+
+    @Test
+    fun `should withdraw application`() {
+        // given
+        justRun { applicationService.withdrawApplication(1L, 10L) }
+
+        // when & then
+        mockMvc
+            .perform(
+                delete("/api/v1/me/applications/1")
+                    .param("applicantId", "10"),
+            )
+            .andExpect(status().isNoContent)
+            .andExpect(jsonPath("$.success").value(true))
+
+        verify(exactly = 1) { applicationService.withdrawApplication(1L, 10L) }
+    }
+
+    @Test
+    fun `should return 404 when withdrawing non-existent application`() {
+        // given
+        every {
+            applicationService.withdrawApplication(999L, 10L)
+        } throws RecruitmentApplicationNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(
+                delete("/api/v1/me/applications/999")
+                    .param("applicantId", "10"),
+            )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `should get applications for recruitment`() {
+        // given
+        every { applicationService.getApplicationsByRecruitment(1L) } returns listOf(mockApplication)
+
+        // when & then
+        mockMvc
+            .perform(get("/api/v1/recruitments/1/applications"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].status").value("PENDING"))
+
+        verify(exactly = 1) { applicationService.getApplicationsByRecruitment(1L) }
+    }
+
+    @Test
+    fun `should accept application`() {
+        // given
+        val acceptedApp = mockk<RecruitmentApplication>(relaxed = true)
+        every { acceptedApp.id } returns 1L
+        every { acceptedApp.recruitment } returns mockRecruitment
+        every { acceptedApp.applicantId } returns 10L
+        every { acceptedApp.message } returns "열심히 하겠습니다"
+        every { acceptedApp.preferredPositions } returns "투수,포수"
+        every { acceptedApp.status } returns ApplicationStatus.ACCEPTED
+        every { acceptedApp.appliedAt } returns Instant.now()
+        every { acceptedApp.processedAt } returns Instant.now()
+        every { acceptedApp.processedBy } returns 100L
+        every { acceptedApp.createdAt } returns Instant.now()
+        every { acceptedApp.updatedAt } returns Instant.now()
+
+        every { applicationService.acceptApplication(1L, 100L) } returns acceptedApp
+
+        // when & then
+        mockMvc
+            .perform(
+                patch("/api/v1/recruitments/1/applications/1/accept")
+                    .param("processorId", "100"),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+            .andExpect(jsonPath("$.data.processedBy").value(100))
+
+        verify(exactly = 1) { applicationService.acceptApplication(1L, 100L) }
+    }
+
+    @Test
+    fun `should reject application`() {
+        // given
+        val rejectedApp = mockk<RecruitmentApplication>(relaxed = true)
+        every { rejectedApp.id } returns 1L
+        every { rejectedApp.recruitment } returns mockRecruitment
+        every { rejectedApp.applicantId } returns 10L
+        every { rejectedApp.message } returns "열심히 하겠습니다"
+        every { rejectedApp.preferredPositions } returns "투수,포수"
+        every { rejectedApp.status } returns ApplicationStatus.REJECTED
+        every { rejectedApp.appliedAt } returns Instant.now()
+        every { rejectedApp.processedAt } returns Instant.now()
+        every { rejectedApp.processedBy } returns 100L
+        every { rejectedApp.createdAt } returns Instant.now()
+        every { rejectedApp.updatedAt } returns Instant.now()
+
+        every { applicationService.rejectApplication(1L, 100L) } returns rejectedApp
+
+        // when & then
+        mockMvc
+            .perform(
+                patch("/api/v1/recruitments/1/applications/1/reject")
+                    .param("processorId", "100"),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.status").value("REJECTED"))
+
+        verify(exactly = 1) { applicationService.rejectApplication(1L, 100L) }
+    }
+
+    @Test
+    fun `should return 404 when accepting non-existent application`() {
+        // given
+        every {
+            applicationService.acceptApplication(999L, 100L)
+        } throws RecruitmentApplicationNotFoundException(999L)
+
+        // when & then
+        mockMvc
+            .perform(
+                patch("/api/v1/recruitments/1/applications/999/accept")
+                    .param("processorId", "100"),
+            )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/RecruitmentApplicationExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/RecruitmentApplicationExceptions.kt
@@ -1,0 +1,43 @@
+package com.nextup.common.exception
+
+/**
+ * 모집 지원을 찾을 수 없을 때 발생하는 예외
+ */
+class RecruitmentApplicationNotFoundException(
+    id: Long,
+) : NotFoundException(
+        code = "RECRUITMENT_APPLICATION_NOT_FOUND",
+        message = "모집 지원을 찾을 수 없습니다: $id",
+    )
+
+/**
+ * 이미 지원한 모집 공고에 중복 지원할 때 발생하는 예외
+ */
+class DuplicateApplicationException(
+    recruitmentId: Long,
+    applicantId: Long,
+) : BusinessException(
+        code = "DUPLICATE_APPLICATION",
+        message = "이미 해당 모집 공고에 지원했습니다: recruitmentId=$recruitmentId, applicantId=$applicantId",
+    )
+
+/**
+ * 모집 공고가 마감되었거나 만료된 경우 발생하는 예외
+ */
+class RecruitmentNotOpenException(
+    recruitmentId: Long,
+) : InvalidStateException(
+        code = "RECRUITMENT_NOT_OPEN",
+        message = "모집 공고가 진행 중이 아닙니다: $recruitmentId",
+    )
+
+/**
+ * 이미 해당 팀에 소속된 사용자가 지원할 때 발생하는 예외
+ */
+class AlreadyTeamMemberApplicationException(
+    applicantId: Long,
+    teamId: Long,
+) : BusinessException(
+        code = "ALREADY_TEAM_MEMBER",
+        message = "이미 해당 팀의 멤버입니다: applicantId=$applicantId, teamId=$teamId",
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/RecruitmentApplicationAcceptedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/RecruitmentApplicationAcceptedEvent.kt
@@ -1,0 +1,15 @@
+package com.nextup.core.domain.event
+
+/**
+ * 모집 지원 수락 이벤트
+ *
+ * 모집 공고 지원이 수락되었을 때 발행됩니다.
+ * 팀 자동 합류 처리를 위해 사용됩니다.
+ */
+data class RecruitmentApplicationAcceptedEvent(
+    val applicationId: Long,
+    val recruitmentId: Long,
+    val teamId: Long,
+    val applicantId: Long,
+    val teamName: String,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/recruitment/ApplicationStatus.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/recruitment/ApplicationStatus.kt
@@ -1,0 +1,18 @@
+package com.nextup.core.domain.recruitment
+
+/**
+ * 모집 지원 상태
+ */
+enum class ApplicationStatus {
+    /** 대기 중 */
+    PENDING,
+
+    /** 수락됨 */
+    ACCEPTED,
+
+    /** 거절됨 */
+    REJECTED,
+
+    /** 지원자가 취소함 */
+    WITHDRAWN,
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/recruitment/RecruitmentApplication.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/recruitment/RecruitmentApplication.kt
@@ -1,0 +1,128 @@
+package com.nextup.core.domain.recruitment
+
+import com.nextup.core.common.BaseTimeEntity
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * 모집 공고 지원 엔티티
+ *
+ * 팀 모집 공고에 대한 지원 정보를 관리합니다.
+ * Rich Domain Model 원칙에 따라 비즈니스 로직을 Entity 내부에 캡슐화합니다.
+ */
+@Entity
+@Table(
+    name = "recruitment_applications",
+    indexes = [
+        Index(name = "idx_ra_recruitment_id", columnList = "recruitment_id"),
+        Index(name = "idx_ra_applicant_id", columnList = "applicant_id"),
+        Index(name = "idx_ra_status", columnList = "status"),
+        Index(
+            name = "idx_ra_recruitment_applicant",
+            columnList = "recruitment_id, applicant_id",
+        ),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_ra_recruitment_applicant_active",
+            columnNames = ["recruitment_id", "applicant_id"],
+        ),
+    ],
+)
+class RecruitmentApplication private constructor(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id", nullable = false)
+    val recruitment: TeamRecruitment,
+    @Column(name = "applicant_id", nullable = false)
+    val applicantId: Long,
+    @Column(nullable = false, length = 500)
+    val message: String,
+    @Column(name = "preferred_positions", nullable = false, length = 255)
+    val preferredPositions: String,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: ApplicationStatus = ApplicationStatus.PENDING,
+    @Column(name = "applied_at", nullable = false)
+    val appliedAt: Instant = Instant.now(),
+    @Column(name = "processed_at")
+    var processedAt: Instant? = null,
+    @Column(name = "processed_by")
+    var processedBy: Long? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : BaseTimeEntity() {
+    /**
+     * 지원을 수락합니다.
+     *
+     * @param processorId 처리자 ID
+     * @throws IllegalStateException PENDING 상태가 아닌 경우
+     */
+    fun accept(processorId: Long) {
+        check(status == ApplicationStatus.PENDING) {
+            "대기 중인 지원만 수락할 수 있습니다"
+        }
+        this.status = ApplicationStatus.ACCEPTED
+        this.processedAt = Instant.now()
+        this.processedBy = processorId
+    }
+
+    /**
+     * 지원을 거절합니다.
+     *
+     * @param processorId 처리자 ID
+     * @throws IllegalStateException PENDING 상태가 아닌 경우
+     */
+    fun reject(processorId: Long) {
+        check(status == ApplicationStatus.PENDING) {
+            "대기 중인 지원만 거절할 수 있습니다"
+        }
+        this.status = ApplicationStatus.REJECTED
+        this.processedAt = Instant.now()
+        this.processedBy = processorId
+    }
+
+    /**
+     * 지원을 취소합니다.
+     *
+     * @throws IllegalStateException PENDING 상태가 아닌 경우
+     */
+    fun withdraw() {
+        check(status == ApplicationStatus.PENDING) {
+            "대기 중인 지원만 취소할 수 있습니다"
+        }
+        this.status = ApplicationStatus.WITHDRAWN
+        this.processedAt = Instant.now()
+    }
+
+    companion object {
+        /**
+         * 모집 공고 지원을 생성합니다.
+         *
+         * @param recruitment 모집 공고
+         * @param applicantId 지원자 ID
+         * @param message 지원 메시지
+         * @param preferredPositions 선호 포지션 (쉼표 구분)
+         * @return 생성된 RecruitmentApplication
+         */
+        fun create(
+            recruitment: TeamRecruitment,
+            applicantId: Long,
+            message: String,
+            preferredPositions: String,
+        ): RecruitmentApplication {
+            require(message.isNotBlank()) { "지원 메시지는 필수입니다" }
+            require(preferredPositions.isNotBlank()) { "선호 포지션은 필수입니다" }
+            require(recruitment.status == RecruitmentStatus.OPEN) {
+                "진행 중인 모집 공고에만 지원할 수 있습니다"
+            }
+
+            return RecruitmentApplication(
+                recruitment = recruitment,
+                applicantId = applicantId,
+                message = message,
+                preferredPositions = preferredPositions,
+            )
+        }
+    }
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/RecruitmentApplicationRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/RecruitmentApplicationRepositoryPort.kt
@@ -1,0 +1,36 @@
+package com.nextup.core.port.repository
+
+import com.nextup.core.domain.recruitment.ApplicationStatus
+import com.nextup.core.domain.recruitment.RecruitmentApplication
+
+/**
+ * RecruitmentApplication Repository Port
+ * Core 모듈의 Repository 인터페이스 - Infrastructure에서 구현
+ */
+interface RecruitmentApplicationRepositoryPort {
+    fun save(application: RecruitmentApplication): RecruitmentApplication
+
+    fun findByIdOrNull(id: Long): RecruitmentApplication?
+
+    fun findByRecruitmentId(recruitmentId: Long): List<RecruitmentApplication>
+
+    fun findByRecruitmentIdAndStatus(
+        recruitmentId: Long,
+        status: ApplicationStatus,
+    ): List<RecruitmentApplication>
+
+    fun findByApplicantId(applicantId: Long): List<RecruitmentApplication>
+
+    fun findByRecruitmentIdAndApplicantId(
+        recruitmentId: Long,
+        applicantId: Long,
+    ): RecruitmentApplication?
+
+    fun existsByRecruitmentIdAndApplicantIdAndStatusIn(
+        recruitmentId: Long,
+        applicantId: Long,
+        statuses: Set<ApplicationStatus>,
+    ): Boolean
+
+    fun delete(application: RecruitmentApplication)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/RecruitmentApplicationService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/RecruitmentApplicationService.kt
@@ -1,0 +1,214 @@
+package com.nextup.core.service.recruitment
+
+import com.nextup.common.exception.AlreadyTeamMemberApplicationException
+import com.nextup.common.exception.DuplicateApplicationException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.common.exception.RecruitmentApplicationNotFoundException
+import com.nextup.common.exception.RecruitmentNotOpenException
+import com.nextup.core.domain.event.RecruitmentApplicationAcceptedEvent
+import com.nextup.core.domain.recruitment.ApplicationStatus
+import com.nextup.core.domain.recruitment.RecruitmentApplication
+import com.nextup.core.domain.recruitment.RecruitmentStatus
+import com.nextup.core.port.repository.RecruitmentApplicationRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import com.nextup.core.port.repository.TeamRecruitmentRepositoryPort
+import com.nextup.core.service.recruitment.dto.ApplyRecruitmentRequest
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 모집 공고 지원 서비스
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class RecruitmentApplicationService(
+    private val applicationRepository: RecruitmentApplicationRepositoryPort,
+    private val recruitmentRepository: TeamRecruitmentRepositoryPort,
+    private val teamMemberRepository: TeamMemberRepositoryPort,
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+    /**
+     * 모집 공고에 지원합니다.
+     *
+     * @param request 지원 요청
+     * @return 생성된 RecruitmentApplication
+     * @throws RecruitmentNotOpenException 모집 공고가 진행 중이 아닌 경우
+     * @throws DuplicateApplicationException 이미 지원한 경우
+     * @throws AlreadyTeamMemberApplicationException 이미 해당 팀의 멤버인 경우
+     */
+    @Transactional
+    fun apply(request: ApplyRecruitmentRequest): RecruitmentApplication {
+        val recruitment =
+            recruitmentRepository.findByIdOrNull(request.recruitmentId)
+                ?: throw com.nextup.common.exception.RecruitmentNotFoundException(request.recruitmentId)
+
+        // 모집 공고가 진행 중인지 확인
+        if (recruitment.status != RecruitmentStatus.OPEN) {
+            throw RecruitmentNotOpenException(request.recruitmentId)
+        }
+
+        // 마감일이 지났는지 확인
+        if (recruitment.isExpired()) {
+            throw RecruitmentNotOpenException(request.recruitmentId)
+        }
+
+        // 중복 지원 방지 (PENDING 또는 ACCEPTED 상태)
+        val hasActiveApplication =
+            applicationRepository.existsByRecruitmentIdAndApplicantIdAndStatusIn(
+                recruitmentId = request.recruitmentId,
+                applicantId = request.applicantId,
+                statuses = setOf(ApplicationStatus.PENDING, ApplicationStatus.ACCEPTED),
+            )
+        if (hasActiveApplication) {
+            throw DuplicateApplicationException(request.recruitmentId, request.applicantId)
+        }
+
+        // 이미 해당 팀의 멤버인지 확인
+        val isAlreadyMember =
+            teamMemberRepository.existsByTeamIdAndUserId(
+                teamId = recruitment.team.id,
+                userId = request.applicantId,
+            )
+        if (isAlreadyMember) {
+            throw AlreadyTeamMemberApplicationException(request.applicantId, recruitment.team.id)
+        }
+
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = request.applicantId,
+                message = request.message,
+                preferredPositions = request.preferredPositions,
+            )
+
+        return applicationRepository.save(application)
+    }
+
+    /**
+     * 지원을 수락합니다.
+     *
+     * @param applicationId 지원 ID
+     * @param processorId 처리자 ID
+     * @return 수락된 RecruitmentApplication
+     * @throws RecruitmentApplicationNotFoundException 지원을 찾을 수 없는 경우
+     * @throws InvalidStateException PENDING 상태가 아닌 경우
+     */
+    @Transactional
+    fun acceptApplication(
+        applicationId: Long,
+        processorId: Long,
+    ): RecruitmentApplication {
+        val application = getApplicationById(applicationId)
+
+        try {
+            application.accept(processorId)
+        } catch (e: IllegalStateException) {
+            throw InvalidStateException(
+                "INVALID_APPLICATION_STATE",
+                e.message ?: "지원을 수락할 수 없습니다",
+            )
+        }
+
+        // 지원 수락 이벤트 발행 (팀 자동 합류)
+        eventPublisher.publishEvent(
+            RecruitmentApplicationAcceptedEvent(
+                applicationId = application.id,
+                recruitmentId = application.recruitment.id,
+                teamId = application.recruitment.team.id,
+                applicantId = application.applicantId,
+                teamName = application.recruitment.team.name,
+            ),
+        )
+
+        return application
+    }
+
+    /**
+     * 지원을 거절합니다.
+     *
+     * @param applicationId 지원 ID
+     * @param processorId 처리자 ID
+     * @return 거절된 RecruitmentApplication
+     * @throws RecruitmentApplicationNotFoundException 지원을 찾을 수 없는 경우
+     * @throws InvalidStateException PENDING 상태가 아닌 경우
+     */
+    @Transactional
+    fun rejectApplication(
+        applicationId: Long,
+        processorId: Long,
+    ): RecruitmentApplication {
+        val application = getApplicationById(applicationId)
+
+        try {
+            application.reject(processorId)
+        } catch (e: IllegalStateException) {
+            throw InvalidStateException(
+                "INVALID_APPLICATION_STATE",
+                e.message ?: "지원을 거절할 수 없습니다",
+            )
+        }
+
+        return application
+    }
+
+    /**
+     * 지원을 취소합니다. (지원자 본인)
+     *
+     * @param applicationId 지원 ID
+     * @param applicantId 지원자 ID (본인 확인용)
+     * @throws RecruitmentApplicationNotFoundException 지원을 찾을 수 없는 경우
+     * @throws InvalidStateException PENDING 상태가 아닌 경우
+     */
+    @Transactional
+    fun withdrawApplication(
+        applicationId: Long,
+        applicantId: Long,
+    ) {
+        val application = getApplicationById(applicationId)
+
+        require(application.applicantId == applicantId) {
+            "본인의 지원만 취소할 수 있습니다"
+        }
+
+        try {
+            application.withdraw()
+        } catch (e: IllegalStateException) {
+            throw InvalidStateException(
+                "INVALID_APPLICATION_STATE",
+                e.message ?: "지원을 취소할 수 없습니다",
+            )
+        }
+    }
+
+    /**
+     * 모집 공고별 지원자 목록을 조회합니다.
+     *
+     * @param recruitmentId 모집 공고 ID
+     * @return 지원 목록
+     */
+    fun getApplicationsByRecruitment(recruitmentId: Long): List<RecruitmentApplication> =
+        applicationRepository.findByRecruitmentId(recruitmentId)
+
+    /**
+     * 사용자의 지원 현황을 조회합니다.
+     *
+     * @param applicantId 지원자 ID
+     * @return 지원 목록
+     */
+    fun getApplicationsByApplicant(applicantId: Long): List<RecruitmentApplication> =
+        applicationRepository.findByApplicantId(applicantId)
+
+    /**
+     * ID로 지원을 조회합니다.
+     *
+     * @param id 지원 ID
+     * @return RecruitmentApplication
+     * @throws RecruitmentApplicationNotFoundException 지원을 찾을 수 없는 경우
+     */
+    fun getApplicationById(id: Long): RecruitmentApplication =
+        applicationRepository.findByIdOrNull(id)
+            ?: throw RecruitmentApplicationNotFoundException(id)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/dto/ApplyRecruitmentRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/dto/ApplyRecruitmentRequest.kt
@@ -1,0 +1,11 @@
+package com.nextup.core.service.recruitment.dto
+
+/**
+ * 모집 공고 지원 요청 DTO (Core Service용)
+ */
+data class ApplyRecruitmentRequest(
+    val recruitmentId: Long,
+    val applicantId: Long,
+    val message: String,
+    val preferredPositions: String,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/recruitment/RecruitmentApplicationTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/recruitment/RecruitmentApplicationTest.kt
@@ -1,0 +1,264 @@
+package com.nextup.core.domain.recruitment
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class RecruitmentApplicationTest {
+    private lateinit var team: Team
+    private lateinit var recruitment: TeamRecruitment
+
+    @BeforeEach
+    fun setUp() {
+        val association = Association(name = "테스트 협회")
+        val league =
+            League(
+                association = association,
+                name = "테스트 리그",
+                foundedYear = 2020,
+            )
+        team =
+            Team(
+                league = league,
+                name = "테스트 팀",
+                city = "서울",
+                foundedYear = 2020,
+            )
+        recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "투수 모집",
+                description = "경험 많은 투수를 모집합니다",
+                positionsNeeded = "투수,포수",
+                ageRange = "20-35",
+                skillLevel = "중급",
+                location = "서울",
+                deadline = LocalDate.now().plusDays(30),
+            )
+    }
+
+    @Test
+    fun `should create application with valid data`() {
+        // given
+        val applicantId = 1L
+        val message = "열심히 하겠습니다"
+        val preferredPositions = "투수,포수"
+
+        // when
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = applicantId,
+                message = message,
+                preferredPositions = preferredPositions,
+            )
+
+        // then
+        assertThat(application.recruitment).isEqualTo(recruitment)
+        assertThat(application.applicantId).isEqualTo(applicantId)
+        assertThat(application.message).isEqualTo(message)
+        assertThat(application.preferredPositions).isEqualTo(preferredPositions)
+        assertThat(application.status).isEqualTo(ApplicationStatus.PENDING)
+        assertThat(application.processedAt).isNull()
+        assertThat(application.processedBy).isNull()
+    }
+
+    @Test
+    fun `should throw exception when creating application with blank message`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "",
+                preferredPositions = "투수",
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception when creating application with blank positions`() {
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "",
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception when applying to closed recruitment`() {
+        // given
+        recruitment.close()
+
+        // when & then
+        assertThrows<IllegalArgumentException> {
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        }
+    }
+
+    @Test
+    fun `should accept pending application`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        val processorId = 100L
+
+        // when
+        application.accept(processorId)
+
+        // then
+        assertThat(application.status).isEqualTo(ApplicationStatus.ACCEPTED)
+        assertThat(application.processedAt).isNotNull()
+        assertThat(application.processedBy).isEqualTo(processorId)
+    }
+
+    @Test
+    fun `should throw exception when accepting non-pending application`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        application.accept(100L) // ACCEPTED 상태로 변경
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            application.accept(100L)
+        }
+    }
+
+    @Test
+    fun `should reject pending application`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        val processorId = 100L
+
+        // when
+        application.reject(processorId)
+
+        // then
+        assertThat(application.status).isEqualTo(ApplicationStatus.REJECTED)
+        assertThat(application.processedAt).isNotNull()
+        assertThat(application.processedBy).isEqualTo(processorId)
+    }
+
+    @Test
+    fun `should throw exception when rejecting non-pending application`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        application.reject(100L) // REJECTED 상태로 변경
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            application.reject(100L)
+        }
+    }
+
+    @Test
+    fun `should withdraw pending application`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        // when
+        application.withdraw()
+
+        // then
+        assertThat(application.status).isEqualTo(ApplicationStatus.WITHDRAWN)
+        assertThat(application.processedAt).isNotNull()
+        assertThat(application.processedBy).isNull()
+    }
+
+    @Test
+    fun `should throw exception when withdrawing non-pending application`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        application.withdraw() // WITHDRAWN 상태로 변경
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            application.withdraw()
+        }
+    }
+
+    @Test
+    fun `should not accept already rejected application`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        application.reject(100L)
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            application.accept(100L)
+        }
+    }
+
+    @Test
+    fun `should not withdraw already accepted application`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 1L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        application.accept(100L)
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            application.withdraw()
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/recruitment/RecruitmentApplicationServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/recruitment/RecruitmentApplicationServiceTest.kt
@@ -1,0 +1,468 @@
+package com.nextup.core.service.recruitment
+
+import com.nextup.common.exception.AlreadyTeamMemberApplicationException
+import com.nextup.common.exception.DuplicateApplicationException
+import com.nextup.common.exception.InvalidStateException
+import com.nextup.common.exception.RecruitmentApplicationNotFoundException
+import com.nextup.common.exception.RecruitmentNotFoundException
+import com.nextup.common.exception.RecruitmentNotOpenException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.recruitment.ApplicationStatus
+import com.nextup.core.domain.recruitment.RecruitmentApplication
+import com.nextup.core.domain.recruitment.TeamRecruitment
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.RecruitmentApplicationRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import com.nextup.core.port.repository.TeamRecruitmentRepositoryPort
+import com.nextup.core.service.recruitment.dto.ApplyRecruitmentRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDate
+
+class RecruitmentApplicationServiceTest {
+    private lateinit var applicationRepository: RecruitmentApplicationRepositoryPort
+    private lateinit var recruitmentRepository: TeamRecruitmentRepositoryPort
+    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
+    private lateinit var eventPublisher: ApplicationEventPublisher
+    private lateinit var service: RecruitmentApplicationService
+
+    private lateinit var association: Association
+    private lateinit var league: League
+    private lateinit var team: Team
+    private lateinit var recruitment: TeamRecruitment
+
+    @BeforeEach
+    fun setUp() {
+        applicationRepository = mockk()
+        recruitmentRepository = mockk()
+        teamMemberRepository = mockk()
+        eventPublisher = mockk(relaxed = true)
+        service =
+            RecruitmentApplicationService(
+                applicationRepository,
+                recruitmentRepository,
+                teamMemberRepository,
+                eventPublisher,
+            )
+
+        association =
+            Association(
+                name = "서울시야구협회",
+                id = 1L,
+            )
+        league =
+            League(
+                association = association,
+                name = "1부 리그",
+                foundedYear = 2020,
+                id = 1L,
+            )
+        team =
+            Team(
+                league = league,
+                name = "타이거즈",
+                city = "서울",
+                foundedYear = 2021,
+                id = 1L,
+            )
+        recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "투수 모집",
+                description = "주말 리그 투수를 모집합니다",
+                positionsNeeded = "투수, 포수",
+                ageRange = "20-30대",
+                skillLevel = "중급 이상",
+                location = "서울 강남구",
+                deadline = LocalDate.now().plusDays(30),
+            )
+    }
+
+    // ========== apply Tests ==========
+
+    @Test
+    fun `모집 공고에 지원할 수 있다`() {
+        // given
+        val request =
+            ApplyRecruitmentRequest(
+                recruitmentId = 1L,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { recruitmentRepository.findByIdOrNull(1L) } returns recruitment
+        every {
+            applicationRepository.existsByRecruitmentIdAndApplicantIdAndStatusIn(
+                1L,
+                10L,
+                setOf(ApplicationStatus.PENDING, ApplicationStatus.ACCEPTED),
+            )
+        } returns false
+        every { teamMemberRepository.existsByTeamIdAndUserId(1L, 10L) } returns false
+        every { applicationRepository.save(any()) } answers { firstArg() }
+
+        // when
+        val result = service.apply(request)
+
+        // then
+        assertThat(result.applicantId).isEqualTo(10L)
+        assertThat(result.message).isEqualTo("열심히 하겠습니다")
+        assertThat(result.preferredPositions).isEqualTo("투수")
+        assertThat(result.status).isEqualTo(ApplicationStatus.PENDING)
+
+        verify(exactly = 1) { recruitmentRepository.findByIdOrNull(1L) }
+        verify(exactly = 1) { applicationRepository.save(any()) }
+    }
+
+    @Test
+    fun `존재하지 않는 모집 공고에 지원하면 예외가 발생한다`() {
+        // given
+        val request =
+            ApplyRecruitmentRequest(
+                recruitmentId = 999L,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { recruitmentRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThatThrownBy { service.apply(request) }
+            .isInstanceOf(RecruitmentNotFoundException::class.java)
+
+        verify(exactly = 1) { recruitmentRepository.findByIdOrNull(999L) }
+        verify(exactly = 0) { applicationRepository.save(any()) }
+    }
+
+    @Test
+    fun `마감된 모집 공고에 지원하면 예외가 발생한다`() {
+        // given
+        val closedRecruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "투수 모집",
+                description = "설명",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = LocalDate.now().plusDays(30),
+            )
+        closedRecruitment.close()
+
+        val request =
+            ApplyRecruitmentRequest(
+                recruitmentId = 2L,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { recruitmentRepository.findByIdOrNull(2L) } returns closedRecruitment
+
+        // when & then
+        assertThatThrownBy { service.apply(request) }
+            .isInstanceOf(RecruitmentNotOpenException::class.java)
+
+        verify(exactly = 1) { recruitmentRepository.findByIdOrNull(2L) }
+        verify(exactly = 0) { applicationRepository.save(any()) }
+    }
+
+    @Test
+    fun `중복 지원하면 예외가 발생한다`() {
+        // given
+        val request =
+            ApplyRecruitmentRequest(
+                recruitmentId = 1L,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { recruitmentRepository.findByIdOrNull(1L) } returns recruitment
+        every {
+            applicationRepository.existsByRecruitmentIdAndApplicantIdAndStatusIn(
+                1L,
+                10L,
+                setOf(ApplicationStatus.PENDING, ApplicationStatus.ACCEPTED),
+            )
+        } returns true
+
+        // when & then
+        assertThatThrownBy { service.apply(request) }
+            .isInstanceOf(DuplicateApplicationException::class.java)
+
+        verify(exactly = 0) { applicationRepository.save(any()) }
+    }
+
+    @Test
+    fun `이미 팀에 소속된 사용자가 지원하면 예외가 발생한다`() {
+        // given
+        val request =
+            ApplyRecruitmentRequest(
+                recruitmentId = 1L,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { recruitmentRepository.findByIdOrNull(1L) } returns recruitment
+        every {
+            applicationRepository.existsByRecruitmentIdAndApplicantIdAndStatusIn(
+                1L,
+                10L,
+                setOf(ApplicationStatus.PENDING, ApplicationStatus.ACCEPTED),
+            )
+        } returns false
+        every { teamMemberRepository.existsByTeamIdAndUserId(1L, 10L) } returns true
+
+        // when & then
+        assertThatThrownBy { service.apply(request) }
+            .isInstanceOf(AlreadyTeamMemberApplicationException::class.java)
+
+        verify(exactly = 0) { applicationRepository.save(any()) }
+    }
+
+    // ========== acceptApplication Tests ==========
+
+    @Test
+    fun `지원을 수락할 수 있다`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { applicationRepository.findByIdOrNull(1L) } returns application
+
+        // when
+        val result = service.acceptApplication(1L, 100L)
+
+        // then
+        assertThat(result.status).isEqualTo(ApplicationStatus.ACCEPTED)
+        assertThat(result.processedBy).isEqualTo(100L)
+        assertThat(result.processedAt).isNotNull()
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(any<com.nextup.core.domain.event.RecruitmentApplicationAcceptedEvent>())
+        }
+    }
+
+    @Test
+    fun `존재하지 않는 지원을 수락하면 예외가 발생한다`() {
+        // given
+        every { applicationRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThatThrownBy { service.acceptApplication(999L, 100L) }
+            .isInstanceOf(RecruitmentApplicationNotFoundException::class.java)
+    }
+
+    @Test
+    fun `이미 처리된 지원을 수락하면 예외가 발생한다`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        application.reject(100L)
+
+        every { applicationRepository.findByIdOrNull(1L) } returns application
+
+        // when & then
+        assertThatThrownBy { service.acceptApplication(1L, 100L) }
+            .isInstanceOf(InvalidStateException::class.java)
+    }
+
+    // ========== rejectApplication Tests ==========
+
+    @Test
+    fun `지원을 거절할 수 있다`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { applicationRepository.findByIdOrNull(1L) } returns application
+
+        // when
+        val result = service.rejectApplication(1L, 100L)
+
+        // then
+        assertThat(result.status).isEqualTo(ApplicationStatus.REJECTED)
+        assertThat(result.processedBy).isEqualTo(100L)
+        assertThat(result.processedAt).isNotNull()
+    }
+
+    @Test
+    fun `존재하지 않는 지원을 거절하면 예외가 발생한다`() {
+        // given
+        every { applicationRepository.findByIdOrNull(999L) } returns null
+
+        // when & then
+        assertThatThrownBy { service.rejectApplication(999L, 100L) }
+            .isInstanceOf(RecruitmentApplicationNotFoundException::class.java)
+    }
+
+    @Test
+    fun `이미 처리된 지원을 거절하면 예외가 발생한다`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        application.accept(100L)
+
+        every { applicationRepository.findByIdOrNull(1L) } returns application
+
+        // when & then
+        assertThatThrownBy { service.rejectApplication(1L, 100L) }
+            .isInstanceOf(InvalidStateException::class.java)
+    }
+
+    // ========== withdrawApplication Tests ==========
+
+    @Test
+    fun `지원을 취소할 수 있다`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { applicationRepository.findByIdOrNull(1L) } returns application
+
+        // when
+        service.withdrawApplication(1L, 10L)
+
+        // then
+        assertThat(application.status).isEqualTo(ApplicationStatus.WITHDRAWN)
+    }
+
+    @Test
+    fun `다른 사용자의 지원을 취소하면 예외가 발생한다`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+
+        every { applicationRepository.findByIdOrNull(1L) } returns application
+
+        // when & then
+        assertThatThrownBy { service.withdrawApplication(1L, 999L) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `이미 처리된 지원을 취소하면 예외가 발생한다`() {
+        // given
+        val application =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 10L,
+                message = "열심히 하겠습니다",
+                preferredPositions = "투수",
+            )
+        application.accept(100L)
+
+        every { applicationRepository.findByIdOrNull(1L) } returns application
+
+        // when & then
+        assertThatThrownBy { service.withdrawApplication(1L, 10L) }
+            .isInstanceOf(InvalidStateException::class.java)
+    }
+
+    // ========== getApplicationsByRecruitment Tests ==========
+
+    @Test
+    fun `모집 공고별 지원자 목록을 조회할 수 있다`() {
+        // given
+        val app1 =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 10L,
+                message = "메시지1",
+                preferredPositions = "투수",
+            )
+        val app2 =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 20L,
+                message = "메시지2",
+                preferredPositions = "포수",
+            )
+
+        every { applicationRepository.findByRecruitmentId(1L) } returns listOf(app1, app2)
+
+        // when
+        val result = service.getApplicationsByRecruitment(1L)
+
+        // then
+        assertThat(result).hasSize(2)
+        verify(exactly = 1) { applicationRepository.findByRecruitmentId(1L) }
+    }
+
+    // ========== getApplicationsByApplicant Tests ==========
+
+    @Test
+    fun `사용자별 지원 현황을 조회할 수 있다`() {
+        // given
+        val app1 =
+            RecruitmentApplication.create(
+                recruitment = recruitment,
+                applicantId = 10L,
+                message = "메시지1",
+                preferredPositions = "투수",
+            )
+
+        every { applicationRepository.findByApplicantId(10L) } returns listOf(app1)
+
+        // when
+        val result = service.getApplicationsByApplicant(10L)
+
+        // then
+        assertThat(result).hasSize(1)
+        verify(exactly = 1) { applicationRepository.findByApplicantId(10L) }
+    }
+
+    @Test
+    fun `지원이 없으면 빈 리스트를 반환한다`() {
+        // given
+        every { applicationRepository.findByApplicantId(10L) } returns emptyList()
+
+        // when
+        val result = service.getApplicationsByApplicant(10L)
+
+        // then
+        assertThat(result).isEmpty()
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecruitmentApplicationEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecruitmentApplicationEventListener.kt
@@ -1,0 +1,38 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.core.domain.event.RecruitmentApplicationAcceptedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * 모집 지원 이벤트 리스너
+ *
+ * 지원 수락 시 팀 자동 합류 처리를 담당합니다.
+ */
+@Component
+class RecruitmentApplicationEventListener {
+    private val logger = LoggerFactory.getLogger(RecruitmentApplicationEventListener::class.java)
+
+    /**
+     * 모집 지원 수락 이벤트를 처리합니다.
+     *
+     * 지원 수락 시 해당 지원자를 팀에 자동 합류시킵니다.
+     * 실제 팀 멤버 추가는 TeamMembershipService를 통해 처리됩니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleApplicationAccepted(event: RecruitmentApplicationAcceptedEvent) {
+        logger.info(
+            "모집 지원 수락 처리 - applicationId={}, teamId={}, applicantId={}, teamName={}",
+            event.applicationId,
+            event.teamId,
+            event.applicantId,
+            event.teamName,
+        )
+        // TODO: TeamMembershipService를 통한 팀 자동 합류 처리
+        // 팀 합류에는 등번호 배정 등 추가 정보가 필요하므로,
+        // 이 이벤트는 알림 발송 등의 용도로 사용하고
+        // 실제 팀 합류는 별도 프로세스로 처리합니다.
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/recruitment/RecruitmentApplicationRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/recruitment/RecruitmentApplicationRepository.kt
@@ -1,0 +1,42 @@
+package com.nextup.infrastructure.repository.recruitment
+
+import com.nextup.core.domain.recruitment.ApplicationStatus
+import com.nextup.core.domain.recruitment.RecruitmentApplication
+import com.nextup.core.port.repository.RecruitmentApplicationRepositoryPort
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface RecruitmentApplicationRepository :
+    JpaRepository<RecruitmentApplication, Long>,
+    RecruitmentApplicationRepositoryPort {
+    override fun findByIdOrNull(id: Long): RecruitmentApplication? = findById(id).orElse(null)
+
+    override fun findByRecruitmentId(recruitmentId: Long): List<RecruitmentApplication>
+
+    override fun findByRecruitmentIdAndStatus(
+        recruitmentId: Long,
+        status: ApplicationStatus,
+    ): List<RecruitmentApplication>
+
+    override fun findByApplicantId(applicantId: Long): List<RecruitmentApplication>
+
+    override fun findByRecruitmentIdAndApplicantId(
+        recruitmentId: Long,
+        applicantId: Long,
+    ): RecruitmentApplication?
+
+    @Query(
+        """
+        SELECT CASE WHEN COUNT(a) > 0 THEN true ELSE false END
+        FROM RecruitmentApplication a
+        WHERE a.recruitment.id = :recruitmentId
+        AND a.applicantId = :applicantId
+        AND a.status IN :statuses
+        """,
+    )
+    override fun existsByRecruitmentIdAndApplicantIdAndStatusIn(
+        recruitmentId: Long,
+        applicantId: Long,
+        statuses: Set<ApplicationStatus>,
+    ): Boolean
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V041__create_recruitment_applications_table.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V041__create_recruitment_applications_table.sql
@@ -1,0 +1,20 @@
+-- #349: 모집 공고 지원(Apply) 흐름 구현
+CREATE TABLE recruitment_applications (
+    id                  BIGSERIAL       PRIMARY KEY,
+    recruitment_id      BIGINT          NOT NULL REFERENCES team_recruitments(id),
+    applicant_id        BIGINT          NOT NULL,
+    message             VARCHAR(500)    NOT NULL,
+    preferred_positions VARCHAR(255)    NOT NULL,
+    status              VARCHAR(20)     NOT NULL DEFAULT 'PENDING',
+    applied_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    processed_at        TIMESTAMPTZ,
+    processed_by        BIGINT,
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    CONSTRAINT uk_ra_recruitment_applicant_active UNIQUE (recruitment_id, applicant_id)
+);
+
+CREATE INDEX idx_ra_recruitment_id ON recruitment_applications(recruitment_id);
+CREATE INDEX idx_ra_applicant_id ON recruitment_applications(applicant_id);
+CREATE INDEX idx_ra_status ON recruitment_applications(status);
+CREATE INDEX idx_ra_recruitment_applicant ON recruitment_applications(recruitment_id, applicant_id);


### PR DESCRIPTION
>- close #349

## Summary

모집 공고에 대한 지원(Apply) 전체 흐름을 구현합니다. 지원자는 진행 중인 모집 공고에 지원할 수 있으며, 팀 관리자는 지원을 수락/거절할 수 있습니다.

## Tasks

- [x] `RecruitmentApplication` 도메인 엔티티 구현 (Rich Domain Model: private constructor + companion object.create())
- [x] `ApplicationStatus` 열거형 구현 (PENDING/ACCEPTED/REJECTED/WITHDRAWN)
- [x] `RecruitmentApplicationRepositoryPort` 포트 인터페이스 정의
- [x] `RecruitmentApplicationService` 서비스 구현 (지원/수락/거절/취소)
- [x] 비즈니스 규칙 구현: 중복 지원 방지, 팀 소속 확인, 모집 마감 검증
- [x] `RecruitmentApplicationAcceptedEvent` 도메인 이벤트 발행 (지원 수락 시)
- [x] `RecruitmentApplicationExceptions` 커스텀 예외 정의
- [x] `RecruitmentApplicationRepository` JPA 구현체
- [x] `RecruitmentApplicationEventListener` 이벤트 리스너
- [x] V041 DB 마이그레이션 (recruitment_applications 테이블)
- [x] API 엔드포인트 6개 구현:
  - `POST /api/v1/recruitments/{id}/apply` — 지원하기
  - `GET /api/v1/me/applications` — 내 지원 현황
  - `DELETE /api/v1/me/applications/{appId}` — 지원 취소
  - `GET /api/v1/recruitments/{id}/applications` — 지원자 목록
  - `PATCH /api/v1/recruitments/{id}/applications/{appId}/accept` — 수락
  - `PATCH /api/v1/recruitments/{id}/applications/{appId}/reject` — 거절
- [x] Entity 단위 테스트 (RecruitmentApplicationTest: 11개)
- [x] Service 단위 테스트 (RecruitmentApplicationServiceTest: 14개)
- [x] Controller 테스트 (RecruitmentApplicationControllerTest: 11개)

## To Reviewer

- Hexagonal Architecture 준수: Core(Entity, Port) → Infrastructure(Repository, Listener) → API(Controller, DTO)
- Zero Entity Leak: 모든 Controller 응답은 `RecruitmentApplicationResponse` DTO로 변환
- ApiResponse 래핑 필수 준수
- `BaseTimeEntity` 상속 (Instant 타입, UTC 기준)
- 지원 수락 시 `RecruitmentApplicationAcceptedEvent` 이벤트 발행 (팀 자동 합류는 별도 프로세스로 처리 - 등번호 배정 등 추가 정보 필요)
