### PR TITLE
feat(#426): verify 스킬 2개 추가 및 인가/레이어 규칙 신설

### DIFF
--- a/.claude/rules/authorization.md
+++ b/.claude/rules/authorization.md
@@ -1,0 +1,50 @@
+# Authorization Rules (인가 규칙)
+
+## 절대 규칙: mutating 엔드포인트에 @PreAuthorize 필수
+
+Controller에 POST/PUT/PATCH/DELETE 엔드포인트를 작성하거나 수정할 때:
+
+1. **반드시 `@PreAuthorize`를 추가하라** — 없으면 IDOR 취약점이다
+2. **identity 파라미터는 `@AuthenticationPrincipal`에서 도출하라** — `@RequestParam`이나 `@RequestBody`에서 teamId/playerId/scorerId/userId/appealerId를 받으면 안 된다
+3. **잠금 소유자 검증을 추가하라** — scorer 엔드포인트에서 경기 잠금 소유자가 맞는지 확인
+
+## 위반 예시 (이렇게 작성하면 안 됨)
+
+```kotlin
+// ❌ REJECT: @PreAuthorize 없음
+@DeleteMapping("/{id}")
+fun cancelBooking(@PathVariable id: Long): ApiResponse<BookingResponse>
+
+// ❌ REJECT: scorerId를 클라이언트 입력으로 받음
+@PostMapping("/{gameId}/lock")
+fun lockGame(@PathVariable gameId: Long, @RequestParam scorerId: Long)
+
+// ❌ REJECT: teamId를 RequestBody에서 받음
+@PostMapping
+fun createRequest(@RequestBody request: CreateRequest) // request.teamId를 검증 없이 사용
+```
+
+## 올바른 예시 (반드시 이렇게 작성)
+
+```kotlin
+// ✅ PASS: @PreAuthorize + @AuthenticationPrincipal
+@PreAuthorize("@teamSecurity.isOwnerOrManager(#request.teamId, authentication.principal)")
+@DeleteMapping("/{id}")
+fun cancelBooking(
+    @PathVariable id: Long,
+    @AuthenticationPrincipal userId: Long,
+): ApiResponse<BookingResponse>
+
+// ✅ PASS: scorerId를 principal에서 도출
+@PostMapping("/{gameId}/lock")
+fun lockGame(
+    @PathVariable gameId: Long,
+    @AuthenticationPrincipal scorerId: Long,
+)
+```
+
+## 예외
+
+- GET 엔드포인트 (공개 조회 API)는 면제
+- `/auth/login`, `/auth/register` 등 인증 자체를 수행하는 엔드포인트는 면제
+- 클래스 레벨 @PreAuthorize가 적용된 Controller는 개별 메서드에 없어도 허용

--- a/.claude/rules/repository-injection.md
+++ b/.claude/rules/repository-injection.md
@@ -1,0 +1,61 @@
+# Repository Injection Rules (Controller 레이어 규칙)
+
+## 절대 규칙: Controller에서 Repository 직접 주입 금지
+
+Controller 클래스를 작성하거나 수정할 때:
+
+1. **Repository/RepositoryPort를 constructor에 주입하지 마라** — 반드시 Service를 통해 접근
+2. **Controller에서 Repository 메서드를 직접 호출하지 마라** — `save()`, `findById()`, `delete()` 등
+3. **Controller에서 Core 도메인 Repository를 import하지 마라**
+
+## 왜 금지인가
+
+Controller가 Repository를 직접 사용하면:
+- **인가(Authorization) 우회**: Service에서 수행해야 할 권한 검증을 건너뜀
+- **감사 로깅 누락**: AuditLogAspect가 Service 레벨에서 동작하므로 기록이 남지 않음
+- **도메인 불변식 무시**: Entity의 비즈니스 규칙 검증을 우회
+- **배치 최적화 불가**: Service에서 N+1 해결 등 최적화를 적용할 수 없음
+
+## 위반 예시 (이렇게 작성하면 안 됨)
+
+```kotlin
+// ❌ REJECT: Controller에 Repository 주입
+@RestController
+class TeamController(
+    private val teamRepository: TeamRepositoryPort,  // ❌
+    private val leagueRepository: LeagueRepositoryPort,  // ❌
+) {
+    @PostMapping
+    fun createTeam(@RequestBody request: CreateTeamRequest): ApiResponse<TeamResponse> {
+        val league = leagueRepository.findById(request.leagueId)  // ❌ Service 우회
+            ?: throw LeagueNotFoundException(request.leagueId)
+        val team = Team(league, request.name, ...)  // ❌ Entity 직접 생성
+        teamRepository.save(team)  // ❌ Repository 직접 호출
+    }
+}
+```
+
+## 올바른 예시 (반드시 이렇게 작성)
+
+```kotlin
+// ✅ PASS: Service를 통해 접근
+@RestController
+class TeamController(
+    private val teamService: TeamService,  // ✅ Service만 주입
+) {
+    @PreAuthorize("hasRole('USER')")
+    @PostMapping
+    fun createTeam(
+        @AuthenticationPrincipal userId: Long,
+        @RequestBody request: CreateTeamRequest,
+    ): ApiResponse<TeamResponse> {
+        val team = teamService.createTeam(userId, request)  // ✅ Service 경유
+        return ApiResponse.success(TeamResponse.from(team))
+    }
+}
+```
+
+## 예외
+
+- `@Configuration` 클래스에서 초기 데이터 설정 시 Repository 사용은 허용
+- 테스트 코드(`src/test/`)에서는 면제

--- a/.claude/skills/manage-skills/SKILL.md
+++ b/.claude/skills/manage-skills/SKILL.md
@@ -35,6 +35,8 @@ argument-hint: "[선택사항: 특정 스킬 이름 또는 집중할 영역]"
 | `verify-api-response` | Controller의 ApiResponse 래핑 사용 검증 | `**/controller/**/*.kt` |
 | `verify-custom-exception` | BusinessException 계열 커스텀 예외 사용 검증 | `*/src/main/kotlin/**/*.kt` |
 | `verify-url-prefix` | 모듈별 URL 프리픽스 통일 검증 | `**/controller/**/*.kt` |
+| `verify-authorization` | mutating 엔드포인트 @PreAuthorize/@AuthenticationPrincipal 적용 검증 | `**/controller/**/*.kt` |
+| `verify-repository-injection` | Controller에서 Repository/RepositoryPort 직접 주입 금지 검증 | `**/controller/**/*.kt` |
 
 ## 워크플로우
 

--- a/.claude/skills/verify-api-response/SKILL.md
+++ b/.claude/skills/verify-api-response/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-api-response
-description: 모든 Controller가 ApiResponse로 감싸서 반환하는지 검증합니다. Controller 추가/수정 후 사용.
+description: Controller 엔드포인트의 반환 타입을 작성할 때 반드시 이 스킬을 참조하라. 모든 Controller 메서드는 ApiResponse<T>로 감싸서 반환해야 한다. ResponseEntity나 raw 타입을 반환하려 할 때 즉시 트리거하라. fun 메서드의 반환 타입을 정의하는 순간 항상 확인.
 ---
 
 # ApiResponse 사용 검증

--- a/.claude/skills/verify-authorization/SKILL.md
+++ b/.claude/skills/verify-authorization/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: verify-authorization
+description: Controller에 POST/PUT/PATCH/DELETE 엔드포인트를 작성하거나 수정할 때 반드시 이 스킬을 참조하라. @PreAuthorize 없는 mutating 엔드포인트는 IDOR 취약점이다. teamId/playerId/scorerId를 @RequestParam이나 @RequestBody로 받는 코드를 작성하려 할 때 즉시 트리거하라. Controller 코드를 생성, 수정, 리뷰할 때 항상 사용.
+---
+
+# 인가(Authorization) 검증
+
+## Purpose
+
+1. mutating 엔드포인트(POST/PUT/PATCH/DELETE)에 `@PreAuthorize`가 적용되었는지 검증
+2. identity-bearing 파라미터(teamId, playerId, scorerId 등)가 `@AuthenticationPrincipal`에서 도출되는지 검증
+3. 클라이언트 입력을 서버 측 검증 없이 신뢰하는 IDOR 패턴을 탐지
+
+## When to Run
+
+- 새로운 Controller 또는 mutating 엔드포인트 추가 후
+- 인가/인증 관련 코드 변경 후
+- `@PreAuthorize` 또는 `@AuthenticationPrincipal` 관련 수정 후
+- PR 전 통합 검증 시
+
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `nextup-api/src/main/kotlin/com/nextup/api/controller/**/*.kt` | API 컨트롤러 |
+| `nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/**/*.kt` | 백오피스 컨트롤러 |
+| `nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/**/*.kt` | 스코어러 컨트롤러 |
+| `nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/security/**/*.kt` | 보안 설정 |
+
+## Workflow
+
+### Step 1: mutating 엔드포인트 중 @PreAuthorize 미적용 탐지
+
+모든 Controller에서 `@PostMapping`, `@PutMapping`, `@PatchMapping`, `@DeleteMapping`이 있는 함수 중 `@PreAuthorize`가 없는 것을 탐지합니다.
+
+**도구:** Grep (multiline)
+
+**패턴:**
+```
+@(PostMapping|PutMapping|PatchMapping|DeleteMapping)
+```
+
+**대상:** `**/controller/**/*.kt`
+
+각 매칭에 대해 해당 함수 위에 `@PreAuthorize`가 있는지 확인합니다. 없으면 FAIL.
+
+**PASS 기준:** 모든 mutating 엔드포인트에 `@PreAuthorize` 적용
+**FAIL 기준:** `@PreAuthorize` 없는 mutating 엔드포인트 존재
+
+**수정 방법:**
+```kotlin
+// FAIL
+@PostMapping
+fun createRequest(@RequestBody request: CreateRequest): ApiResponse<Response> { ... }
+
+// PASS
+@PreAuthorize("@teamSecurity.isOwnerOrManager(#request.teamId, authentication.principal)")
+@PostMapping
+fun createRequest(
+    @AuthenticationPrincipal userId: Long,
+    @RequestBody request: CreateRequest,
+): ApiResponse<Response> { ... }
+```
+
+### Step 2: identity 파라미터가 클라이언트 입력으로 전달되는 IDOR 패턴 탐지
+
+Controller 메서드에서 `teamId`, `playerId`, `scorerId`, `userId`, `appealerId` 등 identity 파라미터를 `@RequestParam` 또는 `@RequestBody`에서 직접 받아 Service에 전달하는 패턴을 탐지합니다.
+
+**도구:** Grep
+
+**패턴:**
+```
+@RequestParam.*(teamId|playerId|scorerId|userId|appealerId|sellerId|buyerId)
+```
+
+**대상:** `**/controller/**/*.kt`
+
+**PASS 기준:** identity 파라미터가 `@AuthenticationPrincipal`에서 도출
+**FAIL 기준:** identity 파라미터를 `@RequestParam`/`@RequestBody`에서 직접 수신
+
+**수정 방법:**
+```kotlin
+// FAIL — 클라이언트 입력 신뢰
+@PostMapping("/{gameId}/lock")
+fun lockGame(@PathVariable gameId: Long, @RequestParam scorerId: Long): ApiResponse<GameResponse>
+
+// PASS — 서버에서 도출
+@PostMapping("/{gameId}/lock")
+fun lockGame(@PathVariable gameId: Long, @AuthenticationPrincipal scorerId: Long): ApiResponse<GameResponse>
+```
+
+### Step 3: 클래스 레벨 @PreAuthorize 확인
+
+Controller 클래스에 `@PreAuthorize`가 있으면 해당 클래스의 모든 메서드에 적용됩니다. 이 경우 개별 메서드에 `@PreAuthorize`가 없어도 PASS로 처리합니다.
+
+**도구:** Grep (multiline)
+
+**패턴:**
+```
+@PreAuthorize.*\n.*class.*Controller
+```
+
+**대상:** `**/controller/**/*.kt`
+
+클래스 레벨 `@PreAuthorize`가 있는 Controller는 Step 1의 FAIL 목록에서 제외합니다.
+
+## Output Format
+
+```markdown
+| # | 파일 | 라인 | 문제 | 심각도 |
+|---|------|------|------|--------|
+| 1 | `MercenaryRequestController.kt:29` | @PreAuthorize 없는 POST | 🔴 CRITICAL (IDOR) |
+| 2 | `GameScorerController.kt:136` | scorerId를 @RequestParam으로 수신 | 🔴 CRITICAL (IDOR) |
+```
+
+## Exceptions
+
+1. **GET 엔드포인트** — `@GetMapping`은 읽기 전용이므로 `@PreAuthorize` 필수가 아님 (공개 조회 API)
+2. **인증 관련 엔드포인트** — `/auth/login`, `/auth/register`, `/auth/refresh` 등 인증 자체를 수행하는 엔드포인트는 면제
+3. **Swagger/Actuator 엔드포인트** — 시스템 관리용 엔드포인트는 SecurityConfig에서 별도 관리
+4. **클래스 레벨 @PreAuthorize 적용 Controller** — 개별 메서드에 없어도 클래스 레벨에서 적용되면 PASS
+5. **테스트 코드** — `src/test/` 내 파일은 면제

--- a/.claude/skills/verify-authorization/evals/trigger-eval.json
+++ b/.claude/skills/verify-authorization/evals/trigger-eval.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "MercenaryRequestController에 용병 요청 수락 API를 추가해줘. PATCH /api/v1/mercenary-requests/{id}/accept 엔드포인트로 만들고, request body에 teamId를 받아서 처리하면 돼",
+    "should_trigger": true
+  },
+  {
+    "query": "nextup-scorer에 새로운 POST 엔드포인트를 만들어야 하는데, 기록원이 경기 잠금을 요청하는 API야. scorerId를 @RequestParam으로 받아서 GameLifecycleService.lockGame에 전달하면 돼",
+    "should_trigger": true
+  },
+  {
+    "query": "BookingController에 예약 취소 기능 추가해줘. DELETE /api/v1/bookings/{id} 로 만들어주면 되고, 예약 id만 받으면 돼",
+    "should_trigger": true
+  },
+  {
+    "query": "AppealController를 만들어야 해. POST로 이의제기를 생성하는데, request body에서 appealerId를 받아서 Appeal 엔티티에 넘겨줘",
+    "should_trigger": true
+  },
+  {
+    "query": "RecruitmentController에 모집 공고 삭제 API 추가해줘. @DeleteMapping으로 만들면 되는데, 팀 모집 공고를 삭제하는 거야",
+    "should_trigger": true
+  },
+  {
+    "query": "팀 대시보드 조회 API를 만들어줘. GET /api/v1/teams/{teamId}/dashboard 엔드포인트로 팀 정보, 최근 경기, 순위를 한번에 보여주는 거야",
+    "should_trigger": false
+  },
+  {
+    "query": "BattingRecord 엔티티에 도루 성공/실패 필드를 추가하고 싶어. stolenBases랑 caughtStealing 필드를 Int로 추가해줘",
+    "should_trigger": false
+  },
+  {
+    "query": "GameScheduleServiceImpl에서 getGames 메서드의 페이징을 DB 레벨로 바꿔줘. 지금 findAll() 후 메모리 페이징하는 걸 Pageable로 전환해야 해",
+    "should_trigger": false
+  },
+  {
+    "query": "application.yml에 HikariCP 커넥션 풀 설정을 추가해줘. maximumPoolSize를 20으로 하고 connectionTimeout은 30초로",
+    "should_trigger": false
+  },
+  {
+    "query": "CompetitionResponse DTO에 팀 수 필드를 추가하고 mapper도 수정해줘",
+    "should_trigger": false
+  }
+]

--- a/.claude/skills/verify-custom-exception/SKILL.md
+++ b/.claude/skills/verify-custom-exception/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-custom-exception
-description: 표준 Java 예외 대신 BusinessException 계열 커스텀 예외 사용을 검증합니다. 예외 처리 로직 변경 후 사용.
+description: 예외를 throw하는 코드를 작성할 때 반드시 이 스킬을 참조하라. IllegalArgumentException, IllegalStateException 등 표준 Java 예외를 사용하면 안 되며, 반드시 BusinessException 계열 커스텀 예외를 사용해야 한다. throw 키워드를 작성하거나, catch 블록을 수정하거나, 새로운 예외 클래스를 만들 때 즉시 트리거하라.
 ---
 
 # CustomException 사용 검증

--- a/.claude/skills/verify-dependency/SKILL.md
+++ b/.claude/skills/verify-dependency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-dependency
-description: 멀티모듈 의존성 방향 규칙을 검증합니다. 모듈 간 import/의존성 변경 후 사용.
+description: import문을 작성하거나 모듈 간 코드를 참조할 때 반드시 이 스킬을 참조하라. 의존성 방향은 Outside→Inside만 허용되며, Core가 Infra/API를 알면 절대 안 된다. 다른 모듈의 클래스를 import하려 할 때, build.gradle.kts에 의존성을 추가할 때, 새 모듈에 코드를 작성할 때 즉시 트리거하라. API 계층 모듈(api, backoffice, scorer) 간 상호 의존도 금지.
 ---
 
 # 모듈 의존성 방향 검증

--- a/.claude/skills/verify-entity-leak/SKILL.md
+++ b/.claude/skills/verify-entity-leak/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-entity-leak
-description: Controller 반환 타입에 Entity 직접 노출을 검증합니다. Entity/DTO 변경 후 사용.
+description: Controller의 반환 타입을 작성하거나 수정할 때 반드시 이 스킬을 참조하라. Entity를 API 응답으로 직접 반환하는 것은 Zero Entity Leak 위반이며 즉시 REJECT 사유다. Controller에서 fun 메서드의 반환 타입을 정의하거나, Response DTO를 만들거나, Entity를 import할 때 즉시 트리거하라. 반드시 DTO/Response로 변환하여 반환해야 한다.
 ---
 
 # Zero Entity Leak 검증

--- a/.claude/skills/verify-implementation/SKILL.md
+++ b/.claude/skills/verify-implementation/SKILL.md
@@ -34,6 +34,8 @@ argument-hint: "[선택사항: 특정 verify 스킬 이름]"
 | 3 | `verify-api-response` | Controller의 ApiResponse 래핑 사용 검증 |
 | 4 | `verify-custom-exception` | BusinessException 계열 커스텀 예외 사용 검증 |
 | 5 | `verify-url-prefix` | 모듈별 URL 프리픽스 통일 검증 |
+| 6 | `verify-authorization` | mutating 엔드포인트 @PreAuthorize/@AuthenticationPrincipal 적용 검증 |
+| 7 | `verify-repository-injection` | Controller에서 Repository/RepositoryPort 직접 주입 금지 검증 |
 
 ## 워크플로우
 

--- a/.claude/skills/verify-repository-injection/SKILL.md
+++ b/.claude/skills/verify-repository-injection/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: verify-repository-injection
+description: Controller 클래스를 작성하거나 수정할 때 반드시 이 스킬을 참조하라. Controller에 Repository나 RepositoryPort를 주입하는 것은 레이어 바이패스이며 인가/감사/불변식 검증을 우회하는 심각한 아키텍처 위반이다. Controller의 constructor 파라미터를 추가하거나, import문을 작성할 때 즉시 트리거하라. 항상 Service를 통해 접근해야 한다.
+---
+
+# Controller Repository 직접 주입 금지 검증
+
+## Purpose
+
+1. Controller가 Service 계층을 건너뛰고 Repository/RepositoryPort를 직접 주입하는 패턴 탐지
+2. 레이어 바이패스로 인한 인가 우회, 감사 로깅 누락, 도메인 불변식 검증 누락 방지
+3. Hexagonal Architecture의 레이어 분리 원칙 준수 검증
+
+## When to Run
+
+- 새로운 Controller 추가 후
+- Controller의 의존성(constructor 파라미터) 변경 후
+- Repository/RepositoryPort 관련 수정 후
+- PR 전 통합 검증 시
+
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `nextup-api/src/main/kotlin/com/nextup/api/controller/**/*.kt` | API 컨트롤러 |
+| `nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/**/*.kt` | 백오피스 컨트롤러 |
+| `nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/**/*.kt` | 스코어러 컨트롤러 |
+| `nextup-core/src/main/kotlin/com/nextup/core/repository/**/*.kt` | Repository Port 인터페이스 |
+| `nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/**/*.kt` | Repository 구현체 |
+
+## Workflow
+
+### Step 1: Controller에서 Repository import 탐지
+
+Controller 파일에서 Repository 또는 RepositoryPort를 import하는지 검사합니다.
+
+**도구:** Grep
+
+**패턴:**
+```
+^import.*\.(repository|Repository|RepositoryPort)
+```
+
+**대상:** `**/controller/**/*.kt`
+
+**PASS 기준:** Controller에서 Repository/RepositoryPort import 0건
+**FAIL 기준:** Controller가 Repository/RepositoryPort를 직접 import
+
+**수정 방법:**
+```kotlin
+// FAIL — Controller가 Repository 직접 사용
+import com.nextup.core.repository.TeamRepositoryPort
+
+@RestController
+class TeamController(
+    private val teamRepository: TeamRepositoryPort,  // ❌ 레이어 바이패스
+) {
+    fun createTeam() {
+        val team = teamRepository.save(team)  // ❌ Service 우회
+    }
+}
+
+// PASS — Service를 통해 접근
+import com.nextup.core.service.team.TeamService
+
+@RestController
+class TeamController(
+    private val teamService: TeamService,  // ✅ Service 경유
+) {
+    fun createTeam() {
+        val team = teamService.createTeam(request)  // ✅ 인가/감사/불변식 포함
+    }
+}
+```
+
+### Step 2: Constructor 파라미터에서 Repository 타입 탐지
+
+Controller 클래스의 constructor에 `Repository` 또는 `RepositoryPort` 타입이 포함되는지 검사합니다.
+
+**도구:** Grep
+
+**패턴:**
+```
+(val|var)\s+\w*(repository|Repository|RepositoryPort)\w*\s*:
+```
+
+**대상:** `**/controller/**/*.kt`
+
+**PASS 기준:** Controller constructor에 Repository 타입 파라미터 0건
+**FAIL 기준:** Repository 타입이 Controller constructor에 존재
+
+### Step 3: Controller 내에서 Repository 메서드 직접 호출 탐지
+
+Controller 메서드 내에서 `repository.save()`, `repository.findById()`, `repository.delete()` 등 Repository 메서드를 직접 호출하는지 검사합니다.
+
+**도구:** Grep
+
+**패턴:**
+```
+(repository|Repository|RepositoryPort)\.(save|find|delete|exists|count)
+```
+
+**대상:** `**/controller/**/*.kt`
+
+**PASS 기준:** Controller에서 Repository 메서드 직접 호출 0건
+**FAIL 기준:** Controller가 Repository 메서드를 직접 호출
+
+## Output Format
+
+```markdown
+| # | 파일 | 라인 | 문제 | 심각도 |
+|---|------|------|------|--------|
+| 1 | `TeamController.kt:40` | TeamRepositoryPort 직접 주입 | 🟠 HIGH (레이어 바이패스) |
+| 2 | `TeamController.kt:62` | teamRepository.save() 직접 호출 | 🟠 HIGH (인가/감사 우회) |
+```
+
+## Exceptions
+
+1. **테스트 코드** — `src/test/` 내 파일은 면제
+2. **Infrastructure 모듈의 Service 구현체** — `ServiceImpl`에서 Repository를 사용하는 것은 정상 (Hexagonal Adapter)
+3. **Configuration 클래스** — `@Configuration` 클래스에서 Repository를 사용하는 것은 면제 (초기 데이터 설정 등)

--- a/.claude/skills/verify-repository-injection/evals/trigger-eval.json
+++ b/.claude/skills/verify-repository-injection/evals/trigger-eval.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "TeamController에서 팀 생성 로직을 만들어야 하는데, LeagueRepositoryPort를 주입받아서 리그 존재 여부를 직접 확인하고 TeamRepositoryPort.save()로 저장하면 될 것 같아",
+    "should_trigger": true
+  },
+  {
+    "query": "CompetitionController에 대회 참가 팀 목록 조회를 추가해줘. CompetitionPlayerRepositoryPort를 주입받아서 findByCompetitionId로 가져오면 돼",
+    "should_trigger": true
+  },
+  {
+    "query": "ProfileController를 만들어야 하는데 사용자의 팀 멤버십을 보여줘야 해. TeamMemberRepositoryPort를 constructor에 추가해서 직접 조회하려고",
+    "should_trigger": true
+  },
+  {
+    "query": "BattingRecordController에 GamePlayerRepositoryPort를 주입해서 타석 기록을 조회하는 API를 만들어줘",
+    "should_trigger": true
+  },
+  {
+    "query": "새로운 StadiumController를 만드는데 StadiumRepositoryPort를 import해서 구장 목록을 직접 조회하려고 해",
+    "should_trigger": true
+  },
+  {
+    "query": "TeamDashboardServiceImpl에서 teamRepository.findById를 호출해서 팀 정보를 가져오는 로직을 추가해줘",
+    "should_trigger": false
+  },
+  {
+    "query": "BoxScoreServiceImpl의 N+1 문제를 해결하기 위해 BattingRecordRepositoryPort에 findAllByGamePlayerIds 배치 메서드를 추가해줘",
+    "should_trigger": false
+  },
+  {
+    "query": "Game 엔티티에 lockForScorer 메서드를 수정해서 비관적 락으로 바꾸고 싶어",
+    "should_trigger": false
+  },
+  {
+    "query": "StatsEventListener에서 retryOnOptimisticLock 로직을 @Retryable로 교체해줘",
+    "should_trigger": false
+  },
+  {
+    "query": "nextup-api의 SecurityConfig에서 CORS 설정을 수정해야 해. allowedOrigins에 새 도메인을 추가해줘",
+    "should_trigger": false
+  }
+]

--- a/.claude/skills/verify-url-prefix/SKILL.md
+++ b/.claude/skills/verify-url-prefix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-url-prefix
-description: 모듈별 URL 프리픽스 통일을 검증합니다. Controller 추가/수정 후 사용.
+description: Controller에 @RequestMapping 경로를 작성할 때 반드시 이 스킬을 참조하라. 각 모듈은 정해진 URL 프리픽스를 사용해야 한다(api=/api/v1, backoffice=/admin/v1, scorer=/scorer/v1). @RequestMapping, @GetMapping, @PostMapping 등에 경로를 정의할 때 즉시 트리거하라. 새 Controller 생성 시 항상 확인.
 ---
 
 # URL 프리픽스 통일 검증

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ nextup-scorer     ─┘
 | `verify-api-response` | Controller의 ApiResponse 래핑 사용 검증 |
 | `verify-custom-exception` | BusinessException 계열 커스텀 예외 사용 검증 |
 | `verify-url-prefix` | 모듈별 URL 프리픽스 통일 검증 |
+| `verify-authorization` | mutating 엔드포인트 @PreAuthorize/@AuthenticationPrincipal 적용 검증 |
+| `verify-repository-injection` | Controller에서 Repository/RepositoryPort 직접 주입 금지 검증 |
 
 ### Rules (절대 규칙)
 
@@ -121,6 +123,8 @@ nextup-scorer     ─┘
 | `dependency` | 멀티모듈 의존성 방향 규칙 |
 | `security` | Zero Entity Leak, OWASP 보안 규칙 |
 | `tdd` | Core/Service 계층 TDD 필수, 80% 커버리지 |
+| `authorization` | mutating 엔드포인트 @PreAuthorize 필수, identity는 @AuthenticationPrincipal에서 도출 |
+| `repository-injection` | Controller에서 Repository/RepositoryPort 직접 주입 금지, 반드시 Service 경유 |
 
 ### Commands (슬래시 명령어)
 


### PR DESCRIPTION
## Summary
- 파괴적 기술 검토(#425)에서 발견된 반복적 위반 패턴 방지를 위한 규칙 및 스킬 추가
- `.claude/rules/` 규칙은 매 세션 자동 로드되어 코드 작성 시점에 위반 방지
- `verify-*` 스킬은 `/verify-implementation` 호출 시 사후 검증

## Tasks
- [x] `authorization.md` 규칙 신설 — mutating 엔드포인트 `@PreAuthorize` 필수
- [x] `repository-injection.md` 규칙 신설 — Controller→Repository 직접 주입 금지
- [x] `verify-authorization` 스킬 생성
- [x] `verify-repository-injection` 스킬 생성
- [x] 기존 7개 verify 스킬 description 공격적 재작성 (트리거 최적화)
- [x] CLAUDE.md, manage-skills, verify-implementation 테이블 업데이트

## To Reviewer
- 규칙 트리거 테스트 완료: "BookingController에 예약 취소 기능 추가해줘" → IDOR 누락 자동 감지 ✅
- False positive 테스트 완료: Service 레이어 작업 시 불필요 트리거 안 됨 ✅
- 관련 이슈: #425 (파괴적 기술 검토 Critical 6건), #426

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)"