### PR TITLE
fix(#379): 경기 취소/몰수 시 순위 캐시 무효화 및 이벤트 발행 추가

### DIFF
--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
@@ -6,11 +6,15 @@ import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
 import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import com.nextup.infrastructure.config.CacheConfig
+import com.nextup.infrastructure.listener.StatsEventListener.Companion.retryOnOptimisticLock
 import org.slf4j.LoggerFactory
+import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -40,6 +44,8 @@ class GameCancelEventListener(
     private val battingRecordRepository: BattingRecordRepositoryPort,
     private val pitchingRecordRepository: PitchingRecordRepositoryPort,
     private val fieldingRecordRepository: FieldingRecordRepositoryPort,
+    private val gameRepository: GameRepositoryPort,
+    private val cacheManager: CacheManager,
 ) {
     private val logger = LoggerFactory.getLogger(GameCancelEventListener::class.java)
 
@@ -55,6 +61,14 @@ class GameCancelEventListener(
         val gameId = event.gameId
         logger.info("경기 취소 스탯 롤백 시작 (gameId={})", gameId)
 
+        retryOnOptimisticLock("onGameCancelled(gameId=$gameId)") {
+            rollbackStats(gameId)
+        }
+
+        evictStandingsCache(gameId)
+    }
+
+    private fun rollbackStats(gameId: Long) {
         val battingRecords = battingRecordRepository.findAllByGameId(gameId)
         val pitchingRecords = pitchingRecordRepository.findAllByGameId(gameId)
         val fieldingRecords = fieldingRecordRepository.findAllByGameId(gameId)
@@ -223,6 +237,24 @@ class GameCancelEventListener(
             battingRecords.size,
             pitchingRecords.size,
             fieldingRecords.size,
+        )
+    }
+
+    private fun evictStandingsCache(gameId: Long) {
+        val game =
+            gameRepository.findByIdOrNull(gameId)
+                ?: run {
+                    logger.warn("캐시 무효화 중 경기를 찾을 수 없음 (gameId={})", gameId)
+                    return
+                }
+
+        val competitionId = game.competition.id
+        cacheManager.getCache(CacheConfig.STANDINGS_CACHE)?.evict(competitionId)
+
+        logger.debug(
+            "경기 취소 후 순위 캐시 무효화 완료 (competitionId={}, gameId={})",
+            competitionId,
+            gameId,
         )
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListener.kt
@@ -4,10 +4,12 @@ import com.nextup.core.domain.attendance.PollStatus
 import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.election.ElectionStatus
+import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.TeamDisbandedEvent
 import com.nextup.core.domain.event.TeamMemberKickedEvent
 import com.nextup.core.domain.event.TeamMemberLeftEvent
 import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.HomeAway
 import com.nextup.core.domain.game.LineupSubmissionStatus
 import com.nextup.core.domain.stadium.BookingStatus
 import com.nextup.core.domain.team.JoinRequestStatus
@@ -23,6 +25,7 @@ import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
 import com.nextup.core.port.repository.StadiumBookingRepositoryPort
 import com.nextup.core.port.repository.TeamJoinRequestRepositoryPort
 import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -48,6 +51,7 @@ class TeamMemberEventListener(
     private val electionRepository: ElectionRepositoryPort,
     private val teamJoinRequestRepository: TeamJoinRequestRepositoryPort,
     private val activityScoreRepository: ActivityScoreRepositoryPort,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     private val logger = LoggerFactory.getLogger(TeamMemberEventListener::class.java)
 
@@ -212,6 +216,21 @@ class TeamMemberEventListener(
                         gameTeams = gameTeams,
                     )
                     gameRepository.save(game)
+
+                    val homeTeam = gameTeams.find { it.homeAway == HomeAway.HOME }
+                    val awayTeam = gameTeams.find { it.homeAway == HomeAway.AWAY }
+                    if (homeTeam != null && awayTeam != null) {
+                        eventPublisher.publishEvent(
+                            GameResultConfirmedEvent(
+                                gameId = game.id,
+                                homeTeamId = homeTeam.team.id,
+                                awayTeamId = awayTeam.team.id,
+                                homeScore = homeTeam.totalScore,
+                                awayScore = awayTeam.totalScore,
+                            ),
+                        )
+                    }
+
                     logger.info(
                         "경기 몰수승 처리 - gameId={}, competitionId={}, winnerTeamId={}",
                         game.id,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
@@ -1,8 +1,10 @@
 package com.nextup.infrastructure.listener
 
+import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.event.GameCancelledEvent
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.PitchingDecision
 import com.nextup.core.domain.game.PitchingRecord
@@ -21,10 +23,12 @@ import com.nextup.core.port.repository.CareerBattingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.CareerPitchingStatsRepositoryPort
 import com.nextup.core.port.repository.FieldingRecordRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import com.nextup.infrastructure.config.CacheConfig
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -33,6 +37,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
 
 @DisplayName("GameCancelEventListener 테스트")
 class GameCancelEventListenerTest {
@@ -45,6 +51,9 @@ class GameCancelEventListenerTest {
     private val battingRecordRepository = mockk<BattingRecordRepositoryPort>()
     private val pitchingRecordRepository = mockk<PitchingRecordRepositoryPort>()
     private val fieldingRecordRepository = mockk<FieldingRecordRepositoryPort>()
+    private val gameRepository = mockk<GameRepositoryPort>()
+    private val cacheManager = mockk<CacheManager>()
+    private val standingsCache = mockk<Cache>(relaxed = true)
 
     private val listener =
         GameCancelEventListener(
@@ -57,6 +66,8 @@ class GameCancelEventListenerTest {
             battingRecordRepository = battingRecordRepository,
             pitchingRecordRepository = pitchingRecordRepository,
             fieldingRecordRepository = fieldingRecordRepository,
+            gameRepository = gameRepository,
+            cacheManager = cacheManager,
         )
 
     private val testBatter =
@@ -86,6 +97,8 @@ class GameCancelEventListenerTest {
 
     private val gameId = 100L
     private val cancelEvent = GameCancelledEvent(gameId = gameId)
+    private val mockGame = mockk<Game>()
+    private val mockCompetition = mockk<Competition>()
 
     @BeforeEach
     fun setUp() {
@@ -95,6 +108,11 @@ class GameCancelEventListenerTest {
         every { mockPitcherGamePlayer.player } returns testPitcher
         every { mockFieldingRecord.gamePlayer } returns mockFielderGamePlayer
         every { mockFielderGamePlayer.player } returns testBatter
+
+        every { gameRepository.findByIdOrNull(gameId) } returns mockGame
+        every { mockGame.competition } returns mockCompetition
+        every { mockCompetition.id } returns 200L
+        every { cacheManager.getCache(CacheConfig.STANDINGS_CACHE) } returns standingsCache
     }
 
     @Nested
@@ -579,6 +597,44 @@ class GameCancelEventListenerTest {
             verify { careerBattingStatsRepository.save(careerStats) }
             assertThat(seasonStats.gamesPlayed).isEqualTo(0)
             assertThat(careerStats.gamesPlayed).isEqualTo(0)
+        }
+    }
+
+    @Nested
+    @DisplayName("onGameCancelled - 순위 캐시 무효화")
+    inner class StandingsCacheEviction {
+        @BeforeEach
+        fun setUpDefault() {
+            every { fieldingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { seasonFieldingStatsRepository.findAllByGameId(gameId) } returns emptyList()
+        }
+
+        @Test
+        fun `경기 취소 시 해당 대회의 순위 캐시가 무효화된다`() {
+            // given
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            verify { cacheManager.getCache(CacheConfig.STANDINGS_CACHE) }
+            verify { standingsCache.evict(200L) }
+        }
+
+        @Test
+        fun `경기를 찾을 수 없으면 캐시 무효화를 건너뛴다`() {
+            // given
+            every { gameRepository.findByIdOrNull(gameId) } returns null
+            every { battingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(gameId) } returns emptyList()
+
+            // when
+            listener.onGameCancelled(cancelEvent)
+
+            // then
+            verify(exactly = 0) { standingsCache.evict(any()) }
         }
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/TeamMemberEventListenerTest.kt
@@ -12,6 +12,7 @@ import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.election.Election
 import com.nextup.core.domain.election.ElectionStatus
 import com.nextup.core.domain.election.ElectionType
+import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.TeamDisbandedEvent
 import com.nextup.core.domain.event.TeamMemberKickedEvent
 import com.nextup.core.domain.event.TeamMemberLeftEvent
@@ -45,11 +46,13 @@ import com.nextup.core.port.repository.TeamJoinRequestRepositoryPort
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -67,6 +70,7 @@ class TeamMemberEventListenerTest {
     private val electionRepository = mockk<ElectionRepositoryPort>()
     private val teamJoinRequestRepository = mockk<TeamJoinRequestRepositoryPort>()
     private val activityScoreRepository = mockk<ActivityScoreRepositoryPort>()
+    private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
 
     private val listener =
         TeamMemberEventListener(
@@ -81,6 +85,7 @@ class TeamMemberEventListenerTest {
             electionRepository = electionRepository,
             teamJoinRequestRepository = teamJoinRequestRepository,
             activityScoreRepository = activityScoreRepository,
+            eventPublisher = eventPublisher,
         )
 
     private lateinit var association: Association
@@ -881,6 +886,65 @@ class TeamMemberEventListenerTest {
             assert(scheduledGame.status == GameStatus.FORFEITED)
             assert(inProgressGame.status == GameStatus.FORFEITED)
             assert(finishedGame.status == GameStatus.FINISHED)
+        }
+
+        @Test
+        @DisplayName("팀 해산 몰수승 처리 후 GameResultConfirmedEvent가 발행된다")
+        fun `should publish GameResultConfirmedEvent after forfeit on team disband`() {
+            // given
+            val event = TeamDisbandedEvent(teamId = 1L)
+
+            val opponentTeam = Team(league = league, name = "라이언즈", city = "부산", foundedYear = 2016)
+            setFieldId(opponentTeam, Team::class.java, 2L)
+
+            val competition =
+                Competition(
+                    league = league,
+                    name = "2026 시즌",
+                    year = 2026,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2026, 3, 1),
+                )
+            setFieldId(competition, Competition::class.java, 100L)
+            competition.start()
+
+            val scheduledGame2 =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = team,
+                    awayTeam = opponentTeam,
+                    scheduledAt = LocalDateTime.now().plusDays(1),
+                    status = GameStatus.SCHEDULED,
+                    id = 1000L,
+                )
+
+            every {
+                competitionPlayerRepository.findActiveCompetitionIdsByTeamId(1L)
+            } returns setOf(100L)
+            every {
+                competitionPlayerRepository.findByTeamIdAndStatus(1L, CompetitionPlayerStatus.ACTIVE)
+            } returns emptyList()
+            every { competitionRepository.findByIdOrNull(100L) } returns competition
+            every { gameRepository.findByCompetitionId(100L) } returns listOf(scheduledGame2)
+            every { gameRepository.save(any()) } returnsArgument 0
+            every { bracketEntryRepository.findByCompetitionId(100L) } returns emptyList()
+
+            every { stadiumBookingRepository.findByTeamIdAndStatus(1L, BookingStatus.CONFIRMED) } returns emptyList()
+            every { attendancePollRepository.findByTeamId(1L, PollStatus.OPEN) } returns emptyList()
+            every { electionRepository.findAllByTeamId(1L) } returns emptyList()
+            every { teamJoinRequestRepository.findByTeamId(1L) } returns emptyList()
+            justRun { activityScoreRepository.deleteByTeamId(1L) }
+
+            // when
+            listener.handleTeamDisbanded(event)
+
+            // then
+            val eventSlot = slot<GameResultConfirmedEvent>()
+            verify { eventPublisher.publishEvent(capture(eventSlot)) }
+
+            val capturedEvent = eventSlot.captured
+            assert(capturedEvent.gameId == 1000L)
         }
 
         @Test


### PR DESCRIPTION
## Summary

>- close #379

**경기 취소 시 순위 캐시가 무효화되지 않는 문제(H9)와 팀 해산 몰수승 처리 시 GameResultConfirmedEvent가 미발행되는 문제(H4)를 수정합니다.**

## Tasks

- GameCancelEventListener에 CacheManager 주입 및 standings 캐시 무효화 로직 추가
- GameCancelEventListener에 optimistic locking 재시도 패턴 적용
- TeamMemberEventListener.forfeitGamesForTeam()에서 몰수 처리 후 GameResultConfirmedEvent 발행
- 관련 단위 테스트 추가

## To Reviewer

GameResultEventListener의 캐시 무효화 패턴과 StatsEventListener의 retryOnOptimisticLock 패턴을 참고하여 구현했습니다.