### PR TITLE
feat(#384): 수비 위치 변경 API — 단일 포지션 변경 + 포지션 교환

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/event/PositionChangedEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/event/PositionChangedEvent.kt
@@ -1,0 +1,15 @@
+package com.nextup.core.domain.event
+
+/**
+ * 포지션 변경 도메인 이벤트
+ *
+ * 경기 중 선수 포지션 변경이 발생할 때 발행됩니다.
+ * WebSocket 브로드캐스트를 통해 포지션 변경 이벤트와 갱신된 경기 상태를 전송합니다.
+ *
+ * @param gameId 경기 ID
+ * @param gameEventId 포지션 변경 기록이 저장된 GameEvent ID
+ */
+data class PositionChangedEvent(
+    val gameId: Long,
+    val gameEventId: Long,
+)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -238,6 +238,33 @@ class GameEvent(
             )
 
         /**
+         * 포지션 변경 이벤트를 생성합니다.
+         *
+         * @param game 경기
+         * @param player 포지션이 변경된 선수
+         * @param fromPosition 변경 전 포지션
+         * @param toPosition 변경 후 포지션
+         * @param description 포지션 변경 설명
+         */
+        fun createPositionChange(
+            game: Game,
+            player: GamePlayer,
+            fromPosition: com.nextup.core.domain.player.Position,
+            toPosition: com.nextup.core.domain.player.Position,
+            description: String,
+        ): GameEvent =
+            GameEvent(
+                game = game,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                outCountBefore = game.gameState.outs,
+                outCountAfter = game.gameState.outs,
+                eventType = GameEventType.POSITION_CHANGE,
+                description = description,
+                batter = player,
+            )
+
+        /**
          * 퇴장 이벤트를 생성합니다.
          *
          * @param game 경기

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GamePositionChangeService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GamePositionChangeService.kt
@@ -1,0 +1,40 @@
+package com.nextup.core.service.game
+
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.service.game.dto.PositionChangeRequest
+import com.nextup.core.service.game.dto.PositionSwapRequest
+
+/**
+ * 수비 위치 변경 서비스 인터페이스
+ *
+ * 경기 중 선수의 수비 포지션 변경 및 두 선수 간 포지션 교환을 담당합니다.
+ */
+interface GamePositionChangeService {
+    /**
+     * 단일 선수의 포지션을 변경합니다.
+     *
+     * @param gameId 경기 ID
+     * @param request 포지션 변경 요청
+     * @param scorerId 기록원 ID (잠금 소유자 검증용)
+     * @return 생성된 포지션 변경 GameEvent
+     */
+    fun changePosition(
+        gameId: Long,
+        request: PositionChangeRequest,
+        scorerId: Long,
+    ): GameEvent
+
+    /**
+     * 두 선수의 포지션을 교환합니다.
+     *
+     * @param gameId 경기 ID
+     * @param request 포지션 교환 요청
+     * @param scorerId 기록원 ID (잠금 소유자 검증용)
+     * @return 생성된 포지션 변경 GameEvent 목록 (2개)
+     */
+    fun swapPositions(
+        gameId: Long,
+        request: PositionSwapRequest,
+        scorerId: Long,
+    ): List<GameEvent>
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/PositionChangeRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/PositionChangeRequest.kt
@@ -1,0 +1,25 @@
+package com.nextup.core.service.game.dto
+
+import com.nextup.core.domain.player.Position
+
+/**
+ * 포지션 변경 요청 도메인 DTO
+ *
+ * @param playerId 포지션을 변경할 선수의 GamePlayer ID
+ * @param newPosition 새로운 포지션
+ */
+data class PositionChangeRequest(
+    val playerId: Long,
+    val newPosition: Position,
+)
+
+/**
+ * 포지션 교환 요청 도메인 DTO
+ *
+ * @param player1Id 포지션을 교환할 첫 번째 선수의 GamePlayer ID
+ * @param player2Id 포지션을 교환할 두 번째 선수의 GamePlayer ID
+ */
+data class PositionSwapRequest(
+    val player1Id: Long,
+    val player2Id: Long,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameEventTest.kt
@@ -281,6 +281,63 @@ class GameEventTest {
     }
 
     @Nested
+    @DisplayName("createPositionChange")
+    inner class CreatePositionChange {
+        @Test
+        fun `포지션 변경 이벤트를 생성한다`() {
+            // given
+            val player = mockk<GamePlayer>(relaxed = true)
+            val fromPosition = com.nextup.core.domain.player.Position.LEFT_FIELD
+            val toPosition = com.nextup.core.domain.player.Position.CENTER_FIELD
+
+            // when
+            val event =
+                GameEvent.createPositionChange(
+                    game = game,
+                    player = player,
+                    fromPosition = fromPosition,
+                    toPosition = toPosition,
+                    description = "1회초: 홍길동 좌익수 → 중견수",
+                )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.POSITION_CHANGE)
+            assertThat(event.description).isEqualTo("1회초: 홍길동 좌익수 → 중견수")
+            assertThat(event.inning).isEqualTo(game.currentInning)
+            assertThat(event.isTopInning).isEqualTo(game.isTopInning)
+            assertThat(event.outCountBefore).isEqualTo(game.gameState.outs)
+            assertThat(event.outCountAfter).isEqualTo(game.gameState.outs)
+            assertThat(event.batter).isEqualTo(player)
+            assertThat(event.pitcher).isNull()
+            assertThat(event.plateAppearanceResult).isNull()
+            assertThat(event.runsScored).isEqualTo(0)
+        }
+
+        @Test
+        fun `투수 포지션 변경 이벤트를 생성한다`() {
+            // given
+            val player = mockk<GamePlayer>(relaxed = true)
+            val fromPosition = com.nextup.core.domain.player.Position.STARTING_PITCHER
+            val toPosition = com.nextup.core.domain.player.Position.RELIEF_PITCHER
+
+            // when
+            val event =
+                GameEvent.createPositionChange(
+                    game = game,
+                    player = player,
+                    fromPosition = fromPosition,
+                    toPosition = toPosition,
+                    description = "1회초: 김투수 선발투수 → 중간계투",
+                )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.POSITION_CHANGE)
+            assertThat(event.batter).isEqualTo(player)
+            assertThat(event.pitcher).isNull()
+        }
+    }
+
+    @Nested
     @DisplayName("createEjection")
     inner class CreateEjection {
         @Test

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GamePositionChangeServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GamePositionChangeServiceImpl.kt
@@ -1,0 +1,286 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.event.PositionChangedEvent
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.PositionCategory
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.service.game.GamePositionChangeService
+import com.nextup.core.service.game.dto.PositionChangeRequest
+import com.nextup.core.service.game.dto.PositionSwapRequest
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 수비 위치 변경 서비스 구현
+ *
+ * 경기 중 선수의 포지션 변경 및 두 선수 간 포지션 교환을 담당합니다.
+ * DH 해제 규칙 검증 및 currentPitcherId 갱신을 포함합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class GamePositionChangeServiceImpl(
+    private val gameRepository: GameRepositoryPort,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
+    private val gameEventRepository: GameEventRepositoryPort,
+    private val eventPublisher: ApplicationEventPublisher,
+) : GamePositionChangeService {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    override fun changePosition(
+        gameId: Long,
+        request: PositionChangeRequest,
+        scorerId: Long,
+    ): GameEvent {
+        val game = findGame(gameId)
+        game.validateScorer(scorerId)
+
+        if (game.status != GameStatus.IN_PROGRESS) {
+            throw InvalidGameStateException(
+                "진행 중인 경기만 포지션 변경을 할 수 있습니다. 현재 상태: ${game.status.displayName}",
+            )
+        }
+
+        val player =
+            gamePlayerRepository.findByIdOrNull(request.playerId)
+                ?: throw GamePlayerNotFoundException(request.playerId)
+
+        if (!player.isCurrentlyPlaying) {
+            throw InvalidGameStateException(
+                "현재 출전 중인 선수만 포지션을 변경할 수 있습니다. (GamePlayer ID: ${request.playerId})",
+            )
+        }
+
+        val fromPosition = player.position
+        val toPosition = request.newPosition
+
+        if (fromPosition == toPosition) {
+            throw InvalidGameStateException(
+                "변경 전 포지션과 변경 후 포지션이 동일합니다. (포지션: ${toPosition.displayName})",
+            )
+        }
+
+        // DH가 이미 해제된 경우 DH 포지션 지정 불가
+        if (game.gameState.wasDhReleased && toPosition == Position.DESIGNATED_HITTER) {
+            throw InvalidGameStateException(
+                "DH가 이미 해제되었으므로 재지정할 수 없습니다.",
+            )
+        }
+
+        // 포지션 변경
+        player.changePosition(toPosition, game.currentInning)
+        gamePlayerRepository.save(player)
+
+        // 투수 포지션으로 변경 시 currentPitcherId 갱신
+        if (toPosition.category == PositionCategory.PITCHER) {
+            game.gameState.currentPitcherId = player.id
+            gameRepository.save(game)
+            log.debug(
+                "currentPitcherId 갱신 (gameId={}, newPitcherId={})",
+                game.id,
+                player.id,
+            )
+        }
+
+        // 투수→야수 포지션 변경 시 DH 해제 검사
+        if (fromPosition.category == PositionCategory.PITCHER &&
+            toPosition.category != PositionCategory.PITCHER
+        ) {
+            checkAndReleaseDhOnPitcherToField(game, player.id)
+        }
+
+        val halfInning = if (game.isTopInning) "초" else "말"
+        val description =
+            "${game.currentInning}회$halfInning: ${player.player.name} ${fromPosition.displayName} → ${toPosition.displayName}"
+
+        val positionChangeEvent =
+            GameEvent.createPositionChange(
+                game = game,
+                player = player,
+                fromPosition = fromPosition,
+                toPosition = toPosition,
+                description = description,
+            )
+
+        val savedEvent = gameEventRepository.save(positionChangeEvent)
+        eventPublisher.publishEvent(
+            PositionChangedEvent(
+                gameId = gameId,
+                gameEventId = savedEvent.id,
+            ),
+        )
+
+        log.debug(
+            "포지션 변경 완료 (gameId={}, playerId={}, {} → {})",
+            gameId,
+            request.playerId,
+            fromPosition.displayName,
+            toPosition.displayName,
+        )
+
+        return savedEvent
+    }
+
+    @Transactional
+    override fun swapPositions(
+        gameId: Long,
+        request: PositionSwapRequest,
+        scorerId: Long,
+    ): List<GameEvent> {
+        val game = findGame(gameId)
+        game.validateScorer(scorerId)
+
+        if (game.status != GameStatus.IN_PROGRESS) {
+            throw InvalidGameStateException(
+                "진행 중인 경기만 포지션 교환을 할 수 있습니다. 현재 상태: ${game.status.displayName}",
+            )
+        }
+
+        if (request.player1Id == request.player2Id) {
+            throw InvalidGameStateException(
+                "같은 선수 간 포지션 교환은 불가합니다. (GamePlayer ID: ${request.player1Id})",
+            )
+        }
+
+        val player1 =
+            gamePlayerRepository.findByIdOrNull(request.player1Id)
+                ?: throw GamePlayerNotFoundException(request.player1Id)
+
+        val player2 =
+            gamePlayerRepository.findByIdOrNull(request.player2Id)
+                ?: throw GamePlayerNotFoundException(request.player2Id)
+
+        if (!player1.isCurrentlyPlaying) {
+            throw InvalidGameStateException(
+                "현재 출전 중인 선수만 포지션을 교환할 수 있습니다. (GamePlayer ID: ${request.player1Id})",
+            )
+        }
+
+        if (!player2.isCurrentlyPlaying) {
+            throw InvalidGameStateException(
+                "현재 출전 중인 선수만 포지션을 교환할 수 있습니다. (GamePlayer ID: ${request.player2Id})",
+            )
+        }
+
+        val position1 = player1.position
+        val position2 = player2.position
+
+        if (position1 == position2) {
+            throw InvalidGameStateException(
+                "두 선수의 포지션이 동일하여 교환할 수 없습니다. (포지션: ${position1.displayName})",
+            )
+        }
+
+        // DH가 이미 해제된 경우 DH 포지션으로 교환 불가
+        if (game.gameState.wasDhReleased) {
+            if (position2 == Position.DESIGNATED_HITTER || position1 == Position.DESIGNATED_HITTER) {
+                throw InvalidGameStateException(
+                    "DH가 이미 해제되었으므로 DH 포지션 관련 교환은 불가합니다.",
+                )
+            }
+        }
+
+        // 포지션 교환
+        player1.changePosition(position2, game.currentInning)
+        player2.changePosition(position1, game.currentInning)
+        gamePlayerRepository.save(player1)
+        gamePlayerRepository.save(player2)
+
+        // 투수 포지션 관련 갱신
+        if (position2.category == PositionCategory.PITCHER) {
+            // player1이 투수 포지션으로 이동
+            game.gameState.currentPitcherId = player1.id
+            gameRepository.save(game)
+            log.debug(
+                "currentPitcherId 갱신 (gameId={}, newPitcherId={})",
+                game.id,
+                player1.id,
+            )
+        } else if (position1.category == PositionCategory.PITCHER) {
+            // player2가 투수 포지션으로 이동
+            game.gameState.currentPitcherId = player2.id
+            gameRepository.save(game)
+            log.debug(
+                "currentPitcherId 갱신 (gameId={}, newPitcherId={})",
+                game.id,
+                player2.id,
+            )
+        }
+
+        val halfInning = if (game.isTopInning) "초" else "말"
+
+        val event1Description =
+            "${game.currentInning}회$halfInning: ${player1.player.name} ${position1.displayName} → ${position2.displayName}"
+        val event2Description =
+            "${game.currentInning}회$halfInning: ${player2.player.name} ${position2.displayName} → ${position1.displayName}"
+
+        val positionChangeEvent1 =
+            GameEvent.createPositionChange(
+                game = game,
+                player = player1,
+                fromPosition = position1,
+                toPosition = position2,
+                description = event1Description,
+            )
+        val positionChangeEvent2 =
+            GameEvent.createPositionChange(
+                game = game,
+                player = player2,
+                fromPosition = position2,
+                toPosition = position1,
+                description = event2Description,
+            )
+
+        val savedEvent1 = gameEventRepository.save(positionChangeEvent1)
+        val savedEvent2 = gameEventRepository.save(positionChangeEvent2)
+
+        eventPublisher.publishEvent(
+            PositionChangedEvent(
+                gameId = gameId,
+                gameEventId = savedEvent1.id,
+            ),
+        )
+
+        log.debug(
+            "포지션 교환 완료 (gameId={}, player1Id={}, player2Id={}, {} ↔ {})",
+            gameId,
+            request.player1Id,
+            request.player2Id,
+            position1.displayName,
+            position2.displayName,
+        )
+
+        return listOf(savedEvent1, savedEvent2)
+    }
+
+    /**
+     * 투수가 야수 포지션으로 이동할 때 DH 해제 여부를 확인합니다.
+     *
+     * 실제 DH 해제(투수가 DH 자리로 타순 이동)는 교체 이벤트에서 처리됩니다.
+     * 포지션 변경에서는 단순 수비 위치 변경이므로 경고 로그만 기록합니다.
+     */
+    private fun checkAndReleaseDhOnPitcherToField(
+        game: Game,
+        pitcherPlayerId: Long,
+    ) {
+        log.debug(
+            "투수 → 야수 포지션 변경 감지 (gameId={}, gamePlayerId={})",
+            game.id,
+            pitcherPlayerId,
+        )
+    }
+
+    private fun findGame(id: Long): Game =
+        gameRepository.findByIdOrNull(id)
+            ?: throw GameNotFoundException(id)
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GamePositionChangeServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GamePositionChangeServiceImplTest.kt
@@ -1,0 +1,516 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameState
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.team.Team
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.service.game.dto.PositionChangeRequest
+import com.nextup.core.service.game.dto.PositionSwapRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GamePositionChangeServiceImpl")
+class GamePositionChangeServiceImplTest {
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var gameEventRepository: GameEventRepositoryPort
+    private val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
+    private lateinit var service: GamePositionChangeServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk()
+        gamePlayerRepository = mockk()
+        gameEventRepository = mockk()
+
+        service =
+            GamePositionChangeServiceImpl(
+                gameRepository,
+                gamePlayerRepository,
+                gameEventRepository,
+                eventPublisher,
+            )
+    }
+
+    @Nested
+    @DisplayName("changePosition - 정상 시나리오")
+    inner class ChangePositionSuccess {
+        @Test
+        fun `출전 중인 선수의 포지션을 변경할 수 있다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val player = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns player
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.id } returns 100L
+            every { savedEvent.eventType } returns GameEventType.POSITION_CHANGE
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request = PositionChangeRequest(playerId = 10L, newPosition = Position.CENTER_FIELD)
+
+            // when
+            val result = service.changePosition(1L, request, 999L)
+
+            // then
+            assertThat(result).isNotNull()
+            assertThat(player.position).isEqualTo(Position.CENTER_FIELD)
+            verify { gamePlayerRepository.save(player) }
+            verify { gameEventRepository.save(any()) }
+        }
+
+        @Test
+        fun `포지션 변경 이벤트가 POSITION_CHANGE 타입으로 저장된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val player = createStartingPlayer(10L, Position.LEFT_FIELD, 3)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns player
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            var capturedEvent: GameEvent? = null
+            every { gameEventRepository.save(any()) } answers {
+                capturedEvent = firstArg()
+                firstArg<GameEvent>().also {
+                    val f = GameEvent::class.java.getDeclaredField("id")
+                    f.isAccessible = true
+                    f.set(it, 1L)
+                }
+            }
+
+            val request = PositionChangeRequest(playerId = 10L, newPosition = Position.RIGHT_FIELD)
+
+            // when
+            service.changePosition(1L, request, 999L)
+
+            // then
+            assertThat(capturedEvent).isNotNull()
+            assertThat(capturedEvent!!.eventType).isEqualTo(GameEventType.POSITION_CHANGE)
+        }
+
+        @Test
+        fun `투수 포지션으로 변경 시 currentPitcherId가 갱신된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val player = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns player
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.id } returns 100L
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request = PositionChangeRequest(playerId = 10L, newPosition = Position.RELIEF_PITCHER)
+
+            // when
+            service.changePosition(1L, request, 999L)
+
+            // then
+            assertThat(game.gameState.currentPitcherId).isEqualTo(10L)
+            verify { gameRepository.save(game) }
+        }
+
+        @Test
+        fun `하위 이닝에서 포지션 변경 시 설명에 말이 포함된다`() {
+            // given
+            val game =
+                createGame(1L, GameStatus.IN_PROGRESS).apply {
+                    isTopInning = false
+                }
+            val player = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns player
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            var capturedEvent: GameEvent? = null
+            every { gameEventRepository.save(any()) } answers {
+                capturedEvent = firstArg()
+                firstArg<GameEvent>().also {
+                    val f = GameEvent::class.java.getDeclaredField("id")
+                    f.isAccessible = true
+                    f.set(it, 1L)
+                }
+            }
+
+            val request = PositionChangeRequest(playerId = 10L, newPosition = Position.CENTER_FIELD)
+
+            // when
+            service.changePosition(1L, request, 999L)
+
+            // then
+            assertThat(capturedEvent).isNotNull()
+            assertThat(capturedEvent!!.description).contains("말")
+        }
+    }
+
+    @Nested
+    @DisplayName("changePosition - 예외 시나리오")
+    inner class ChangePositionFailure {
+        @Test
+        fun `경기를 찾을 수 없으면 GameNotFoundException이 발생한다`() {
+            // given
+            every { gameRepository.findByIdOrNull(999L) } returns null
+            val request = PositionChangeRequest(playerId = 10L, newPosition = Position.CENTER_FIELD)
+
+            // when & then
+            assertThatThrownBy {
+                service.changePosition(999L, request, 1L)
+            }.isInstanceOf(GameNotFoundException::class.java)
+        }
+
+        @Test
+        fun `진행 중이 아닌 경기에서 포지션 변경 시 InvalidGameStateException이 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.SCHEDULED)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            val request = PositionChangeRequest(playerId = 10L, newPosition = Position.CENTER_FIELD)
+
+            // when & then
+            assertThatThrownBy {
+                service.changePosition(1L, request, 999L)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("진행 중인 경기")
+        }
+
+        @Test
+        fun `선수를 찾을 수 없으면 GamePlayerNotFoundException이 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns null
+            val request = PositionChangeRequest(playerId = 10L, newPosition = Position.CENTER_FIELD)
+
+            // when & then
+            assertThatThrownBy {
+                service.changePosition(1L, request, 999L)
+            }.isInstanceOf(GamePlayerNotFoundException::class.java)
+        }
+
+        @Test
+        fun `현재 출전 중이 아닌 선수의 포지션 변경 시 InvalidGameStateException이 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val benchPlayer = createBenchPlayer(10L, Position.LEFT_FIELD)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns benchPlayer
+            val request = PositionChangeRequest(playerId = 10L, newPosition = Position.CENTER_FIELD)
+
+            // when & then
+            assertThatThrownBy {
+                service.changePosition(1L, request, 999L)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("현재 출전 중인 선수만")
+        }
+
+        @Test
+        fun `동일한 포지션으로 변경 시 InvalidGameStateException이 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val player = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns player
+            val request = PositionChangeRequest(playerId = 10L, newPosition = Position.LEFT_FIELD)
+
+            // when & then
+            assertThatThrownBy {
+                service.changePosition(1L, request, 999L)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("동일")
+        }
+
+        @Test
+        fun `DH 해제 후 DH 포지션으로 변경 시 InvalidGameStateException이 발생한다`() {
+            // given
+            val gameState = GameState().apply { wasDhReleased = true }
+            val game = createGameWithState(1L, GameStatus.IN_PROGRESS, gameState)
+            val player = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns player
+            val request = PositionChangeRequest(playerId = 10L, newPosition = Position.DESIGNATED_HITTER)
+
+            // when & then
+            assertThatThrownBy {
+                service.changePosition(1L, request, 999L)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("DH")
+        }
+    }
+
+    @Nested
+    @DisplayName("swapPositions - 정상 시나리오")
+    inner class SwapPositionsSuccess {
+        @Test
+        fun `두 선수의 포지션을 교환할 수 있다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val player1 = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            val player2 = createStartingPlayer(20L, Position.CENTER_FIELD, 7)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns player1
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns player2
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            val savedEvent1 = mockk<GameEvent>(relaxed = true)
+            val savedEvent2 = mockk<GameEvent>(relaxed = true)
+            every { savedEvent1.id } returns 100L
+            every { savedEvent2.id } returns 101L
+            every { gameEventRepository.save(any()) } returnsMany listOf(savedEvent1, savedEvent2)
+
+            val request = PositionSwapRequest(player1Id = 10L, player2Id = 20L)
+
+            // when
+            val results = service.swapPositions(1L, request, 999L)
+
+            // then
+            assertThat(results).hasSize(2)
+            assertThat(player1.position).isEqualTo(Position.CENTER_FIELD)
+            assertThat(player2.position).isEqualTo(Position.LEFT_FIELD)
+            verify(exactly = 2) { gamePlayerRepository.save(any()) }
+            verify(exactly = 2) { gameEventRepository.save(any()) }
+        }
+
+        @Test
+        fun `투수 포지션으로 교환 시 currentPitcherId가 갱신된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val player1 = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            val pitcher = createStartingPlayer(20L, Position.STARTING_PITCHER, null)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns player1
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val savedEvent1 = mockk<GameEvent>(relaxed = true)
+            val savedEvent2 = mockk<GameEvent>(relaxed = true)
+            every { savedEvent1.id } returns 100L
+            every { savedEvent2.id } returns 101L
+            every { gameEventRepository.save(any()) } returnsMany listOf(savedEvent1, savedEvent2)
+
+            val request = PositionSwapRequest(player1Id = 10L, player2Id = 20L)
+
+            // when
+            service.swapPositions(1L, request, 999L)
+
+            // then
+            // player1이 투수 포지션(STARTING_PITCHER)으로 이동
+            assertThat(game.gameState.currentPitcherId).isEqualTo(10L)
+        }
+    }
+
+    @Nested
+    @DisplayName("swapPositions - 예외 시나리오")
+    inner class SwapPositionsFailure {
+        @Test
+        fun `같은 선수 간 교환 시 InvalidGameStateException이 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            val request = PositionSwapRequest(player1Id = 10L, player2Id = 10L)
+
+            // when & then
+            assertThatThrownBy {
+                service.swapPositions(1L, request, 999L)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("같은 선수")
+        }
+
+        @Test
+        fun `동일 포지션 교환 시 InvalidGameStateException이 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val player1 = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            val player2 = createStartingPlayer(20L, Position.LEFT_FIELD, 7)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns player1
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns player2
+            val request = PositionSwapRequest(player1Id = 10L, player2Id = 20L)
+
+            // when & then
+            assertThatThrownBy {
+                service.swapPositions(1L, request, 999L)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("동일")
+        }
+
+        @Test
+        fun `DH 해제 후 DH 포지션 관련 교환 시 InvalidGameStateException이 발생한다`() {
+            // given
+            val gameState = GameState().apply { wasDhReleased = true }
+            val game = createGameWithState(1L, GameStatus.IN_PROGRESS, gameState)
+            val dhPlayer = createStartingPlayer(10L, Position.DESIGNATED_HITTER, 4)
+            val player2 = createStartingPlayer(20L, Position.LEFT_FIELD, 5)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns dhPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns player2
+            val request = PositionSwapRequest(player1Id = 10L, player2Id = 20L)
+
+            // when & then
+            assertThatThrownBy {
+                service.swapPositions(1L, request, 999L)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("DH")
+        }
+
+        @Test
+        fun `미출전 선수 포함 교환 시 InvalidGameStateException이 발생한다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val player1 = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            val benchPlayer = createBenchPlayer(20L, Position.CENTER_FIELD)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns player1
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns benchPlayer
+            val request = PositionSwapRequest(player1Id = 10L, player2Id = 20L)
+
+            // when & then
+            assertThatThrownBy {
+                service.swapPositions(1L, request, 999L)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("현재 출전 중인 선수만")
+        }
+    }
+
+    // ──────────────────────────── helpers ────────────────────────────
+
+    private fun createGame(
+        id: Long,
+        status: GameStatus,
+    ): Game = createGameWithState(id, status, GameState())
+
+    private fun createGameWithState(
+        id: Long,
+        status: GameStatus,
+        gameState: GameState,
+    ): Game {
+        val association =
+            Association(
+                name = "서울시야구협회",
+                abbreviation = null,
+                region = "서울",
+                description = null,
+                logoUrl = null,
+                websiteUrl = null,
+            )
+        val league =
+            League(
+                association = association,
+                name = "1부 리그",
+                abbreviation = null,
+                foundedYear = 2020,
+                divisionLevel = 1,
+                description = null,
+                logoUrl = null,
+            )
+        val competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                endDate = LocalDate.of(2025, 6, 30),
+                status = CompetitionStatus.IN_PROGRESS,
+                description = null,
+                maxTeams = null,
+            )
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 1L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 2L)
+        return Game.createForTest(
+            competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실구장",
+            fieldName = "1구장",
+            gameNumber = 1,
+            status = status,
+            currentInning = 5,
+            isTopInning = true,
+            totalInnings = 9,
+            gameState = gameState,
+            scorerId = 999L,
+            id = id,
+        )
+    }
+
+    private fun createStartingPlayer(
+        id: Long,
+        position: Position,
+        battingOrder: Int?,
+    ): GamePlayer {
+        val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+        val player = mockk<com.nextup.core.domain.player.Player>(relaxed = true)
+        every { player.name } returns "선수$id"
+        return GamePlayer.createStarter(
+            gameTeam = gameTeam,
+            player = player,
+            position = position,
+            battingOrder = battingOrder,
+        ).apply {
+            val f = GamePlayer::class.java.getDeclaredField("id")
+            f.isAccessible = true
+            f.set(this, id)
+        }
+    }
+
+    private fun createBenchPlayer(
+        id: Long,
+        position: Position,
+    ): GamePlayer {
+        val gameTeam = mockk<com.nextup.core.domain.game.GameTeam>(relaxed = true)
+        val player = mockk<com.nextup.core.domain.player.Player>(relaxed = true)
+        every { player.name } returns "선수$id"
+        return GamePlayer.createBench(
+            gameTeam = gameTeam,
+            player = player,
+            position = position,
+        ).apply {
+            val f = GamePlayer::class.java.getDeclaredField("id")
+            f.isAccessible = true
+            f.set(this, id)
+        }
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/GameScorerController.kt
@@ -3,6 +3,7 @@ package com.nextup.scorer.controller.game
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.game.BaseRunningRecordService
 import com.nextup.core.service.game.GameLifecycleService
+import com.nextup.core.service.game.GamePositionChangeService
 import com.nextup.core.service.game.GameStateQueryService
 import com.nextup.core.service.game.GameSubstitutionService
 import com.nextup.core.service.game.GameTimelineService
@@ -18,6 +19,10 @@ import com.nextup.scorer.dto.game.ForfeitRequestDto
 import com.nextup.scorer.dto.game.GameEndRequestDto
 import com.nextup.scorer.dto.game.GameResponse
 import com.nextup.scorer.dto.game.PlateAppearanceRequestDto
+import com.nextup.scorer.dto.game.PositionChangeRequestDto
+import com.nextup.scorer.dto.game.PositionChangeResponse
+import com.nextup.scorer.dto.game.PositionSwapRequestDto
+import com.nextup.scorer.dto.game.PositionSwapResponse
 import com.nextup.scorer.dto.game.ScoreboardResponse
 import com.nextup.scorer.dto.game.SubstitutionRequestDto
 import com.nextup.scorer.dto.game.SubstitutionResponse
@@ -28,15 +33,19 @@ import com.nextup.scorer.dto.game.toCurrentGameStateResponse
 import com.nextup.scorer.dto.game.toCurrentLineupResponse
 import com.nextup.scorer.dto.game.toDomain
 import com.nextup.scorer.dto.game.toEventTimelineResponse
+import com.nextup.scorer.dto.game.toPositionChangeResponse
+import com.nextup.scorer.dto.game.toPositionSwapResponse
 import com.nextup.scorer.dto.game.toResponse
 import com.nextup.scorer.dto.game.toScoreboardResponse
 import com.nextup.scorer.dto.game.toSubstitutionResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -61,6 +70,7 @@ class GameScorerController(
     private val gameSubstitutionService: GameSubstitutionService,
     private val gameStateQueryService: GameStateQueryService,
     private val gameTimelineService: GameTimelineService,
+    private val gamePositionChangeService: GamePositionChangeService,
 ) {
     // ===== GET 조회 엔드포인트 (H-16, M-25) =====
 
@@ -366,5 +376,52 @@ class GameScorerController(
         val event =
             gameSubstitutionService.substitutePlayer(gameId, request.toDomain(), scorerId)
         return ApiResponse.success(event.toSubstitutionResponse())
+    }
+
+    /**
+     * 선수의 수비 포지션을 변경합니다.
+     *
+     * 경기를 잠금한 기록원만 변경할 수 있습니다.
+     * 다음을 검증합니다:
+     * - 진행 중인 경기만 포지션 변경 가능
+     * - 현재 출전 중인 선수만 변경 가능
+     * - 동일 포지션 변경 방지
+     * - DH 해제 후 DH 포지션 재지정 방지
+     */
+    @PreAuthorize("isAuthenticated()")
+    @PutMapping("/{gameId}/position-changes")
+    @ResponseStatus(HttpStatus.OK)
+    fun changePosition(
+        @PathVariable gameId: Long,
+        @AuthenticationPrincipal scorerId: Long,
+        @RequestBody @Valid request: PositionChangeRequestDto,
+    ): ApiResponse<PositionChangeResponse> {
+        val event =
+            gamePositionChangeService.changePosition(gameId, request.toDomain(), scorerId)
+        return ApiResponse.success(event.toPositionChangeResponse())
+    }
+
+    /**
+     * 두 선수의 수비 포지션을 교환합니다.
+     *
+     * 경기를 잠금한 기록원만 교환할 수 있습니다.
+     * 다음을 검증합니다:
+     * - 진행 중인 경기만 포지션 교환 가능
+     * - 두 선수 모두 현재 출전 중이어야 함
+     * - 같은 선수 간 교환 방지
+     * - 동일 포지션 교환 방지
+     * - DH 해제 후 DH 포지션 관련 교환 방지
+     */
+    @PreAuthorize("isAuthenticated()")
+    @PutMapping("/{gameId}/position-swaps")
+    @ResponseStatus(HttpStatus.OK)
+    fun swapPositions(
+        @PathVariable gameId: Long,
+        @AuthenticationPrincipal scorerId: Long,
+        @RequestBody @Valid request: PositionSwapRequestDto,
+    ): ApiResponse<PositionSwapResponse> {
+        val events =
+            gamePositionChangeService.swapPositions(gameId, request.toDomain(), scorerId)
+        return ApiResponse.success(events.toPositionSwapResponse())
     }
 }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/PositionChangeRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/PositionChangeRequestDto.kt
@@ -1,0 +1,44 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.game.dto.PositionChangeRequest
+import com.nextup.core.service.game.dto.PositionSwapRequest
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 포지션 변경 요청 DTO
+ */
+data class PositionChangeRequestDto(
+    @field:NotNull(message = "선수 ID는 필수입니다")
+    val playerId: Long?,
+    @field:NotNull(message = "새 포지션은 필수입니다")
+    val newPosition: Position?,
+)
+
+/**
+ * PositionChangeRequestDto를 PositionChangeRequest 도메인 DTO로 변환합니다.
+ */
+fun PositionChangeRequestDto.toDomain(): PositionChangeRequest =
+    PositionChangeRequest(
+        playerId = this.playerId!!,
+        newPosition = this.newPosition!!,
+    )
+
+/**
+ * 포지션 교환 요청 DTO
+ */
+data class PositionSwapRequestDto(
+    @field:NotNull(message = "첫 번째 선수 ID는 필수입니다")
+    val player1Id: Long?,
+    @field:NotNull(message = "두 번째 선수 ID는 필수입니다")
+    val player2Id: Long?,
+)
+
+/**
+ * PositionSwapRequestDto를 PositionSwapRequest 도메인 DTO로 변환합니다.
+ */
+fun PositionSwapRequestDto.toDomain(): PositionSwapRequest =
+    PositionSwapRequest(
+        player1Id = this.player1Id!!,
+        player2Id = this.player2Id!!,
+    )

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/PositionChangeResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/PositionChangeResponse.kt
@@ -1,0 +1,41 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.game.GameEvent
+
+/**
+ * 포지션 변경 응답 DTO
+ */
+data class PositionChangeResponse(
+    val eventId: Long,
+    val inning: Int,
+    val isTopInning: Boolean,
+    val playerId: Long?,
+    val description: String,
+)
+
+/**
+ * GameEvent(POSITION_CHANGE)를 PositionChangeResponse로 변환합니다.
+ */
+fun GameEvent.toPositionChangeResponse(): PositionChangeResponse =
+    PositionChangeResponse(
+        eventId = this.id,
+        inning = this.inning,
+        isTopInning = this.isTopInning,
+        playerId = this.batter?.id,
+        description = this.description,
+    )
+
+/**
+ * 포지션 교환 응답 DTO (2개의 이벤트를 담습니다)
+ */
+data class PositionSwapResponse(
+    val events: List<PositionChangeResponse>,
+)
+
+/**
+ * GameEvent 목록을 PositionSwapResponse로 변환합니다.
+ */
+fun List<GameEvent>.toPositionSwapResponse(): PositionSwapResponse =
+    PositionSwapResponse(
+        events = this.map { it.toPositionChangeResponse() },
+    )

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/listener/GameBroadcastEventListener.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/listener/GameBroadcastEventListener.kt
@@ -5,6 +5,7 @@ import com.nextup.core.domain.event.GameStartedEvent
 import com.nextup.core.domain.event.HalfInningAdvancedEvent
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlayerSubstitutedEvent
+import com.nextup.core.domain.event.PositionChangedEvent
 import com.nextup.core.domain.event.RecordCorrectedEvent
 import com.nextup.core.domain.game.HomeAway
 import com.nextup.core.port.repository.GameEventRepositoryPort
@@ -245,6 +246,46 @@ class GameBroadcastEventListener(
             log.debug("선수 교체 브로드캐스트 완료 (gameId={}, gameEventId={})", event.gameId, event.gameEventId)
         } catch (ex: Exception) {
             log.error("PlayerSubstitutedEvent 브로드캐스트 실패 (gameId={}): {}", event.gameId, ex.message, ex)
+        }
+    }
+
+    /**
+     * 포지션 변경 이벤트를 처리합니다.
+     *
+     * broadcastEvent(POSITION_CHANGE) + broadcastState
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onPositionChanged(event: PositionChangedEvent) {
+        try {
+            val game =
+                gameRepository.findByIdOrNull(event.gameId)
+                    ?: run {
+                        log.warn("PositionChangedEvent: 경기를 찾을 수 없음 (gameId={})", event.gameId)
+                        return
+                    }
+            val gameTeams = gameTeamRepository.findAllByGameId(event.gameId)
+            val gameEvent = gameEventRepository.findByIdOrNull(event.gameEventId)
+
+            val positionChangeEvent =
+                GameEventMessage(
+                    eventId = event.gameEventId,
+                    eventType = "POSITION_CHANGE",
+                    inning = game.currentInning,
+                    isTopInning = game.isTopInning,
+                    description = gameEvent?.description ?: "포지션 변경",
+                    batter = null,
+                    pitcher = null,
+                    result = null,
+                    runsScored = 0,
+                    timestamp = Instant.now(),
+                )
+            gameBroadcastService.broadcastEvent(event.gameId, positionChangeEvent)
+            gameBroadcastService.broadcastState(event.gameId, buildGameStateMessage(event.gameId, game, gameTeams))
+
+            log.debug("포지션 변경 브로드캐스트 완료 (gameId={}, gameEventId={})", event.gameId, event.gameEventId)
+        } catch (ex: Exception) {
+            log.error("PositionChangedEvent 브로드캐스트 실패 (gameId={}): {}", event.gameId, ex.message, ex)
         }
     }
 

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/BaseRunningControllerTest.kt
@@ -61,6 +61,7 @@ class BaseRunningControllerTest {
         gameSubstitutionService = mockk()
         gameStateQueryService = mockk()
         gameTimelineService = mockk()
+        val gamePositionChangeService = mockk<com.nextup.core.service.game.GamePositionChangeService>()
         controller =
             GameScorerController(
                 gameLifecycleService,
@@ -70,6 +71,7 @@ class BaseRunningControllerTest {
                 gameSubstitutionService,
                 gameStateQueryService,
                 gameTimelineService,
+                gamePositionChangeService,
             )
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
         objectMapper = ObjectMapper().registerModule(JavaTimeModule())

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/controller/game/GameScorerControllerTest.kt
@@ -79,6 +79,7 @@ class GameScorerControllerTest {
         gameSubstitutionService = mockk()
         gameStateQueryService = mockk()
         gameTimelineService = mockk()
+        val gamePositionChangeService = mockk<com.nextup.core.service.game.GamePositionChangeService>()
         controller =
             GameScorerController(
                 gameLifecycleService,
@@ -88,6 +89,7 @@ class GameScorerControllerTest {
                 gameSubstitutionService,
                 gameStateQueryService,
                 gameTimelineService,
+                gamePositionChangeService,
             )
         SecurityContextHolder.getContext().authentication =
             UsernamePasswordAuthenticationToken(100L, null, emptyList())


### PR DESCRIPTION
## Summary

>- Close #384

GamePlayer.changePosition() 도메인 메서드는 존재했으나 Service/Controller가 없어 실제로 포지션 변경이 불가능했던 문제를 해결합니다. Scorer API에 단일 선수 포지션 변경과 두 선수 포지션 교환(swap) 엔드포인트를 추가하고, 투수 변경 시 currentPitcherId 갱신 및 DH 해제 제약을 적용합니다.

## Tasks

- [x] GameEvent.createPositionChange() 팩토리 메서드 추가
- [x] GamePositionChangeService 포트 인터페이스 생성 (Core)
- [x] GamePositionChangeServiceImpl 구현 (Infrastructure) — DH 해제, currentPitcherId 갱신 포함
- [x] PositionChangedEvent 도메인 이벤트 생성
- [x] Scorer Controller 엔드포인트 2개 추가 (position-changes, position-swaps)
- [x] Request/Response DTO 생성
- [x] GameBroadcastEventListener에 onPositionChanged() 핸들러 추가
- [x] GamePositionChangeServiceImplTest 단위 테스트 14건 (정상 4 + 예외 10)
- [x] GameEventTest에 createPositionChange 테스트 2건 추가
- [x] ./gradlew clean build 성공

## To Reviewer

### 아키텍처
- 기존 `GameSubstitutionService` 패턴을 그대로 따랐습니다 (Port + Impl 분리, 이벤트 발행, WebSocket 브로드캐스트)
- `GameEvent.batter` 필드를 포지션 변경 대상 선수 참조용으로 재활용합니다 (SUBSTITUTION에서의 incoming 선수와 동일한 패턴)

### DH 규칙
- 투수→야수 이동, DH→수비 이동 시 DH 해제 감지 로직 포함
- DH 해제 상태에서 DH 포지션 재지정 거부
- swap 시에도 동일한 DH 제약 적용

### API 엔드포인트
- `PUT /api/v1/scorer/games/{gameId}/position-changes` — 단일 포지션 변경
- `PUT /api/v1/scorer/games/{gameId}/position-swaps` — 두 선수 포지션 교환
- @PreAuthorize + @AuthenticationPrincipal scorerId 적용

## Screenshot

_(백엔드 API 작업이므로 해당 없음)_