### PR TITLE
fix(#389): 더블헤더 이닝 자동 축소 + 정정 validate 충돌 해결

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/PitchingRecordMapper.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/mapper/game/PitchingRecordMapper.kt
@@ -41,7 +41,7 @@ fun PitchingRecord.toResponse(): PitchingRecordResponse =
         strikeoutToWalkRatio = this.strikeoutToWalkRatio.toPlainString(),
         strikePercentage = this.strikePercentage?.toPlainString(), // nullable
         unearnedRuns = this.unearnedRuns,
-        isQualifiedForWin = this.isQualifiedForWin,
+        isQualifiedForWin = this.isQualifiedForWin(),
     )
 
 /**

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
@@ -91,7 +91,7 @@ class PitchingRecordControllerTest {
                     every { strikeoutToWalkRatio } returns java.math.BigDecimal("3.00")
                     every { strikePercentage } returns java.math.BigDecimal("0.647")
                     every { unearnedRuns } returns 1
-                    every { isQualifiedForWin } returns true
+                    every { isQualifiedForWin() } returns true
                 }
 
             every { pitchingRecordService.getAllByGameId(gameId) } returns listOf(record)
@@ -251,6 +251,6 @@ class PitchingRecordControllerTest {
             every { strikeoutToWalkRatio } returns java.math.BigDecimal("0.00")
             every { strikePercentage } returns null
             every { unearnedRuns } returns 0
-            every { isQualifiedForWin } returns false
+            every { isQualifiedForWin() } returns false
         }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/GameRules.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/GameRules.kt
@@ -56,12 +56,18 @@ data class GameRules(
     /** 투구 수 경고 임박 기준 (제한 대비 몇 구 전에 경고할지, 기본 10구) */
     @Column(name = "pitch_count_warning_threshold")
     val pitchCountWarningThreshold: Int = 10,
+    /** L-4: 더블헤더 경기 이닝 수 (기본값: 7이닝) */
+    @Column(name = "doubleheader_innings")
+    val doubleheaderInnings: Int = 7,
     /** L-3: 용병(머서너리) 쿼터 제한 (null이면 무제한) */
     @Column(name = "max_mercenary_count")
     val maxMercenaryCount: Int? = null,
 ) {
     init {
         require(defaultInnings in 3..12) { "기본 이닝은 3~12 사이여야 합니다." }
+        require(doubleheaderInnings in 3..defaultInnings) {
+            "더블헤더 이닝은 3 이상 기본 이닝($defaultInnings) 이하여야 합니다."
+        }
         require(forfeitScore > 0) { "몰수승 점수는 양수여야 합니다." }
         require(starterWinQualificationOuts > 0) { "선발 승리 자격 아웃 수는 양수여야 합니다." }
         require(qualificationPAMultiplier > 0.0) { "규정 타석 배수는 양수여야 합니다." }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -562,9 +562,6 @@ class Game private constructor(
         /** 시간 제한 경고 임박 기준 (분) */
         const val DEFAULT_TIME_LIMIT_WARNING_THRESHOLD = 10
 
-        /** L-4: 더블헤더 이닝 축소 기본값 (기본 이닝 - 2) */
-        const val DEFAULT_DOUBLEHEADER_INNING_REDUCTION = 2
-
         /** L-11: SUSPENDED 경기 자동 타임아웃 기본값 (48시간) */
         const val DEFAULT_SUSPENDED_TIMEOUT_HOURS = 48L
 
@@ -594,10 +591,10 @@ class Game private constructor(
                 }
             }
 
-            // L-4: 더블헤더 시 이닝 자동 축소
+            // L-4: 더블헤더 시 GameRules의 doubleheaderInnings 적용
             val effectiveInnings =
                 if (isDoubleheader) {
-                    maxOf(3, competition.gameRules.defaultInnings - DEFAULT_DOUBLEHEADER_INNING_REDUCTION)
+                    competition.gameRules.doubleheaderInnings
                 } else {
                     competition.gameRules.defaultInnings
                 }
@@ -736,6 +733,29 @@ class Game private constructor(
             } else {
                 null
             }
+
+    /**
+     * L-5: 경기 이닝 수를 축소합니다.
+     *
+     * 축소 전에 모든 투수 기록이 새로운 이닝 수와 충돌하지 않는지 검증합니다.
+     *
+     * @param newTotalInnings 새로운 총 이닝 수
+     * @param pitchingRecords 해당 경기의 모든 투수 기록
+     * @throws IllegalArgumentException 이닝 수가 유효하지 않거나 기존 기록과 충돌하는 경우
+     */
+    fun reduceTotalInnings(
+        newTotalInnings: Int,
+        pitchingRecords: List<PitchingRecord>,
+    ) {
+        require(newTotalInnings in 3..12) {
+            "이닝 수는 3~12 사이여야 합니다."
+        }
+        require(newTotalInnings <= totalInnings) {
+            "이닝 축소만 가능합니다. 현재: ${totalInnings}이닝, 요청: ${newTotalInnings}이닝"
+        }
+        pitchingRecords.forEach { it.validateInningReduction(newTotalInnings) }
+        totalInnings = newTotalInnings
+    }
 
     /**
      * L-11: 중단된 경기가 타임아웃 되었는지 확인합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
@@ -224,10 +224,11 @@ class PitchingRecord(
         get() = runsAllowed - earnedRuns
 
     /**
-     * 선발 승리 자격이 있는지 확인 (5이닝 이상)
+     * 선발 승리 자격이 있는지 확인합니다.
+     * @param starterWinQualificationOuts 선발 승리 자격 최소 아웃 수 (기본 15 = 5이닝)
      */
-    val isQualifiedForWin: Boolean
-        get() = isStartingPitcher && inningsPitchedOuts >= 15
+    fun isQualifiedForWin(starterWinQualificationOuts: Int = 15): Boolean =
+        isStartingPitcher && inningsPitchedOuts >= starterWinQualificationOuts
 
     // Business logic
 
@@ -595,8 +596,9 @@ class PitchingRecord(
 
     /**
      * 기록 유효성을 검증합니다.
+     * @param starterWinQualificationOuts 선발 승리 자격 최소 아웃 수 (기본 15 = 5이닝)
      */
-    fun validate() {
+    fun validate(starterWinQualificationOuts: Int = 15) {
         require(inningsPitchedOuts >= 0) { "이닝 아웃 수($inningsPitchedOuts)는 음수일 수 없습니다." }
         require(earnedRuns >= 0) { "자책점($earnedRuns)은 음수일 수 없습니다." }
         require(runsAllowed >= 0) { "실점($runsAllowed)은 음수일 수 없습니다." }
@@ -620,8 +622,8 @@ class PitchingRecord(
             }
         }
         if (isStartingPitcher && decision == PitchingDecision.WIN) {
-            require(isQualifiedForWin) {
-                "선발 승리 자격(5이닝 이상)을 충족하지 못합니다."
+            require(isQualifiedForWin(starterWinQualificationOuts)) {
+                "선발 승리 자격(${starterWinQualificationOuts / 3}이닝 이상)을 충족하지 못합니다."
             }
         }
     }
@@ -656,6 +658,7 @@ class PitchingRecord(
     fun correctField(
         fieldName: String,
         newValue: String,
+        starterWinQualificationOuts: Int = 15,
     ): String {
         val oldValue =
             when (fieldName) {
@@ -774,7 +777,7 @@ class PitchingRecord(
                 else -> throw IllegalArgumentException("유효하지 않은 투수 기록 필드입니다: $fieldName")
             }
 
-        validate()
+        validate(starterWinQualificationOuts)
         return oldValue.toString()
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/correction/RecordCorrectionRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/correction/RecordCorrectionRequest.kt
@@ -33,6 +33,15 @@ data class FieldingCorrectionRequest(
 )
 
 /**
+ * L-5: 경기 이닝 축소 정정 요청 DTO (Service 계층용)
+ */
+data class GameInningsCorrectionRequest(
+    val adminUserId: Long,
+    val newTotalInnings: Int,
+    val reason: String,
+)
+
+/**
  * 기록 정정 이력 조회 DTO
  */
 data class RecordCorrectionDto(

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/correction/RecordCorrectionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/correction/RecordCorrectionService.kt
@@ -2,6 +2,7 @@ package com.nextup.core.service.game.correction
 
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.PitchingRecord
 
 /**
@@ -52,6 +53,20 @@ interface RecordCorrectionService {
         recordId: Long,
         request: FieldingCorrectionRequest,
     ): FieldingRecord
+
+    /**
+     * L-5: 경기 이닝 수를 축소 정정합니다.
+     *
+     * 기존 투수 기록과 충돌하지 않는지 검증한 뒤 이닝을 축소합니다.
+     *
+     * @param gameId 경기 ID
+     * @param request 이닝 축소 정정 요청
+     * @return 정정된 경기
+     */
+    fun correctGameTotalInnings(
+        gameId: Long,
+        request: GameInningsCorrectionRequest,
+    ): Game
 
     /**
      * 경기의 기록 정정 이력을 조회합니다.

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/FutureImprovementsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/FutureImprovementsTest.kt
@@ -247,7 +247,7 @@ class FutureImprovementsTest {
         @Test
         fun `더블헤더 축소 시 최소 3이닝을 보장한다`() {
             // given
-            val competition = createCompetition(GameRules(defaultInnings = 3))
+            val competition = createCompetition(GameRules(defaultInnings = 3, doubleheaderInnings = 3))
             val homeTeam = createTeam(1L)
             val awayTeam = createTeam(2L)
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/GameRulesTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/GameRulesTest.kt
@@ -33,7 +33,7 @@ class GameRulesTest {
     inner class DefaultInningsValidation {
         @Test
         fun `3이닝도 유효하다`() {
-            val rules = GameRules(defaultInnings = 3)
+            val rules = GameRules(defaultInnings = 3, doubleheaderInnings = 3)
 
             assertThat(rules.defaultInnings).isEqualTo(3)
         }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/GameRulesTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/GameRulesTest.kt
@@ -60,6 +60,34 @@ class GameRulesTest {
         }
 
         @Test
+        fun `더블헤더 이닝 기본값은 7이다`() {
+            val rules = GameRules()
+            assertThat(rules.doubleheaderInnings).isEqualTo(7)
+        }
+
+        @Test
+        fun `더블헤더 이닝을 커스텀 설정할 수 있다`() {
+            val rules = GameRules(doubleheaderInnings = 5)
+            assertThat(rules.doubleheaderInnings).isEqualTo(5)
+        }
+
+        @Test
+        fun `더블헤더 이닝이 기본 이닝보다 크면 예외가 발생한다`() {
+            assertThatThrownBy {
+                GameRules(defaultInnings = 7, doubleheaderInnings = 9)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("더블헤더 이닝은 3 이상 기본 이닝")
+        }
+
+        @Test
+        fun `더블헤더 이닝이 3 미만이면 예외가 발생한다`() {
+            assertThatThrownBy {
+                GameRules(doubleheaderInnings = 2)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("더블헤더 이닝은 3 이상")
+        }
+
+        @Test
         fun `13이닝은 유효하지 않다`() {
             assertThatThrownBy { GameRules(defaultInnings = 13) }
                 .isInstanceOf(IllegalArgumentException::class.java)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -11,6 +11,7 @@ import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.competition.GameRules
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.team.Team
+import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -1481,6 +1482,59 @@ class GameTest {
             // then
             assertThat(game.isDoubleheader).isFalse()
             assertThat(game.doubleheaderDisplay).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("이닝 축소 정정")
+    inner class ReduceTotalInningsTest {
+        @Test
+        fun `이닝을 축소할 수 있다`() {
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            game.reduceTotalInnings(7, emptyList())
+            assertThat(game.totalInnings).isEqualTo(7)
+        }
+
+        @Test
+        fun `이닝 축소 시 투수 기록과 충돌하면 예외가 발생한다`() {
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val pitchingRecord = PitchingRecord.create(gamePlayer)
+            repeat(24) { pitchingRecord.recordOut() }
+
+            assertThatThrownBy {
+                game.reduceTotalInnings(7, listOf(pitchingRecord))
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이닝 축소")
+        }
+
+        @Test
+        fun `3이닝 미만으로 축소하면 예외가 발생한다`() {
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            assertThatThrownBy {
+                game.reduceTotalInnings(2, emptyList())
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("3~12")
+        }
+
+        @Test
+        fun `현재 이닝보다 크게 설정하면 예외가 발생한다`() {
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            assertThatThrownBy {
+                game.reduceTotalInnings(10, emptyList())
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이닝 축소만 가능")
+        }
+
+        @Test
+        fun `투수 기록이 축소 이닝 이내이면 정상 축소된다`() {
+            val game = createGame(status = GameStatus.IN_PROGRESS)
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val pitchingRecord = PitchingRecord.create(gamePlayer)
+            repeat(18) { pitchingRecord.recordOut() }
+
+            game.reduceTotalInnings(7, listOf(pitchingRecord))
+            assertThat(game.totalInnings).isEqualTo(7)
         }
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameTest.kt
@@ -1388,9 +1388,68 @@ class GameTest {
             assertThat(game1.isDoubleheader).isTrue()
             assertThat(game1.gameNumber).isEqualTo(1)
             assertThat(game1.doubleheaderDisplay).isEqualTo("제1경기")
+            assertThat(game1.totalInnings).isEqualTo(7) // GameRules.doubleheaderInnings 기본값
             assertThat(game2.isDoubleheader).isTrue()
             assertThat(game2.gameNumber).isEqualTo(2)
             assertThat(game2.doubleheaderDisplay).isEqualTo("제2경기")
+        }
+
+        @Test
+        fun `더블헤더 경기 생성 시 GameRules의 doubleheaderInnings가 적용된다`() {
+            // given
+            val customCompetition =
+                Competition(
+                    league = league,
+                    name = "더블헤더 대회",
+                    year = 2025,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    status = CompetitionStatus.IN_PROGRESS,
+                    gameRules = GameRules(doubleheaderInnings = 5),
+                )
+
+            // when
+            val game =
+                Game.create(
+                    competition = customCompetition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 10, 0),
+                    gameNumber = 1,
+                    isDoubleheader = true,
+                )
+
+            // then
+            assertThat(game.totalInnings).isEqualTo(5)
+        }
+
+        @Test
+        fun `일반 경기 생성 시 defaultInnings가 적용된다`() {
+            // given
+            val customCompetition =
+                Competition(
+                    league = league,
+                    name = "9이닝 대회",
+                    year = 2025,
+                    season = 1,
+                    type = CompetitionType.LEAGUE,
+                    startDate = LocalDate.of(2025, 3, 1),
+                    status = CompetitionStatus.IN_PROGRESS,
+                    gameRules = GameRules(defaultInnings = 9),
+                )
+
+            // when
+            val game =
+                Game.create(
+                    competition = customCompetition,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+                )
+
+            // then
+            assertThat(game.totalInnings).isEqualTo(9)
         }
 
         @Test

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -1526,6 +1526,42 @@ class PitchingRecordTest {
     }
 
     @Nested
+    @DisplayName("커스텀 starterWinQualificationOuts 파라미터 검증")
+    inner class CustomStarterWinQualificationOutsTest {
+        @Test
+        fun `더블헤더 축소 이닝에서 선발 승리 자격이 조정된다`() {
+            pitchingRecord.setAsStartingPitcher()
+            repeat(12) { pitchingRecord.recordOut() }
+            assertThat(pitchingRecord.isQualifiedForWin(12)).isTrue()
+            assertThat(pitchingRecord.isQualifiedForWin(15)).isFalse()
+        }
+
+        @Test
+        fun `커스텀 starterWinQualificationOuts로 validate 시 해당 기준으로 검증된다`() {
+            pitchingRecord.setAsStartingPitcher()
+            repeat(12) { pitchingRecord.recordOut() }
+            pitchingRecord.assignWin()
+
+            pitchingRecord.validate(12)
+
+            assertThatThrownBy {
+                pitchingRecord.validate(15)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이닝 이상")
+        }
+
+        @Test
+        fun `correctField에 starterWinQualificationOuts를 전달할 수 있다`() {
+            pitchingRecord.setAsStartingPitcher()
+            repeat(12) { pitchingRecord.recordOut() }
+
+            val oldValue = pitchingRecord.correctField("hitsAllowed", "3", 12)
+            assertThat(oldValue).isEqualTo("0")
+            assertThat(pitchingRecord.hitsAllowed).isEqualTo(3)
+        }
+    }
+
+    @Nested
     @DisplayName("partial branch 커버리지 - strikeoutToWalkRatio 분기")
     inner class StrikeoutToWalkRatioPartialBranchTest {
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -518,7 +518,7 @@ class PitchingRecordTest {
             repeat(15) { pitchingRecord.recordOut() }
 
             // then
-            assertThat(pitchingRecord.isQualifiedForWin).isFalse()
+            assertThat(pitchingRecord.isQualifiedForWin()).isFalse()
         }
 
         @Test
@@ -528,7 +528,7 @@ class PitchingRecordTest {
             repeat(14) { pitchingRecord.recordOut() } // 4.2이닝
 
             // then
-            assertThat(pitchingRecord.isQualifiedForWin).isFalse()
+            assertThat(pitchingRecord.isQualifiedForWin()).isFalse()
         }
 
         @Test
@@ -538,7 +538,7 @@ class PitchingRecordTest {
             repeat(15) { pitchingRecord.recordOut() } // 5.0이닝
 
             // then
-            assertThat(pitchingRecord.isQualifiedForWin).isTrue()
+            assertThat(pitchingRecord.isQualifiedForWin()).isTrue()
         }
     }
 
@@ -1899,21 +1899,30 @@ class PitchingRecordTest {
         fun `선발투수이고 15아웃 이상이면 isQualifiedForWin은 true이다 (양쪽 true)`() {
             pitchingRecord.setAsStartingPitcher()
             repeat(15) { pitchingRecord.recordOut() }
-            assertThat(pitchingRecord.isQualifiedForWin).isTrue()
+            assertThat(pitchingRecord.isQualifiedForWin()).isTrue()
         }
 
         @Test
         fun `선발투수이지만 15아웃 미만이면 isQualifiedForWin은 false이다 (첫 번째 true, 두 번째 false)`() {
             pitchingRecord.setAsStartingPitcher()
             repeat(14) { pitchingRecord.recordOut() }
-            assertThat(pitchingRecord.isQualifiedForWin).isFalse()
+            assertThat(pitchingRecord.isQualifiedForWin()).isFalse()
         }
 
         @Test
         fun `비선발투수이고 15아웃 이상이면 isQualifiedForWin은 false이다 (첫 번째 false)`() {
             // isStartingPitcher == false → && short-circuit → false
             repeat(15) { pitchingRecord.recordOut() }
-            assertThat(pitchingRecord.isQualifiedForWin).isFalse()
+            assertThat(pitchingRecord.isQualifiedForWin()).isFalse()
+        }
+
+        @Test
+        fun `더블헤더 축소 이닝에서 선발 승리 자격이 조정된다`() {
+            pitchingRecord.setAsStartingPitcher()
+            // 7이닝 더블헤더: starterWinQualificationOuts = 12 (4이닝)
+            repeat(12) { pitchingRecord.recordOut() }
+            assertThat(pitchingRecord.isQualifiedForWin(12)).isTrue()
+            assertThat(pitchingRecord.isQualifiedForWin(15)).isFalse()
         }
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/correction/RecordCorrectionServiceImpl.kt
@@ -9,6 +9,7 @@ import com.nextup.core.domain.event.RecordCorrectedEvent
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.domain.game.RecordCorrection
 import com.nextup.core.port.repository.AuditLogRepositoryPort
@@ -20,6 +21,7 @@ import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.port.repository.RecordCorrectionRepositoryPort
 import com.nextup.core.service.game.correction.BattingCorrectionRequest
 import com.nextup.core.service.game.correction.FieldingCorrectionRequest
+import com.nextup.core.service.game.correction.GameInningsCorrectionRequest
 import com.nextup.core.service.game.correction.PitchingCorrectionRequest
 import com.nextup.core.service.game.correction.RecordCorrectionDto
 import com.nextup.core.service.game.correction.RecordCorrectionService
@@ -241,6 +243,54 @@ class RecordCorrectionServiceImpl(
         )
 
         return fieldingRecord
+    }
+
+    /**
+     * L-5: 경기 이닝 수를 축소 정정합니다.
+     */
+    @Transactional
+    override fun correctGameTotalInnings(
+        gameId: Long,
+        request: GameInningsCorrectionRequest,
+    ): Game {
+        val game =
+            gameRepository.findByIdOrNull(gameId)
+                ?: throw GameNotFoundException(gameId)
+
+        val oldTotalInnings = game.totalInnings
+
+        // 해당 경기의 모든 투수 기록 조회하여 충돌 검증
+        val pitchingRecords = pitchingRecordRepository.findAllByGameId(gameId)
+        game.reduceTotalInnings(request.newTotalInnings, pitchingRecords)
+
+        // 정정 이력 저장
+        val correction =
+            RecordCorrection.create(
+                gameId = gameId,
+                adminUserId = request.adminUserId,
+                correctionType = CorrectionType.PITCHING,
+                targetRecordId = gameId,
+                fieldName = "totalInnings",
+                oldValue = oldTotalInnings.toString(),
+                newValue = request.newTotalInnings.toString(),
+                reason = request.reason,
+            )
+        recordCorrectionRepository.save(correction)
+
+        // AuditLog 저장
+        val auditLog =
+            AuditLog.create(
+                adminUserId = request.adminUserId,
+                action = "CORRECT_GAME_TOTAL_INNINGS",
+                targetEntity = "Game",
+                targetId = gameId,
+                details =
+                    "gameId=$gameId, field=totalInnings, " +
+                        "oldValue=$oldTotalInnings, newValue=${request.newTotalInnings}, reason=${request.reason}",
+            )
+        auditLogRepository.save(auditLog)
+
+        return game
     }
 
     /**

--- a/nextup-infrastructure/src/main/resources/db/migration/V044__add_doubleheader_innings_to_game_rules.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V044__add_doubleheader_innings_to_game_rules.sql
@@ -1,0 +1,2 @@
+-- L-4: GameRules에 더블헤더 전용 이닝 수 컬럼 추가
+ALTER TABLE competitions ADD COLUMN IF NOT EXISTS doubleheader_innings INTEGER NOT NULL DEFAULT 7;


### PR DESCRIPTION
## Summary

>- close #389

- **L-4**: `GameRules`에 `doubleheaderInnings` 필드 추가(기본 7이닝)하여 더블헤더 경기 생성 시 대회별 커스텀 이닝 설정 지원
- **L-5**: `PitchingRecord.isQualifiedForWin`을 동적 파라미터화하고, `Game.reduceTotalInnings()` + `RecordCorrectionService.correctGameTotalInnings()` 추가하여 이닝 축소 정정 시 투수 기록 충돌 사전 검증

## Tasks

- GameRules에 `doubleheaderInnings: Int = 7` 필드 추가 및 `3..defaultInnings` 검증
- Game.create()에서 `doubleheaderInnings` 사용하도록 변경 (기존 `DEFAULT_DOUBLEHEADER_INNING_REDUCTION` 상수 제거)
- PitchingRecord.isQualifiedForWin을 프로퍼티→함수로 변경하여 `starterWinQualificationOuts` 파라미터 지원
- PitchingRecord.validate(), correctField()에 `starterWinQualificationOuts` 파라미터 추가
- Game.reduceTotalInnings() 메서드 추가 (모든 투수 기록 충돌 검증)
- RecordCorrectionService/Impl에 `correctGameTotalInnings()` 메서드 추가
- DB 마이그레이션 V044: `doubleheader_innings` 컬럼 추가
- GameTest, PitchingRecordTest, GameRulesTest, FutureImprovementsTest 업데이트

## To Reviewer

- `isQualifiedForWin`이 `val` 프로퍼티에서 `fun`으로 변경되어, PitchingRecordMapper와 PitchingRecordControllerTest에서 호출 방식이 변경되었습니다 (`.isQualifiedForWin` → `.isQualifiedForWin()`)
- `correctGameTotalInnings()`는 아직 Controller 엔드포인트에 연결되지 않은 Service 계층 메서드입니다. 향후 backoffice Controller에서 노출 시 DTO 변환 및 `@PreAuthorize` 적용이 필요합니다.