### PR TITLE
fix(#431): Controller→Repository 직접 주입 7곳 제거 및 Controller↔Service 계약 수정

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/appeal/AppealController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/appeal/AppealController.kt
@@ -7,6 +7,7 @@ import com.nextup.core.service.appeal.AppealService
 import com.nextup.core.service.appeal.dto.CreateAppealRequest
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 /**
@@ -48,9 +49,9 @@ class AppealController(
      */
     @GetMapping("/appeals")
     fun getMyAppeals(
-        @RequestParam appealerId: Long,
+        @AuthenticationPrincipal userId: Long,
     ): ApiResponse<List<AppealResponse>> {
-        val appeals = appealService.getAppealsByAppealer(appealerId)
+        val appeals = appealService.getAppealsByAppealer(userId)
         return ApiResponse.success(appeals.map { AppealResponse.from(it) })
     }
 

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/competition/CompetitionController.kt
@@ -4,9 +4,7 @@ import com.nextup.api.dto.competition.CompetitionResponse
 import com.nextup.api.dto.competition.CompetitionTeamResponse
 import com.nextup.api.dto.standings.StandingsResponse
 import com.nextup.common.dto.ApiResponse
-import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.competition.CompetitionStatus
-import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.service.competition.CompetitionService
 import com.nextup.core.service.standings.StandingsService
 import org.springframework.web.bind.annotation.GetMapping
@@ -23,7 +21,6 @@ import org.springframework.web.bind.annotation.RestController
 class CompetitionController(
     private val competitionService: CompetitionService,
     private val standingsService: StandingsService,
-    private val competitionPlayerRepository: CompetitionPlayerRepositoryPort,
 ) {
     /**
      * 대회 목록을 조회합니다.
@@ -97,23 +94,11 @@ class CompetitionController(
     fun getCompetitionTeams(
         @PathVariable id: Long,
     ): ApiResponse<List<CompetitionTeamResponse>> {
-        // 대회 존재 확인
-        competitionService.getById(id)
-
-        val activePlayers =
-            competitionPlayerRepository.findByCompetitionIdAndStatus(
-                id,
-                CompetitionPlayerStatus.ACTIVE,
-            )
-
+        val teamPlayerCounts = competitionService.getCompetitionTeams(id)
         val teamResponses =
-            activePlayers
-                .groupBy { it.team }
-                .map { (team, players) ->
-                    CompetitionTeamResponse.from(team, players.size)
-                }
+            teamPlayerCounts
+                .map { (team, playerCount) -> CompetitionTeamResponse.from(team, playerCount) }
                 .sortedBy { it.name }
-
         return ApiResponse.success(teamResponses)
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BattingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/BattingRecordController.kt
@@ -4,8 +4,6 @@ import com.nextup.api.dto.game.BattingRecordResponse
 import com.nextup.api.dto.game.CreateBattingRecordRequest
 import com.nextup.api.mapper.game.toResponse
 import com.nextup.common.dto.ApiResponse
-import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
-import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.BattingRecordService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -21,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/games/{gameId}/batting-records")
 class BattingRecordController(
     private val battingRecordService: BattingRecordService,
-    private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
     @GetMapping
     fun getBattingRecordsByGame(
@@ -37,11 +34,7 @@ class BattingRecordController(
         @PathVariable gameId: Long,
         @Valid @RequestBody request: CreateBattingRecordRequest,
     ): ApiResponse<BattingRecordResponse> {
-        val gamePlayer =
-            gamePlayerRepository.findByGameIdAndPlayerId(gameId, request.playerId)
-                ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, request.playerId)
-
-        val record = battingRecordService.createRecord(gamePlayer.id)
+        val record = battingRecordService.createRecordByGameAndPlayer(gameId, request.playerId)
         return ApiResponse.success(record.toResponse())
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/PitchingRecordController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/PitchingRecordController.kt
@@ -4,8 +4,6 @@ import com.nextup.api.dto.game.CreatePitchingRecordRequest
 import com.nextup.api.dto.game.PitchingRecordResponse
 import com.nextup.api.mapper.game.toResponse
 import com.nextup.common.dto.ApiResponse
-import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
-import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.PitchingRecordService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -21,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/games/{gameId}/pitching-records")
 class PitchingRecordController(
     private val pitchingRecordService: PitchingRecordService,
-    private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
     @GetMapping
     fun getPitchingRecordsByGame(
@@ -37,11 +34,8 @@ class PitchingRecordController(
         @PathVariable gameId: Long,
         @Valid @RequestBody request: CreatePitchingRecordRequest,
     ): ApiResponse<PitchingRecordResponse> {
-        val gamePlayer =
-            gamePlayerRepository.findByGameIdAndPlayerId(gameId, request.playerId)
-                ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, request.playerId)
-
-        val record = pitchingRecordService.createRecord(gamePlayer.id, request.isStartingPitcher)
+        val record =
+            pitchingRecordService.createRecordByGameAndPlayer(gameId, request.playerId, request.isStartingPitcher)
         return ApiResponse.success(record.toResponse())
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/recruitment/RecruitmentController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/recruitment/RecruitmentController.kt
@@ -9,6 +9,7 @@ import com.nextup.core.service.recruitment.dto.CreateRecruitmentRequest
 import com.nextup.core.service.recruitment.dto.UpdateRecruitmentRequest
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 
 /**
@@ -46,6 +47,7 @@ class RecruitmentController(
      */
     @PostMapping("/teams/{teamId}/recruitments")
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun createRecruitment(
         @PathVariable teamId: Long,
         @Valid @RequestBody request: CreateRecruitmentApiRequest,
@@ -71,6 +73,7 @@ class RecruitmentController(
      * 팀의 모집 공고를 수정합니다.
      */
     @PutMapping("/teams/{teamId}/recruitments/{id}")
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun updateRecruitment(
         @PathVariable teamId: Long,
         @PathVariable id: Long,
@@ -79,6 +82,7 @@ class RecruitmentController(
         val recruitment =
             recruitmentService.updateRecruitment(
                 id = id,
+                teamId = teamId,
                 request =
                     UpdateRecruitmentRequest(
                         title = request.title,
@@ -96,11 +100,12 @@ class RecruitmentController(
      */
     @DeleteMapping("/teams/{teamId}/recruitments/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun deleteRecruitment(
         @PathVariable teamId: Long,
         @PathVariable id: Long,
     ): ApiResponse<Unit> {
-        recruitmentService.deleteRecruitment(id)
+        recruitmentService.deleteRecruitment(id, teamId)
         return ApiResponse.success(Unit)
     }
 }

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/BookingTransferController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/stadium/BookingTransferController.kt
@@ -8,6 +8,8 @@ import com.nextup.core.service.stadium.BookingTransferService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -35,6 +37,7 @@ class BookingTransferController(
     @PostMapping
     fun requestTransfer(
         @RequestBody @Valid request: CreateBookingTransferApiRequest,
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<BookingTransferResponse>> {
         val transfer =
             bookingTransferService.createTransfer(
@@ -46,6 +49,7 @@ class BookingTransferController(
                     request.expiresAt
                         ?: java.time.Instant.now()
                             .plusSeconds(BookingTransferService.DEFAULT_EXPIRY_SECONDS),
+                userId = userId,
             )
         return ResponseEntity
             .status(HttpStatus.CREATED)
@@ -61,11 +65,13 @@ class BookingTransferController(
     fun acceptTransfer(
         @PathVariable transferId: Long,
         @RequestBody @Valid request: AcceptBookingTransferApiRequest,
+        @AuthenticationPrincipal userId: Long,
     ): ApiResponse<BookingTransferResponse> {
         val transfer =
             bookingTransferService.acceptTransfer(
                 transferId = transferId,
                 buyerTeamId = request.buyerTeamId,
+                userId = userId,
             )
         return ApiResponse.success(BookingTransferResponse.from(transfer))
     }
@@ -76,6 +82,7 @@ class BookingTransferController(
      * PATCH /api/v1/booking-transfers/{transferId}/reject
      */
     @PatchMapping("/{transferId}/reject")
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun rejectTransfer(
         @PathVariable transferId: Long,
         @RequestParam teamId: Long,
@@ -105,6 +112,7 @@ class BookingTransferController(
      * GET /api/v1/booking-transfers/my?teamId={teamId}
      */
     @GetMapping("/my")
+    @PreAuthorize("@teamSecurity.isMember(#teamId, authentication.principal)")
     fun getMyTransfers(
         @RequestParam teamId: Long,
     ): ApiResponse<List<BookingTransferResponse>> {

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamController.kt
@@ -6,11 +6,7 @@ import com.nextup.api.dto.team.TeamSummaryResponse
 import com.nextup.api.dto.team.UpdateTeamRequest
 import com.nextup.common.dto.ApiResponse
 import com.nextup.common.exception.InvalidInputException
-import com.nextup.common.exception.LeagueNotFoundException
-import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.team.Team
-import com.nextup.core.port.repository.LeagueRepositoryPort
-import com.nextup.core.port.repository.TeamRepositoryPort
 import com.nextup.core.service.team.TeamMembershipService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -37,8 +33,6 @@ import java.time.LocalDate
 @RequestMapping("/api/v1/teams")
 class TeamController(
     private val teamMembershipService: TeamMembershipService,
-    private val teamRepository: TeamRepositoryPort,
-    private val leagueRepository: LeagueRepositoryPort,
 ) {
     /**
      * 팀을 생성합니다. 생성자가 OWNER로 자동 등록됩니다.
@@ -54,23 +48,15 @@ class TeamController(
         val leagueId =
             request.leagueId
                 ?: throw InvalidInputException("INVALID_INPUT", "리그 ID는 필수입니다")
-        val league =
-            leagueRepository.findByIdOrNull(leagueId)
-                ?: throw LeagueNotFoundException(leagueId)
-
-        val team =
-            Team(
-                league = league,
-                name = request.name,
-                city = request.city,
-                abbreviation = request.abbreviation,
-                foundedYear = LocalDate.now().year,
-            )
 
         val savedTeam =
             teamMembershipService.createTeamWithOwner(
                 userId = userId,
-                team = team,
+                leagueId = leagueId,
+                name = request.name,
+                city = request.city,
+                abbreviation = request.abbreviation,
+                foundedYear = LocalDate.now().year,
                 uniformNumber = request.uniformNumber,
             )
 
@@ -91,17 +77,13 @@ class TeamController(
         @RequestBody @Valid request: UpdateTeamRequest,
         @AuthenticationPrincipal userId: Long,
     ): ApiResponse<TeamDetailResponse> {
-        val team =
-            teamRepository.findByIdWithLeague(teamId)
-                ?: throw TeamNotFoundException(teamId)
-
-        team.updateBasicInfo(
-            name = request.name,
-            city = request.city,
-            abbreviation = request.abbreviation,
-        )
-
-        val savedTeam = teamRepository.save(team)
+        val savedTeam =
+            teamMembershipService.updateTeam(
+                teamId = teamId,
+                name = request.name,
+                city = request.city,
+                abbreviation = request.abbreviation,
+            )
         val memberCount = teamMembershipService.getTeamMemberCount(teamId)
 
         return ApiResponse.success(savedTeam.toDetailResponse(memberCount))
@@ -116,9 +98,7 @@ class TeamController(
     fun getTeam(
         @PathVariable teamId: Long,
     ): ApiResponse<TeamDetailResponse> {
-        val team =
-            teamRepository.findByIdWithLeague(teamId)
-                ?: throw TeamNotFoundException(teamId)
+        val team = teamMembershipService.getTeamWithLeague(teamId)
         val memberCount = teamMembershipService.getTeamMemberCount(teamId)
 
         return ApiResponse.success(team.toDetailResponse(memberCount))
@@ -134,7 +114,7 @@ class TeamController(
         @RequestParam(required = false) name: String?,
         @RequestParam(required = false) city: String?,
     ): ApiResponse<List<TeamSummaryResponse>> {
-        val teams = teamRepository.findActiveTeamsByFilter(name, city)
+        val teams = teamMembershipService.getActiveTeamsByFilter(name, city)
 
         val teamIds = teams.map { it.id }
         val memberCounts = teamMembershipService.getTeamMemberCounts(teamIds)

--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/user/ProfileController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/user/ProfileController.kt
@@ -3,8 +3,8 @@ package com.nextup.api.controller.user
 import com.nextup.api.dto.game.GameSummaryResponse
 import com.nextup.api.dto.user.*
 import com.nextup.common.dto.ApiResponse
-import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.game.GameScheduleService
+import com.nextup.core.service.team.TeamMembershipService
 import com.nextup.core.service.user.UserService
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/v1/me")
 class ProfileController(
     private val userService: UserService,
-    private val teamMemberRepository: TeamMemberRepositoryPort,
+    private val teamMembershipService: TeamMembershipService,
     private val gameScheduleService: GameScheduleService,
 ) {
     /**
@@ -40,7 +40,7 @@ class ProfileController(
     fun getMyTeams(
         @AuthenticationPrincipal userId: Long,
     ): ApiResponse<List<MyTeamResponse>> {
-        val activeMembers = teamMemberRepository.findAllActiveByUserId(userId)
+        val activeMembers = teamMembershipService.getActiveTeamsByUserId(userId)
         return ApiResponse.success(activeMembers.map { MyTeamResponse.from(it) })
     }
 
@@ -52,7 +52,7 @@ class ProfileController(
         @AuthenticationPrincipal userId: Long,
         @RequestParam(defaultValue = "10") limit: Int,
     ): ApiResponse<List<GameSummaryResponse>> {
-        val activeMembers = teamMemberRepository.findAllActiveByUserId(userId)
+        val activeMembers = teamMembershipService.getActiveTeamsByUserId(userId)
         val teamIds = activeMembers.map { it.team.id }
         val games = gameScheduleService.getUpcomingGamesByTeamIds(teamIds, limit)
         return ApiResponse.success(games.map { GameSummaryResponse.from(it) })

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/appeal/AppealControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/appeal/AppealControllerTest.kt
@@ -44,6 +44,9 @@ class AppealControllerTest {
             MockMvcBuilders
                 .standaloneSetup(controller)
                 .setControllerAdvice(GlobalExceptionHandler())
+                .setCustomArgumentResolvers(
+                    AuthenticationPrincipalResolver(100L),
+                )
                 .build()
 
         every { mockGame.id } returns 1L
@@ -151,7 +154,7 @@ class AppealControllerTest {
 
         // when & then
         mockMvc
-            .perform(get("/api/v1/appeals").param("appealerId", "100"))
+            .perform(get("/api/v1/appeals"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data").isArray)
@@ -164,17 +167,17 @@ class AppealControllerTest {
     @Test
     fun `should get empty list when no appeals found for appealer`() {
         // given
-        every { appealService.getAppealsByAppealer(999L) } returns emptyList()
+        every { appealService.getAppealsByAppealer(100L) } returns emptyList()
 
         // when & then
         mockMvc
-            .perform(get("/api/v1/appeals").param("appealerId", "999"))
+            .perform(get("/api/v1/appeals"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data").isArray)
             .andExpect(jsonPath("$.data").isEmpty)
 
-        verify(exactly = 1) { appealService.getAppealsByAppealer(999L) }
+        verify(exactly = 1) { appealService.getAppealsByAppealer(100L) }
     }
 
     @Test
@@ -259,4 +262,23 @@ class AppealControllerTest {
                 .andExpect(jsonPath("$.data.type").value(type.name))
         }
     }
+}
+
+/**
+ * 테스트용 @AuthenticationPrincipal 리졸버
+ */
+private class AuthenticationPrincipalResolver(
+    private val userId: Long,
+) : org.springframework.web.method.support.HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: org.springframework.core.MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(
+            org.springframework.security.core.annotation.AuthenticationPrincipal::class.java,
+        )
+
+    override fun resolveArgument(
+        parameter: org.springframework.core.MethodParameter,
+        mavContainer: org.springframework.web.method.support.ModelAndViewContainer?,
+        webRequest: org.springframework.web.context.request.NativeWebRequest,
+        binderFactory: org.springframework.web.bind.support.WebDataBinderFactory?,
+    ): Any = userId
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerStandingsTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerStandingsTest.kt
@@ -7,7 +7,6 @@ import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
-import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.service.competition.CompetitionService
 import com.nextup.core.service.standings.StandingsService
 import com.nextup.core.service.standings.dto.StandingsDto
@@ -32,15 +31,13 @@ class CompetitionControllerStandingsTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var competitionService: CompetitionService
     private lateinit var standingsService: StandingsService
-    private lateinit var competitionPlayerRepository: CompetitionPlayerRepositoryPort
 
     @BeforeEach
     fun setUp() {
         competitionService = mockk()
         standingsService = mockk()
-        competitionPlayerRepository = mockk()
 
-        val controller = CompetitionController(competitionService, standingsService, competitionPlayerRepository)
+        val controller = CompetitionController(competitionService, standingsService)
         mockMvc =
             MockMvcBuilders
                 .standaloneSetup(controller)

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/competition/CompetitionControllerTest.kt
@@ -2,14 +2,11 @@ package com.nextup.api.controller.competition
 
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
-import com.nextup.core.domain.competition.CompetitionPlayer
-import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.team.Team
-import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.service.competition.CompetitionService
 import com.nextup.core.service.standings.StandingsService
 import io.mockk.every
@@ -30,15 +27,13 @@ class CompetitionControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var competitionService: CompetitionService
     private lateinit var standingsService: StandingsService
-    private lateinit var competitionPlayerRepository: CompetitionPlayerRepositoryPort
     private lateinit var controller: CompetitionController
 
     @BeforeEach
     fun setUp() {
         competitionService = mockk()
         standingsService = mockk()
-        competitionPlayerRepository = mockk()
-        controller = CompetitionController(competitionService, standingsService, competitionPlayerRepository)
+        controller = CompetitionController(competitionService, standingsService)
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
     }
 
@@ -166,24 +161,10 @@ class CompetitionControllerTest {
             val competitionId = 1L
             val association = createAssociation(1L, "서울시야구협회")
             val league = createLeague(1L, "1부 리그", association)
-            val competition = createCompetition(competitionId, league, "2025 춘계대회", 2025, 1)
             val team1 = createTeam(1L, league, "타이거즈", "서울")
             val team2 = createTeam(2L, league, "베어스", "인천")
-            val player1 = createPlayer(1L, "선수1")
-            val player2 = createPlayer(2L, "선수2")
-            val player3 = createPlayer(3L, "선수3")
 
-            val cp1 = CompetitionPlayer.register(competition, team1, player1)
-            val cp2 = CompetitionPlayer.register(competition, team1, player2)
-            val cp3 = CompetitionPlayer.register(competition, team2, player3)
-
-            every { competitionService.getById(competitionId) } returns competition
-            every {
-                competitionPlayerRepository.findByCompetitionIdAndStatus(
-                    competitionId,
-                    CompetitionPlayerStatus.ACTIVE,
-                )
-            } returns listOf(cp1, cp2, cp3)
+            every { competitionService.getCompetitionTeams(competitionId) } returns mapOf(team1 to 2, team2 to 1)
 
             // when & then
             mockMvc
@@ -198,17 +179,8 @@ class CompetitionControllerTest {
         fun `should return empty list when no teams registered`() {
             // given
             val competitionId = 1L
-            val association = createAssociation(1L, "서울시야구협회")
-            val league = createLeague(1L, "1부 리그", association)
-            val competition = createCompetition(competitionId, league, "2025 춘계대회", 2025, 1)
 
-            every { competitionService.getById(competitionId) } returns competition
-            every {
-                competitionPlayerRepository.findByCompetitionIdAndStatus(
-                    competitionId,
-                    CompetitionPlayerStatus.ACTIVE,
-                )
-            } returns emptyList()
+            every { competitionService.getCompetitionTeams(competitionId) } returns emptyMap()
 
             // when & then
             mockMvc

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BattingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/BattingRecordControllerTest.kt
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nextup.api.dto.game.CreateBattingRecordRequest
 import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
 import com.nextup.common.exception.RecordAlreadyExistsException
 import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.GamePlayer
-import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.BattingRecordService
 import io.mockk.every
 import io.mockk.mockk
@@ -27,7 +27,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 class BattingRecordControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var battingRecordService: BattingRecordService
-    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var objectMapper: ObjectMapper
 
     private val gameId = 1L
@@ -37,10 +36,9 @@ class BattingRecordControllerTest {
     @BeforeEach
     fun setUp() {
         battingRecordService = mockk()
-        gamePlayerRepository = mockk()
         objectMapper = jacksonObjectMapper()
 
-        val controller = BattingRecordController(battingRecordService, gamePlayerRepository)
+        val controller = BattingRecordController(battingRecordService)
         mockMvc =
             MockMvcBuilders
                 .standaloneSetup(controller)
@@ -166,8 +164,7 @@ class BattingRecordControllerTest {
                     every { stolenBasePercentage } returns java.math.BigDecimal("0.000")
                 }
 
-            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
-            every { battingRecordService.createRecord(gamePlayerId) } returns record
+            every { battingRecordService.createRecordByGameAndPlayer(gameId, playerId) } returns record
 
             // when & then
             mockMvc
@@ -185,7 +182,9 @@ class BattingRecordControllerTest {
         fun `should return 404 when game player not found`() {
             // given
             val request = CreateBattingRecordRequest(playerId = playerId)
-            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns null
+            every {
+                battingRecordService.createRecordByGameAndPlayer(gameId, playerId)
+            } throws GamePlayerNotFoundByGameAndPlayerException(gameId, playerId)
 
             // when & then
             mockMvc
@@ -202,14 +201,10 @@ class BattingRecordControllerTest {
         fun `should return 400 when record already exists`() {
             // given
             val request = CreateBattingRecordRequest(playerId = playerId)
-            val gamePlayer =
-                mockk<GamePlayer> {
-                    every { id } returns gamePlayerId
-                }
 
-            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
-            every { battingRecordService.createRecord(gamePlayerId) } throws
-                RecordAlreadyExistsException(gamePlayerId, "Batting")
+            every {
+                battingRecordService.createRecordByGameAndPlayer(gameId, playerId)
+            } throws RecordAlreadyExistsException(gamePlayerId, "Batting")
 
             // when & then
             mockMvc

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/PitchingRecordControllerTest.kt
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nextup.api.dto.game.CreatePitchingRecordRequest
 import com.nextup.api.exception.GlobalExceptionHandler
+import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
 import com.nextup.common.exception.RecordAlreadyExistsException
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.PitchingDecision
 import com.nextup.core.domain.game.PitchingRecord
-import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.PitchingRecordService
 import io.mockk.every
 import io.mockk.mockk
@@ -28,7 +28,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 class PitchingRecordControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var pitchingRecordService: PitchingRecordService
-    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var objectMapper: ObjectMapper
 
     private val gameId = 1L
@@ -38,10 +37,9 @@ class PitchingRecordControllerTest {
     @BeforeEach
     fun setUp() {
         pitchingRecordService = mockk()
-        gamePlayerRepository = mockk()
         objectMapper = jacksonObjectMapper()
 
-        val controller = PitchingRecordController(pitchingRecordService, gamePlayerRepository)
+        val controller = PitchingRecordController(pitchingRecordService)
         mockMvc =
             MockMvcBuilders
                 .standaloneSetup(controller)
@@ -135,8 +133,7 @@ class PitchingRecordControllerTest {
                 }
             val record = createMockPitchingRecord(gamePlayer, isStartingPitcher = true)
 
-            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
-            every { pitchingRecordService.createRecord(gamePlayerId, true) } returns record
+            every { pitchingRecordService.createRecordByGameAndPlayer(gameId, playerId, true) } returns record
 
             // when & then
             mockMvc
@@ -160,8 +157,7 @@ class PitchingRecordControllerTest {
                 }
             val record = createMockPitchingRecord(gamePlayer, isStartingPitcher = false)
 
-            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
-            every { pitchingRecordService.createRecord(gamePlayerId, false) } returns record
+            every { pitchingRecordService.createRecordByGameAndPlayer(gameId, playerId, false) } returns record
 
             // when & then
             mockMvc
@@ -178,7 +174,9 @@ class PitchingRecordControllerTest {
         fun `should return 404 when game player not found`() {
             // given
             val request = CreatePitchingRecordRequest(playerId = playerId)
-            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns null
+            every {
+                pitchingRecordService.createRecordByGameAndPlayer(gameId, playerId, false)
+            } throws GamePlayerNotFoundByGameAndPlayerException(gameId, playerId)
 
             // when & then
             mockMvc
@@ -195,14 +193,10 @@ class PitchingRecordControllerTest {
         fun `should return 400 when record already exists`() {
             // given
             val request = CreatePitchingRecordRequest(playerId = playerId)
-            val gamePlayer =
-                mockk<GamePlayer> {
-                    every { id } returns gamePlayerId
-                }
 
-            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns gamePlayer
-            every { pitchingRecordService.createRecord(gamePlayerId, false) } throws
-                RecordAlreadyExistsException(gamePlayerId, "Pitching")
+            every {
+                pitchingRecordService.createRecordByGameAndPlayer(gameId, playerId, false)
+            } throws RecordAlreadyExistsException(gamePlayerId, "Pitching")
 
             // when & then
             mockMvc

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/recruitment/RecruitmentControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/recruitment/RecruitmentControllerTest.kt
@@ -234,7 +234,7 @@ class RecruitmentControllerTest {
         every { updatedRecruitment.createdAt } returns Instant.now()
         every { updatedRecruitment.updatedAt } returns Instant.now()
 
-        every { recruitmentService.updateRecruitment(any(), any()) } returns updatedRecruitment
+        every { recruitmentService.updateRecruitment(any(), any(), any()) } returns updatedRecruitment
 
         // when & then
         mockMvc
@@ -247,13 +247,13 @@ class RecruitmentControllerTest {
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.title").value("새 제목"))
 
-        verify(exactly = 1) { recruitmentService.updateRecruitment(any(), any()) }
+        verify(exactly = 1) { recruitmentService.updateRecruitment(any(), any(), any()) }
     }
 
     @Test
     fun `should delete recruitment`() {
         // given
-        justRun { recruitmentService.deleteRecruitment(1L) }
+        justRun { recruitmentService.deleteRecruitment(1L, 1L) }
 
         // when & then
         mockMvc
@@ -261,13 +261,13 @@ class RecruitmentControllerTest {
             .andExpect(status().isNoContent)
             .andExpect(jsonPath("$.success").value(true))
 
-        verify(exactly = 1) { recruitmentService.deleteRecruitment(1L) }
+        verify(exactly = 1) { recruitmentService.deleteRecruitment(1L, 1L) }
     }
 
     @Test
     fun `should return 404 when deleting non-existent recruitment`() {
         // given
-        every { recruitmentService.deleteRecruitment(999L) } throws RecruitmentNotFoundException(999L)
+        every { recruitmentService.deleteRecruitment(999L, 1L) } throws RecruitmentNotFoundException(999L)
 
         // when & then
         mockMvc

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingTransferControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/stadium/BookingTransferControllerTest.kt
@@ -34,6 +34,8 @@ class BookingTransferControllerTest {
     private lateinit var bookingTransferService: BookingTransferService
     private lateinit var objectMapper: ObjectMapper
 
+    private val authenticatedUserId = 100L
+
     @BeforeEach
     fun setUp() {
         bookingTransferService = mockk()
@@ -42,6 +44,9 @@ class BookingTransferControllerTest {
             MockMvcBuilders
                 .standaloneSetup(controller)
                 .setControllerAdvice(GlobalExceptionHandler())
+                .setCustomArgumentResolvers(
+                    AuthenticationPrincipalResolver(authenticatedUserId),
+                )
                 .build()
         objectMapper =
             jacksonObjectMapper().registerModule(JavaTimeModule())
@@ -92,6 +97,7 @@ class BookingTransferControllerTest {
                     price = BigDecimal("50000"),
                     message = "양도합니다",
                     expiresAt = any(),
+                    userId = any(),
                 )
             } returns transfer
 
@@ -127,6 +133,7 @@ class BookingTransferControllerTest {
                     price = null,
                     message = null,
                     expiresAt = expiresAt,
+                    userId = any(),
                 )
             } returns transfer
 
@@ -158,6 +165,7 @@ class BookingTransferControllerTest {
                 bookingTransferService.acceptTransfer(
                     transferId = 1L,
                     buyerTeamId = 20L,
+                    userId = any(),
                 )
             } returns transfer
 
@@ -181,6 +189,7 @@ class BookingTransferControllerTest {
                 bookingTransferService.acceptTransfer(
                     transferId = 999L,
                     buyerTeamId = 20L,
+                    userId = any(),
                 )
             } throws BookingTransferNotFoundException(999L)
 
@@ -324,4 +333,23 @@ class BookingTransferControllerTest {
                 .andExpect(jsonPath("$.data.length()").value(0))
         }
     }
+}
+
+/**
+ * 테스트용 @AuthenticationPrincipal 리졸버
+ */
+private class AuthenticationPrincipalResolver(
+    private val userId: Long,
+) : org.springframework.web.method.support.HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: org.springframework.core.MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(
+            org.springframework.security.core.annotation.AuthenticationPrincipal::class.java,
+        )
+
+    override fun resolveArgument(
+        parameter: org.springframework.core.MethodParameter,
+        mavContainer: org.springframework.web.method.support.ModelAndViewContainer?,
+        webRequest: org.springframework.web.context.request.NativeWebRequest,
+        binderFactory: org.springframework.web.bind.support.WebDataBinderFactory?,
+    ): Any = userId
 }

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamControllerTest.kt
@@ -3,12 +3,9 @@ package com.nextup.api.controller.team
 import com.nextup.api.dto.team.CreateTeamRequest
 import com.nextup.api.dto.team.UpdateTeamRequest
 import com.nextup.common.exception.InvalidInputException
-import com.nextup.common.exception.LeagueNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.team.Team
-import com.nextup.core.port.repository.LeagueRepositoryPort
-import com.nextup.core.port.repository.TeamRepositoryPort
 import com.nextup.core.service.team.TeamMembershipService
 import io.mockk.every
 import io.mockk.justRun
@@ -24,8 +21,6 @@ import org.junit.jupiter.api.assertThrows
 @DisplayName("TeamController")
 class TeamControllerTest {
     private lateinit var teamMembershipService: TeamMembershipService
-    private lateinit var teamRepository: TeamRepositoryPort
-    private lateinit var leagueRepository: LeagueRepositoryPort
     private lateinit var controller: TeamController
 
     private val league =
@@ -48,9 +43,7 @@ class TeamControllerTest {
     @BeforeEach
     fun setUp() {
         teamMembershipService = mockk()
-        teamRepository = mockk()
-        leagueRepository = mockk()
-        controller = TeamController(teamMembershipService, teamRepository, leagueRepository)
+        controller = TeamController(teamMembershipService)
     }
 
     @Nested
@@ -67,11 +60,14 @@ class TeamControllerTest {
                     abbreviation = "TGR",
                     uniformNumber = 1,
                 )
-            every { leagueRepository.findByIdOrNull(1L) } returns league
             every {
                 teamMembershipService.createTeamWithOwner(
                     userId = 100L,
-                    team = any(),
+                    leagueId = 1L,
+                    name = "타이거즈",
+                    city = "서울",
+                    abbreviation = "TGR",
+                    foundedYear = any(),
                     uniformNumber = 1,
                 )
             } returns team
@@ -87,23 +83,6 @@ class TeamControllerTest {
             assertThat(response.data?.city).isEqualTo("서울")
             assertThat(response.data?.leagueName).isEqualTo("1부 리그")
             assertThat(response.data?.memberCount).isEqualTo(1)
-        }
-
-        @Test
-        fun `should throw when league not found`() {
-            // given
-            val request =
-                CreateTeamRequest(
-                    name = "타이거즈",
-                    city = "서울",
-                    leagueId = 999L,
-                )
-            every { leagueRepository.findByIdOrNull(999L) } returns null
-
-            // when & then
-            assertThrows<LeagueNotFoundException> {
-                controller.createTeam(request, 100L)
-            }
         }
 
         @Test
@@ -130,9 +109,14 @@ class TeamControllerTest {
         fun `should update team`() {
             // given
             val request = UpdateTeamRequest(name = "뉴타이거즈")
-            every { teamRepository.findByIdWithLeague(10L) } returns team
-            every { team.updateBasicInfo(name = "뉴타이거즈", city = null, abbreviation = null) } returns Unit
-            every { teamRepository.save(team) } returns team
+            every {
+                teamMembershipService.updateTeam(
+                    teamId = 10L,
+                    name = "뉴타이거즈",
+                    city = null,
+                    abbreviation = null,
+                )
+            } returns team
             every { teamMembershipService.getTeamMemberCount(10L) } returns 5
 
             // when
@@ -147,7 +131,14 @@ class TeamControllerTest {
         fun `should throw when team not found`() {
             // given
             val request = UpdateTeamRequest(name = "뉴타이거즈")
-            every { teamRepository.findByIdWithLeague(10L) } returns null
+            every {
+                teamMembershipService.updateTeam(
+                    teamId = 10L,
+                    name = "뉴타이거즈",
+                    city = null,
+                    abbreviation = null,
+                )
+            } throws TeamNotFoundException(10L)
 
             // when & then
             assertThrows<TeamNotFoundException> {
@@ -162,7 +153,7 @@ class TeamControllerTest {
         @Test
         fun `should return team detail`() {
             // given
-            every { teamRepository.findByIdWithLeague(10L) } returns team
+            every { teamMembershipService.getTeamWithLeague(10L) } returns team
             every { teamMembershipService.getTeamMemberCount(10L) } returns 15
 
             // when
@@ -178,7 +169,7 @@ class TeamControllerTest {
         @Test
         fun `should throw when team not found`() {
             // given
-            every { teamRepository.findByIdWithLeague(999L) } returns null
+            every { teamMembershipService.getTeamWithLeague(999L) } throws TeamNotFoundException(999L)
 
             // when & then
             assertThrows<TeamNotFoundException> {
@@ -202,7 +193,7 @@ class TeamControllerTest {
                     every { logoUrl } returns null
                     every { isActive } returns true
                 }
-            every { teamRepository.findActiveTeamsByFilter(null, null) } returns listOf(team, team2)
+            every { teamMembershipService.getActiveTeamsByFilter(null, null) } returns listOf(team, team2)
             every { teamMembershipService.getTeamMemberCounts(listOf(10L, 20L)) } returns mapOf(10L to 15, 20L to 12)
 
             // when
@@ -216,7 +207,7 @@ class TeamControllerTest {
         @Test
         fun `should filter by name`() {
             // given
-            every { teamRepository.findActiveTeamsByFilter("타이거", null) } returns listOf(team)
+            every { teamMembershipService.getActiveTeamsByFilter("타이거", null) } returns listOf(team)
             every { teamMembershipService.getTeamMemberCounts(listOf(10L)) } returns mapOf(10L to 15)
 
             // when
@@ -230,7 +221,7 @@ class TeamControllerTest {
         @Test
         fun `should filter by city`() {
             // given
-            every { teamRepository.findActiveTeamsByFilter(null, "서울") } returns listOf(team)
+            every { teamMembershipService.getActiveTeamsByFilter(null, "서울") } returns listOf(team)
             every { teamMembershipService.getTeamMemberCounts(listOf(10L)) } returns mapOf(10L to 15)
 
             // when
@@ -253,9 +244,8 @@ class TeamControllerTest {
                     every { isActive } returns true
                 }
             every {
-                teamRepository.findActiveTeamsByFilter(null, null)
+                teamMembershipService.getActiveTeamsByFilter(null, null)
             } returns listOf(team, team2)
-            // team2(20L)의 카운트가 map에 없음 → ?: 0 분기 커버
             every {
                 teamMembershipService.getTeamMemberCounts(listOf(10L, 20L))
             } returns mapOf(10L to 15)
@@ -273,7 +263,7 @@ class TeamControllerTest {
         @Test
         fun `should return empty when no match`() {
             // given
-            every { teamRepository.findActiveTeamsByFilter("없는팀", null) } returns emptyList()
+            every { teamMembershipService.getActiveTeamsByFilter("없는팀", null) } returns emptyList()
             every { teamMembershipService.getTeamMemberCounts(emptyList()) } returns emptyMap()
 
             // when

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/user/ProfileControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/user/ProfileControllerTest.kt
@@ -7,9 +7,9 @@ import com.nextup.core.domain.team.TeamMember
 import com.nextup.core.domain.team.TeamMemberRole
 import com.nextup.core.domain.user.OAuthProvider
 import com.nextup.core.domain.user.User
-import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.game.GameScheduleService
 import com.nextup.core.service.game.dto.GameSummaryDto
+import com.nextup.core.service.team.TeamMembershipService
 import com.nextup.core.service.user.UserService
 import io.mockk.every
 import io.mockk.mockk
@@ -24,19 +24,19 @@ import java.time.LocalDateTime
 @DisplayName("ProfileController 테스트")
 class ProfileControllerTest {
     private lateinit var userService: UserService
-    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
+    private lateinit var teamMembershipService: TeamMembershipService
     private lateinit var gameScheduleService: GameScheduleService
     private lateinit var profileController: ProfileController
 
     @BeforeEach
     fun setUp() {
         userService = mockk()
-        teamMemberRepository = mockk()
+        teamMembershipService = mockk()
         gameScheduleService = mockk()
         profileController =
             ProfileController(
                 userService,
-                teamMemberRepository,
+                teamMembershipService,
                 gameScheduleService,
             )
     }
@@ -160,7 +160,7 @@ class ProfileControllerTest {
                     joinedAt = LocalDateTime.of(2026, 3, 1, 0, 0),
                 )
 
-            every { teamMemberRepository.findAllActiveByUserId(userId) } returns listOf(member1, member2)
+            every { teamMembershipService.getActiveTeamsByUserId(userId) } returns listOf(member1, member2)
 
             // when
             val response = profileController.getMyTeams(userId)
@@ -184,14 +184,14 @@ class ProfileControllerTest {
             assertThat(second.role).isEqualTo(TeamMemberRole.MEMBER)
             assertThat(second.uniformNumber).isEqualTo(3)
 
-            verify { teamMemberRepository.findAllActiveByUserId(userId) }
+            verify { teamMembershipService.getActiveTeamsByUserId(userId) }
         }
 
         @Test
         fun `should return empty list when user has no teams`() {
             // given
             val userId = 1L
-            every { teamMemberRepository.findAllActiveByUserId(userId) } returns emptyList()
+            every { teamMembershipService.getActiveTeamsByUserId(userId) } returns emptyList()
 
             // when
             val response = profileController.getMyTeams(userId)
@@ -199,7 +199,7 @@ class ProfileControllerTest {
             // then
             assertThat(response.success).isTrue()
             assertThat(response.data).isEmpty()
-            verify { teamMemberRepository.findAllActiveByUserId(userId) }
+            verify { teamMembershipService.getActiveTeamsByUserId(userId) }
         }
     }
 
@@ -215,7 +215,7 @@ class ProfileControllerTest {
             val member1 = createMockTeamMember(team = team1)
             val member2 = createMockTeamMember(team = team2)
 
-            every { teamMemberRepository.findAllActiveByUserId(userId) } returns listOf(member1, member2)
+            every { teamMembershipService.getActiveTeamsByUserId(userId) } returns listOf(member1, member2)
 
             val gameSummaries =
                 listOf(
@@ -268,7 +268,7 @@ class ProfileControllerTest {
             assertThat(response.data!![0].gameId).isEqualTo(100L)
             assertThat(response.data!![1].gameId).isEqualTo(200L)
 
-            verify { teamMemberRepository.findAllActiveByUserId(userId) }
+            verify { teamMembershipService.getActiveTeamsByUserId(userId) }
             verify { gameScheduleService.getUpcomingGamesByTeamIds(listOf(10L, 20L), 10) }
         }
 
@@ -276,7 +276,7 @@ class ProfileControllerTest {
         fun `should return empty list when user has no teams`() {
             // given
             val userId = 1L
-            every { teamMemberRepository.findAllActiveByUserId(userId) } returns emptyList()
+            every { teamMembershipService.getActiveTeamsByUserId(userId) } returns emptyList()
             every { gameScheduleService.getUpcomingGamesByTeamIds(emptyList(), 10) } returns emptyList()
 
             // when
@@ -294,7 +294,7 @@ class ProfileControllerTest {
             val team1 = createMockTeam(10L, "팀A")
             val member1 = createMockTeamMember(team = team1)
 
-            every { teamMemberRepository.findAllActiveByUserId(userId) } returns listOf(member1)
+            every { teamMembershipService.getActiveTeamsByUserId(userId) } returns listOf(member1)
             every { gameScheduleService.getUpcomingGamesByTeamIds(listOf(10L), 5) } returns emptyList()
 
             // when

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/stadium/BookingTransferController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/stadium/BookingTransferController.kt
@@ -9,6 +9,7 @@ import com.nextup.core.service.stadium.BookingTransferService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -36,6 +37,7 @@ class BookingTransferController(
     fun createTransfer(
         @PathVariable bookingId: Long,
         @RequestBody @Valid request: CreateBookingTransferRequest,
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<BookingTransferResponse>> {
         val transfer =
             bookingTransferService.createTransfer(
@@ -47,6 +49,7 @@ class BookingTransferController(
                     request.expiresAt
                         ?: java.time.Instant.now()
                             .plusSeconds(BookingTransferService.DEFAULT_EXPIRY_SECONDS),
+                userId = userId,
             )
         return ResponseEntity
             .status(HttpStatus.CREATED)
@@ -73,11 +76,13 @@ class BookingTransferController(
     fun acceptTransfer(
         @PathVariable transferId: Long,
         @RequestBody @Valid request: AcceptBookingTransferRequest,
+        @AuthenticationPrincipal userId: Long,
     ): ApiResponse<BookingTransferResponse> {
         val transfer =
             bookingTransferService.acceptTransfer(
                 transferId = transferId,
                 buyerTeamId = request.buyerTeamId,
+                userId = userId,
             )
         return ApiResponse.success(BookingTransferResponse.from(transfer))
     }

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminController.kt
@@ -3,11 +3,8 @@ package com.nextup.backoffice.controller.team
 import com.nextup.backoffice.dto.team.TeamMemberAdminResponse
 import com.nextup.backoffice.dto.team.UpdateMemberStatusRequest
 import com.nextup.common.dto.ApiResponse
-import com.nextup.common.exception.InvalidInputException
-import com.nextup.common.exception.TeamMemberNotFoundException
 import com.nextup.core.common.PageResult
 import com.nextup.core.domain.team.TeamMemberStatus
-import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.audit.AuditService
 import com.nextup.core.service.team.TeamMembershipService
 import com.nextup.infrastructure.common.toPageCommand
@@ -29,7 +26,6 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/backoffice/teams/{teamId}/members")
 class TeamMemberAdminController(
     private val teamMembershipService: TeamMembershipService,
-    private val teamMemberRepository: TeamMemberRepositoryPort,
     private val auditService: AuditService,
 ) {
     @GetMapping
@@ -39,23 +35,7 @@ class TeamMemberAdminController(
         @PageableDefault(size = 20) pageable: Pageable,
     ): ApiResponse<PageResult<TeamMemberAdminResponse>> {
         val pageCommand = pageable.toPageCommand()
-        val members =
-            if (status != null) {
-                val list = teamMemberRepository.findByTeamIdAndStatus(teamId, status)
-                val start = pageCommand.page * pageCommand.size
-                val end = minOf(start + pageCommand.size, list.size)
-                val totalPages =
-                    if (pageCommand.size == 0) 0 else (list.size + pageCommand.size - 1) / pageCommand.size
-                PageResult(
-                    content = if (start < list.size) list.subList(start, end) else emptyList(),
-                    page = pageCommand.page,
-                    size = pageCommand.size,
-                    totalElements = list.size.toLong(),
-                    totalPages = totalPages,
-                )
-            } else {
-                teamMemberRepository.findByTeamIdWithUserAndPlayer(teamId, pageCommand)
-            }
+        val members = teamMembershipService.getMembersByTeamIdPaged(teamId, status, pageCommand)
         return ApiResponse.success(members.map { TeamMemberAdminResponse.from(it) })
     }
 
@@ -66,19 +46,12 @@ class TeamMemberAdminController(
         @Valid @RequestBody request: UpdateMemberStatusRequest,
         @AuthenticationPrincipal admin: CustomUserDetails,
     ): ApiResponse<TeamMemberAdminResponse> {
-        val member =
-            teamMemberRepository.findByIdOrNull(memberId) ?: throw TeamMemberNotFoundException(memberId)
-        when (request.status) {
-            TeamMemberStatus.ACTIVE -> {
-                if (member.status == TeamMemberStatus.SUSPENDED) member.status = TeamMemberStatus.ACTIVE
-            }
-            TeamMemberStatus.SUSPENDED -> {
-                member.status = TeamMemberStatus.SUSPENDED
-                member.memo = request.reason
-            }
-            else -> throw InvalidInputException("INVALID_STATUS", "Cannot change to status: ${request.status}")
-        }
-        val updated = teamMemberRepository.save(member)
+        val updated =
+            teamMembershipService.updateMemberStatus(
+                memberId = memberId,
+                status = request.status,
+                reason = request.reason,
+            )
         auditService.log(
             adminUserId = admin.id,
             action = "UPDATE_MEMBER_STATUS",
@@ -95,7 +68,7 @@ class TeamMemberAdminController(
         @PathVariable memberId: Long,
         @AuthenticationPrincipal admin: CustomUserDetails,
     ): ApiResponse<Unit> {
-        teamMemberRepository.deleteById(memberId)
+        teamMembershipService.deleteMemberByAdmin(memberId)
         auditService.log(
             adminUserId = admin.id,
             action = "DELETE_MEMBER",

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/stadium/BookingTransferControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/stadium/BookingTransferControllerTest.kt
@@ -36,7 +36,13 @@ class BookingTransferControllerTest {
     fun setUp() {
         bookingTransferService = mockk()
         val controller = BookingTransferController(bookingTransferService)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(
+                    AuthenticationPrincipalResolver(100L),
+                )
+                .build()
         objectMapper =
             jacksonObjectMapper().registerModule(JavaTimeModule())
     }
@@ -85,6 +91,7 @@ class BookingTransferControllerTest {
                     price = BigDecimal("50000"),
                     message = "양도합니다",
                     expiresAt = any(),
+                    userId = any(),
                 )
             } returns transfer
 
@@ -119,6 +126,7 @@ class BookingTransferControllerTest {
                     price = null,
                     message = null,
                     expiresAt = expiresAt,
+                    userId = any(),
                 )
             } returns transfer
 
@@ -179,6 +187,7 @@ class BookingTransferControllerTest {
                 bookingTransferService.acceptTransfer(
                     transferId = 1L,
                     buyerTeamId = 20L,
+                    userId = any(),
                 )
             } returns transfer
 
@@ -221,4 +230,23 @@ class BookingTransferControllerTest {
                 .andExpect(jsonPath("$.data.status").value("CANCELLED"))
         }
     }
+}
+
+/**
+ * 테스트용 @AuthenticationPrincipal 리졸버
+ */
+private class AuthenticationPrincipalResolver(
+    private val userId: Long,
+) : org.springframework.web.method.support.HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: org.springframework.core.MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(
+            org.springframework.security.core.annotation.AuthenticationPrincipal::class.java,
+        )
+
+    override fun resolveArgument(
+        parameter: org.springframework.core.MethodParameter,
+        mavContainer: org.springframework.web.method.support.ModelAndViewContainer?,
+        webRequest: org.springframework.web.context.request.NativeWebRequest,
+        binderFactory: org.springframework.web.bind.support.WebDataBinderFactory?,
+    ): Any = userId
 }

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/team/TeamMemberAdminControllerTest.kt
@@ -10,7 +10,6 @@ import com.nextup.core.domain.team.TeamMember
 import com.nextup.core.domain.team.TeamMemberRole
 import com.nextup.core.domain.team.TeamMemberStatus
 import com.nextup.core.domain.user.User
-import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import com.nextup.core.service.audit.AuditService
 import com.nextup.core.service.team.TeamMembershipService
 import com.nextup.infrastructure.security.userdetails.CustomUserDetails
@@ -39,7 +38,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 class TeamMemberAdminControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var teamMembershipService: TeamMembershipService
-    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
     private lateinit var auditService: AuditService
     private lateinit var controller: TeamMemberAdminController
     private lateinit var objectMapper: ObjectMapper
@@ -52,7 +50,6 @@ class TeamMemberAdminControllerTest {
     @BeforeEach
     fun setUp() {
         teamMembershipService = mockk()
-        teamMemberRepository = mockk()
         auditService = mockk(relaxed = true)
 
         val adminUserDetails = mockk<CustomUserDetails>()
@@ -62,7 +59,7 @@ class TeamMemberAdminControllerTest {
         val authentication = UsernamePasswordAuthenticationToken(adminUserDetails, null, emptyList())
         SecurityContextHolder.getContext().authentication = authentication
 
-        controller = TeamMemberAdminController(teamMembershipService, teamMemberRepository, auditService)
+        controller = TeamMemberAdminController(teamMembershipService, auditService)
         mockMvc =
             MockMvcBuilders
                 .standaloneSetup(controller)
@@ -101,7 +98,7 @@ class TeamMemberAdminControllerTest {
                     totalElements = 1L,
                     totalPages = 1,
                 )
-            every { teamMemberRepository.findByTeamIdWithUserAndPlayer(1L, any()) } returns pageResult
+            every { teamMembershipService.getMembersByTeamIdPaged(1L, null, any()) } returns pageResult
 
             mockMvc.perform(get("/api/backoffice/teams/1/members"))
                 .andExpect(status().isOk)
@@ -111,7 +108,17 @@ class TeamMemberAdminControllerTest {
 
         @Test
         fun `should return members filtered by status`() {
-            every { teamMemberRepository.findByTeamIdAndStatus(1L, TeamMemberStatus.ACTIVE) } returns listOf(member)
+            val pageResult =
+                PageResult(
+                    content = listOf(member),
+                    page = 0,
+                    size = 20,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
+            every {
+                teamMembershipService.getMembersByTeamIdPaged(1L, TeamMemberStatus.ACTIVE, any())
+            } returns pageResult
 
             mockMvc.perform(get("/api/backoffice/teams/1/members").param("status", "ACTIVE"))
                 .andExpect(status().isOk)
@@ -125,8 +132,9 @@ class TeamMemberAdminControllerTest {
     inner class UpdateMemberStatus {
         @Test
         fun `should suspend member`() {
-            every { teamMemberRepository.findByIdOrNull(50L) } returns member
-            every { teamMemberRepository.save(any()) } answers { firstArg() }
+            every {
+                teamMembershipService.updateMemberStatus(50L, TeamMemberStatus.SUSPENDED, "회비 미납")
+            } returns member
             val request = UpdateMemberStatusRequest(status = TeamMemberStatus.SUSPENDED, reason = "회비 미납")
 
             mockMvc.perform(
@@ -135,14 +143,15 @@ class TeamMemberAdminControllerTest {
                     .content(objectMapper.writeValueAsString(request)),
             ).andExpect(status().isOk).andExpect(jsonPath("$.success").value(true))
 
-            verify { teamMemberRepository.save(any()) }
+            verify { teamMembershipService.updateMemberStatus(50L, TeamMemberStatus.SUSPENDED, "회비 미납") }
         }
 
         @Test
         fun `should activate suspended member`() {
             member.status = TeamMemberStatus.SUSPENDED
-            every { teamMemberRepository.findByIdOrNull(50L) } returns member
-            every { teamMemberRepository.save(any()) } answers { firstArg() }
+            every {
+                teamMembershipService.updateMemberStatus(50L, TeamMemberStatus.ACTIVE, null)
+            } returns member
             val request = UpdateMemberStatusRequest(status = TeamMemberStatus.ACTIVE)
 
             mockMvc.perform(
@@ -151,12 +160,15 @@ class TeamMemberAdminControllerTest {
                     .content(objectMapper.writeValueAsString(request)),
             ).andExpect(status().isOk).andExpect(jsonPath("$.success").value(true))
 
-            verify { teamMemberRepository.save(any()) }
+            verify { teamMembershipService.updateMemberStatus(50L, TeamMemberStatus.ACTIVE, null) }
         }
 
         @Test
         fun `should throw for invalid status transition`() {
-            every { teamMemberRepository.findByIdOrNull(50L) } returns member
+            every {
+                teamMembershipService.updateMemberStatus(50L, TeamMemberStatus.LEFT, null)
+            } throws
+                com.nextup.common.exception.InvalidInputException("INVALID_STATUS_TRANSITION", "LEFT 상태로 직접 변경할 수 없습니다")
             val request = UpdateMemberStatusRequest(status = TeamMemberStatus.LEFT)
             val adminDetails = mockk<CustomUserDetails>()
             every { adminDetails.id } returns 1L
@@ -172,19 +184,19 @@ class TeamMemberAdminControllerTest {
     inner class DeleteMember {
         @Test
         fun `should delete member`() {
-            justRun { teamMemberRepository.deleteById(50L) }
+            justRun { teamMembershipService.deleteMemberByAdmin(50L) }
 
             mockMvc.perform(delete("/api/backoffice/teams/1/members/50"))
                 .andExpect(status().isOk).andExpect(jsonPath("$.success").value(true))
 
-            verify { teamMemberRepository.deleteById(50L) }
+            verify { teamMembershipService.deleteMemberByAdmin(50L) }
         }
     }
 
     private fun <T> setId(
         entity: T,
         clazz: Class<*>,
-        id: Long
+        id: Long,
     ) {
         val idField = clazz.getDeclaredField("id")
         idField.isAccessible = true

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/competition/CompetitionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/competition/CompetitionService.kt
@@ -5,9 +5,11 @@ import com.nextup.common.exception.InvalidCompetitionStateException
 import com.nextup.common.exception.LeagueNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
 import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.BracketEntryRepositoryPort
 import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.port.repository.CompetitionRepositoryPort
@@ -187,6 +189,25 @@ class CompetitionService(
             throw InvalidCompetitionStateException(e.message ?: "Cannot postpone competition")
         }
         return competition
+    }
+
+    /**
+     * 대회 참가 팀 목록을 조회합니다.
+     *
+     * 활성 상태(ACTIVE)의 대회 등록 선수를 기준으로
+     * 팀별 등록 선수 수를 반환합니다.
+     *
+     * @param competitionId 대회 ID
+     * @return 팀 → 등록 선수 수 매핑
+     */
+    fun getCompetitionTeams(competitionId: Long): Map<Team, Int> {
+        getById(competitionId)
+        val activePlayers =
+            competitionPlayerRepository.findByCompetitionIdAndStatus(
+                competitionId,
+                CompetitionPlayerStatus.ACTIVE,
+            )
+        return activePlayers.groupBy { it.team }.mapValues { it.value.size }
     }
 
     /**

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/BattingRecordService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/BattingRecordService.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.service.game
 
 import com.nextup.common.exception.BattingRecordNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
 import com.nextup.common.exception.GamePlayerNotFoundException
 import com.nextup.common.exception.RecordAlreadyExistsException
 import com.nextup.core.domain.game.BattingRecord
@@ -21,6 +22,20 @@ class BattingRecordService(
     private val battingRecordRepository: BattingRecordRepositoryPort,
     private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
+    /**
+     * gameId와 playerId로 타격 기록을 생성합니다.
+     */
+    @Transactional
+    fun createRecordByGameAndPlayer(
+        gameId: Long,
+        playerId: Long,
+    ): BattingRecord {
+        val gamePlayer =
+            gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId)
+                ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, playerId)
+        return createRecord(gamePlayer.id)
+    }
+
     /**
      * 타격 기록을 생성합니다.
      */

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/FieldingRecordService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/FieldingRecordService.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.service.game
 
 import com.nextup.common.exception.FieldingRecordNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
 import com.nextup.common.exception.GamePlayerNotFoundException
 import com.nextup.common.exception.RecordAlreadyExistsException
 import com.nextup.core.domain.game.FieldingRecord
@@ -20,6 +21,20 @@ class FieldingRecordService(
     private val fieldingRecordRepository: FieldingRecordRepositoryPort,
     private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
+    /**
+     * gameId와 playerId로 수비 기록을 생성합니다.
+     */
+    @Transactional
+    fun createRecordByGameAndPlayer(
+        gameId: Long,
+        playerId: Long,
+    ): FieldingRecord {
+        val gamePlayer =
+            gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId)
+                ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, playerId)
+        return createRecord(gamePlayer.id)
+    }
+
     /**
      * 수비 기록을 생성합니다.
      */

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/PitchingRecordService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/PitchingRecordService.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.service.game
 
+import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
 import com.nextup.common.exception.GamePlayerNotFoundException
 import com.nextup.common.exception.PitchingRecordNotFoundException
 import com.nextup.common.exception.RecordAlreadyExistsException
@@ -20,6 +21,21 @@ class PitchingRecordService(
     private val pitchingRecordRepository: PitchingRecordRepositoryPort,
     private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
+    /**
+     * gameId와 playerId로 투수 기록을 생성합니다.
+     */
+    @Transactional
+    fun createRecordByGameAndPlayer(
+        gameId: Long,
+        playerId: Long,
+        isStartingPitcher: Boolean = false,
+    ): PitchingRecord {
+        val gamePlayer =
+            gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId)
+                ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, playerId)
+        return createRecord(gamePlayer.id, isStartingPitcher)
+    }
+
     /**
      * 투수 기록을 생성합니다.
      */

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/TeamRecruitmentService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/recruitment/TeamRecruitmentService.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.service.recruitment
 
+import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.RecruitmentNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
@@ -53,9 +54,11 @@ class TeamRecruitmentService(
     @Transactional
     fun updateRecruitment(
         id: Long,
+        teamId: Long,
         request: UpdateRecruitmentRequest,
     ): TeamRecruitment {
         val recruitment = getById(id)
+        verifyTeamOwnership(recruitment, teamId)
 
         try {
             recruitment.update(
@@ -119,8 +122,24 @@ class TeamRecruitmentService(
      * 모집 공고를 삭제합니다.
      */
     @Transactional
-    fun deleteRecruitment(id: Long) {
+    fun deleteRecruitment(
+        id: Long,
+        teamId: Long
+    ) {
         val recruitment = getById(id)
+        verifyTeamOwnership(recruitment, teamId)
         recruitmentRepository.delete(recruitment)
+    }
+
+    private fun verifyTeamOwnership(
+        recruitment: TeamRecruitment,
+        teamId: Long,
+    ) {
+        if (recruitment.team.id != teamId) {
+            throw ForbiddenException(
+                "RECRUITMENT_NOT_OWNED",
+                "해당 팀의 모집 공고가 아닙니다",
+            )
+        }
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/BookingTransferService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/stadium/BookingTransferService.kt
@@ -9,6 +9,7 @@ import com.nextup.core.domain.stadium.BookingTransfer
 import com.nextup.core.domain.stadium.TransferStatus
 import com.nextup.core.port.repository.BookingTransferRepositoryPort
 import com.nextup.core.port.repository.StadiumBookingRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -24,12 +25,14 @@ import java.time.Instant
 class BookingTransferService(
     private val bookingTransferRepository: BookingTransferRepositoryPort,
     private val bookingRepository: StadiumBookingRepositoryPort,
+    private val teamMemberRepository: TeamMemberRepositoryPort,
 ) {
     /**
      * 예약 양도를 등록합니다.
      *
      * 예약 소유팀만 양도 등록이 가능하며, 예약 상태가 CONFIRMED여야 합니다.
      * 동일 예약에 대해 이미 OPEN 상태의 양도가 존재하면 안 됩니다.
+     * userId가 제공된 경우 해당 사용자가 팀 멤버인지 검증합니다.
      */
     @Transactional
     fun createTransfer(
@@ -38,7 +41,9 @@ class BookingTransferService(
         price: BigDecimal?,
         message: String?,
         expiresAt: Instant = Instant.now().plusSeconds(DEFAULT_EXPIRY_SECONDS),
+        userId: Long,
     ): BookingTransfer {
+        verifyTeamMembership(teamId, userId)
         val booking =
             bookingRepository.findByIdOrNull(bookingId)
                 ?: throw BookingNotFoundException(bookingId)
@@ -77,12 +82,15 @@ class BookingTransferService(
      * 예약 양도를 수락합니다.
      *
      * 양도를 수락하면 예약 소유권이 구매팀으로 이전됩니다.
+     * userId가 제공된 경우 해당 사용자가 구매팀 멤버인지 검증합니다.
      */
     @Transactional
     fun acceptTransfer(
         transferId: Long,
         buyerTeamId: Long,
+        userId: Long,
     ): BookingTransfer {
+        verifyTeamMembership(buyerTeamId, userId)
         val transfer =
             bookingTransferRepository.findByIdOrNull(transferId)
                 ?: throw BookingTransferNotFoundException(transferId)
@@ -140,6 +148,16 @@ class BookingTransferService(
         return (sellerTransfers + buyerTransfers)
             .distinctBy { it.id }
             .sortedByDescending { it.createdAt }
+    }
+
+    private fun verifyTeamMembership(
+        teamId: Long,
+        userId: Long,
+    ) {
+        teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+            ?: throw BookingTransferForbiddenException(
+                "User $userId is not a member of team $teamId",
+            )
     }
 
     companion object {

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
@@ -1,10 +1,13 @@
 package com.nextup.core.service.team
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.team.JoinRequestStatus
 import com.nextup.core.domain.team.Team
 import com.nextup.core.domain.team.TeamJoinRequest
 import com.nextup.core.domain.team.TeamMember
 import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.domain.team.TeamMemberStatus
 
 /**
  * 팀 멤버십 서비스 인터페이스
@@ -149,20 +152,6 @@ interface TeamMembershipService {
     fun getMemberById(memberId: Long): TeamMember?
 
     /**
-     * 팀을 생성하고 생성자를 OWNER로 등록합니다.
-     *
-     * @param userId 생성자 사용자 ID
-     * @param team 생성할 팀
-     * @param uniformNumber OWNER의 등번호
-     * @return 생성된 Team
-     */
-    fun createTeamWithOwner(
-        userId: Long,
-        team: Team,
-        uniformNumber: Int,
-    ): Team
-
-    /**
      * 팀을 삭제합니다. OWNER만 가능하며 멤버가 1명일 때만 삭제 가능합니다.
      *
      * @param teamId 팀 ID
@@ -191,4 +180,109 @@ interface TeamMembershipService {
      * @return 팀 ID → 활성 멤버 수 맵
      */
     fun getTeamMemberCounts(teamIds: List<Long>): Map<Long, Int>
+
+    /**
+     * 팀 정보를 수정합니다.
+     *
+     * @param teamId 팀 ID
+     * @param name 새 팀 이름 (null이면 변경 없음)
+     * @param city 새 도시 (null이면 변경 없음)
+     * @param abbreviation 새 약자 (null이면 변경 없음)
+     * @return 수정된 Team
+     * @throws TeamNotFoundException 팀을 찾을 수 없는 경우
+     */
+    fun updateTeam(
+        teamId: Long,
+        name: String?,
+        city: String?,
+        abbreviation: String?,
+    ): Team
+
+    /**
+     * League를 포함한 팀 상세 정보를 조회합니다.
+     *
+     * @param teamId 팀 ID
+     * @return Team (League 페치 포함)
+     * @throws TeamNotFoundException 팀을 찾을 수 없는 경우
+     */
+    fun getTeamWithLeague(teamId: Long): Team
+
+    /**
+     * 이름/도시 필터로 활성 팀 목록을 조회합니다.
+     *
+     * @param name 팀 이름 필터 (null이면 전체)
+     * @param city 도시 필터 (null이면 전체)
+     * @return 활성 팀 목록
+     */
+    fun getActiveTeamsByFilter(
+        name: String?,
+        city: String?,
+    ): List<Team>
+
+    /**
+     * 팀을 생성하고 생성자를 OWNER로 등록합니다. (필드 기반 시그니처)
+     *
+     * @param userId 생성자 사용자 ID
+     * @param leagueId 소속 리그 ID
+     * @param name 팀 이름
+     * @param city 도시
+     * @param abbreviation 약자
+     * @param foundedYear 창단 연도
+     * @param uniformNumber OWNER의 등번호
+     * @return 생성된 Team
+     */
+    fun createTeamWithOwner(
+        userId: Long,
+        leagueId: Long,
+        name: String,
+        city: String,
+        abbreviation: String?,
+        foundedYear: Int,
+        uniformNumber: Int,
+    ): Team
+
+    /**
+     * 사용자의 활성 팀 멤버십 목록을 조회합니다. (ProfileController용)
+     *
+     * @param userId 사용자 ID
+     * @return 활성 TeamMember 목록
+     */
+    fun getActiveTeamsByUserId(userId: Long): List<TeamMember>
+
+    /**
+     * 팀 멤버 목록을 페이징으로 조회합니다. (관리자용)
+     *
+     * @param teamId 팀 ID
+     * @param status 상태 필터 (null이면 전체)
+     * @param pageCommand 페이징 요청
+     * @return 페이징된 TeamMember 결과
+     */
+    fun getMembersByTeamIdPaged(
+        teamId: Long,
+        status: TeamMemberStatus?,
+        pageCommand: PageCommand,
+    ): PageResult<TeamMember>
+
+    /**
+     * 멤버 상태를 변경합니다. (관리자용)
+     *
+     * @param memberId 멤버 ID
+     * @param status 새 상태 (ACTIVE 또는 SUSPENDED만 허용)
+     * @param reason 사유 (SUSPENDED 시 필요)
+     * @return 변경된 TeamMember
+     * @throws TeamMemberNotFoundException 멤버를 찾을 수 없는 경우
+     * @throws InvalidInputException 허용되지 않는 상태인 경우
+     */
+    fun updateMemberStatus(
+        memberId: Long,
+        status: TeamMemberStatus,
+        reason: String?,
+    ): TeamMember
+
+    /**
+     * 멤버를 삭제합니다. (관리자용)
+     *
+     * @param memberId 멤버 ID
+     */
+    fun deleteMemberByAdmin(memberId: Long)
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/recruitment/TeamRecruitmentServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/recruitment/TeamRecruitmentServiceTest.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.service.recruitment
 
+import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.RecruitmentNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
@@ -159,7 +160,7 @@ class TeamRecruitmentServiceTest {
         every { recruitmentRepository.findByIdOrNull(1L) } returns recruitment
 
         // when
-        val result = service.updateRecruitment(1L, updateRequest)
+        val result = service.updateRecruitment(1L, 1L, updateRequest)
 
         // then
         assertThat(result.title).isEqualTo("투수 및 포수 모집")
@@ -195,11 +196,43 @@ class TeamRecruitmentServiceTest {
         every { recruitmentRepository.findByIdOrNull(1L) } returns recruitment
 
         // when
-        val result = service.updateRecruitment(1L, updateRequest)
+        val result = service.updateRecruitment(1L, 1L, updateRequest)
 
         // then
         assertThat(result.title).isEqualTo("투수 긴급 모집")
         assertThat(result.description).isEqualTo("주말 리그 투수를 모집합니다") // 변경되지 않음
+
+        verify(exactly = 1) { recruitmentRepository.findByIdOrNull(1L) }
+    }
+
+    @Test
+    fun `다른 팀의 모집 공고를 수정하면 예외가 발생한다`() {
+        // given
+        val recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "투수 모집",
+                description = "주말 리그 투수를 모집합니다",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = LocalDate.now().plusDays(30),
+            )
+
+        val updateRequest =
+            UpdateRecruitmentRequest(
+                title = "투수 긴급 모집",
+                description = null,
+                positionsNeeded = null,
+                deadline = null,
+            )
+
+        every { recruitmentRepository.findByIdOrNull(1L) } returns recruitment
+
+        // when & then
+        assertThatThrownBy { service.updateRecruitment(1L, 999L, updateRequest) }
+            .isInstanceOf(ForbiddenException::class.java)
 
         verify(exactly = 1) { recruitmentRepository.findByIdOrNull(1L) }
     }
@@ -231,7 +264,7 @@ class TeamRecruitmentServiceTest {
         every { recruitmentRepository.findByIdOrNull(1L) } returns recruitment
 
         // when & then
-        assertThatThrownBy { service.updateRecruitment(1L, updateRequest) }
+        assertThatThrownBy { service.updateRecruitment(1L, 1L, updateRequest) }
             .isInstanceOf(InvalidStateException::class.java)
 
         verify(exactly = 1) { recruitmentRepository.findByIdOrNull(1L) }
@@ -251,7 +284,7 @@ class TeamRecruitmentServiceTest {
         every { recruitmentRepository.findByIdOrNull(999L) } returns null
 
         // when & then
-        assertThatThrownBy { service.updateRecruitment(999L, updateRequest) }
+        assertThatThrownBy { service.updateRecruitment(999L, 1L, updateRequest) }
             .isInstanceOf(RecruitmentNotFoundException::class.java)
 
         verify(exactly = 1) { recruitmentRepository.findByIdOrNull(999L) }
@@ -555,11 +588,36 @@ class TeamRecruitmentServiceTest {
         every { recruitmentRepository.delete(recruitment) } returns Unit
 
         // when
-        service.deleteRecruitment(1L)
+        service.deleteRecruitment(1L, 1L)
 
         // then
         verify(exactly = 1) { recruitmentRepository.findByIdOrNull(1L) }
         verify(exactly = 1) { recruitmentRepository.delete(recruitment) }
+    }
+
+    @Test
+    fun `다른 팀의 모집 공고를 삭제하면 예외가 발생한다`() {
+        // given
+        val recruitment =
+            TeamRecruitment.create(
+                team = team,
+                title = "투수 모집",
+                description = "주말 리그 투수를 모집합니다",
+                positionsNeeded = "투수",
+                ageRange = null,
+                skillLevel = null,
+                location = null,
+                deadline = LocalDate.now().plusDays(30),
+            )
+
+        every { recruitmentRepository.findByIdOrNull(1L) } returns recruitment
+
+        // when & then
+        assertThatThrownBy { service.deleteRecruitment(1L, 999L) }
+            .isInstanceOf(ForbiddenException::class.java)
+
+        verify(exactly = 1) { recruitmentRepository.findByIdOrNull(1L) }
+        verify(exactly = 0) { recruitmentRepository.delete(any()) }
     }
 
     @Test
@@ -568,7 +626,7 @@ class TeamRecruitmentServiceTest {
         every { recruitmentRepository.findByIdOrNull(999L) } returns null
 
         // when & then
-        assertThatThrownBy { service.deleteRecruitment(999L) }
+        assertThatThrownBy { service.deleteRecruitment(999L, 1L) }
             .isInstanceOf(RecruitmentNotFoundException::class.java)
 
         verify(exactly = 1) { recruitmentRepository.findByIdOrNull(999L) }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/BookingTransferServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/stadium/BookingTransferServiceTest.kt
@@ -9,8 +9,10 @@ import com.nextup.core.domain.stadium.BookingTransfer
 import com.nextup.core.domain.stadium.StadiumBooking
 import com.nextup.core.domain.stadium.StadiumSlot
 import com.nextup.core.domain.stadium.TransferStatus
+import com.nextup.core.domain.team.TeamMember
 import com.nextup.core.port.repository.BookingTransferRepositoryPort
 import com.nextup.core.port.repository.StadiumBookingRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -27,13 +29,15 @@ import java.time.Instant
 class BookingTransferServiceTest {
     private lateinit var bookingTransferRepository: BookingTransferRepositoryPort
     private lateinit var bookingRepository: StadiumBookingRepositoryPort
+    private lateinit var teamMemberRepository: TeamMemberRepositoryPort
     private lateinit var service: BookingTransferService
 
     @BeforeEach
     fun setUp() {
         bookingTransferRepository = mockk()
         bookingRepository = mockk()
-        service = BookingTransferService(bookingTransferRepository, bookingRepository)
+        teamMemberRepository = mockk()
+        service = BookingTransferService(bookingTransferRepository, bookingRepository, teamMemberRepository)
     }
 
     private fun createMockBooking(
@@ -73,7 +77,9 @@ class BookingTransferServiceTest {
             // given
             val booking = createMockBooking(id = 1L, teamId = 10L)
             val transfer = createMockTransfer()
+            val mockMember = mockk<TeamMember>(relaxed = true)
 
+            every { teamMemberRepository.findByTeamIdAndUserId(10L, 100L) } returns mockMember
             every { bookingRepository.findByIdOrNull(1L) } returns booking
             every { bookingTransferRepository.existsOpenTransferForBooking(1L) } returns false
             every { bookingTransferRepository.save(any()) } returns transfer
@@ -85,6 +91,7 @@ class BookingTransferServiceTest {
                     teamId = 10L,
                     price = BigDecimal("50000"),
                     message = "양도합니다",
+                    userId = 100L,
                 )
 
             // then
@@ -93,8 +100,27 @@ class BookingTransferServiceTest {
         }
 
         @Test
+        fun `should throw exception when user is not a team member`() {
+            // given
+            every { teamMemberRepository.findByTeamIdAndUserId(10L, 999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                service.createTransfer(
+                    bookingId = 1L,
+                    teamId = 10L,
+                    price = null,
+                    message = null,
+                    userId = 999L,
+                )
+            }.isInstanceOf(BookingTransferForbiddenException::class.java)
+        }
+
+        @Test
         fun `should throw exception when booking not found`() {
             // given
+            val mockMember = mockk<TeamMember>(relaxed = true)
+            every { teamMemberRepository.findByTeamIdAndUserId(10L, 100L) } returns mockMember
             every { bookingRepository.findByIdOrNull(99L) } returns null
 
             // when & then
@@ -104,6 +130,7 @@ class BookingTransferServiceTest {
                     teamId = 10L,
                     price = null,
                     message = null,
+                    userId = 100L,
                 )
             }.isInstanceOf(BookingNotFoundException::class.java)
         }
@@ -112,6 +139,8 @@ class BookingTransferServiceTest {
         fun `should throw exception when team does not own the booking`() {
             // given
             val booking = createMockBooking(teamId = 10L)
+            val mockMember = mockk<TeamMember>(relaxed = true)
+            every { teamMemberRepository.findByTeamIdAndUserId(99L, 100L) } returns mockMember
             every { bookingRepository.findByIdOrNull(1L) } returns booking
 
             // when & then
@@ -121,6 +150,7 @@ class BookingTransferServiceTest {
                     teamId = 99L,
                     price = null,
                     message = null,
+                    userId = 100L,
                 )
             }.isInstanceOf(BookingTransferForbiddenException::class.java)
         }
@@ -129,6 +159,8 @@ class BookingTransferServiceTest {
         fun `should throw exception when open transfer already exists`() {
             // given
             val booking = createMockBooking(teamId = 10L)
+            val mockMember = mockk<TeamMember>(relaxed = true)
+            every { teamMemberRepository.findByTeamIdAndUserId(10L, 100L) } returns mockMember
             every { bookingRepository.findByIdOrNull(1L) } returns booking
             every { bookingTransferRepository.existsOpenTransferForBooking(1L) } returns true
 
@@ -139,6 +171,7 @@ class BookingTransferServiceTest {
                     teamId = 10L,
                     price = null,
                     message = null,
+                    userId = 100L,
                 )
             }.isInstanceOf(BookingTransferInvalidStateException::class.java)
                 .hasMessageContaining("open transfer already exists")
@@ -153,14 +186,16 @@ class BookingTransferServiceTest {
             // given
             val transfer = createMockTransfer(sellerTeamId = 10L)
             val booking = createMockBooking(teamId = 10L)
+            val mockMember = mockk<TeamMember>(relaxed = true)
 
+            every { teamMemberRepository.findByTeamIdAndUserId(20L, 200L) } returns mockMember
             every { bookingTransferRepository.findByIdOrNull(1L) } returns transfer
             every { bookingRepository.findByIdOrNull(transfer.bookingId) } returns booking
             every { bookingTransferRepository.save(any()) } returns transfer
             every { bookingRepository.save(any()) } returns booking
 
             // when
-            val result = service.acceptTransfer(transferId = 1L, buyerTeamId = 20L)
+            val result = service.acceptTransfer(transferId = 1L, buyerTeamId = 20L, userId = 200L)
 
             // then
             assertThat(result.status).isEqualTo(TransferStatus.ACCEPTED)
@@ -170,13 +205,26 @@ class BookingTransferServiceTest {
         }
 
         @Test
+        fun `should throw exception when user is not a buyer team member`() {
+            // given
+            every { teamMemberRepository.findByTeamIdAndUserId(20L, 999L) } returns null
+
+            // when & then
+            assertThatThrownBy {
+                service.acceptTransfer(transferId = 1L, buyerTeamId = 20L, userId = 999L)
+            }.isInstanceOf(BookingTransferForbiddenException::class.java)
+        }
+
+        @Test
         fun `should throw exception when transfer not found`() {
             // given
+            val mockMember = mockk<TeamMember>(relaxed = true)
+            every { teamMemberRepository.findByTeamIdAndUserId(20L, 200L) } returns mockMember
             every { bookingTransferRepository.findByIdOrNull(99L) } returns null
 
             // when & then
             assertThatThrownBy {
-                service.acceptTransfer(transferId = 99L, buyerTeamId = 20L)
+                service.acceptTransfer(transferId = 99L, buyerTeamId = 20L, userId = 200L)
             }.isInstanceOf(BookingTransferNotFoundException::class.java)
         }
 
@@ -184,12 +232,14 @@ class BookingTransferServiceTest {
         fun `should throw exception when booking not found during accept`() {
             // given
             val transfer = createMockTransfer()
+            val mockMember = mockk<TeamMember>(relaxed = true)
+            every { teamMemberRepository.findByTeamIdAndUserId(20L, 200L) } returns mockMember
             every { bookingTransferRepository.findByIdOrNull(1L) } returns transfer
             every { bookingRepository.findByIdOrNull(transfer.bookingId) } returns null
 
             // when & then
             assertThatThrownBy {
-                service.acceptTransfer(transferId = 1L, buyerTeamId = 20L)
+                service.acceptTransfer(transferId = 1L, buyerTeamId = 20L, userId = 200L)
             }.isInstanceOf(BookingNotFoundException::class.java)
         }
     }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
@@ -1,6 +1,8 @@
 package com.nextup.infrastructure.service.team
 
 import com.nextup.common.exception.*
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.event.TeamJoinApprovedEvent
 import com.nextup.core.domain.event.TeamJoinRejectedEvent
 import com.nextup.core.domain.event.TeamMemberKickedEvent
@@ -22,6 +24,7 @@ class TeamMembershipServiceImpl(
     private val teamJoinRequestRepository: TeamJoinRequestRepositoryPort,
     private val teamBlacklistRepository: TeamBlacklistRepositoryPort,
     private val teamRepository: TeamRepositoryPort,
+    private val leagueRepository: LeagueRepositoryPort,
     private val userRepository: UserRepositoryPort,
     private val playerRepository: PlayerRepositoryPort,
     private val eventPublisher: ApplicationEventPublisher,
@@ -307,53 +310,6 @@ class TeamMembershipServiceImpl(
     }
 
     @Transactional
-    override fun createTeamWithOwner(
-        userId: Long,
-        team: Team,
-        uniformNumber: Int,
-    ): Team {
-        // 등번호 유효성 검증
-        if (uniformNumber !in 1..99) {
-            throw InvalidUniformNumberException(uniformNumber)
-        }
-
-        val user =
-            userRepository.findByIdOrNull(userId)
-                ?: throw UserNotFoundException(userId)
-        val player =
-            user.player
-                ?: throw PlayerNotFoundException(userId)
-
-        // 이미 다른 팀에 소속된 경우 검증
-        val activeMember = teamMemberRepository.findActiveByUserId(userId)
-        if (activeMember != null) {
-            throw AlreadyInTeamException(userId, activeMember.team.id, activeMember.team.name)
-        }
-
-        // 팀 이름 중복 검증
-        val existingTeam = teamRepository.findByName(team.name)
-        if (existingTeam != null) {
-            throw TeamAlreadyExistsException(team.name)
-        }
-
-        // 팀 저장
-        val savedTeam = teamRepository.save(team)
-
-        // OWNER로 멤버 생성
-        val ownerMember =
-            TeamMember.create(
-                team = savedTeam,
-                user = user,
-                player = player,
-                uniformNumber = uniformNumber,
-                role = TeamMemberRole.OWNER,
-            )
-        teamMemberRepository.save(ownerMember)
-
-        return savedTeam
-    }
-
-    @Transactional
     override fun deleteTeam(
         teamId: Long,
         userId: Long,
@@ -393,5 +349,142 @@ class TeamMembershipServiceImpl(
         if (teamIds.isEmpty()) return emptyMap()
         return teamMemberRepository.countByTeamIdsAndStatus(teamIds, TeamMemberStatus.ACTIVE)
             .mapValues { it.value.toInt() }
+    }
+
+    @Transactional
+    override fun updateTeam(
+        teamId: Long,
+        name: String?,
+        city: String?,
+        abbreviation: String?,
+    ): Team {
+        val team =
+            teamRepository.findByIdWithLeague(teamId)
+                ?: throw TeamNotFoundException(teamId)
+        team.updateBasicInfo(name = name, city = city, abbreviation = abbreviation)
+        return teamRepository.save(team)
+    }
+
+    override fun getTeamWithLeague(teamId: Long): Team =
+        teamRepository.findByIdWithLeague(teamId)
+            ?: throw TeamNotFoundException(teamId)
+
+    override fun getActiveTeamsByFilter(
+        name: String?,
+        city: String?,
+    ): List<Team> = teamRepository.findActiveTeamsByFilter(name, city)
+
+    @Transactional
+    override fun createTeamWithOwner(
+        userId: Long,
+        leagueId: Long,
+        name: String,
+        city: String,
+        abbreviation: String?,
+        foundedYear: Int,
+        uniformNumber: Int,
+    ): Team {
+        if (uniformNumber !in 1..99) {
+            throw InvalidUniformNumberException(uniformNumber)
+        }
+
+        val league =
+            leagueRepository.findByIdOrNull(leagueId)
+                ?: throw LeagueNotFoundException(leagueId)
+
+        val user =
+            userRepository.findByIdOrNull(userId)
+                ?: throw UserNotFoundException(userId)
+        val player =
+            user.player
+                ?: throw PlayerNotFoundException(userId)
+
+        val activeMember = teamMemberRepository.findActiveByUserId(userId)
+        if (activeMember != null) {
+            throw AlreadyInTeamException(userId, activeMember.team.id, activeMember.team.name)
+        }
+
+        val existingTeam = teamRepository.findByName(name)
+        if (existingTeam != null) {
+            throw TeamAlreadyExistsException(name)
+        }
+
+        val team =
+            Team(
+                league = league,
+                name = name,
+                city = city,
+                abbreviation = abbreviation,
+                foundedYear = foundedYear,
+            )
+        val savedTeam = teamRepository.save(team)
+
+        val ownerMember =
+            TeamMember.create(
+                team = savedTeam,
+                user = user,
+                player = player,
+                uniformNumber = uniformNumber,
+                role = TeamMemberRole.OWNER,
+            )
+        teamMemberRepository.save(ownerMember)
+
+        return savedTeam
+    }
+
+    override fun getActiveTeamsByUserId(userId: Long): List<TeamMember> =
+        teamMemberRepository.findAllActiveByUserId(userId)
+
+    override fun getMembersByTeamIdPaged(
+        teamId: Long,
+        status: TeamMemberStatus?,
+        pageCommand: PageCommand,
+    ): PageResult<TeamMember> =
+        if (status != null) {
+            val list = teamMemberRepository.findByTeamIdAndStatus(teamId, status)
+            val start = pageCommand.page * pageCommand.size
+            val end = minOf(start + pageCommand.size, list.size)
+            val totalPages =
+                if (pageCommand.size == 0) 0 else (list.size + pageCommand.size - 1) / pageCommand.size
+            PageResult(
+                content = if (start < list.size) list.subList(start, end) else emptyList(),
+                page = pageCommand.page,
+                size = pageCommand.size,
+                totalElements = list.size.toLong(),
+                totalPages = totalPages,
+            )
+        } else {
+            teamMemberRepository.findByTeamIdWithUserAndPlayer(teamId, pageCommand)
+        }
+
+    @Transactional
+    override fun updateMemberStatus(
+        memberId: Long,
+        status: TeamMemberStatus,
+        reason: String?,
+    ): TeamMember {
+        val member =
+            teamMemberRepository.findByIdOrNull(memberId)
+                ?: throw TeamMemberNotFoundException(memberId)
+        when (status) {
+            TeamMemberStatus.ACTIVE -> {
+                if (member.status == TeamMemberStatus.SUSPENDED) member.status = TeamMemberStatus.ACTIVE
+            }
+            TeamMemberStatus.SUSPENDED -> {
+                member.status = TeamMemberStatus.SUSPENDED
+                member.memo = reason
+            }
+            else ->
+                throw InvalidInputException(
+                    "INVALID_STATUS",
+                    "Cannot change to status: $status",
+                )
+        }
+        return teamMemberRepository.save(member)
+    }
+
+    @Transactional
+    override fun deleteMemberByAdmin(memberId: Long) {
+        teamMemberRepository.deleteById(memberId)
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplGetMemberByIdTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplGetMemberByIdTest.kt
@@ -28,6 +28,7 @@ class TeamMembershipServiceImplGetMemberByIdTest {
                 mockk(),
                 mockk(),
                 mockk(),
+                mockk(),
                 eventPublisher,
             )
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImplTest.kt
@@ -30,6 +30,7 @@ class TeamMembershipServiceImplTest {
     private lateinit var teamJoinRequestRepository: TeamJoinRequestRepositoryPort
     private lateinit var teamBlacklistRepository: TeamBlacklistRepositoryPort
     private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var leagueRepository: LeagueRepositoryPort
     private lateinit var userRepository: UserRepositoryPort
     private lateinit var playerRepository: PlayerRepositoryPort
     private lateinit var eventPublisher: ApplicationEventPublisher
@@ -47,6 +48,7 @@ class TeamMembershipServiceImplTest {
         teamJoinRequestRepository = mockk()
         teamBlacklistRepository = mockk()
         teamRepository = mockk()
+        leagueRepository = mockk()
         userRepository = mockk()
         playerRepository = mockk()
         eventPublisher = mockk(relaxed = true)
@@ -57,6 +59,7 @@ class TeamMembershipServiceImplTest {
                 teamJoinRequestRepository,
                 teamBlacklistRepository,
                 teamRepository,
+                leagueRepository,
                 userRepository,
                 playerRepository,
                 eventPublisher,
@@ -793,21 +796,23 @@ class TeamMembershipServiceImplTest {
     @Nested
     @DisplayName("createTeamWithOwner")
     inner class CreateTeamWithOwner {
+        private val leagueId = 5L
+
         @Test
         fun `should create team and register owner`() {
             // given
+            val association = Association(name = "서울시야구협회", region = "서울")
+            val league = League(association = association, name = "1부 리그", foundedYear = 2020)
+
+            every { leagueRepository.findByIdOrNull(leagueId) } returns league
             every { userRepository.findByIdOrNull(2L) } returns user
             every { teamMemberRepository.findActiveByUserId(2L) } returns null
             every { teamRepository.findByName("뉴팀") } returns null
             every { teamRepository.save(any()) } answers { firstArg() }
             every { teamMemberRepository.save(any()) } answers { firstArg() }
 
-            val association = Association(name = "서울시야구협회", region = "서울")
-            val league = League(association = association, name = "1부 리그", foundedYear = 2020)
-            val newTeam = Team(league = league, name = "뉴팀", city = "서울", foundedYear = 2026)
-
             // when
-            val result = service.createTeamWithOwner(2L, newTeam, 7)
+            val result = service.createTeamWithOwner(2L, leagueId, "뉴팀", "서울", null, 2026, 7)
 
             // then
             assertThat(result.name).isEqualTo("뉴팀")
@@ -819,22 +824,28 @@ class TeamMembershipServiceImplTest {
         fun `should throw when uniform number is invalid`() {
             // when & then
             assertThatThrownBy {
-                service.createTeamWithOwner(2L, team, 0)
+                service.createTeamWithOwner(2L, leagueId, "타이거즈", "서울", null, 2015, 0)
             }.isInstanceOf(InvalidUniformNumberException::class.java)
 
             assertThatThrownBy {
-                service.createTeamWithOwner(2L, team, 100)
+                service.createTeamWithOwner(2L, leagueId, "타이거즈", "서울", null, 2015, 100)
             }.isInstanceOf(InvalidUniformNumberException::class.java)
         }
 
         @Test
         fun `should throw when user not found`() {
             // given
+            every { leagueRepository.findByIdOrNull(leagueId) } returns
+                League(
+                    association = Association(name = "서울시야구협회", region = "서울"),
+                    name = "1부 리그",
+                    foundedYear = 2020,
+                )
             every { userRepository.findByIdOrNull(999L) } returns null
 
             // when & then
             assertThatThrownBy {
-                service.createTeamWithOwner(999L, team, 7)
+                service.createTeamWithOwner(999L, leagueId, "타이거즈", "서울", null, 2015, 7)
             }.isInstanceOf(UserNotFoundException::class.java)
         }
 
@@ -844,11 +855,17 @@ class TeamMembershipServiceImplTest {
             val userWithoutPlayer = User.createLocalUser("noplayer@example.com", "password", "없음")
             setUserId(userWithoutPlayer, 50L)
 
+            every { leagueRepository.findByIdOrNull(leagueId) } returns
+                League(
+                    association = Association(name = "서울시야구협회", region = "서울"),
+                    name = "1부 리그",
+                    foundedYear = 2020,
+                )
             every { userRepository.findByIdOrNull(50L) } returns userWithoutPlayer
 
             // when & then
             assertThatThrownBy {
-                service.createTeamWithOwner(50L, team, 7)
+                service.createTeamWithOwner(50L, leagueId, "타이거즈", "서울", null, 2015, 7)
             }.isInstanceOf(PlayerNotFoundException::class.java)
         }
 
@@ -856,25 +873,37 @@ class TeamMembershipServiceImplTest {
         fun `should throw when user already in team`() {
             // given
             val existingMember = TeamMember.create(team, user, player, 10)
+            every { leagueRepository.findByIdOrNull(leagueId) } returns
+                League(
+                    association = Association(name = "서울시야구협회", region = "서울"),
+                    name = "1부 리그",
+                    foundedYear = 2020,
+                )
             every { userRepository.findByIdOrNull(2L) } returns user
             every { teamMemberRepository.findActiveByUserId(2L) } returns existingMember
 
             // when & then
             assertThatThrownBy {
-                service.createTeamWithOwner(2L, team, 7)
+                service.createTeamWithOwner(2L, leagueId, "타이거즈", "서울", null, 2015, 7)
             }.isInstanceOf(AlreadyInTeamException::class.java)
         }
 
         @Test
         fun `should throw when team name already exists`() {
             // given
+            every { leagueRepository.findByIdOrNull(leagueId) } returns
+                League(
+                    association = Association(name = "서울시야구협회", region = "서울"),
+                    name = "1부 리그",
+                    foundedYear = 2020,
+                )
             every { userRepository.findByIdOrNull(2L) } returns user
             every { teamMemberRepository.findActiveByUserId(2L) } returns null
             every { teamRepository.findByName("타이거즈") } returns team
 
             // when & then
             assertThatThrownBy {
-                service.createTeamWithOwner(2L, team, 7)
+                service.createTeamWithOwner(2L, leagueId, "타이거즈", "서울", null, 2015, 7)
             }.isInstanceOf(TeamAlreadyExistsException::class.java)
         }
     }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerController.kt
@@ -1,8 +1,6 @@
 package com.nextup.scorer.controller.fielding
 
 import com.nextup.common.dto.ApiResponse
-import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
-import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.FieldingRecordService
 import com.nextup.scorer.dto.fielding.FieldingEventRequest
 import com.nextup.scorer.dto.fielding.FieldingEventType
@@ -27,7 +25,6 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/scorer/games/{gameId}/fielding")
 class FieldingRecordScorerController(
     private val fieldingRecordService: FieldingRecordService,
-    private val gamePlayerRepository: GamePlayerRepositoryPort,
 ) {
     /**
      * 수비 기록을 생성합니다 (경기 시작 시 선수별 초기화).
@@ -40,10 +37,7 @@ class FieldingRecordScorerController(
         @PathVariable gameId: Long,
         @PathVariable playerId: Long,
     ): ApiResponse<FieldingRecordResponse> {
-        val gamePlayer =
-            gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId)
-                ?: throw GamePlayerNotFoundByGameAndPlayerException(gameId, playerId)
-        val record = fieldingRecordService.createRecord(gamePlayer.id)
+        val record = fieldingRecordService.createRecordByGameAndPlayer(gameId, playerId)
         return ApiResponse.success(record.toScorerResponse())
     }
 

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/fielding/FieldingRecordScorerControllerTest.kt
@@ -2,9 +2,9 @@ package com.nextup.scorer.controller.fielding
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nextup.common.exception.GamePlayerNotFoundByGameAndPlayerException
 import com.nextup.core.domain.game.FieldingRecord
 import com.nextup.core.domain.game.GamePlayer
-import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.service.game.FieldingRecordService
 import com.nextup.scorer.dto.fielding.FieldingEventRequest
 import com.nextup.scorer.dto.fielding.FieldingEventType
@@ -28,7 +28,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 class FieldingRecordScorerControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var fieldingRecordService: FieldingRecordService
-    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
     private lateinit var objectMapper: ObjectMapper
 
     private val gameId = 1L
@@ -38,13 +37,11 @@ class FieldingRecordScorerControllerTest {
     @BeforeEach
     fun setUp() {
         fieldingRecordService = mockk()
-        gamePlayerRepository = mockk()
         objectMapper = jacksonObjectMapper()
 
         val controller =
             FieldingRecordScorerController(
                 fieldingRecordService = fieldingRecordService,
-                gamePlayerRepository = gamePlayerRepository,
             )
         mockMvc =
             MockMvcBuilders
@@ -73,8 +70,7 @@ class FieldingRecordScorerControllerTest {
             every { mockRecord.totalChances } returns 0
             every { mockRecord.fieldingPercentage } returns null
 
-            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns mockGamePlayer
-            every { fieldingRecordService.createRecord(gamePlayerId) } returns mockRecord
+            every { fieldingRecordService.createRecordByGameAndPlayer(gameId, playerId) } returns mockRecord
 
             // when & then
             mockMvc
@@ -87,13 +83,15 @@ class FieldingRecordScorerControllerTest {
                 .andExpect(jsonPath("$.data.assists").value(0))
                 .andExpect(jsonPath("$.data.errors").value(0))
 
-            verify(exactly = 1) { fieldingRecordService.createRecord(gamePlayerId) }
+            verify(exactly = 1) { fieldingRecordService.createRecordByGameAndPlayer(gameId, playerId) }
         }
 
         @Test
         fun `GamePlayer를 찾을 수 없으면 404를 반환한다`() {
             // given
-            every { gamePlayerRepository.findByGameIdAndPlayerId(gameId, playerId) } returns null
+            every {
+                fieldingRecordService.createRecordByGameAndPlayer(gameId, playerId)
+            } throws GamePlayerNotFoundByGameAndPlayerException(gameId, playerId)
 
             // when & then
             mockMvc


### PR DESCRIPTION
## Summary

>- close #431, Ref #425

파괴적 기술 검토(#425) 3자 합의에 따라, Controller에서 Repository를 직접 주입하여 Service 레이어를 우회하는 7곳을 제거하고, Controller↔Service 계약이 파손된 4곳의 IDOR 취약점을 수정합니다.

## Tasks

### Phase 1: Controller→Repository 직접 주입 제거 (7곳)
- [x] `TeamController`: `TeamRepositoryPort`, `LeagueRepositoryPort` 제거 → `TeamMembershipService`로 CRUD 이동
- [x] `CompetitionController`: `CompetitionPlayerRepositoryPort` 제거 → `CompetitionService.getCompetitionTeams()`
- [x] `BattingRecordController`: `GamePlayerRepositoryPort` 제거 → `BattingRecordService.createRecordByGameAndPlayer()`
- [x] `PitchingRecordController`: `GamePlayerRepositoryPort` 제거 → `PitchingRecordService.createRecordByGameAndPlayer()`
- [x] `ProfileController`: `TeamMemberRepositoryPort` 제거 → `TeamMembershipService.getActiveTeamsByUserId()`
- [x] `FieldingRecordScorerController`: `GamePlayerRepositoryPort` 제거 → `FieldingRecordService.createRecordByGameAndPlayer()`
- [x] `TeamMemberAdminController`: `TeamMemberRepositoryPort` 제거 → `TeamMembershipService` 메서드로 비즈니스 로직 이동

### Phase 2: Controller↔Service 계약 파손 수정 (IDOR 취약점)
- [x] `RecruitmentController`: `teamId` 소유권 검증 + `@PreAuthorize` 추가
- [x] `AppealController`: `@RequestParam appealerId` → `@AuthenticationPrincipal userId` 전환
- [x] `BookingTransferController`: `@PreAuthorize` 팀 멤버십 검증 + Service `userId` 검증 추가

### 미포함 (별도 이슈로 분리 권장)
- [ ] Entity 팩토리 패턴 위반 수정 (Team, Competition, Player, League, Association) — 100+ 테스트 파일 영향

## To Reviewer

- Controller가 Repository를 직접 주입하던 패턴이 완전히 제거되어, 모든 데이터 접근이 Service 레이어를 거칩니다.
- IDOR 취약점 수정: `appealerId`, `sellerTeamId`, `teamId` 등 클라이언트 입력 identity 파라미터에 서버 측 검증이 추가되었습니다.
- Entity 팩토리 패턴(private constructor + create())은 100개 이상 테스트 파일에 영향을 미쳐 별도 PR로 분리를 권장합니다.
- 빌드/ktlint/단위테스트 모두 통과 확인. Integration 테스트 10개 실패는 Testcontainers(Docker) 환경 문제입니다.