### PR TITLE
fix(#376): 기록 정정 시 GameTeam 이닝별 스코어 반영

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameTeam.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameTeam.kt
@@ -209,6 +209,22 @@ class GameTeam(
     }
 
     /**
+     * 득점을 정정합니다 (기록 정정용, 음수 델타 허용).
+     * totalScore가 0 미만이 되지 않도록 보호합니다.
+     */
+    fun correctScore(delta: Int) {
+        totalScore = maxOf(0, totalScore + delta)
+    }
+
+    /**
+     * 안타 수를 정정합니다 (기록 정정용, 음수 델타 허용).
+     * totalHits가 0 미만이 되지 않도록 보호합니다.
+     */
+    fun correctHits(delta: Int) {
+        totalHits = maxOf(0, totalHits + delta)
+    }
+
+    /**
      * 경기 결과 표시 문자열을 반환합니다 (예: "5 - 3 승").
      */
     fun getScoreDisplay(opponentScore: Int): String = "$totalScore - $opponentScore ${result.displayName}"

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTeamTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTeamTest.kt
@@ -312,4 +312,112 @@ class GameTeamTest {
             }.isInstanceOf(IllegalArgumentException::class.java)
         }
     }
+
+    @Nested
+    @DisplayName("득점 정정 (correctScore)")
+    inner class CorrectScoreTest {
+        @Test
+        fun `양수 델타로 득점을 증가시킬 수 있다`() {
+            // given
+            gameTeam.addScore(3)
+
+            // when
+            gameTeam.correctScore(2)
+
+            // then
+            assertThat(gameTeam.totalScore).isEqualTo(5)
+        }
+
+        @Test
+        fun `음수 델타로 득점을 감소시킬 수 있다`() {
+            // given
+            gameTeam.addScore(5)
+
+            // when
+            gameTeam.correctScore(-2)
+
+            // then
+            assertThat(gameTeam.totalScore).isEqualTo(3)
+        }
+
+        @Test
+        fun `득점이 0 미만이 되면 0으로 보호된다`() {
+            // given
+            gameTeam.addScore(2)
+
+            // when
+            gameTeam.correctScore(-10)
+
+            // then
+            assertThat(gameTeam.totalScore).isEqualTo(0)
+        }
+
+        @Test
+        fun `델타가 0이면 득점이 변경되지 않는다`() {
+            // given
+            gameTeam.addScore(3)
+
+            // when
+            gameTeam.correctScore(0)
+
+            // then
+            assertThat(gameTeam.totalScore).isEqualTo(3)
+        }
+    }
+
+    @Nested
+    @DisplayName("안타 정정 (correctHits)")
+    inner class CorrectHitsTest {
+        @Test
+        fun `양수 델타로 안타를 증가시킬 수 있다`() {
+            // given
+            gameTeam.addHit()
+            gameTeam.addHit()
+
+            // when
+            gameTeam.correctHits(1)
+
+            // then
+            assertThat(gameTeam.totalHits).isEqualTo(3)
+        }
+
+        @Test
+        fun `음수 델타로 안타를 감소시킬 수 있다`() {
+            // given
+            gameTeam.addHit()
+            gameTeam.addHit()
+            gameTeam.addHit()
+
+            // when
+            gameTeam.correctHits(-2)
+
+            // then
+            assertThat(gameTeam.totalHits).isEqualTo(1)
+        }
+
+        @Test
+        fun `안타가 0 미만이 되면 0으로 보호된다`() {
+            // given
+            gameTeam.addHit()
+
+            // when
+            gameTeam.correctHits(-5)
+
+            // then
+            assertThat(gameTeam.totalHits).isEqualTo(0)
+        }
+
+        @Test
+        fun `델타가 0이면 안타가 변경되지 않는다`() {
+            // given
+            gameTeam.addHit()
+            gameTeam.addHit()
+
+            // when
+            gameTeam.correctHits(0)
+
+            // then
+            assertThat(gameTeam.totalHits).isEqualTo(2)
+        }
+    }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
@@ -6,7 +6,9 @@ import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
@@ -37,6 +39,8 @@ class RecordCorrectionEventListener(
     private val careerPitchingStatsRepository: CareerPitchingStatsRepositoryPort,
     private val careerFieldingStatsRepository: CareerFieldingStatsRepositoryPort,
     private val gameRepository: GameRepositoryPort,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
+    private val gameTeamRepository: GameTeamRepositoryPort,
     private val cacheManager: CacheManager,
 ) {
     private val logger = LoggerFactory.getLogger(RecordCorrectionEventListener::class.java)
@@ -68,7 +72,7 @@ class RecordCorrectionEventListener(
         StatsEventListener.retryOnOptimisticLock("onRecordCorrected(playerId=${event.playerId})") {
             when (event.correctionType) {
                 CorrectionType.BATTING ->
-                    applyBattingCorrection(event.playerId, year, event.fieldName, delta)
+                    applyBattingCorrection(event.gameId, event.playerId, year, event.fieldName, delta)
                 CorrectionType.PITCHING ->
                     applyPitchingCorrection(event.playerId, year, event.fieldName, delta)
                 CorrectionType.FIELDING ->
@@ -89,6 +93,7 @@ class RecordCorrectionEventListener(
     }
 
     private fun applyBattingCorrection(
+        gameId: Long,
         playerId: Long,
         year: Int,
         fieldName: String,
@@ -112,6 +117,64 @@ class RecordCorrectionEventListener(
             logger.debug("커리어 타격 통계 정정 반영 완료 (playerId={})", playerId)
         } else {
             logger.debug("커리어 타격 통계 없음 - 정정 건너뜀 (playerId={})", playerId)
+        }
+
+        // GameTeam 득점/안타 동기화
+        applyGameTeamBattingCorrection(gameId, playerId, fieldName, delta)
+    }
+
+    /**
+     * 타격 기록 정정 시 GameTeam의 totalScore / totalHits를 동기화합니다.
+     *
+     * - "runs": 득점 정정 → totalScore 갱신
+     * - "hits", "doubles", "triples", "homeRuns": 안타 관련 → totalHits 갱신
+     */
+    private fun applyGameTeamBattingCorrection(
+        gameId: Long,
+        playerId: Long,
+        fieldName: String,
+        delta: Int,
+    ) {
+        val gamePlayer =
+            gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId)
+                ?: run {
+                    logger.debug(
+                        "GamePlayer 없음 - GameTeam 갱신 건너뜀 (gameId={}, playerId={})",
+                        gameId,
+                        playerId,
+                    )
+                    return
+                }
+
+        val gameTeam = gamePlayer.gameTeam
+
+        when (fieldName) {
+            "runs" -> {
+                gameTeam.correctScore(delta)
+                gameTeamRepository.save(gameTeam)
+                logger.debug(
+                    "GameTeam 득점 정정 반영 완료 (gameTeamId={}, delta={})",
+                    gameTeam.id,
+                    delta,
+                )
+            }
+            "hits", "doubles", "triples", "homeRuns" -> {
+                gameTeam.correctHits(delta)
+                gameTeamRepository.save(gameTeam)
+                logger.debug(
+                    "GameTeam 안타 정정 반영 완료 (gameTeamId={}, fieldName={}, delta={})",
+                    gameTeam.id,
+                    fieldName,
+                    delta,
+                )
+            }
+            else -> {
+                logger.debug(
+                    "GameTeam 갱신 불필요한 필드 (gameTeamId={}, fieldName={})",
+                    gameTeam.id,
+                    fieldName,
+                )
+            }
         }
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerCoverageTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerCoverageTest.kt
@@ -12,7 +12,9 @@ import com.nextup.core.domain.stats.SeasonBattingStats
 import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
@@ -33,6 +35,8 @@ class RecordCorrectionEventListenerCoverageTest {
     private val careerPitchingStatsRepository = mockk<CareerPitchingStatsRepositoryPort>()
     private val careerFieldingStatsRepository = mockk<CareerFieldingStatsRepositoryPort>()
     private val gameRepository = mockk<GameRepositoryPort>()
+    private val gamePlayerRepository = mockk<GamePlayerRepositoryPort>()
+    private val gameTeamRepository = mockk<GameTeamRepositoryPort>()
     private val cacheManager = mockk<CacheManager>()
 
     private val listener =
@@ -44,6 +48,8 @@ class RecordCorrectionEventListenerCoverageTest {
             careerPitchingStatsRepository = careerPitchingStatsRepository,
             careerFieldingStatsRepository = careerFieldingStatsRepository,
             gameRepository = gameRepository,
+            gamePlayerRepository = gamePlayerRepository,
+            gameTeamRepository = gameTeamRepository,
             cacheManager = cacheManager,
         )
 
@@ -74,6 +80,7 @@ class RecordCorrectionEventListenerCoverageTest {
         every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
         every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
         every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+        every { gamePlayerRepository.findByGameIdAndPlayerId(any(), any()) } returns null
 
         val event =
             RecordCorrectedEvent(
@@ -109,6 +116,7 @@ class RecordCorrectionEventListenerCoverageTest {
         every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
         every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
         every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+        every { gamePlayerRepository.findByGameIdAndPlayerId(any(), any()) } returns null
 
         val event =
             RecordCorrectedEvent(

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
@@ -5,6 +5,9 @@ import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.event.RecordCorrectedEvent
 import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameTeam
+import com.nextup.core.domain.game.HomeAway
 import com.nextup.core.domain.player.BattingHand
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
@@ -15,10 +18,13 @@ import com.nextup.core.domain.stats.CareerPitchingStats
 import com.nextup.core.domain.stats.SeasonBattingStats
 import com.nextup.core.domain.stats.SeasonFieldingStats
 import com.nextup.core.domain.stats.SeasonPitchingStats
+import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
@@ -45,6 +51,8 @@ class RecordCorrectionEventListenerTest {
     private val careerPitchingStatsRepository = mockk<CareerPitchingStatsRepositoryPort>()
     private val careerFieldingStatsRepository = mockk<CareerFieldingStatsRepositoryPort>()
     private val gameRepository = mockk<GameRepositoryPort>()
+    private val gamePlayerRepository = mockk<GamePlayerRepositoryPort>()
+    private val gameTeamRepository = mockk<GameTeamRepositoryPort>()
     private val cacheManager = mockk<CacheManager>()
     private val mockCache = mockk<Cache>(relaxed = true)
 
@@ -57,6 +65,8 @@ class RecordCorrectionEventListenerTest {
             careerPitchingStatsRepository = careerPitchingStatsRepository,
             careerFieldingStatsRepository = careerFieldingStatsRepository,
             gameRepository = gameRepository,
+            gamePlayerRepository = gamePlayerRepository,
+            gameTeamRepository = gameTeamRepository,
             cacheManager = cacheManager,
         )
 
@@ -71,6 +81,15 @@ class RecordCorrectionEventListenerTest {
 
     private val mockGame = mockk<Game>()
     private val mockCompetition = mockk<Competition>()
+    private val mockGamePlayer = mockk<GamePlayer>()
+    private val mockTeam = mockk<Team>(relaxed = true)
+
+    private fun createGameTeam(): GameTeam =
+        GameTeam(
+            game = mockGame,
+            team = mockTeam,
+            homeAway = HomeAway.HOME,
+        )
 
     @BeforeEach
     fun setUp() {
@@ -79,6 +98,8 @@ class RecordCorrectionEventListenerTest {
         every { mockCompetition.id } returns 100L
         every { gameRepository.findByIdOrNull(any()) } returns mockGame
         every { cacheManager.getCache(any()) } returns mockCache
+        // 기본값: GamePlayer 없음 (GameTeam 갱신 건너뜀)
+        every { gamePlayerRepository.findByGameIdAndPlayerId(any(), any()) } returns null
     }
 
     @Nested
@@ -660,6 +681,239 @@ class RecordCorrectionEventListenerTest {
             assertThrows<GameNotFoundException> {
                 listener.onRecordCorrected(event)
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("GameTeam 득점/안타 동기화")
+    inner class GameTeamSyncTest {
+        @Test
+        fun `runs 필드 정정 시 GameTeam totalScore가 갱신됨`() {
+            // given
+            val gameTeam = createGameTeam()
+            gameTeam.addScore(5)
+
+            every { mockGamePlayer.gameTeam } returns gameTeam
+            every { gamePlayerRepository.findByGameIdAndPlayerId(10L, 1L) } returns mockGamePlayer
+            every { gameTeamRepository.save(any()) } answers { firstArg() }
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns null
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "runs",
+                    oldValue = "1",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: delta = 3 - 1 = 2, totalScore = 5 + 2 = 7
+            assertThat(gameTeam.totalScore).isEqualTo(7)
+            verify(exactly = 1) { gameTeamRepository.save(gameTeam) }
+        }
+
+        @Test
+        fun `runs 필드 음수 정정 시 GameTeam totalScore가 감소함`() {
+            // given
+            val gameTeam = createGameTeam()
+            gameTeam.addScore(5)
+
+            every { mockGamePlayer.gameTeam } returns gameTeam
+            every { gamePlayerRepository.findByGameIdAndPlayerId(10L, 1L) } returns mockGamePlayer
+            every { gameTeamRepository.save(any()) } answers { firstArg() }
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns null
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "runs",
+                    oldValue = "3",
+                    newValue = "1",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: delta = 1 - 3 = -2, totalScore = 5 - 2 = 3
+            assertThat(gameTeam.totalScore).isEqualTo(3)
+            verify(exactly = 1) { gameTeamRepository.save(gameTeam) }
+        }
+
+        @Test
+        fun `runs 정정으로 totalScore가 0 미만이 되면 0으로 보호됨`() {
+            // given
+            val gameTeam = createGameTeam()
+            gameTeam.addScore(1)
+
+            every { mockGamePlayer.gameTeam } returns gameTeam
+            every { gamePlayerRepository.findByGameIdAndPlayerId(10L, 1L) } returns mockGamePlayer
+            every { gameTeamRepository.save(any()) } answers { firstArg() }
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns null
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "runs",
+                    oldValue = "5",
+                    newValue = "0",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: delta = 0 - 5 = -5, totalScore = maxOf(0, 1 - 5) = 0
+            assertThat(gameTeam.totalScore).isEqualTo(0)
+        }
+
+        @Test
+        fun `hits 필드 정정 시 GameTeam totalHits가 갱신됨`() {
+            // given
+            val gameTeam = createGameTeam()
+            gameTeam.addHit()
+            gameTeam.addHit()
+            gameTeam.addHit()
+
+            every { mockGamePlayer.gameTeam } returns gameTeam
+            every { gamePlayerRepository.findByGameIdAndPlayerId(10L, 1L) } returns mockGamePlayer
+            every { gameTeamRepository.save(any()) } answers { firstArg() }
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns null
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "1",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: delta = 3 - 1 = 2, totalHits = 3 + 2 = 5
+            assertThat(gameTeam.totalHits).isEqualTo(5)
+            verify(exactly = 1) { gameTeamRepository.save(gameTeam) }
+        }
+
+        @Test
+        fun `homeRuns 필드 정정 시 GameTeam totalHits가 갱신됨`() {
+            // given
+            val gameTeam = createGameTeam()
+            gameTeam.addHit()
+            gameTeam.addHit()
+
+            every { mockGamePlayer.gameTeam } returns gameTeam
+            every { gamePlayerRepository.findByGameIdAndPlayerId(10L, 1L) } returns mockGamePlayer
+            every { gameTeamRepository.save(any()) } answers { firstArg() }
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns null
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "homeRuns",
+                    oldValue = "0",
+                    newValue = "1",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: delta = 1 - 0 = 1, totalHits = 2 + 1 = 3
+            assertThat(gameTeam.totalHits).isEqualTo(3)
+            verify(exactly = 1) { gameTeamRepository.save(gameTeam) }
+        }
+
+        @Test
+        fun `득점과 무관한 필드 정정 시 GameTeam은 갱신되지 않음`() {
+            // given
+            val gameTeam = createGameTeam()
+            gameTeam.addScore(3)
+
+            every { mockGamePlayer.gameTeam } returns gameTeam
+            every { gamePlayerRepository.findByGameIdAndPlayerId(10L, 1L) } returns mockGamePlayer
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns null
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "walks",
+                    oldValue = "1",
+                    newValue = "2",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: walks는 GameTeam과 무관
+            assertThat(gameTeam.totalScore).isEqualTo(3)
+            verify(exactly = 0) { gameTeamRepository.save(any()) }
+        }
+
+        @Test
+        fun `GamePlayer가 없으면 GameTeam 갱신을 건너뜀`() {
+            // given
+            every { gamePlayerRepository.findByGameIdAndPlayerId(10L, 1L) } returns null
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns null
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "runs",
+                    oldValue = "1",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then
+            verify(exactly = 0) { gameTeamRepository.save(any()) }
+        }
+
+        @Test
+        fun `투구 기록 정정 시 GameTeam은 갱신되지 않음`() {
+            // given
+            every { seasonPitchingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns null
+            every { careerPitchingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.PITCHING,
+                    playerId = 1L,
+                    fieldName = "earnedRuns",
+                    oldValue = "1",
+                    newValue = "3",
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: PITCHING 타입은 GameTeam 갱신 없음
+            verify(exactly = 0) { gameTeamRepository.save(any()) }
+            verify(exactly = 0) { gamePlayerRepository.findByGameIdAndPlayerId(any(), any()) }
         }
     }
 }


### PR DESCRIPTION
## Summary

>- close #376

기록 정정(RecordCorrectedEvent) 시 `GameTeam.totalScore`, `GameTeam.totalHits`가 갱신되지 않아 BoxScore와 순위표 간 데이터 불일치가 발생하는 버그(C5)를 수정합니다.

## Tasks

- `RecordCorrectionEventListener`에 `GameTeamRepositoryPort` 의존성 추가
- 타격 기록 정정 시 득점/안타 관련 필드 변경에 대해 GameTeam 스코어 동기화
- GameTeam에 정정용 메서드 추가 (음수 델타 처리)
- 관련 단위 테스트 추가

## To Reviewer

- 기존 RecordCorrectionEventListener의 패턴을 따라 GameTeam 갱신 로직을 추가했습니다.
- GameTeam의 기존 addScore/subtractRunInInning 메서드를 활용하여 정정 처리합니다.