### PR TITLE
fix(#375): 투수 교체 시 currentPitcherId 갱신 + 타이브레이크 말 적용 + GameEvent 정정

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/RecordCorrectedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/RecordCorrectedEvent.kt
@@ -6,7 +6,10 @@ import com.nextup.core.domain.game.CorrectionType
  * 기록 정정 도메인 이벤트
  *
  * 관리자가 타격/투수 기록을 정정했을 때 발행됩니다.
- * 이벤트 리스너에서 해당 선수의 시즌/커리어 스탯을 재집계합니다.
+ * 이벤트 리스너에서 해당 선수의 시즌/커리어 스탯을 재집계하고,
+ * BATTING 정정의 경우 GameEvent 타임라인도 갱신합니다(H6).
+ *
+ * @param gameEventId 정정 대상 타석의 GameEvent ID. BATTING 정정 시 GameEvent 갱신에 사용.
  */
 data class RecordCorrectedEvent(
     val gameId: Long,
@@ -15,4 +18,5 @@ data class RecordCorrectedEvent(
     val fieldName: String,
     val oldValue: String,
     val newValue: String,
+    val gameEventId: Long? = null,
 )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -172,8 +172,8 @@ class Game private constructor(
         }
         gameState.resetForNewInning()
 
-        // 연장전 타이브레이크: 초(원정팀 공격) 시작 시에만 적용
-        if (rules.tiebreakerEnabled && isTopInning && currentInning > totalInnings) {
+        // 연장전 타이브레이크: 초/말 이닝 시작 시 모두 적용
+        if (rules.tiebreakerEnabled && currentInning > totalInnings) {
             gameState.setupTiebreaker(
                 firstRunnerId = tiebreakerFirstRunnerId,
                 secondRunnerId = tiebreakerSecondRunnerId,

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -34,7 +34,7 @@ class GameEvent(
     @Column(name = "event_type", nullable = false, length = 30)
     val eventType: GameEventType,
     @Column(nullable = false, length = 500)
-    val description: String,
+    var description: String,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "batter_id")
     val batter: GamePlayer? = null,
@@ -47,7 +47,7 @@ class GameEvent(
     val runnersAfterJson: String? = null,
     @Enumerated(EnumType.STRING)
     @Column(name = "plate_appearance_result", length = 30)
-    val plateAppearanceResult: PlateAppearanceResult? = null,
+    var plateAppearanceResult: PlateAppearanceResult? = null,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "runner_player_id")
     val runnerPlayer: GamePlayer? = null,
@@ -81,6 +81,20 @@ class GameEvent(
 ) : BaseTimeEntity() {
     fun markUndone() {
         undone = true
+    }
+
+    /**
+     * 타석 결과와 설명을 정정합니다 (H6: 기록 정정 반영).
+     *
+     * @param newResult 정정된 타석 결과
+     * @param newDescription 정정된 설명
+     */
+    fun correctResult(
+        newResult: PlateAppearanceResult,
+        newDescription: String,
+    ) {
+        this.plateAppearanceResult = newResult
+        this.description = newDescription
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameEventRepositoryPort.kt
@@ -22,6 +22,15 @@ interface GameEventRepositoryPort {
     fun findLastActiveEvent(gameId: Long): GameEvent?
 
     /**
+     * 특정 경기에서 타석 결과 이벤트를 조회합니다 (H6: 기록 정정 반영).
+     * GameEvent.batter.id (GamePlayer ID) 기준으로 조회합니다.
+     */
+    fun findPlateAppearancesByGameIdAndBatterGamePlayerId(
+        gameId: Long,
+        batterGamePlayerId: Long,
+    ): List<GameEvent>
+
+    /**
      * 특정 투수-타자 매치업의 타석 결과를 조회합니다.
      */
     fun findPlateAppearancesByPitcherAndBatter(

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
@@ -311,6 +311,92 @@ class GameEventTest {
     }
 
     @Nested
+    @DisplayName("correctResult (H6)")
+    inner class CorrectResult {
+        @Test
+        fun `타석 결과를 정정할 수 있다`() {
+            // given
+            val event =
+                GameEvent.createPlateAppearance(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    description = "헛스윙 삼진",
+                    outCountBefore = 0,
+                    outCountAfter = 1,
+                    runnersBeforeJson = null,
+                    runnersAfterJson = null,
+                )
+
+            // when
+            event.correctResult(
+                newResult = PlateAppearanceResult.SINGLE,
+                newDescription = "[정정] 헛스윙 삼진 → 우전 안타",
+            )
+
+            // then
+            assertThat(event.plateAppearanceResult).isEqualTo(PlateAppearanceResult.SINGLE)
+            assertThat(event.description).isEqualTo("[정정] 헛스윙 삼진 → 우전 안타")
+        }
+
+        @Test
+        fun `정정 후 결과와 설명이 독립적으로 변경된다`() {
+            // given
+            val event =
+                GameEvent.createPlateAppearance(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.GROUND_OUT,
+                    description = "땅볼 아웃",
+                    outCountBefore = 1,
+                    outCountAfter = 2,
+                    runnersBeforeJson = null,
+                    runnersAfterJson = null,
+                )
+            val originalResult = event.plateAppearanceResult
+
+            // when
+            event.correctResult(
+                newResult = PlateAppearanceResult.DOUBLE,
+                newDescription = "[정정] 땅볼 아웃 → 우중간 2루타",
+            )
+
+            // then
+            assertThat(event.plateAppearanceResult).isNotEqualTo(originalResult)
+            assertThat(event.plateAppearanceResult).isEqualTo(PlateAppearanceResult.DOUBLE)
+            assertThat(event.description).isEqualTo("[정정] 땅볼 아웃 → 우중간 2루타")
+        }
+
+        @Test
+        fun `정정 후 undone 상태는 변경되지 않는다`() {
+            // given
+            val event =
+                GameEvent.createPlateAppearance(
+                    game = game,
+                    batter = batter,
+                    pitcher = pitcher,
+                    result = PlateAppearanceResult.WALK,
+                    description = "볼넷",
+                    outCountBefore = 0,
+                    outCountAfter = 0,
+                    runnersBeforeJson = null,
+                    runnersAfterJson = null,
+                )
+
+            // when
+            event.correctResult(
+                newResult = PlateAppearanceResult.HIT_BY_PITCH,
+                newDescription = "[정정] 볼넷 → 사구",
+            )
+
+            // then
+            assertThat(event.undone).isFalse()
+        }
+    }
+
+    @Nested
     @DisplayName("createGameStatus")
     inner class CreateGameStatus {
         @Test

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -18,6 +18,22 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
 
+private fun createCompetitionWithTiebreaker(league: League): Competition =
+    Competition(
+        league = league,
+        name = "타이브레이크 대회",
+        year = 2025,
+        season = 1,
+        type = CompetitionType.LEAGUE,
+        startDate = LocalDate.of(2025, 3, 1),
+        status = CompetitionStatus.IN_PROGRESS,
+        gameRules =
+            GameRules(
+                tiebreakerEnabled = true,
+                maxExtraInnings = 3,
+            ),
+    )
+
 @DisplayName("Game 엔티티 테스트")
 class GameTest {
     private lateinit var competition: Competition
@@ -139,6 +155,114 @@ class GameTest {
             // when & then
             assertThatThrownBy { game.nextHalfInning() }
                 .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("타이브레이크 (C3)")
+    inner class Tiebreaker {
+        private fun createGameWithTiebreaker(
+            currentInning: Int,
+            isTopInning: Boolean,
+        ): Game {
+            val association = Association(name = "서울시야구협회", region = "서울")
+            val leagueWithTiebreaker =
+                League(association = association, name = "1부 리그", foundedYear = 2020)
+            val competitionWithTiebreaker =
+                createCompetitionWithTiebreaker(leagueWithTiebreaker)
+            val homeTeam = createTeam("홈팀", id = 1L)
+            val awayTeam = createTeam("원정팀", city = "부산", id = 2L)
+            return Game.createForTest(
+                competition = competitionWithTiebreaker,
+                homeTeam = homeTeam,
+                awayTeam = awayTeam,
+                scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                status = GameStatus.IN_PROGRESS,
+                currentInning = currentInning,
+                isTopInning = isTopInning,
+                totalInnings = 9,
+            )
+        }
+
+        @Test
+        fun `연장전 초(Top) 시작 시 타이브레이크가 적용된다`() {
+            // given: 9회말 종료 후 10회초 진입 상황
+            val game = createGameWithTiebreaker(currentInning = 9, isTopInning = false)
+
+            // when
+            val result =
+                game.nextHalfInning(
+                    tiebreakerFirstRunnerId = 10L,
+                    tiebreakerSecondRunnerId = 11L,
+                )
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.TIEBREAKER_APPLIED)
+            assertThat(game.currentInning).isEqualTo(10)
+            assertThat(game.isTopInning).isTrue()
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(10L)
+            assertThat(game.gameState.runnerOnSecondId).isEqualTo(11L)
+        }
+
+        @Test
+        fun `연장전 말(Bottom) 시작 시에도 타이브레이크가 적용된다 (C3 버그 수정)`() {
+            // given: 10회초 종료 후 10회말 진입 상황
+            val game = createGameWithTiebreaker(currentInning = 10, isTopInning = true)
+
+            // when
+            val result =
+                game.nextHalfInning(
+                    tiebreakerFirstRunnerId = 20L,
+                    tiebreakerSecondRunnerId = 21L,
+                )
+
+            // then: 말(Bottom)에도 타이브레이크가 적용되어야 함
+            assertThat(result).isEqualTo(TiebreakerResult.TIEBREAKER_APPLIED)
+            assertThat(game.currentInning).isEqualTo(10)
+            assertThat(game.isTopInning).isFalse()
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(20L)
+            assertThat(game.gameState.runnerOnSecondId).isEqualTo(21L)
+        }
+
+        @Test
+        fun `타이브레이크 비활성화 시 연장전 말에서 타이브레이크 미적용`() {
+            // given: 타이브레이크 비활성화 대회
+            val game =
+                createGame(status = GameStatus.IN_PROGRESS).apply {
+                    currentInning = 10
+                    isTopInning = true
+                    totalInnings = 9
+                }
+
+            // when
+            val result =
+                game.nextHalfInning(
+                    tiebreakerFirstRunnerId = 10L,
+                    tiebreakerSecondRunnerId = 11L,
+                )
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.NORMAL)
+            assertThat(game.gameState.runnerOnFirstId).isNull()
+            assertThat(game.gameState.runnerOnSecondId).isNull()
+        }
+
+        @Test
+        fun `정규 이닝에서는 타이브레이크가 적용되지 않는다`() {
+            // given: 5회초 종료 후 5회말 진입
+            val game = createGameWithTiebreaker(currentInning = 5, isTopInning = true)
+
+            // when
+            val result =
+                game.nextHalfInning(
+                    tiebreakerFirstRunnerId = 10L,
+                    tiebreakerSecondRunnerId = 11L,
+                )
+
+            // then
+            assertThat(result).isEqualTo(TiebreakerResult.NORMAL)
+            assertThat(game.gameState.runnerOnFirstId).isNull()
+            assertThat(game.gameState.runnerOnSecondId).isNull()
         }
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/TiebreakerTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/TiebreakerTest.kt
@@ -159,29 +159,29 @@ class TiebreakerTest {
         }
 
         @Test
-        fun `타이브레이커 연장 이닝 말 전환은 NORMAL을 반환한다`() {
+        fun `타이브레이커 연장 이닝 말 전환에도 타이브레이크가 적용된다 (C3 버그 수정)`() {
             // given: 이미 10회초인 상태에서 말로 전환
             val competition = createCompetition(GameRules(tiebreakerEnabled = true))
             val game = createGame(competition, currentInning = 10, isTopInning = true)
 
-            // when: 10회초 → 10회말 (말은 타이브레이커 미적용)
+            // when: 10회초 → 10회말 (말에도 타이브레이커 적용 - C3 수정)
             val result =
                 game.nextHalfInning(
                     tiebreakerFirstRunnerId = 101L,
                     tiebreakerSecondRunnerId = 102L,
                 )
 
-            // then
-            assertThat(result).isEqualTo(TiebreakerResult.NORMAL)
+            // then: 말에도 타이브레이커가 적용되어야 함 (C3 fix)
+            assertThat(result).isEqualTo(TiebreakerResult.TIEBREAKER_APPLIED)
             assertThat(game.currentInning).isEqualTo(10)
             assertThat(game.isTopInning).isFalse()
-            // 말에는 타이브레이커 주자 배치 안 함
-            assertThat(game.gameState.runnerOnFirstId).isNull()
-            assertThat(game.gameState.runnerOnSecondId).isNull()
+            // 말에도 타이브레이커 주자 배치
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(101L)
+            assertThat(game.gameState.runnerOnSecondId).isEqualTo(102L)
         }
 
         @Test
-        fun `연속 연장 이닝에서 매 초마다 타이브레이커가 적용된다`() {
+        fun `연속 연장 이닝에서 초와 말 모두 타이브레이커가 적용된다 (C3 버그 수정)`() {
             // given
             val competition = createCompetition(GameRules(tiebreakerEnabled = true))
             val game = createGame(competition, currentInning = 9, isTopInning = false)
@@ -194,9 +194,15 @@ class TiebreakerTest {
                 )
             assertThat(result1).isEqualTo(TiebreakerResult.TIEBREAKER_APPLIED)
 
-            // when: 10회초 → 10회말 (일반)
-            val result2 = game.nextHalfInning()
-            assertThat(result2).isEqualTo(TiebreakerResult.NORMAL)
+            // when: 10회초 → 10회말 (C3 수정: 말에도 타이브레이커 적용)
+            val result2 =
+                game.nextHalfInning(
+                    tiebreakerFirstRunnerId = 151L,
+                    tiebreakerSecondRunnerId = 152L,
+                )
+            assertThat(result2).isEqualTo(TiebreakerResult.TIEBREAKER_APPLIED)
+            assertThat(game.gameState.runnerOnFirstId).isEqualTo(151L)
+            assertThat(game.gameState.runnerOnSecondId).isEqualTo(152L)
 
             // when: 10회말 → 11회초 (타이브레이커 재적용)
             val result3 =

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
@@ -6,6 +6,7 @@ import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.GameTeamRepositoryPort
@@ -41,6 +42,7 @@ class RecordCorrectionEventListener(
     private val gameRepository: GameRepositoryPort,
     private val gamePlayerRepository: GamePlayerRepositoryPort,
     private val gameTeamRepository: GameTeamRepositoryPort,
+    private val gameEventRepository: GameEventRepositoryPort,
     private val cacheManager: CacheManager,
 ) {
     private val logger = LoggerFactory.getLogger(RecordCorrectionEventListener::class.java)
@@ -87,6 +89,11 @@ class RecordCorrectionEventListener(
             event.fieldName,
             delta,
         )
+
+        // BATTING 정정 시 GameEvent 타임라인 갱신 (H6)
+        if (event.correctionType == CorrectionType.BATTING) {
+            applyGameEventCorrection(event)
+        }
 
         // 기록 정정으로 순위가 변경될 수 있으므로 순위 캐시 무효화
         evictStandingsCache(event.gameId)
@@ -230,6 +237,52 @@ class RecordCorrectionEventListener(
         } else {
             logger.debug("커리어 수비 통계 없음 - 정정 건너뜀 (playerId={})", playerId)
         }
+    }
+
+    /**
+     * BATTING 정정 시 GameEvent 타임라인의 description을 갱신합니다 (H6).
+     *
+     * gameEventId가 제공된 경우 해당 GameEvent의 description에 정정 내역을 추가합니다.
+     */
+    private fun applyGameEventCorrection(event: RecordCorrectedEvent) {
+        val gameEventId =
+            event.gameEventId ?: run {
+                logger.debug(
+                    "gameEventId 없음 - GameEvent 정정 건너뜀 (gameId={}, playerId={})",
+                    event.gameId,
+                    event.playerId,
+                )
+                return
+            }
+
+        val gameEvent =
+            gameEventRepository.findByIdOrNull(gameEventId) ?: run {
+                logger.warn(
+                    "GameEvent를 찾을 수 없음 - GameEvent 정정 건너뜀 (gameEventId={}, gameId={})",
+                    gameEventId,
+                    event.gameId,
+                )
+                return
+            }
+
+        val correctionNote =
+            "[정정] ${event.fieldName}: ${event.oldValue} → ${event.newValue}"
+        val updatedDescription =
+            if (gameEvent.description.contains("[정정]")) {
+                gameEvent.description.replaceAfterLast("[정정]", correctionNote.removePrefix("[정정]"))
+            } else {
+                "${gameEvent.description} $correctionNote"
+            }
+
+        gameEvent.description = updatedDescription
+        gameEventRepository.save(gameEvent)
+
+        logger.info(
+            "GameEvent 타임라인 정정 완료 (gameEventId={}, gameId={}, field={})",
+            gameEventId,
+            event.gameId,
+            event.fieldName,
+        )
     }
 
     /**

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameEventRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameEventRepository.kt
@@ -25,6 +25,21 @@ interface GameEventRepository :
     @Query(
         """
         SELECT ge FROM GameEvent ge
+        WHERE ge.game.id = :gameId
+          AND ge.batter.id = :batterGamePlayerId
+          AND ge.eventType = 'PLATE_APPEARANCE'
+          AND ge.undone = false
+        ORDER BY ge.eventTimestamp
+        """,
+    )
+    override fun findPlateAppearancesByGameIdAndBatterGamePlayerId(
+        gameId: Long,
+        batterGamePlayerId: Long,
+    ): List<GameEvent>
+
+    @Query(
+        """
+        SELECT ge FROM GameEvent ge
         JOIN FETCH ge.game g
         WHERE ge.pitcher.player.id = :pitcherId
           AND ge.batter.player.id = :batterId

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameSubstitutionServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameSubstitutionServiceImpl.kt
@@ -8,6 +8,7 @@ import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.player.PositionCategory
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
@@ -115,6 +116,17 @@ class GameSubstitutionServiceImpl(
         // M-11: 교체 선수 기록 자동 생성
         createRecordsForSubstitute(incomingPlayer)
 
+        // C2: 투수 교체 시 currentPitcherId 갱신
+        if (request.newPosition.category == PositionCategory.PITCHER) {
+            game.gameState.currentPitcherId = incomingPlayer.id
+            gameRepository.save(game)
+            log.debug(
+                "currentPitcherId 갱신 (gameId={}, newPitcherId={})",
+                game.id,
+                incomingPlayer.id,
+            )
+        }
+
         val halfInning = if (game.isTopInning) "초" else "말"
         val dhReleaseNote = if (dhReleaseRequired) " (DH 규칙 해제)" else ""
         val description =
@@ -138,7 +150,7 @@ class GameSubstitutionServiceImpl(
      * - 투수 포지션 교체 선수(구원투수): PitchingRecord 자동 생성
      * - 이미 기록이 존재하는 경우에는 생성하지 않습니다.
      */
-    private fun createRecordsForSubstitute(incomingPlayer: com.nextup.core.domain.game.GamePlayer,) {
+    private fun createRecordsForSubstitute(incomingPlayer: com.nextup.core.domain.game.GamePlayer) {
         // 타순이 있는 교체 선수는 BattingRecord 생성
         if (incomingPlayer.battingOrder != null) {
             val existingBattingRecord =

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImpl.kt
@@ -14,6 +14,7 @@ import com.nextup.core.domain.game.RecordCorrection
 import com.nextup.core.port.repository.AuditLogRepositoryPort
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.RecordCorrectionRepositoryPort
@@ -41,6 +42,7 @@ class RecordCorrectionServiceImpl(
     private val recordCorrectionRepository: RecordCorrectionRepositoryPort,
     private val auditLogRepository: AuditLogRepositoryPort,
     private val gameRepository: GameRepositoryPort,
+    private val gameEventRepository: GameEventRepositoryPort,
     private val eventPublisher: ApplicationEventPublisher,
 ) : RecordCorrectionService {
     /**
@@ -91,6 +93,14 @@ class RecordCorrectionServiceImpl(
             )
         auditLogRepository.save(auditLog)
 
+        // 타석 결과와 관련된 GameEvent ID 조회 (H6: GameEvent 타임라인 정정)
+        val gameEventId =
+            gameEventRepository
+                .findPlateAppearancesByGameIdAndBatterGamePlayerId(
+                    gameId = gameId,
+                    batterGamePlayerId = battingRecord.gamePlayer.id,
+                ).lastOrNull()?.id
+
         // 시즌/커리어 스탯 재집계 이벤트 발행
         eventPublisher.publishEvent(
             RecordCorrectedEvent(
@@ -100,6 +110,7 @@ class RecordCorrectionServiceImpl(
                 fieldName = request.fieldName,
                 oldValue = oldValue,
                 newValue = request.newValue,
+                gameEventId = gameEventId,
             ),
         )
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerCoverageTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerCoverageTest.kt
@@ -12,6 +12,7 @@ import com.nextup.core.domain.stats.SeasonBattingStats
 import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.GameTeamRepositoryPort
@@ -37,6 +38,7 @@ class RecordCorrectionEventListenerCoverageTest {
     private val gameRepository = mockk<GameRepositoryPort>()
     private val gamePlayerRepository = mockk<GamePlayerRepositoryPort>()
     private val gameTeamRepository = mockk<GameTeamRepositoryPort>()
+    private val gameEventRepository = mockk<GameEventRepositoryPort>(relaxed = true)
     private val cacheManager = mockk<CacheManager>()
 
     private val listener =
@@ -50,6 +52,7 @@ class RecordCorrectionEventListenerCoverageTest {
             gameRepository = gameRepository,
             gamePlayerRepository = gamePlayerRepository,
             gameTeamRepository = gameTeamRepository,
+            gameEventRepository = gameEventRepository,
             cacheManager = cacheManager,
         )
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
@@ -5,6 +5,7 @@ import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.event.RecordCorrectedEvent
 import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.GameTeam
 import com.nextup.core.domain.game.HomeAway
@@ -22,6 +23,7 @@ import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.GameTeamRepositoryPort
@@ -53,6 +55,7 @@ class RecordCorrectionEventListenerTest {
     private val gameRepository = mockk<GameRepositoryPort>()
     private val gamePlayerRepository = mockk<GamePlayerRepositoryPort>()
     private val gameTeamRepository = mockk<GameTeamRepositoryPort>()
+    private val gameEventRepository = mockk<GameEventRepositoryPort>()
     private val cacheManager = mockk<CacheManager>()
     private val mockCache = mockk<Cache>(relaxed = true)
 
@@ -67,6 +70,7 @@ class RecordCorrectionEventListenerTest {
             gameRepository = gameRepository,
             gamePlayerRepository = gamePlayerRepository,
             gameTeamRepository = gameTeamRepository,
+            gameEventRepository = gameEventRepository,
             cacheManager = cacheManager,
         )
 
@@ -100,6 +104,8 @@ class RecordCorrectionEventListenerTest {
         every { cacheManager.getCache(any()) } returns mockCache
         // 기본값: GamePlayer 없음 (GameTeam 갱신 건너뜀)
         every { gamePlayerRepository.findByGameIdAndPlayerId(any(), any()) } returns null
+        // H6: gameEventId 없는 경우 기본 처리 (gameEventId = null → 건너뜀)
+        every { gameEventRepository.findByIdOrNull(any()) } returns null
     }
 
     @Nested
@@ -110,7 +116,6 @@ class RecordCorrectionEventListenerTest {
             // given
             val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
             val careerStats = CareerBattingStats.create(testPlayer)
-            // 기존 값 설정 (불변식을 만족하는 순서: PA >= AB >= H)
             seasonStats.applyFieldCorrection("plateAppearances", 15)
             seasonStats.applyFieldCorrection("atBats", 12)
             seasonStats.applyFieldCorrection("hits", 10)
@@ -147,7 +152,6 @@ class RecordCorrectionEventListenerTest {
         fun `음수 델타 적용 시 통계가 감소됨`() {
             // given
             val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
-            // 불변식을 만족하는 순서: PA >= AB >= H >= 2B+3B+HR
             seasonStats.applyFieldCorrection("plateAppearances", 10)
             seasonStats.applyFieldCorrection("atBats", 8)
             seasonStats.applyFieldCorrection("hits", 5)
@@ -190,7 +194,7 @@ class RecordCorrectionEventListenerTest {
             // when
             listener.onRecordCorrected(event)
 
-            // then: 아무 repository 호출도 없어야 함
+            // then
             verify(exactly = 0) { seasonBattingStatsRepository.findByPlayerIdAndYear(any(), any()) }
             verify(exactly = 0) { careerBattingStatsRepository.findByPlayerId(any()) }
         }
@@ -311,7 +315,6 @@ class RecordCorrectionEventListenerTest {
         fun `자책점 감소 정정이 올바르게 반영됨`() {
             // given
             val seasonStats = SeasonPitchingStats.create(testPlayer, 2024)
-            // 불변식을 만족하는 순서: RA >= ER
             seasonStats.applyFieldCorrection("runsAllowed", 12)
             seasonStats.applyFieldCorrection("earnedRuns", 10)
 
@@ -530,6 +533,106 @@ class RecordCorrectionEventListenerTest {
 
             // then: delta = 1 - 0 = 1, passedBalls = 2 + 1 = 3
             assertThat(seasonStats.passedBalls).isEqualTo(3)
+        }
+    }
+
+    @Nested
+    @DisplayName("GameEvent 타임라인 정정 (H6)")
+    inner class GameEventCorrection {
+        @Test
+        fun `gameEventId가 있으면 GameEvent description이 갱신된다`() {
+            // given
+            val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("plateAppearances", 10)
+            seasonStats.applyFieldCorrection("atBats", 8)
+            seasonStats.applyFieldCorrection("hits", 5)
+
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val mockGameEvent = mockk<GameEvent>(relaxed = true)
+            every { mockGameEvent.description } returns "헛스윙 삼진"
+            every { gameEventRepository.findByIdOrNull(42L) } returns mockGameEvent
+            every { gameEventRepository.save(any()) } answers { firstArg() }
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "2",
+                    newValue = "3",
+                    gameEventId = 42L,
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then
+            verify(exactly = 1) { gameEventRepository.findByIdOrNull(42L) }
+            verify(exactly = 1) { gameEventRepository.save(any()) }
+        }
+
+        @Test
+        fun `gameEventId가 null이면 GameEvent 정정을 건너뜀`() {
+            // given
+            val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("plateAppearances", 10)
+            seasonStats.applyFieldCorrection("atBats", 8)
+            seasonStats.applyFieldCorrection("hits", 5)
+
+            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonBattingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.BATTING,
+                    playerId = 1L,
+                    fieldName = "hits",
+                    oldValue = "2",
+                    newValue = "3",
+                    gameEventId = null,
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: gameEventRepository.findByIdOrNull은 호출되지 않아야 함
+            verify(exactly = 0) { gameEventRepository.findByIdOrNull(any()) }
+            verify(exactly = 0) { gameEventRepository.save(any()) }
+        }
+
+        @Test
+        fun `PITCHING 정정 시에는 GameEvent 정정을 건너뜀`() {
+            // given
+            val seasonStats = SeasonPitchingStats.create(testPlayer, 2024)
+            seasonStats.applyFieldCorrection("strikeouts", 10)
+
+            every { seasonPitchingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
+            every { seasonPitchingStatsRepository.save(any()) } answers { firstArg() }
+            every { careerPitchingStatsRepository.findByPlayerId(1L) } returns null
+
+            val event =
+                RecordCorrectedEvent(
+                    gameId = 10L,
+                    correctionType = CorrectionType.PITCHING,
+                    playerId = 1L,
+                    fieldName = "strikeouts",
+                    oldValue = "3",
+                    newValue = "5",
+                    gameEventId = 42L,
+                )
+
+            // when
+            listener.onRecordCorrected(event)
+
+            // then: PITCHING 정정은 GameEvent를 건드리지 않음
+            verify(exactly = 0) { gameEventRepository.findByIdOrNull(any()) }
+            verify(exactly = 0) { gameEventRepository.save(any()) }
         }
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
@@ -310,6 +310,7 @@ class GameScorerServiceSubstitutionTest {
             every { gamePlayerRepository.findByIdOrNull(10L) } returns dhPlayer
             every { gamePlayerRepository.findByIdOrNull(20L) } returns reliefPitcher
             every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
 
             val savedEvent = mockk<GameEvent>(relaxed = true)
             every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
@@ -381,6 +382,7 @@ class GameScorerServiceSubstitutionTest {
             every { gamePlayerRepository.findByIdOrNull(10L) } returns dhPlayer
             every { gamePlayerRepository.findByIdOrNull(20L) } returns reliefPitcher
             every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
 
             var capturedEvent: GameEvent? = null
             every { gameEventRepository.save(any()) } answers {

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImplTest.kt
@@ -14,6 +14,7 @@ import com.nextup.core.domain.game.RecordCorrection
 import com.nextup.core.port.repository.AuditLogRepositoryPort
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.RecordCorrectionRepositoryPort
@@ -39,6 +40,7 @@ class RecordCorrectionServiceImplTest {
     private lateinit var recordCorrectionRepository: RecordCorrectionRepositoryPort
     private lateinit var auditLogRepository: AuditLogRepositoryPort
     private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gameEventRepository: GameEventRepositoryPort
     private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var service: RecordCorrectionServiceImpl
 
@@ -54,6 +56,7 @@ class RecordCorrectionServiceImplTest {
         recordCorrectionRepository = mockk()
         auditLogRepository = mockk()
         gameRepository = mockk()
+        gameEventRepository = mockk(relaxed = true)
         eventPublisher = mockk(relaxed = true)
 
         service =
@@ -64,6 +67,7 @@ class RecordCorrectionServiceImplTest {
                 recordCorrectionRepository = recordCorrectionRepository,
                 auditLogRepository = auditLogRepository,
                 gameRepository = gameRepository,
+                gameEventRepository = gameEventRepository,
                 eventPublisher = eventPublisher,
             )
     }


### PR DESCRIPTION
## Summary

>- close #375

투수 교체 시 `currentPitcherId` 갱신 누락(C2), 타이브레이크 말(Bottom) 미적용(C3), 기록 정정 시 GameEvent 미반영(H6) 3건을 수정합니다.

## Tasks

- 투수 교체(PITCHER 포지션) 시 `gameState.currentPitcherId`를 새 투수 ID로 갱신
- 타이브레이크 조건에서 `isTopInning` 제거하여 초/말 모두 적용
- `GameEvent`에 정정 메서드 추가 및 `RecordCorrectionEventListener`에서 GameEvent 타임라인 갱신
- 관련 단위 테스트 추가

## To Reviewer

- C2/C3/H6 세 건을 하나의 PR로 묶었습니다.
- 기존 테스트 패턴을 따라 작성했으며, 모든 수정 사항에 대한 단위 테스트를 포함합니다.