### PR TITLE
feat(#377): 경기 중단(suspend) 서비스 메서드 및 Scorer API 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
@@ -64,4 +64,11 @@ interface GameLifecycleService {
         gameId: Long,
         scorerId: Long,
     ): Game
+
+    fun suspendGame(
+        gameId: Long,
+        reason: String? = null,
+    ): Game
+
+    fun resumeGame(gameId: Long): Game
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
@@ -129,9 +129,12 @@ class GameLifecycleServiceImpl(
     ): Game {
         val game = findGame(gameId)
 
-        if (game.status != GameStatus.SCHEDULED && game.status != GameStatus.POSTPONED) {
+        if (game.status != GameStatus.SCHEDULED &&
+            game.status != GameStatus.POSTPONED &&
+            game.status != GameStatus.SUSPENDED
+        ) {
             throw InvalidGameStateException(
-                "예정 또는 연기 상태의 경기만 취소할 수 있습니다. 현재 상태: ${game.status.displayName}",
+                "예정, 연기, 또는 중단 상태의 경기만 취소할 수 있습니다. 현재 상태: ${game.status.displayName}",
             )
         }
 
@@ -217,6 +220,23 @@ class GameLifecycleServiceImpl(
         }
 
         return savedGame
+    }
+
+    @Transactional
+    override fun suspendGame(
+        gameId: Long,
+        reason: String?,
+    ): Game {
+        val game = findGame(gameId)
+        game.suspend(reason)
+        return gameRepository.save(game)
+    }
+
+    @Transactional
+    override fun resumeGame(gameId: Long): Game {
+        val game = findGame(gameId)
+        game.resume()
+        return gameRepository.save(game)
     }
 
     /**

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplSuspendTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplSuspendTest.kt
@@ -1,0 +1,301 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameState
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.GameTeamRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.service.game.PitchingDecisionService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameLifecycleServiceImpl - suspend/resume 테스트")
+class GameLifecycleServiceImplSuspendTest {
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gameTeamRepository: GameTeamRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var eventPublisher: ApplicationEventPublisher
+    private lateinit var service: GameLifecycleServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        gameTeamRepository = mockk()
+        pitchingRecordRepository = mockk()
+        eventPublisher = mockk(relaxed = true)
+        every { gameTeamRepository.findAllByGameId(any()) } returns emptyList()
+        every { pitchingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        service =
+            GameLifecycleServiceImpl(
+                gameRepository,
+                gameTeamRepository,
+                pitchingRecordRepository,
+                PitchingDecisionService(),
+                eventPublisher,
+            )
+    }
+
+    @Nested
+    @DisplayName("suspendGame")
+    inner class SuspendGame {
+        @Test
+        fun `should suspend game when status is IN_PROGRESS`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = service.suspendGame(1L, "우천 중단")
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.SUSPENDED)
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should suspend game without reason`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = service.suspendGame(1L, null)
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.SUSPENDED)
+        }
+
+        @Test
+        fun `should throw exception when game is SCHEDULED`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { service.suspendGame(1L, "중단 사유") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("진행 중인 경기만 중단할 수 있습니다")
+        }
+
+        @Test
+        fun `should throw exception when game is FINISHED`() {
+            // given
+            val game = createGame(1L, GameStatus.FINISHED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { service.suspendGame(1L, "중단 사유") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("진행 중인 경기만 중단할 수 있습니다")
+        }
+
+        @Test
+        fun `should throw exception when game not found`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy { service.suspendGame(999L, "중단 사유") }
+                .isInstanceOf(GameNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("resumeGame")
+    inner class ResumeGame {
+        @Test
+        fun `should resume game when status is SUSPENDED`() {
+            // given
+            val game = createGame(1L, GameStatus.SUSPENDED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = service.resumeGame(1L)
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.IN_PROGRESS)
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when game is IN_PROGRESS`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { service.resumeGame(1L) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("중단된 경기만 재개할 수 있습니다")
+        }
+
+        @Test
+        fun `should throw exception when game is SCHEDULED`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { service.resumeGame(1L) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("중단된 경기만 재개할 수 있습니다")
+        }
+
+        @Test
+        fun `should throw exception when game not found`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+
+            // when & then
+            assertThatThrownBy { service.resumeGame(999L) }
+                .isInstanceOf(GameNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelGame - SUSPENDED 상태 허용")
+    inner class CancelGameSuspended {
+        @Test
+        fun `should cancel game when status is SUSPENDED`() {
+            // given
+            val game = createGame(1L, GameStatus.SUSPENDED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            val result = service.cancelGame(1L, "경기 취소")
+
+            // then
+            assertThat(result.status).isEqualTo(GameStatus.CANCELLED)
+            verify { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `should throw exception when game is IN_PROGRESS`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+
+            // when & then
+            assertThatThrownBy { service.cancelGame(1L, "사유") }
+                .isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("예정, 연기, 또는 중단 상태의 경기만 취소할 수 있습니다")
+        }
+    }
+
+    private fun createAssociation(id: Long): Association =
+        Association(
+            name = "서울시야구협회",
+            abbreviation = null,
+            region = "서울",
+            description = null,
+            logoUrl = null,
+            websiteUrl = null,
+        ).apply {
+            val idField = Association::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createLeague(
+        id: Long,
+        association: Association,
+    ): League =
+        League(
+            association = association,
+            name = "1부 리그",
+            abbreviation = null,
+            foundedYear = 2020,
+            divisionLevel = 1,
+            description = null,
+            logoUrl = null,
+        ).apply {
+            val idField = League::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createCompetition(
+        id: Long,
+        league: League,
+    ): Competition =
+        Competition(
+            league = league,
+            name = "2025 춘계대회",
+            year = 2025,
+            season = 1,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(2025, 3, 1),
+            endDate = LocalDate.of(2025, 6, 30),
+            status = CompetitionStatus.IN_PROGRESS,
+            description = null,
+            maxTeams = null,
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createGame(
+        id: Long,
+        status: GameStatus,
+    ): Game {
+        val association = createAssociation(1L)
+        val league = createLeague(1L, association)
+        val competition = createCompetition(1L, league)
+        val homeTeam =
+            Team(
+                league = league,
+                name = "홈팀",
+                city = "서울",
+                foundedYear = 2020,
+                id = 10L,
+            )
+        val awayTeam =
+            Team(
+                league = league,
+                name = "원정팀",
+                city = "부산",
+                foundedYear = 2020,
+                id = 11L,
+            )
+
+        return Game.createForTest(
+            competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실구장",
+            fieldName = "1구장",
+            gameNumber = 1,
+            status = status,
+            currentInning = 5,
+            isTopInning = true,
+            totalInnings = 9,
+            gameState = GameState(),
+            id = id,
+        )
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -1395,7 +1395,7 @@ class GameScorerServiceImplTest {
             // when & then
             assertThatThrownBy { gameLifecycleService.cancelGame(1L, "사유") }
                 .isInstanceOf(InvalidGameStateException::class.java)
-                .hasMessageContaining("예정 또는 연기 상태의 경기만 취소할 수 있습니다")
+                .hasMessageContaining("예정, 연기, 또는 중단 상태의 경기만 취소할 수 있습니다")
         }
 
         @Test
@@ -1407,7 +1407,7 @@ class GameScorerServiceImplTest {
             // when & then
             assertThatThrownBy { gameLifecycleService.cancelGame(1L, "사유") }
                 .isInstanceOf(InvalidGameStateException::class.java)
-                .hasMessageContaining("예정 또는 연기 상태의 경기만 취소할 수 있습니다")
+                .hasMessageContaining("예정, 연기, 또는 중단 상태의 경기만 취소할 수 있습니다")
         }
 
         @Test

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -21,6 +21,7 @@ import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
 import com.nextup.scorer.dto.game.ScoreboardResponse
 import com.nextup.scorer.dto.game.SubstitutionRequestDto
 import com.nextup.scorer.dto.game.SubstitutionResponse
+import com.nextup.scorer.dto.game.SuspendGameRequestDto
 import com.nextup.scorer.dto.game.UndoResponse
 import com.nextup.scorer.dto.game.toBaseRunningResponse
 import com.nextup.scorer.dto.game.toCurrentGameStateResponse
@@ -280,6 +281,40 @@ class GameScorerController(
                 gameId = gameId,
                 reason = request.reason,
             )
+        return ApiResponse.success(game.toResponse())
+    }
+
+    /**
+     * 경기를 중단합니다.
+     *
+     * 진행 중(IN_PROGRESS) 상태의 경기를 우천 등의 사유로 중단합니다.
+     * 중단된 경기는 resume API로 재개할 수 있습니다.
+     */
+    @PostMapping("/{gameId}/suspend")
+    @ResponseStatus(HttpStatus.OK)
+    fun suspendGame(
+        @PathVariable gameId: Long,
+        @RequestBody request: SuspendGameRequestDto = SuspendGameRequestDto(),
+    ): ApiResponse<GameResponse> {
+        val game =
+            gameLifecycleService.suspendGame(
+                gameId = gameId,
+                reason = request.reason,
+            )
+        return ApiResponse.success(game.toResponse())
+    }
+
+    /**
+     * 중단된 경기를 재개합니다.
+     *
+     * SUSPENDED 상태의 경기를 중단 시점의 이닝/아웃/주자 상태부터 이어서 진행합니다.
+     */
+    @PostMapping("/{gameId}/resume")
+    @ResponseStatus(HttpStatus.OK)
+    fun resumeGame(
+        @PathVariable gameId: Long,
+    ): ApiResponse<GameResponse> {
+        val game = gameLifecycleService.resumeGame(gameId = gameId)
         return ApiResponse.success(game.toResponse())
     }
 

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/SuspendGameRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/SuspendGameRequestDto.kt
@@ -1,0 +1,8 @@
+package com.nextup.scorer.dto.game
+
+/**
+ * 경기 중단 요청 DTO
+ */
+data class SuspendGameRequestDto(
+    val reason: String? = null,
+)

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -838,6 +838,68 @@ class GameScorerControllerTest {
 
     // ===== 테스트 헬퍼 메서드 =====
 
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/suspend")
+    inner class SuspendGame {
+        @Test
+        fun `should suspend game successfully`() {
+            // given
+            val game = createGame(1L, GameStatus.SUSPENDED)
+            every { gameLifecycleService.suspendGame(1L, "우천") } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/1/suspend")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mapOf("reason" to "우천"))),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.status").value("SUSPENDED"))
+
+            verify(exactly = 1) { gameLifecycleService.suspendGame(1L, "우천") }
+        }
+
+        @Test
+        fun `should suspend game without reason`() {
+            // given
+            val game = createGame(1L, GameStatus.SUSPENDED)
+            every { gameLifecycleService.suspendGame(1L, null) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/1/suspend")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.data.status").value("SUSPENDED"))
+
+            verify(exactly = 1) { gameLifecycleService.suspendGame(1L, null) }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/scorer/games/{gameId}/resume")
+    inner class ResumeGame {
+        @Test
+        fun `should resume game successfully`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameLifecycleService.resumeGame(1L) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/1/resume"),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+
+            verify(exactly = 1) { gameLifecycleService.resumeGame(1L) }
+        }
+    }
+
     private fun createGamePlayer(
         id: Long,
         gameTeam: GameTeam,

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -877,6 +877,22 @@ class GameScorerControllerTest {
 
             verify(exactly = 1) { gameLifecycleService.suspendGame(1L, null) }
         }
+
+        @Test
+        fun `should suspend game without request body`() {
+            // given
+            val game = createGame(1L, GameStatus.SUSPENDED)
+            every { gameLifecycleService.suspendGame(1L, null) } returns game
+
+            // when & then
+            mockMvc.perform(
+                post("/api/scorer/games/1/suspend"),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.data.status").value("SUSPENDED"))
+
+            verify(exactly = 1) { gameLifecycleService.suspendGame(1L, null) }
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary

>- close #377

5이닝 미만 우천 중단 시 사용할 `suspendGame()` / `resumeGame()` 서비스 메서드와 Scorer API 엔드포인트를 추가합니다.

## Tasks

- `GameLifecycleService` 인터페이스에 `suspendGame`, `resumeGame` 메서드 추가
- `GameLifecycleServiceImpl`에 구현체 추가
- `cancelGame()` 상태 체크에 SUSPENDED 추가 (도메인과 일관성)
- Scorer API에 `POST /{gameId}/suspend`, `POST /{gameId}/resume` 엔드포인트 추가
- `SuspendGameRequestDto` 생성
- 관련 단위 테스트 추가

## To Reviewer

- 도메인 레벨(`Game.suspend()`, `Game.resume()`)은 이미 구현되어 있어 서비스/API 계층만 추가했습니다.
- `cancelGame()`의 서비스 레이어 상태 체크가 도메인(`Game.cancel()`)과 불일치했던 부분도 함께 수정했습니다.