### PR TITLE
feat(#332): 기록원 경기 독점 잠금 검증 추가

### DIFF
--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
@@ -94,3 +94,25 @@ class GameNotLockedByCurrentScorerException(
         "GAME_NOT_LOCKED_BY_SCORER",
         "Game $gameId is not locked by scorer $scorerId",
     )
+
+/**
+ * 경기가 잠금되지 않은 상태에서 기록을 시도할 때 발생하는 예외
+ */
+class GameNotLockedForRecordingException(
+    gameId: Long,
+) : InvalidStateException(
+        "GAME_NOT_LOCKED",
+        "Game $gameId is not locked by any scorer. Lock the game before recording.",
+    )
+
+/**
+ * 잠금한 기록원이 아닌 다른 사용자가 기록을 시도할 때 발생하는 예외
+ */
+class ScorerMismatchException(
+    gameId: Long,
+    requestScorerId: Long,
+    lockedScorerId: Long,
+) : ForbiddenException(
+        "SCORER_MISMATCH",
+        "Game $gameId is locked by scorer $lockedScorerId, but scorer $requestScorerId attempted to record.",
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -2,6 +2,8 @@ package com.nextup.core.domain.game
 
 import com.nextup.common.exception.GameAlreadyLockedException
 import com.nextup.common.exception.GameNotLockedByCurrentScorerException
+import com.nextup.common.exception.GameNotLockedForRecordingException
+import com.nextup.common.exception.ScorerMismatchException
 import com.nextup.core.common.BaseTimeEntity
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.team.Team
@@ -134,6 +136,25 @@ class Game private constructor(
         get() = scorerId != null
 
     /**
+     * 기록 API 호출 시 기록원 잠금 검증을 수행합니다.
+     *
+     * 경기가 잠금되지 않은 상태이면 [GameNotLockedForRecordingException]을 발생시키고,
+     * 잠금한 기록원과 요청 기록원이 다르면 [ScorerMismatchException]을 발생시킵니다.
+     *
+     * @param requestScorerId 기록을 요청하는 기록원 ID
+     * @throws GameNotLockedForRecordingException 경기가 잠금되지 않은 경우
+     * @throws ScorerMismatchException 잠금한 기록원과 요청 기록원이 다른 경우
+     */
+    fun validateScorer(requestScorerId: Long) {
+        if (this.scorerId == null) {
+            throw GameNotLockedForRecordingException(id)
+        }
+        if (this.scorerId != requestScorerId) {
+            throw ScorerMismatchException(id, requestScorerId, this.scorerId!!)
+        }
+    }
+
+    /**
      * 다음 이닝으로 진행합니다.
      *
      * 연장전 타이브레이크 활성화 시 초(원정팀 공격) 시작마다 무사 1,2루 상태를 자동 설정합니다.
@@ -227,6 +248,7 @@ class Game private constructor(
         status = GameStatus.FINISHED
         endedAt = LocalDateTime.now()
         determineResults(gameTeams)
+        forceUnlockScorer()
     }
 
     /**
@@ -271,6 +293,7 @@ class Game private constructor(
         if (gameTeams.isNotEmpty()) {
             determineResults(gameTeams)
         }
+        forceUnlockScorer()
     }
 
     /**
@@ -369,6 +392,7 @@ class Game private constructor(
         if (reason != null) {
             note = (note?.let { "$it\n" } ?: "") + "취소 사유: $reason"
         }
+        forceUnlockScorer()
     }
 
     /**
@@ -427,6 +451,7 @@ class Game private constructor(
                 gameTeam.updateResult(GameResult.LOSS)
             }
         }
+        forceUnlockScorer()
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/BaseRunningRecordService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/BaseRunningRecordService.kt
@@ -12,5 +12,6 @@ interface BaseRunningRecordService {
     fun recordBaseRunning(
         gameId: Long,
         request: BaseRunningRequest,
+        scorerId: Long,
     ): GameEvent
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameLifecycleService.kt
@@ -10,24 +10,33 @@ import java.time.LocalDateTime
  * 경기 시작, 이닝 진행, 종료, 몰수, 취소, 연기, 일정 변경을 담당합니다.
  */
 interface GameLifecycleService {
-    fun startGame(gameId: Long): Game
+    fun startGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game
 
-    fun advanceHalfInning(gameId: Long): Game
+    fun advanceHalfInning(
+        gameId: Long,
+        scorerId: Long,
+    ): Game
 
     fun endGame(
         gameId: Long,
         reason: GameEndReason,
+        scorerId: Long,
     ): Game
 
     fun forfeitGame(
         gameId: Long,
         winnerTeamId: Long,
         reason: String,
+        scorerId: Long,
     ): Game
 
     fun cancelGame(
         gameId: Long,
         reason: String? = null,
+        scorerId: Long,
     ): Game
 
     fun postponeGame(
@@ -68,7 +77,11 @@ interface GameLifecycleService {
     fun suspendGame(
         gameId: Long,
         reason: String? = null,
+        scorerId: Long,
     ): Game
 
-    fun resumeGame(gameId: Long): Game
+    fun resumeGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameSubstitutionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameSubstitutionService.kt
@@ -12,5 +12,6 @@ interface GameSubstitutionService {
     fun substitutePlayer(
         gameId: Long,
         request: SubstitutionRequest,
+        scorerId: Long,
     ): GameEvent
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameUndoService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameUndoService.kt
@@ -8,5 +8,8 @@ import com.nextup.core.domain.game.GameEvent
  * 마지막 이벤트를 되돌리는 Undo 기능을 담당합니다.
  */
 interface GameUndoService {
-    fun undoLastEvent(gameId: Long): GameEvent
+    fun undoLastEvent(
+        gameId: Long,
+        scorerId: Long,
+    ): GameEvent
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/PlateAppearanceRecordService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/PlateAppearanceRecordService.kt
@@ -12,5 +12,6 @@ interface PlateAppearanceRecordService {
     fun recordPlateAppearance(
         gameId: Long,
         request: PlateAppearanceRequest,
+        scorerId: Long,
     ): PlateAppearanceRecordResult
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -2,6 +2,8 @@ package com.nextup.core.domain.game
 
 import com.nextup.common.exception.GameAlreadyLockedException
 import com.nextup.common.exception.GameNotLockedByCurrentScorerException
+import com.nextup.common.exception.GameNotLockedForRecordingException
+import com.nextup.common.exception.ScorerMismatchException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
@@ -1797,6 +1799,116 @@ class GameTest {
             // then
             assertThat(game.scorerId).isEqualTo(100L)
             assertThat(game.isLocked).isTrue()
+        }
+
+        @Test
+        fun `잠금한 기록원이 validateScorer를 호출하면 예외가 발생하지 않는다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when & then - 예외 없이 통과
+            game.validateScorer(100L)
+        }
+
+        @Test
+        fun `잠금되지 않은 경기에서 validateScorer를 호출하면 GameNotLockedForRecordingException이 발생한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+
+            // when & then
+            assertThatThrownBy { game.validateScorer(100L) }
+                .isInstanceOf(GameNotLockedForRecordingException::class.java)
+                .hasMessageContaining("not locked by any scorer")
+        }
+
+        @Test
+        fun `다른 기록원이 validateScorer를 호출하면 ScorerMismatchException이 발생한다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when & then
+            assertThatThrownBy { game.validateScorer(200L) }
+                .isInstanceOf(ScorerMismatchException::class.java)
+                .hasMessageContaining("locked by scorer 100")
+                .hasMessageContaining("scorer 200 attempted")
+        }
+
+        @Test
+        fun `경기 종료 시 기록원 잠금이 자동 해제된다`() {
+            // given
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            game.lockForScorer(100L)
+
+            // when
+            game.finish(game.gameTeams)
+
+            // then
+            assertThat(game.scorerId).isNull()
+            assertThat(game.isLocked).isFalse()
+        }
+
+        @Test
+        fun `경기 취소 시 기록원 잠금이 자동 해제된다`() {
+            // given
+            val game = createGame(status = GameStatus.SCHEDULED)
+            game.lockForScorer(100L)
+
+            // when
+            game.cancel("테스트 취소")
+
+            // then
+            assertThat(game.scorerId).isNull()
+            assertThat(game.isLocked).isFalse()
+        }
+
+        @Test
+        fun `콜드게임 시 기록원 잠금이 자동 해제된다`() {
+            // given
+            val homeTeam = createTeam("홈팀", id = 1L)
+            val awayTeam = createTeam("원정팀", city = "부산", id = 2L)
+            val game =
+                Game.createForTest(
+                    competition = competition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                    location = "잠실야구장",
+                    status = GameStatus.IN_PROGRESS,
+                    currentInning = 5,
+                    isTopInning = true,
+                )
+            game.lockForScorer(100L)
+
+            // when
+            game.callGame(
+                minimumInning = 5,
+                reason = "우천",
+                gameTeams = game.gameTeams,
+            )
+
+            // then
+            assertThat(game.scorerId).isNull()
+            assertThat(game.isLocked).isFalse()
+        }
+
+        @Test
+        fun `몰수 처리 시 기록원 잠금이 자동 해제된다`() {
+            // given
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            game.lockForScorer(100L)
+
+            // when
+            game.forfeit(
+                winnerTeamId = 1L,
+                reason = "출석 인원 부족",
+                gameTeams = game.gameTeams,
+            )
+
+            // then
+            assertThat(game.scorerId).isNull()
+            assertThat(game.isLocked).isFalse()
         }
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/BaseRunningRecordServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/BaseRunningRecordServiceImpl.kt
@@ -38,8 +38,10 @@ class BaseRunningRecordServiceImpl(
     override fun recordBaseRunning(
         gameId: Long,
         request: BaseRunningRequest,
+        scorerId: Long,
     ): GameEvent {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
 
         if (game.status != GameStatus.IN_PROGRESS) {
             throw InvalidGameStateException(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
@@ -38,15 +38,23 @@ class GameLifecycleServiceImpl(
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional
-    override fun startGame(gameId: Long): Game {
+    override fun startGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
         game.start()
         return gameRepository.save(game)
     }
 
     @Transactional
-    override fun advanceHalfInning(gameId: Long): Game {
+    override fun advanceHalfInning(
+        gameId: Long,
+        scorerId: Long,
+    ): Game {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
 
         if (game.status != GameStatus.IN_PROGRESS) {
             throw InvalidGameStateException("진행 중인 경기만 이닝을 진행할 수 있습니다. 현재 상태: ${game.status.displayName}")
@@ -60,8 +68,10 @@ class GameLifecycleServiceImpl(
     override fun endGame(
         gameId: Long,
         reason: GameEndReason,
+        scorerId: Long,
     ): Game {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
 
         if (game.status != GameStatus.IN_PROGRESS) {
             throw InvalidGameStateException("진행 중인 경기만 종료할 수 있습니다. 현재 상태: ${game.status.displayName}")
@@ -94,8 +104,10 @@ class GameLifecycleServiceImpl(
         gameId: Long,
         winnerTeamId: Long,
         reason: String,
+        scorerId: Long,
     ): Game {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
 
         if (game.status != GameStatus.SCHEDULED && game.status != GameStatus.IN_PROGRESS) {
             throw InvalidGameStateException(
@@ -126,8 +138,10 @@ class GameLifecycleServiceImpl(
     override fun cancelGame(
         gameId: Long,
         reason: String?,
+        scorerId: Long,
     ): Game {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
 
         if (game.status != GameStatus.SCHEDULED &&
             game.status != GameStatus.POSTPONED &&
@@ -226,15 +240,21 @@ class GameLifecycleServiceImpl(
     override fun suspendGame(
         gameId: Long,
         reason: String?,
+        scorerId: Long,
     ): Game {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
         game.suspend(reason)
         return gameRepository.save(game)
     }
 
     @Transactional
-    override fun resumeGame(gameId: Long): Game {
+    override fun resumeGame(
+        gameId: Long,
+        scorerId: Long,
+    ): Game {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
         game.resume()
         return gameRepository.save(game)
     }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameSubstitutionServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameSubstitutionServiceImpl.kt
@@ -3,123 +3,6 @@ package com.nextup.infrastructure.service.game
 import com.nextup.common.exception.GameNotFoundException
 import com.nextup.common.exception.GamePlayerNotFoundException
 import com.nextup.common.exception.InvalidGameStateException
-import com.nextup.core.domain.game.Game
-import com.nextup.core.domain.game.GameEvent
-import com.nextup.core.domain.game.GameStatus
-import com.nextup.core.domain.player.Position
-import com.nextup.core.port.repository.GameEventRepositoryPort
-import com.nextup.core.port.repository.GamePlayerRepositoryPort
-import com.nextup.core.port.repository.GameRepositoryPort
-import com.nextup.core.service.game.GameSubstitutionService
-import com.nextup.core.service.game.dto.SubstitutionRequest
-import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
-
-/**
- * 선수 교체 서비스 구현
- *
- * 선수 교체, DH 해제 규칙 검증을 담당합니다.
- */
-@Service
-@Transactional(readOnly = true)
-class GameSubstitutionServiceImpl(
-    private val gameRepository: GameRepositoryPort,
-    private val gamePlayerRepository: GamePlayerRepositoryPort,
-    private val gameEventRepository: GameEventRepositoryPort,
-) : GameSubstitutionService {
-    private val log = LoggerFactory.getLogger(javaClass)
-
-    @Transactional
-    override fun substitutePlayer(
-        gameId: Long,
-        request: SubstitutionRequest,
-    ): GameEvent {
-        val game = findGame(gameId)
-
-        if (game.status != GameStatus.IN_PROGRESS) {
-            throw InvalidGameStateException(
-                "진행 중인 경기만 선수 교체를 할 수 있습니다. 현재 상태: ${game.status.displayName}",
-            )
-        }
-
-        val outgoingPlayer =
-            gamePlayerRepository.findByIdOrNull(request.outgoingPlayerId)
-                ?: throw GamePlayerNotFoundException(request.outgoingPlayerId)
-
-        val incomingPlayer =
-            gamePlayerRepository.findByIdOrNull(request.incomingPlayerId)
-                ?: throw GamePlayerNotFoundException(request.incomingPlayerId)
-
-        if (incomingPlayer.hasExited) {
-            throw InvalidGameStateException(
-                "이미 퇴장한 선수는 재출전할 수 없습니다. (GamePlayer ID: ${request.incomingPlayerId})",
-            )
-        }
-
-        if (!outgoingPlayer.isCurrentlyPlaying) {
-            throw InvalidGameStateException(
-                "현재 출전 중인 선수만 교체할 수 있습니다. (GamePlayer ID: ${request.outgoingPlayerId})",
-            )
-        }
-
-        if (game.gameState.wasDhReleased && request.newPosition == Position.DESIGNATED_HITTER) {
-            throw InvalidGameStateException(
-                "DH가 이미 해제되었으므로 재지정할 수 없습니다.",
-            )
-        }
-
-        if (outgoingPlayer.isDesignatedHitter) {
-            try {
-                outgoingPlayer.validateDhRelease(incomingPlayer, request.newBattingOrder)
-            } catch (e: IllegalArgumentException) {
-                throw InvalidGameStateException(e.message ?: "DH 해제 규칙 위반")
-            }
-        }
-
-        val dhReleaseRequired = outgoingPlayer.isDhReleaseRequired(incomingPlayer)
-        if (dhReleaseRequired) {
-            outgoingPlayer.releaseDH()
-            game.gameState.wasDhReleased = true
-            gamePlayerRepository.save(outgoingPlayer)
-        }
-
-        outgoingPlayer.exitGame(game.currentInning)
-        gamePlayerRepository.save(outgoingPlayer)
-
-        incomingPlayer.enterAsSubstitute(
-            inning = game.currentInning,
-            newPosition = request.newPosition,
-            newBattingOrder = request.newBattingOrder,
-        )
-        gamePlayerRepository.save(incomingPlayer)
-
-        val halfInning = if (game.isTopInning) "초" else "말"
-        val dhReleaseNote = if (dhReleaseRequired) " (DH 규칙 해제)" else ""
-        val description =
-            "${game.currentInning}회$halfInning: ${outgoingPlayer.player.name} → ${incomingPlayer.player.name} (${request.newPosition.displayName})$dhReleaseNote"
-
-        val substitutionEvent =
-            GameEvent.createSubstitution(
-                game = game,
-                incomingPlayer = incomingPlayer,
-                outgoingPlayer = outgoingPlayer,
-                description = description,
-            )
-
-        return gameEventRepository.save(substitutionEvent)
-    }
-
-    private fun findGame(id: Long): Game =
-        gameRepository.findByIdOrNull(id)
-            ?: throw GameNotFoundException(id)
-}
-=======
-package com.nextup.infrastructure.service.game
-
-import com.nextup.common.exception.GameNotFoundException
-import com.nextup.common.exception.GamePlayerNotFoundException
-import com.nextup.common.exception.InvalidGameStateException
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
@@ -158,8 +41,10 @@ class GameSubstitutionServiceImpl(
     override fun substitutePlayer(
         gameId: Long,
         request: SubstitutionRequest,
+        scorerId: Long,
     ): GameEvent {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
 
         if (game.status != GameStatus.IN_PROGRESS) {
             throw InvalidGameStateException(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameUndoServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameUndoServiceImpl.kt
@@ -36,8 +36,12 @@ class GameUndoServiceImpl(
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional
-    override fun undoLastEvent(gameId: Long): GameEvent {
+    override fun undoLastEvent(
+        gameId: Long,
+        scorerId: Long,
+    ): GameEvent {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
 
         if (!game.canUndo()) {
             throw UndoNotAvailableException(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/PlateAppearanceRecordServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/PlateAppearanceRecordServiceImpl.kt
@@ -49,8 +49,10 @@ class PlateAppearanceRecordServiceImpl(
     override fun recordPlateAppearance(
         gameId: Long,
         request: PlateAppearanceRequest,
+        scorerId: Long,
     ): PlateAppearanceRecordResult {
         val game = findGame(gameId)
+        game.validateScorer(scorerId)
 
         if (game.status != GameStatus.IN_PROGRESS) {
             throw InvalidGameStateException("진행 중인 경기만 타석 기록을 입력할 수 있습니다. 현재 상태: ${game.status.displayName}")

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplSuspendTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplSuspendTest.kt
@@ -65,7 +65,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = service.suspendGame(1L, "우천 중단")
+            val result = service.suspendGame(1L, "우천 중단", 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.SUSPENDED)
@@ -80,7 +80,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = service.suspendGame(1L, null)
+            val result = service.suspendGame(1L, null, 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.SUSPENDED)
@@ -93,7 +93,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { service.suspendGame(1L, "중단 사유") }
+            assertThatThrownBy { service.suspendGame(1L, "중단 사유", 999L) }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("진행 중인 경기만 중단할 수 있습니다")
         }
@@ -105,7 +105,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { service.suspendGame(1L, "중단 사유") }
+            assertThatThrownBy { service.suspendGame(1L, "중단 사유", 999L) }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("진행 중인 경기만 중단할 수 있습니다")
         }
@@ -116,7 +116,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.findByIdOrNull(999L) } returns null
 
             // when & then
-            assertThatThrownBy { service.suspendGame(999L, "중단 사유") }
+            assertThatThrownBy { service.suspendGame(999L, "중단 사유", 999L) }
                 .isInstanceOf(GameNotFoundException::class.java)
         }
     }
@@ -132,7 +132,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = service.resumeGame(1L)
+            val result = service.resumeGame(1L, 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.IN_PROGRESS)
@@ -146,7 +146,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { service.resumeGame(1L) }
+            assertThatThrownBy { service.resumeGame(1L, 999L) }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("중단된 경기만 재개할 수 있습니다")
         }
@@ -158,7 +158,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { service.resumeGame(1L) }
+            assertThatThrownBy { service.resumeGame(1L, 999L) }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("중단된 경기만 재개할 수 있습니다")
         }
@@ -169,7 +169,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.findByIdOrNull(999L) } returns null
 
             // when & then
-            assertThatThrownBy { service.resumeGame(999L) }
+            assertThatThrownBy { service.resumeGame(999L, 999L) }
                 .isInstanceOf(GameNotFoundException::class.java)
         }
     }
@@ -185,7 +185,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = service.cancelGame(1L, "경기 취소")
+            val result = service.cancelGame(1L, "경기 취소", 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.CANCELLED)
@@ -199,7 +199,7 @@ class GameLifecycleServiceImplSuspendTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { service.cancelGame(1L, "사유") }
+            assertThatThrownBy { service.cancelGame(1L, "사유", 999L) }
                 .isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("예정, 연기, 또는 중단 상태의 경기만 취소할 수 있습니다")
         }
@@ -295,6 +295,7 @@ class GameLifecycleServiceImplSuspendTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
+            scorerId = 999L,
             id = id,
         )
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceBaseRunningTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceBaseRunningTest.kt
@@ -83,7 +83,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when
-            val result = baseRunningRecordService.recordBaseRunning(1L, request)
+            val result = baseRunningRecordService.recordBaseRunning(1L, request, 999L)
 
             // then
             assertThat(result.eventType).isEqualTo(GameEventType.BASE_RUNNING)
@@ -115,7 +115,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when
-            val result = baseRunningRecordService.recordBaseRunning(1L, request)
+            val result = baseRunningRecordService.recordBaseRunning(1L, request, 999L)
 
             // then
             assertThat(result.eventType).isEqualTo(GameEventType.BASE_RUNNING)
@@ -150,7 +150,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when
-            val result = baseRunningRecordService.recordBaseRunning(1L, request)
+            val result = baseRunningRecordService.recordBaseRunning(1L, request, 999L)
 
             // then
             assertThat(result.eventType).isEqualTo(GameEventType.BASE_RUNNING)
@@ -183,7 +183,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when
-            val result = baseRunningRecordService.recordBaseRunning(1L, request)
+            val result = baseRunningRecordService.recordBaseRunning(1L, request, 999L)
 
             // then
             assertThat(result.eventType).isEqualTo(GameEventType.BASE_RUNNING)
@@ -215,7 +215,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when
-            val result = baseRunningRecordService.recordBaseRunning(1L, request)
+            val result = baseRunningRecordService.recordBaseRunning(1L, request, 999L)
 
             // then
             assertThat(result.eventType).isEqualTo(GameEventType.BASE_RUNNING)
@@ -243,7 +243,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when
-            val result = baseRunningRecordService.recordBaseRunning(1L, request)
+            val result = baseRunningRecordService.recordBaseRunning(1L, request, 999L)
 
             // then
             assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.ADVANCED_ON_ERROR)
@@ -270,7 +270,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when
-            val result = baseRunningRecordService.recordBaseRunning(1L, request)
+            val result = baseRunningRecordService.recordBaseRunning(1L, request, 999L)
 
             // then
             assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.ADVANCED_ON_PASSED_BALL)
@@ -297,7 +297,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when
-            val result = baseRunningRecordService.recordBaseRunning(1L, request)
+            val result = baseRunningRecordService.recordBaseRunning(1L, request, 999L)
 
             // then
             assertThat(result.baseRunningResult).isEqualTo(BaseRunningResult.ADVANCED_ON_BALK)
@@ -323,7 +323,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when & then
-            assertThatThrownBy { baseRunningRecordService.recordBaseRunning(999L, request) }
+            assertThatThrownBy { baseRunningRecordService.recordBaseRunning(999L, request, 999L) }
                 .isInstanceOf(GameNotFoundException::class.java)
         }
 
@@ -342,7 +342,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when & then
-            assertThatThrownBy { baseRunningRecordService.recordBaseRunning(1L, request) }
+            assertThatThrownBy { baseRunningRecordService.recordBaseRunning(1L, request, 999L) }
                 .isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("진행 중인 경기만 주루 기록을 입력할 수 있습니다")
         }
@@ -363,7 +363,7 @@ class GameScorerServiceBaseRunningTest {
                 )
 
             // when & then
-            assertThatThrownBy { baseRunningRecordService.recordBaseRunning(1L, request) }
+            assertThatThrownBy { baseRunningRecordService.recordBaseRunning(1L, request, 999L) }
                 .isInstanceOf(GamePlayerNotFoundException::class.java)
         }
     }
@@ -451,6 +451,7 @@ class GameScorerServiceBaseRunningTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
+            scorerId = 999L,
             id = id,
         )
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceConcurrencyTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceConcurrencyTest.kt
@@ -120,7 +120,7 @@ class GameScorerServiceConcurrencyTest {
                 executor.submit {
                     latch.await()
                     try {
-                        gameLifecycleService.startGame(1L)
+                        gameLifecycleService.startGame(1L, 999L)
                         successCount.incrementAndGet()
                     } catch (e: Exception) {
                         failCount.incrementAndGet()
@@ -167,7 +167,7 @@ class GameScorerServiceConcurrencyTest {
                     latch.await()
                     try {
                         val request = createStrikeoutRequest(batterId = 10L, pitcherId = 20L)
-                        plateAppearanceRecordService.recordPlateAppearance(1L, request)
+                        plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
                         successCount.incrementAndGet()
                     } catch (e: Exception) {
                         failCount.incrementAndGet()
@@ -210,7 +210,7 @@ class GameScorerServiceConcurrencyTest {
                 executor.submit {
                     latch.await()
                     try {
-                        gameLifecycleService.advanceHalfInning(1L)
+                        gameLifecycleService.advanceHalfInning(1L, 999L)
                         successCount.incrementAndGet()
                     } catch (e: Exception) {
                         // 상태 오류는 허용됨
@@ -255,7 +255,7 @@ class GameScorerServiceConcurrencyTest {
             executor.submit {
                 latch.await()
                 try {
-                    gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+                    gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
                     endSucceeded.incrementAndGet()
                 } catch (e: Exception) {
                     // ignore
@@ -267,7 +267,7 @@ class GameScorerServiceConcurrencyTest {
                 latch.await()
                 try {
                     val request = createSingleRequest(batterId = 10L, pitcherId = 20L)
-                    plateAppearanceRecordService.recordPlateAppearance(1L, request)
+                    plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
                     recordSucceeded.incrementAndGet()
                 } catch (e: InvalidGameStateException) {
                     // 경기 종료 후 타석 기록 시도는 정상적인 실패
@@ -384,7 +384,7 @@ class GameScorerServiceConcurrencyTest {
             executor.submit {
                 latch.await()
                 try {
-                    gameLifecycleService.forfeitGame(1L, winnerTeamId = 10L, reason = "원정팀 불참")
+                    gameLifecycleService.forfeitGame(1L, winnerTeamId = 10L, reason = "원정팀 불참", scorerId = 999L)
                 } catch (e: Exception) {
                     // ignore
                 }
@@ -393,7 +393,7 @@ class GameScorerServiceConcurrencyTest {
             executor.submit {
                 latch.await()
                 try {
-                    gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+                    gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
                 } catch (e: Exception) {
                     // ignore
                 }
@@ -553,7 +553,7 @@ class GameScorerServiceConcurrencyTest {
             executor.submit {
                 latch.await()
                 try {
-                    gameUndoService.undoLastEvent(1L)
+                    gameUndoService.undoLastEvent(1L, 999L)
                     undoSucceeded.incrementAndGet()
                 } catch (e: Exception) {
                     // ignore
@@ -565,7 +565,7 @@ class GameScorerServiceConcurrencyTest {
                 latch.await()
                 try {
                     val request = createSingleRequest(batterId = 10L, pitcherId = 20L)
-                    plateAppearanceRecordService.recordPlateAppearance(1L, request)
+                    plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
                     recordSucceeded.incrementAndGet()
                 } catch (e: Exception) {
                     // ignore
@@ -601,7 +601,7 @@ class GameScorerServiceConcurrencyTest {
                 executor.submit {
                     latch.await()
                     try {
-                        gameLifecycleService.startGame(999L)
+                        gameLifecycleService.startGame(999L, 999L)
                     } catch (e: GameNotFoundException) {
                         notFoundCount.incrementAndGet()
                     } catch (e: Exception) {
@@ -792,7 +792,7 @@ class GameScorerServiceConcurrencyTest {
                     latch.await()
                     try {
                         val request = createSingleRequest(batterId = 10L, pitcherId = 20L)
-                        plateAppearanceRecordService.recordPlateAppearance(1L, request)
+                        plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
                         successCount.incrementAndGet()
                     } catch (e: InvalidGameStateException) {
                         // 3아웃 초과 등 예상 가능한 상태 오류는 정상
@@ -931,6 +931,7 @@ class GameScorerServiceConcurrencyTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
+            scorerId = 999L,
             id = id,
         )
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceEventPublishingTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceEventPublishingTest.kt
@@ -106,7 +106,7 @@ class GameScorerServiceEventPublishingTest {
                 )
 
             // when
-            plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             val eventSlot = slot<PlateAppearanceRecordedEvent>()
@@ -139,7 +139,7 @@ class GameScorerServiceEventPublishingTest {
                 )
 
             // when
-            plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             val eventSlot = slot<PlateAppearanceRecordedEvent>()
@@ -170,7 +170,7 @@ class GameScorerServiceEventPublishingTest {
                 )
 
             // when
-            plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             verify { eventPublisher.publishEvent(any<PlateAppearanceRecordedEvent>()) }
@@ -199,7 +199,7 @@ class GameScorerServiceEventPublishingTest {
                 )
 
             // when
-            plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             val eventSlot = slot<PlateAppearanceRecordedEvent>()
@@ -247,7 +247,7 @@ class GameScorerServiceEventPublishingTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameUndoService.undoLastEvent(1L)
+            gameUndoService.undoLastEvent(1L, 999L)
 
             // then
             val eventSlot = slot<PlateAppearanceUndoneEvent>()
@@ -297,7 +297,7 @@ class GameScorerServiceEventPublishingTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameUndoService.undoLastEvent(1L)
+            gameUndoService.undoLastEvent(1L, 999L)
 
             // then
             val eventSlot = slot<PlateAppearanceUndoneEvent>()
@@ -333,7 +333,7 @@ class GameScorerServiceEventPublishingTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameUndoService.undoLastEvent(1L)
+            gameUndoService.undoLastEvent(1L, 999L)
 
             // then - PlateAppearanceUndoneEvent 는 발행되지 않아야 함
             verify(exactly = 0) { eventPublisher.publishEvent(any<PlateAppearanceUndoneEvent>()) }
@@ -362,7 +362,7 @@ class GameScorerServiceEventPublishingTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameUndoService.undoLastEvent(1L)
+            gameUndoService.undoLastEvent(1L, 999L)
 
             // then
             verify(exactly = 0) { eventPublisher.publishEvent(any<PlateAppearanceUndoneEvent>()) }
@@ -394,7 +394,7 @@ class GameScorerServiceEventPublishingTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameUndoService.undoLastEvent(1L)
+            gameUndoService.undoLastEvent(1L, 999L)
 
             // then - plateAppearanceResult가 null이므로 이벤트 발행 안 됨
             verify(exactly = 0) { eventPublisher.publishEvent(any<PlateAppearanceUndoneEvent>()) }
@@ -520,6 +520,7 @@ class GameScorerServiceEventPublishingTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
+            scorerId = 999L,
             id = id,
         )
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceImplTest.kt
@@ -104,7 +104,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameLifecycleService.startGame(1L)
+            val result = gameLifecycleService.startGame(1L, 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.IN_PROGRESS)
@@ -119,7 +119,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.findByIdOrNull(999L) } returns null
 
             // when & then
-            assertThatThrownBy { gameLifecycleService.startGame(999L) }
+            assertThatThrownBy { gameLifecycleService.startGame(999L, 999L) }
                 .isInstanceOf(GameNotFoundException::class.java)
         }
     }
@@ -139,7 +139,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameLifecycleService.advanceHalfInning(1L)
+            val result = gameLifecycleService.advanceHalfInning(1L, 999L)
 
             // then
             assertThat(result.isTopInning).isFalse()
@@ -153,7 +153,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { gameLifecycleService.advanceHalfInning(1L) }
+            assertThatThrownBy { gameLifecycleService.advanceHalfInning(1L, 999L) }
                 .isInstanceOf(InvalidGameStateException::class.java)
         }
     }
@@ -170,7 +170,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+            val result = gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.FINISHED)
@@ -186,7 +186,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameLifecycleService.endGame(1L, GameEndReason.MERCY_RULE)
+            val result = gameLifecycleService.endGame(1L, GameEndReason.MERCY_RULE, 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.CALLED)
@@ -202,7 +202,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameLifecycleService.endGame(1L, GameEndReason.WEATHER)
+            val result = gameLifecycleService.endGame(1L, GameEndReason.WEATHER, 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.CALLED)
@@ -215,7 +215,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { gameLifecycleService.endGame(1L, GameEndReason.FORFEIT) }
+            assertThatThrownBy { gameLifecycleService.endGame(1L, GameEndReason.FORFEIT, 999L) }
                 .isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("몰수 처리는 전용 API를 사용해주세요")
         }
@@ -229,7 +229,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameLifecycleService.endGame(1L, GameEndReason.OTHER)
+            val result = gameLifecycleService.endGame(1L, GameEndReason.OTHER, 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.CALLED)
@@ -242,7 +242,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { gameLifecycleService.endGame(1L, GameEndReason.REGULATION) }
+            assertThatThrownBy { gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L) }
                 .isInstanceOf(InvalidGameStateException::class.java)
         }
 
@@ -269,7 +269,7 @@ class GameScorerServiceImplTest {
             every { eventPublisher.publishEvent(capture(eventSlot)) } returns Unit
 
             // when
-            gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+            gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
 
             // then
             verify(exactly = 1) { eventPublisher.publishEvent(any<GameResultConfirmedEvent>()) }
@@ -302,7 +302,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when & then
-            assertThatThrownBy { plateAppearanceRecordService.recordPlateAppearance(1L, request) }
+            assertThatThrownBy { plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L) }
                 .isInstanceOf(InvalidGameStateException::class.java)
         }
 
@@ -325,7 +325,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when & then
-            assertThatThrownBy { plateAppearanceRecordService.recordPlateAppearance(1L, request) }
+            assertThatThrownBy { plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L) }
                 .isInstanceOf(GamePlayerNotFoundException::class.java)
         }
 
@@ -350,7 +350,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when & then
-            assertThatThrownBy { plateAppearanceRecordService.recordPlateAppearance(1L, request) }
+            assertThatThrownBy { plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L) }
                 .isInstanceOf(GamePlayerNotFoundException::class.java)
         }
 
@@ -377,7 +377,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.game.gameState.runnerOnFirstId).isEqualTo(10L)
@@ -407,7 +407,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.game.gameState.runnerOnSecondId).isEqualTo(10L)
@@ -436,7 +436,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.game.gameState.runnerOnThirdId).isEqualTo(10L)
@@ -465,7 +465,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             verify {
@@ -504,7 +504,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.game.gameState.runnerOnFirstId).isEqualTo(10L)
@@ -533,7 +533,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.game.gameState.outs).isEqualTo(1)
@@ -573,7 +573,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             verify {
@@ -625,7 +625,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.game.gameState.outs).isEqualTo(1)
@@ -665,7 +665,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.game.gameState.runnerOnThirdId).isEqualTo(5L)
@@ -699,7 +699,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.warnings).isEmpty()
@@ -732,7 +732,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.warnings).isNotEmpty()
@@ -767,7 +767,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.warnings).isNotEmpty()
@@ -801,7 +801,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.warnings).isNotEmpty()
@@ -835,7 +835,7 @@ class GameScorerServiceImplTest {
                 )
 
             // when
-            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request)
+            val result = plateAppearanceRecordService.recordPlateAppearance(1L, request, 999L)
 
             // then
             assertThat(result.warnings).isEmpty()
@@ -865,8 +865,8 @@ class GameScorerServiceImplTest {
                     gameId = 1L,
                     winnerTeamId = 10L,
                     reason = "상대팀 불참",
+                    scorerId = 999L,
                 )
-
             // then
             assertThat(result.status).isEqualTo(GameStatus.FORFEITED)
             assertThat(result.forfeitReason).isEqualTo("상대팀 불참")
@@ -898,8 +898,8 @@ class GameScorerServiceImplTest {
                     gameId = 1L,
                     winnerTeamId = 20L,
                     reason = "홈팀 규정 위반",
+                    scorerId = 999L,
                 )
-
             // then
             assertThat(result.status).isEqualTo(GameStatus.FORFEITED)
             assertThat(result.forfeitReason).isEqualTo("홈팀 규정 위반")
@@ -918,6 +918,7 @@ class GameScorerServiceImplTest {
                     gameId = 1L,
                     winnerTeamId = 10L,
                     reason = "사유",
+                    scorerId = 999L,
                 )
             }.isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("예정 또는 진행 중인 경기만 몰수 처리할 수 있습니다")
@@ -935,6 +936,7 @@ class GameScorerServiceImplTest {
                     gameId = 1L,
                     winnerTeamId = 10L,
                     reason = "사유",
+                    scorerId = 999L,
                 )
             }.isInstanceOf(InvalidGameStateException::class.java)
         }
@@ -950,6 +952,7 @@ class GameScorerServiceImplTest {
                     gameId = 999L,
                     winnerTeamId = 10L,
                     reason = "사유",
+                    scorerId = 999L,
                 )
             }.isInstanceOf(GameNotFoundException::class.java)
         }
@@ -971,6 +974,7 @@ class GameScorerServiceImplTest {
                     gameId = 1L,
                     winnerTeamId = 10L,
                     reason = "사유",
+                    scorerId = 999L,
                 )
             }.isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("정확히 2개의 팀이 필요합니다")
@@ -1028,7 +1032,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+            gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
 
             // then
             verify { winnerPitcher.assignWin() }
@@ -1050,7 +1054,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+            gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
 
             // then
             verify(exactly = 0) { pitchingRecordRepository.save(any()) }
@@ -1076,7 +1080,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+            gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
 
             // then
             verify(exactly = 0) { pitchingRecordRepository.save(any()) }
@@ -1105,7 +1109,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+            gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
 
             // then - 무승부이므로 PitchingDecisionService가 투수 결정을 부여하지 않음
             // → save 호출 없음
@@ -1127,7 +1131,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+            gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
 
             // then
             verify(exactly = 0) { pitchingRecordRepository.save(any()) }
@@ -1148,7 +1152,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+            gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
 
             // then
             verify(exactly = 0) { pitchingRecordRepository.save(any()) }
@@ -1216,7 +1220,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+            gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
 
             // then
             verify { homeStarter.assignWin() }
@@ -1272,7 +1276,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameLifecycleService.endGame(1L, GameEndReason.MERCY_RULE)
+            gameLifecycleService.endGame(1L, GameEndReason.MERCY_RULE, 999L)
 
             // then
             verify { winnerPitcher.assignWin() }
@@ -1327,7 +1331,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameLifecycleService.endGame(1L, GameEndReason.REGULATION)
+            gameLifecycleService.endGame(1L, GameEndReason.REGULATION, 999L)
 
             // then - winnerTeam==homeTeam → loserTeam==awayTeam
             verify { winnerPitcher.assignWin() }
@@ -1347,7 +1351,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameLifecycleService.cancelGame(1L, "우천 취소")
+            val result = gameLifecycleService.cancelGame(1L, "우천 취소", 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.CANCELLED)
@@ -1363,7 +1367,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameLifecycleService.cancelGame(1L, "대회 취소")
+            val result = gameLifecycleService.cancelGame(1L, "대회 취소", 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.CANCELLED)
@@ -1379,7 +1383,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameLifecycleService.cancelGame(1L, null)
+            val result = gameLifecycleService.cancelGame(1L, null, 999L)
 
             // then
             assertThat(result.status).isEqualTo(GameStatus.CANCELLED)
@@ -1393,7 +1397,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { gameLifecycleService.cancelGame(1L, "사유") }
+            assertThatThrownBy { gameLifecycleService.cancelGame(1L, "사유", 999L) }
                 .isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("예정, 연기, 또는 중단 상태의 경기만 취소할 수 있습니다")
         }
@@ -1405,7 +1409,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { gameLifecycleService.cancelGame(1L, "사유") }
+            assertThatThrownBy { gameLifecycleService.cancelGame(1L, "사유", 999L) }
                 .isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("예정, 연기, 또는 중단 상태의 경기만 취소할 수 있습니다")
         }
@@ -1416,7 +1420,7 @@ class GameScorerServiceImplTest {
             every { gameRepository.findByIdOrNull(999L) } returns null
 
             // when & then
-            assertThatThrownBy { gameLifecycleService.cancelGame(999L, "사유") }
+            assertThatThrownBy { gameLifecycleService.cancelGame(999L, "사유", 999L) }
                 .isInstanceOf(GameNotFoundException::class.java)
         }
 
@@ -1431,7 +1435,7 @@ class GameScorerServiceImplTest {
             every { eventPublisher.publishEvent(capture(eventSlot)) } returns Unit
 
             // when
-            gameLifecycleService.cancelGame(1L, "우천 취소")
+            gameLifecycleService.cancelGame(1L, "우천 취소", 999L)
 
             // then
             verify(exactly = 1) { eventPublisher.publishEvent(any<GameCancelledEvent>()) }
@@ -1560,6 +1564,7 @@ class GameScorerServiceImplTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
+            scorerId = 999L,
             id = id,
         )
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
@@ -96,7 +96,7 @@ class GameScorerServiceSubstitutionTest {
                 )
 
             // when
-            val result = gameSubstitutionService.substitutePlayer(1L, request)
+            val result = gameSubstitutionService.substitutePlayer(1L, request, 999L)
 
             // then
             assertThat(result).isNotNull()
@@ -137,7 +137,7 @@ class GameScorerServiceSubstitutionTest {
                 )
 
             // when
-            val result = gameSubstitutionService.substitutePlayer(1L, request)
+            val result = gameSubstitutionService.substitutePlayer(1L, request, 999L)
 
             // then
             assertThat(result.eventType).isEqualTo(GameEventType.SUBSTITUTION)
@@ -171,7 +171,7 @@ class GameScorerServiceSubstitutionTest {
 
             // when & then
             assertThatThrownBy {
-                gameSubstitutionService.substitutePlayer(1L, request)
+                gameSubstitutionService.substitutePlayer(1L, request, 999L)
             }.isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("이미 퇴장한 선수")
         }
@@ -197,7 +197,7 @@ class GameScorerServiceSubstitutionTest {
 
             // when & then
             assertThatThrownBy {
-                gameSubstitutionService.substitutePlayer(1L, request)
+                gameSubstitutionService.substitutePlayer(1L, request, 999L)
             }.isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("진행 중인 경기만 선수 교체")
         }
@@ -218,7 +218,7 @@ class GameScorerServiceSubstitutionTest {
 
             // when & then
             assertThatThrownBy {
-                gameSubstitutionService.substitutePlayer(999L, request)
+                gameSubstitutionService.substitutePlayer(999L, request, 999L)
             }.isInstanceOf(GameNotFoundException::class.java)
         }
 
@@ -240,7 +240,7 @@ class GameScorerServiceSubstitutionTest {
 
             // when & then
             assertThatThrownBy {
-                gameSubstitutionService.substitutePlayer(1L, request)
+                gameSubstitutionService.substitutePlayer(1L, request, 999L)
             }.isInstanceOf(GamePlayerNotFoundException::class.java)
         }
 
@@ -264,7 +264,7 @@ class GameScorerServiceSubstitutionTest {
 
             // when & then
             assertThatThrownBy {
-                gameSubstitutionService.substitutePlayer(1L, request)
+                gameSubstitutionService.substitutePlayer(1L, request, 999L)
             }.isInstanceOf(GamePlayerNotFoundException::class.java)
         }
 
@@ -290,7 +290,7 @@ class GameScorerServiceSubstitutionTest {
 
             // when & then
             assertThatThrownBy {
-                gameSubstitutionService.substitutePlayer(1L, request)
+                gameSubstitutionService.substitutePlayer(1L, request, 999L)
             }.isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("현재 출전 중인 선수만 교체")
         }
@@ -326,7 +326,7 @@ class GameScorerServiceSubstitutionTest {
                 )
 
             // when
-            gameSubstitutionService.substitutePlayer(1L, request)
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
 
             // then - DH 해제 후 퇴장 처리
             assertThat(dhPlayer.isDesignatedHitter).isFalse()
@@ -364,7 +364,7 @@ class GameScorerServiceSubstitutionTest {
                 )
 
             // when
-            gameSubstitutionService.substitutePlayer(1L, request)
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
 
             // then
             assertThat(capturedEvent).isNotNull()
@@ -400,7 +400,7 @@ class GameScorerServiceSubstitutionTest {
                 )
 
             // when
-            gameSubstitutionService.substitutePlayer(1L, request)
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
 
             // then
             assertThat(capturedEvent).isNotNull()
@@ -429,7 +429,7 @@ class GameScorerServiceSubstitutionTest {
 
             // when & then
             assertThatThrownBy {
-                gameSubstitutionService.substitutePlayer(1L, request)
+                gameSubstitutionService.substitutePlayer(1L, request, 999L)
             }.isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("DH 타순")
         }
@@ -488,6 +488,7 @@ class GameScorerServiceSubstitutionTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
+            scorerId = 999L,
             id = id,
         )
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceUndoTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceUndoTest.kt
@@ -100,7 +100,7 @@ class GameScorerServiceUndoTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameUndoService.undoLastEvent(1L)
+            val result = gameUndoService.undoLastEvent(1L, 999L)
 
             // then
             assertThat(result.undone).isTrue()
@@ -151,7 +151,7 @@ class GameScorerServiceUndoTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameUndoService.undoLastEvent(1L)
+            val result = gameUndoService.undoLastEvent(1L, 999L)
 
             // then
             assertThat(result.undone).isTrue()
@@ -202,7 +202,7 @@ class GameScorerServiceUndoTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameUndoService.undoLastEvent(1L)
+            gameUndoService.undoLastEvent(1L, 999L)
 
             // then
             assertThat(game.gameState.outs).isEqualTo(0) // 아웃 카운트 복원
@@ -218,7 +218,7 @@ class GameScorerServiceUndoTest {
             every { gameRepository.findByIdOrNull(1L) } returns game
 
             // when & then
-            assertThatThrownBy { gameUndoService.undoLastEvent(1L) }
+            assertThatThrownBy { gameUndoService.undoLastEvent(1L, 999L) }
                 .isInstanceOf(UndoNotAvailableException::class.java)
         }
 
@@ -230,7 +230,7 @@ class GameScorerServiceUndoTest {
             every { gameEventRepository.findLastActiveEvent(1L) } returns null
 
             // when & then
-            assertThatThrownBy { gameUndoService.undoLastEvent(1L) }
+            assertThatThrownBy { gameUndoService.undoLastEvent(1L, 999L) }
                 .isInstanceOf(NoEventToUndoException::class.java)
         }
 
@@ -273,7 +273,7 @@ class GameScorerServiceUndoTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when - 첫 번째 Undo
-            gameUndoService.undoLastEvent(1L)
+            gameUndoService.undoLastEvent(1L, 999L)
 
             // then
             assertThat(event2.undone).isTrue()
@@ -311,7 +311,7 @@ class GameScorerServiceUndoTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            gameUndoService.undoLastEvent(1L)
+            gameUndoService.undoLastEvent(1L, 999L)
 
             // then
             assertThat(event.undone).isTrue()
@@ -343,7 +343,7 @@ class GameScorerServiceUndoTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameUndoService.undoLastEvent(1L)
+            val result = gameUndoService.undoLastEvent(1L, 999L)
 
             // then
             assertThat(result.undone).isTrue()
@@ -375,7 +375,7 @@ class GameScorerServiceUndoTest {
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
-            val result = gameUndoService.undoLastEvent(1L)
+            val result = gameUndoService.undoLastEvent(1L, 999L)
 
             // then
             assertThat(result.undone).isTrue()
@@ -505,6 +505,7 @@ class GameScorerServiceUndoTest {
             isTopInning = true,
             totalInnings = 9,
             gameState = GameState(),
+            scorerId = 999L,
             id = id,
         )
     }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -46,6 +46,7 @@ import org.springframework.web.bind.annotation.RestController
  * 기록원 전용 경기 기록 컨트롤러
  *
  * 실시간 경기 기록 입력 및 경기 상태 조회를 위한 API를 제공합니다.
+ * 모든 기록(POST) API는 scorerId 파라미터를 통해 기록원 독점 잠금 검증을 수행합니다.
  * GET 엔드포인트는 기록원 재접속 시 현재 상태를 복원하거나,
  * WebSocket 단절 시 REST fallback으로 활용됩니다.
  */
@@ -158,65 +159,80 @@ class GameScorerController(
 
     /**
      * 경기를 시작합니다.
+     *
+     * 경기를 잠금한 기록원만 시작할 수 있습니다.
      */
     @PostMapping("/{gameId}/start")
     @ResponseStatus(HttpStatus.OK)
     fun startGame(
         @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
     ): ApiResponse<GameResponse> {
-        val game = gameLifecycleService.startGame(gameId)
+        val game = gameLifecycleService.startGame(gameId, scorerId)
         return ApiResponse.success(game.toResponse())
     }
 
     /**
      * 타석 결과를 입력합니다.
      *
+     * 경기를 잠금한 기록원만 기록할 수 있습니다.
      * 응답에 경고 메시지(투구 수 경고, 타순 위반 경고)가 포함될 수 있습니다.
      */
     @PostMapping("/{gameId}/plate-appearances")
     @ResponseStatus(HttpStatus.OK)
     fun recordPlateAppearance(
         @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
         @RequestBody @Valid request: PlateAppearanceRequestDto,
     ): ApiResponse<GameResponse> {
-        val result = plateAppearanceRecordService.recordPlateAppearance(gameId, request.toDomain())
+        val result =
+            plateAppearanceRecordService.recordPlateAppearance(gameId, request.toDomain(), scorerId)
         return ApiResponse.success(result.game.toResponse(warnings = result.warnings))
     }
 
     /**
      * 반 이닝을 진행합니다 (공수 교대).
+     *
+     * 경기를 잠금한 기록원만 진행할 수 있습니다.
      */
     @PostMapping("/{gameId}/half-inning")
     @ResponseStatus(HttpStatus.OK)
     fun advanceHalfInning(
         @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
     ): ApiResponse<GameResponse> {
-        val game = gameLifecycleService.advanceHalfInning(gameId)
+        val game = gameLifecycleService.advanceHalfInning(gameId, scorerId)
         return ApiResponse.success(game.toResponse())
     }
 
     /**
      * 경기를 종료합니다.
+     *
+     * 경기를 잠금한 기록원만 종료할 수 있습니다.
      */
     @PostMapping("/{gameId}/end")
     @ResponseStatus(HttpStatus.OK)
     fun endGame(
         @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
         @RequestBody @Valid request: GameEndRequestDto,
     ): ApiResponse<GameResponse> {
-        val game = gameLifecycleService.endGame(gameId, request.reason!!)
+        val game = gameLifecycleService.endGame(gameId, request.reason!!, scorerId)
         return ApiResponse.success(game.toResponse())
     }
 
     /**
      * 마지막 이벤트를 되돌립니다 (Undo).
+     *
+     * 경기를 잠금한 기록원만 되돌릴 수 있습니다.
      */
     @PostMapping("/{gameId}/undo")
     @ResponseStatus(HttpStatus.OK)
     fun undoLastEvent(
         @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
     ): ApiResponse<UndoResponse> {
-        val undoneEvent = gameUndoService.undoLastEvent(gameId)
+        val undoneEvent = gameUndoService.undoLastEvent(gameId, scorerId)
         val game = undoneEvent.game
         return ApiResponse.success(
             UndoResponse(
@@ -231,21 +247,24 @@ class GameScorerController(
     /**
      * 주루 플레이를 기록합니다.
      *
+     * 경기를 잠금한 기록원만 기록할 수 있습니다.
      * 도루, 도루 실패, 견제사, 폭투 진루 등 타석 외 주루 이벤트를 기록합니다.
      */
     @PostMapping("/{gameId}/base-running")
     @ResponseStatus(HttpStatus.OK)
     fun recordBaseRunning(
         @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
         @RequestBody @Valid request: BaseRunningRequestDto,
     ): ApiResponse<BaseRunningResponse> {
-        val event = baseRunningRecordService.recordBaseRunning(gameId, request.toDomain())
+        val event = baseRunningRecordService.recordBaseRunning(gameId, request.toDomain(), scorerId)
         return ApiResponse.success(event.toBaseRunningResponse())
     }
 
     /**
      * 경기를 몰수 처리합니다.
      *
+     * 경기를 잠금한 기록원만 몰수 처리할 수 있습니다.
      * 승리팀에 7점, 패배팀에 0점을 자동 반영하고 경기를 종료합니다.
      * 몰수 시점까지의 개인 타격/투구 기록은 공식 기록으로 유효합니다 (KBO/MLB 기준).
      */
@@ -253,6 +272,7 @@ class GameScorerController(
     @ResponseStatus(HttpStatus.OK)
     fun forfeitGame(
         @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
         @RequestBody @Valid request: ForfeitRequestDto,
     ): ApiResponse<GameResponse> {
         val game =
@@ -260,6 +280,7 @@ class GameScorerController(
                 gameId = gameId,
                 winnerTeamId = request.winnerTeamId!!,
                 reason = request.reason!!,
+                scorerId = scorerId,
             )
         return ApiResponse.success(game.toResponse())
     }
@@ -267,6 +288,7 @@ class GameScorerController(
     /**
      * 경기를 취소합니다.
      *
+     * 경기를 잠금한 기록원만 취소할 수 있습니다.
      * 예정(SCHEDULED) 또는 연기(POSTPONED) 상태의 경기만 취소 가능합니다.
      * 취소된 경기에 실시간 반영된 시즌 타격/투구 통계는 자동으로 롤백됩니다.
      */
@@ -274,12 +296,14 @@ class GameScorerController(
     @ResponseStatus(HttpStatus.OK)
     fun cancelGame(
         @PathVariable gameId: Long,
-        @RequestBody request: CancelGameRequestDto = CancelGameRequestDto()
+        @RequestParam scorerId: Long,
+        @RequestBody request: CancelGameRequestDto = CancelGameRequestDto(),
     ): ApiResponse<GameResponse> {
         val game =
             gameLifecycleService.cancelGame(
                 gameId = gameId,
                 reason = request.reason,
+                scorerId = scorerId,
             )
         return ApiResponse.success(game.toResponse())
     }
@@ -287,6 +311,7 @@ class GameScorerController(
     /**
      * 경기를 중단합니다.
      *
+     * 경기를 잠금한 기록원만 중단할 수 있습니다.
      * 진행 중(IN_PROGRESS) 상태의 경기를 우천 등의 사유로 중단합니다.
      * 중단된 경기는 resume API로 재개할 수 있습니다.
      */
@@ -294,12 +319,14 @@ class GameScorerController(
     @ResponseStatus(HttpStatus.OK)
     fun suspendGame(
         @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
         @RequestBody request: SuspendGameRequestDto = SuspendGameRequestDto(),
     ): ApiResponse<GameResponse> {
         val game =
             gameLifecycleService.suspendGame(
                 gameId = gameId,
                 reason = request.reason,
+                scorerId = scorerId,
             )
         return ApiResponse.success(game.toResponse())
     }
@@ -307,20 +334,23 @@ class GameScorerController(
     /**
      * 중단된 경기를 재개합니다.
      *
+     * 경기를 잠금한 기록원만 재개할 수 있습니다.
      * SUSPENDED 상태의 경기를 중단 시점의 이닝/아웃/주자 상태부터 이어서 진행합니다.
      */
     @PostMapping("/{gameId}/resume")
     @ResponseStatus(HttpStatus.OK)
     fun resumeGame(
         @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
     ): ApiResponse<GameResponse> {
-        val game = gameLifecycleService.resumeGame(gameId = gameId)
+        val game = gameLifecycleService.resumeGame(gameId = gameId, scorerId = scorerId)
         return ApiResponse.success(game.toResponse())
     }
 
     /**
      * 선수를 교체합니다.
      *
+     * 경기를 잠금한 기록원만 교체할 수 있습니다.
      * 교체 이벤트를 기록하고 다음을 검증합니다:
      * - 퇴장한 선수의 재출전 방지
      * - DH 해제 규칙 (투수가 DH 타순으로만 교체 가능)
@@ -329,9 +359,11 @@ class GameScorerController(
     @ResponseStatus(HttpStatus.OK)
     fun substitutePlayer(
         @PathVariable gameId: Long,
+        @RequestParam scorerId: Long,
         @RequestBody @Valid request: SubstitutionRequestDto,
     ): ApiResponse<SubstitutionResponse> {
-        val event = gameSubstitutionService.substitutePlayer(gameId, request.toDomain())
+        val event =
+            gameSubstitutionService.substitutePlayer(gameId, request.toDomain(), scorerId)
         return ApiResponse.success(event.toSubstitutionResponse())
     }
 }

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
@@ -92,11 +92,12 @@ class BaseRunningControllerTest {
                 )
             val game = createGame(gameId, GameStatus.IN_PROGRESS)
             val event = createBaseRunningEvent(game, Base.FIRST, Base.SECOND, BaseRunningResult.STOLEN_BASE)
-            every { baseRunningRecordService.recordBaseRunning(gameId, any()) } returns event
+            every { baseRunningRecordService.recordBaseRunning(gameId, any(), any()) } returns event
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/base-running")
+                    .param("scorerId", "999")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -106,7 +107,7 @@ class BaseRunningControllerTest {
                 .andExpect(jsonPath("$.data.fromBase").value("FIRST"))
                 .andExpect(jsonPath("$.data.toBase").value("SECOND"))
 
-            verify(exactly = 1) { baseRunningRecordService.recordBaseRunning(gameId, any()) }
+            verify(exactly = 1) { baseRunningRecordService.recordBaseRunning(gameId, any(), any()) }
         }
 
         @Test
@@ -125,11 +126,12 @@ class BaseRunningControllerTest {
                     gameState.outs = 1
                 }
             val event = createBaseRunningEvent(game, Base.FIRST, Base.SECOND, BaseRunningResult.CAUGHT_STEALING)
-            every { baseRunningRecordService.recordBaseRunning(gameId, any()) } returns event
+            every { baseRunningRecordService.recordBaseRunning(gameId, any(), any()) } returns event
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/base-running")
+                    .param("scorerId", "999")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -137,7 +139,7 @@ class BaseRunningControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.result").value("CAUGHT_STEALING"))
 
-            verify(exactly = 1) { baseRunningRecordService.recordBaseRunning(gameId, any()) }
+            verify(exactly = 1) { baseRunningRecordService.recordBaseRunning(gameId, any(), any()) }
         }
 
         @Test
@@ -153,11 +155,12 @@ class BaseRunningControllerTest {
                 )
             val game = createGame(gameId, GameStatus.IN_PROGRESS)
             val event = createBaseRunningEvent(game, Base.SECOND, Base.SECOND, BaseRunningResult.PICKED_OFF)
-            every { baseRunningRecordService.recordBaseRunning(gameId, any()) } returns event
+            every { baseRunningRecordService.recordBaseRunning(gameId, any(), any()) } returns event
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/base-running")
+                    .param("scorerId", "999")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -165,7 +168,7 @@ class BaseRunningControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.result").value("PICKED_OFF"))
 
-            verify(exactly = 1) { baseRunningRecordService.recordBaseRunning(gameId, any()) }
+            verify(exactly = 1) { baseRunningRecordService.recordBaseRunning(gameId, any(), any()) }
         }
 
         @Test
@@ -181,11 +184,12 @@ class BaseRunningControllerTest {
                 )
             val game = createGame(gameId, GameStatus.IN_PROGRESS)
             val event = createBaseRunningEvent(game, Base.SECOND, Base.THIRD, BaseRunningResult.ADVANCED_ON_WILD_PITCH)
-            every { baseRunningRecordService.recordBaseRunning(gameId, any()) } returns event
+            every { baseRunningRecordService.recordBaseRunning(gameId, any(), any()) } returns event
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/base-running")
+                    .param("scorerId", "999")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -193,7 +197,7 @@ class BaseRunningControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.result").value("ADVANCED_ON_WILD_PITCH"))
 
-            verify(exactly = 1) { baseRunningRecordService.recordBaseRunning(gameId, any()) }
+            verify(exactly = 1) { baseRunningRecordService.recordBaseRunning(gameId, any(), any()) }
         }
 
         @Test
@@ -211,6 +215,7 @@ class BaseRunningControllerTest {
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/base-running")
+                    .param("scorerId", "999")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -98,15 +98,19 @@ class GameScorerControllerTest {
         fun `should start game successfully`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val game =
                 createGame(gameId, GameStatus.IN_PROGRESS).apply {
                     currentInning = 1
                     isTopInning = true
                 }
-            every { gameLifecycleService.startGame(gameId) } returns game
+            every { gameLifecycleService.startGame(gameId, scorerId) } returns game
 
             // when & then
-            mockMvc.perform(post("/api/scorer/games/$gameId/start"))
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/start")
+                    .param("scorerId", scorerId.toString()),
+            )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(gameId))
@@ -114,7 +118,7 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.data.currentInning").value(1))
                 .andExpect(jsonPath("$.data.isTopInning").value(true))
 
-            verify(exactly = 1) { gameLifecycleService.startGame(gameId) }
+            verify(exactly = 1) { gameLifecycleService.startGame(gameId, scorerId) }
         }
     }
 
@@ -126,6 +130,7 @@ class GameScorerControllerTest {
         fun `should record plate appearance with single hit`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val request =
                 PlateAppearanceRequestDto(
                     batterId = 10L,
@@ -142,12 +147,13 @@ class GameScorerControllerTest {
                     isTopInning = false
                     gameState.runnerOnFirstId = 10L
                 }
-            every { plateAppearanceRecordService.recordPlateAppearance(gameId, any()) } returns
+            every { plateAppearanceRecordService.recordPlateAppearance(gameId, any(), scorerId) } returns
                 PlateAppearanceRecordResult(game)
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/plate-appearances")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -157,13 +163,14 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
                 .andExpect(jsonPath("$.data.currentInning").value(3))
 
-            verify(exactly = 1) { plateAppearanceRecordService.recordPlateAppearance(gameId, any()) }
+            verify(exactly = 1) { plateAppearanceRecordService.recordPlateAppearance(gameId, any(), scorerId) }
         }
 
         @Test
         fun `should record plate appearance with runner movements`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val request =
                 PlateAppearanceRequestDto(
                     batterId = 10L,
@@ -189,12 +196,13 @@ class GameScorerControllerTest {
                     gameState.runnerOnSecondId = 10L
                     gameState.runnerOnThirdId = 5L
                 }
-            every { plateAppearanceRecordService.recordPlateAppearance(gameId, any()) } returns
+            every { plateAppearanceRecordService.recordPlateAppearance(gameId, any(), scorerId) } returns
                 PlateAppearanceRecordResult(game)
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/plate-appearances")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -204,13 +212,14 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.data.gameState.runnerOnSecondId").value(10))
                 .andExpect(jsonPath("$.data.gameState.runnerOnThirdId").value(5))
 
-            verify(exactly = 1) { plateAppearanceRecordService.recordPlateAppearance(gameId, any()) }
+            verify(exactly = 1) { plateAppearanceRecordService.recordPlateAppearance(gameId, any(), scorerId) }
         }
 
         @Test
         fun `should record strikeout`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val request =
                 PlateAppearanceRequestDto(
                     batterId = 10L,
@@ -227,12 +236,13 @@ class GameScorerControllerTest {
                     isTopInning = true
                     gameState.outs = 1
                 }
-            every { plateAppearanceRecordService.recordPlateAppearance(gameId, any()) } returns
+            every { plateAppearanceRecordService.recordPlateAppearance(gameId, any(), scorerId) } returns
                 PlateAppearanceRecordResult(game)
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/plate-appearances")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -240,7 +250,7 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.gameState.outs").value(1))
 
-            verify(exactly = 1) { plateAppearanceRecordService.recordPlateAppearance(gameId, any()) }
+            verify(exactly = 1) { plateAppearanceRecordService.recordPlateAppearance(gameId, any(), scorerId) }
         }
     }
 
@@ -252,16 +262,20 @@ class GameScorerControllerTest {
         fun `should advance to next half inning`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val game =
                 createGame(gameId, GameStatus.IN_PROGRESS).apply {
                     currentInning = 1
                     isTopInning = false // 1회말로 진행
                     gameState.resetForNewInning()
                 }
-            every { gameLifecycleService.advanceHalfInning(gameId) } returns game
+            every { gameLifecycleService.advanceHalfInning(gameId, scorerId) } returns game
 
             // when & then
-            mockMvc.perform(post("/api/scorer/games/$gameId/half-inning"))
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/half-inning")
+                    .param("scorerId", scorerId.toString()),
+            )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(gameId))
@@ -269,29 +283,33 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.data.isTopInning").value(false))
                 .andExpect(jsonPath("$.data.gameState.outs").value(0))
 
-            verify(exactly = 1) { gameLifecycleService.advanceHalfInning(gameId) }
+            verify(exactly = 1) { gameLifecycleService.advanceHalfInning(gameId, scorerId) }
         }
 
         @Test
         fun `should advance from bottom to next top inning`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val game =
                 createGame(gameId, GameStatus.IN_PROGRESS).apply {
                     currentInning = 2
                     isTopInning = true // 2회초로 진행
                     gameState.resetForNewInning()
                 }
-            every { gameLifecycleService.advanceHalfInning(gameId) } returns game
+            every { gameLifecycleService.advanceHalfInning(gameId, scorerId) } returns game
 
             // when & then
-            mockMvc.perform(post("/api/scorer/games/$gameId/half-inning"))
+            mockMvc.perform(
+                post("/api/scorer/games/$gameId/half-inning")
+                    .param("scorerId", scorerId.toString()),
+            )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.currentInning").value(2))
                 .andExpect(jsonPath("$.data.isTopInning").value(true))
 
-            verify(exactly = 1) { gameLifecycleService.advanceHalfInning(gameId) }
+            verify(exactly = 1) { gameLifecycleService.advanceHalfInning(gameId, scorerId) }
         }
     }
 
@@ -303,17 +321,19 @@ class GameScorerControllerTest {
         fun `should end game with regulation finish`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val request = GameEndRequestDto(reason = GameEndReason.REGULATION)
             val game =
                 createGame(gameId, GameStatus.FINISHED).apply {
                     currentInning = 9
                     isTopInning = false
                 }
-            every { gameLifecycleService.endGame(gameId, GameEndReason.REGULATION) } returns game
+            every { gameLifecycleService.endGame(gameId, GameEndReason.REGULATION, scorerId) } returns game
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/end")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -322,24 +342,26 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.data.id").value(gameId))
                 .andExpect(jsonPath("$.data.status").value("FINISHED"))
 
-            verify(exactly = 1) { gameLifecycleService.endGame(gameId, GameEndReason.REGULATION) }
+            verify(exactly = 1) { gameLifecycleService.endGame(gameId, GameEndReason.REGULATION, scorerId) }
         }
 
         @Test
         fun `should end game with mercy rule`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val request = GameEndRequestDto(reason = GameEndReason.MERCY_RULE)
             val game =
                 createGame(gameId, GameStatus.CALLED).apply {
                     currentInning = 7
                     isTopInning = true
                 }
-            every { gameLifecycleService.endGame(gameId, GameEndReason.MERCY_RULE) } returns game
+            every { gameLifecycleService.endGame(gameId, GameEndReason.MERCY_RULE, scorerId) } returns game
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/end")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -347,24 +369,26 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.status").value("CALLED"))
 
-            verify(exactly = 1) { gameLifecycleService.endGame(gameId, GameEndReason.MERCY_RULE) }
+            verify(exactly = 1) { gameLifecycleService.endGame(gameId, GameEndReason.MERCY_RULE, scorerId) }
         }
 
         @Test
         fun `should end game due to weather`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val request = GameEndRequestDto(reason = GameEndReason.WEATHER)
             val game =
                 createGame(gameId, GameStatus.CALLED).apply {
                     currentInning = 5
                     isTopInning = false
                 }
-            every { gameLifecycleService.endGame(gameId, GameEndReason.WEATHER) } returns game
+            every { gameLifecycleService.endGame(gameId, GameEndReason.WEATHER, scorerId) } returns game
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/end")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -372,24 +396,26 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.status").value("CALLED"))
 
-            verify(exactly = 1) { gameLifecycleService.endGame(gameId, GameEndReason.WEATHER) }
+            verify(exactly = 1) { gameLifecycleService.endGame(gameId, GameEndReason.WEATHER, scorerId) }
         }
 
         @Test
         fun `should end game with forfeit`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val request = GameEndRequestDto(reason = GameEndReason.FORFEIT)
             val game =
                 createGame(gameId, GameStatus.FORFEITED).apply {
                     currentInning = 3
                     isTopInning = true
                 }
-            every { gameLifecycleService.endGame(gameId, GameEndReason.FORFEIT) } returns game
+            every { gameLifecycleService.endGame(gameId, GameEndReason.FORFEIT, scorerId) } returns game
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/end")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -397,7 +423,7 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.status").value("FORFEITED"))
 
-            verify(exactly = 1) { gameLifecycleService.endGame(gameId, GameEndReason.FORFEIT) }
+            verify(exactly = 1) { gameLifecycleService.endGame(gameId, GameEndReason.FORFEIT, scorerId) }
         }
     }
 
@@ -409,12 +435,14 @@ class GameScorerControllerTest {
         fun `should cancel game successfully`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val game = createGame(gameId, GameStatus.CANCELLED)
-            every { gameLifecycleService.cancelGame(gameId, "우천 취소") } returns game
+            every { gameLifecycleService.cancelGame(gameId, "우천 취소", scorerId) } returns game
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/cancel")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(mapOf("reason" to "우천 취소")))
             )
@@ -423,19 +451,21 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.data.id").value(gameId))
                 .andExpect(jsonPath("$.data.status").value("CANCELLED"))
 
-            verify(exactly = 1) { gameLifecycleService.cancelGame(gameId, "우천 취소") }
+            verify(exactly = 1) { gameLifecycleService.cancelGame(gameId, "우천 취소", scorerId) }
         }
 
         @Test
         fun `should cancel game without reason`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val game = createGame(gameId, GameStatus.CANCELLED)
-            every { gameLifecycleService.cancelGame(gameId, null) } returns game
+            every { gameLifecycleService.cancelGame(gameId, null, scorerId) } returns game
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/cancel")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(mapOf<String, String?>()))
             )
@@ -443,7 +473,7 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.status").value("CANCELLED"))
 
-            verify(exactly = 1) { gameLifecycleService.cancelGame(gameId, null) }
+            verify(exactly = 1) { gameLifecycleService.cancelGame(gameId, null, scorerId) }
         }
     }
 
@@ -455,6 +485,7 @@ class GameScorerControllerTest {
         fun `선수 교체 요청이 성공적으로 처리된다`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val game =
                 createGame(gameId, GameStatus.IN_PROGRESS).apply {
                     currentInning = 5
@@ -482,7 +513,7 @@ class GameScorerControllerTest {
                     idField.set(this, 100L)
                 }
 
-            every { gameSubstitutionService.substitutePlayer(gameId, any()) } returns substitutionEvent
+            every { gameSubstitutionService.substitutePlayer(gameId, any(), scorerId) } returns substitutionEvent
 
             val request =
                 SubstitutionRequestDto(
@@ -496,6 +527,7 @@ class GameScorerControllerTest {
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/substitutions")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)),
             )
@@ -506,7 +538,7 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.data.isTopInning").value(true))
                 .andExpect(jsonPath("$.data.description").value("5회초: 홍길동 → 김철수 (좌익수)"))
 
-            verify(exactly = 1) { gameSubstitutionService.substitutePlayer(gameId, any()) }
+            verify(exactly = 1) { gameSubstitutionService.substitutePlayer(gameId, any(), scorerId) }
         }
     }
 
@@ -800,12 +832,14 @@ class GameScorerControllerTest {
         fun `경기를 몰수 처리한다`() {
             // given
             val gameId = 1L
+            val scorerId = 100L
             val game = createGame(gameId, GameStatus.FORFEITED)
             every {
                 gameLifecycleService.forfeitGame(
                     gameId = gameId,
                     winnerTeamId = 1L,
                     reason = "선수 부족",
+                    scorerId = scorerId,
                 )
             } returns game
 
@@ -818,6 +852,7 @@ class GameScorerControllerTest {
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/$gameId/forfeit")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)),
             )
@@ -831,6 +866,7 @@ class GameScorerControllerTest {
                     gameId = gameId,
                     winnerTeamId = 1L,
                     reason = "선수 부족",
+                    scorerId = scorerId,
                 )
             }
         }
@@ -844,12 +880,14 @@ class GameScorerControllerTest {
         @Test
         fun `should suspend game successfully`() {
             // given
+            val scorerId = 100L
             val game = createGame(1L, GameStatus.SUSPENDED)
-            every { gameLifecycleService.suspendGame(1L, "우천") } returns game
+            every { gameLifecycleService.suspendGame(1L, "우천", scorerId) } returns game
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/1/suspend")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(mapOf("reason" to "우천"))),
             )
@@ -857,41 +895,27 @@ class GameScorerControllerTest {
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.status").value("SUSPENDED"))
 
-            verify(exactly = 1) { gameLifecycleService.suspendGame(1L, "우천") }
+            verify(exactly = 1) { gameLifecycleService.suspendGame(1L, "우천", scorerId) }
         }
 
         @Test
         fun `should suspend game without reason`() {
             // given
+            val scorerId = 100L
             val game = createGame(1L, GameStatus.SUSPENDED)
-            every { gameLifecycleService.suspendGame(1L, null) } returns game
+            every { gameLifecycleService.suspendGame(1L, null, scorerId) } returns game
 
             // when & then
             mockMvc.perform(
                 post("/api/scorer/games/1/suspend")
+                    .param("scorerId", scorerId.toString())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{}"),
             )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.data.status").value("SUSPENDED"))
 
-            verify(exactly = 1) { gameLifecycleService.suspendGame(1L, null) }
-        }
-
-        @Test
-        fun `should suspend game without request body`() {
-            // given
-            val game = createGame(1L, GameStatus.SUSPENDED)
-            every { gameLifecycleService.suspendGame(1L, null) } returns game
-
-            // when & then
-            mockMvc.perform(
-                post("/api/scorer/games/1/suspend"),
-            )
-                .andExpect(status().isOk)
-                .andExpect(jsonPath("$.data.status").value("SUSPENDED"))
-
-            verify(exactly = 1) { gameLifecycleService.suspendGame(1L, null) }
+            verify(exactly = 1) { gameLifecycleService.suspendGame(1L, null, scorerId) }
         }
     }
 
@@ -901,18 +925,20 @@ class GameScorerControllerTest {
         @Test
         fun `should resume game successfully`() {
             // given
+            val scorerId = 100L
             val game = createGame(1L, GameStatus.IN_PROGRESS)
-            every { gameLifecycleService.resumeGame(1L) } returns game
+            every { gameLifecycleService.resumeGame(1L, scorerId) } returns game
 
             // when & then
             mockMvc.perform(
-                post("/api/scorer/games/1/resume"),
+                post("/api/scorer/games/1/resume")
+                    .param("scorerId", scorerId.toString()),
             )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
 
-            verify(exactly = 1) { gameLifecycleService.resumeGame(1L) }
+            verify(exactly = 1) { gameLifecycleService.resumeGame(1L, scorerId) }
         }
     }
 


### PR DESCRIPTION
## Summary

>- close #332

**기록원이 경기를 독점 잠금하고, 모든 기록 API에서 잠금 검증을 수행하도록 구현합니다.**

## Tasks

- Game 엔티티에 validateScorer() 검증 메서드 추가
- 모든 기록 API(타석, 교체, 실행 취소, 주루, 경기 진행)에 scorerId 검증 강제
- GameNotLockedForRecordingException, ScorerMismatchException 커스텀 예외 추가
- 경기 종료/취소/몰수 시 자동 잠금 해제
- GameScorerController에 scorerId 파라미터 추가
- 단위 테스트 추가

## To Reviewer

scorerId와 lockForScorer/unlockScorer는 이미 존재합니다. 이번 PR은 모든 기록 API에서 잠금 검증을 강제하는 것에 초점을 맞췄습니다.