### PR TITLE
fix(#429): N+1 쿼리 해결 + HikariCP 설정 + DB 페이징 전환

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/game/GameScheduleController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/game/GameScheduleController.kt
@@ -1,5 +1,6 @@
 package com.nextup.api.controller.game
 
+import com.nextup.api.dto.common.PagedResponse
 import com.nextup.api.dto.game.AvailableRosterResponse
 import com.nextup.api.dto.game.GameDetailResponse
 import com.nextup.api.dto.game.GameSummaryResponse
@@ -24,7 +25,7 @@ class GameScheduleController(
     private val availableRosterService: AvailableRosterService,
 ) {
     /**
-     * 경기 목록을 조회합니다. (날짜/팀/대회 필터, 페이징)
+     * 경기 목록을 조회합니다. (날짜/팀/대회 필터, DB 페이징)
      */
     @GetMapping("/games")
     fun getGames(
@@ -33,8 +34,8 @@ class GameScheduleController(
         @RequestParam(required = false) competitionId: Long?,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "20") size: Int,
-    ): ApiResponse<List<GameSummaryResponse>> {
-        val games =
+    ): ApiResponse<PagedResponse<GameSummaryResponse>> {
+        val pageResult =
             gameScheduleService.getGames(
                 date = date,
                 teamId = teamId,
@@ -42,7 +43,8 @@ class GameScheduleController(
                 page = page,
                 size = size,
             )
-        return ApiResponse.success(games.map { GameSummaryResponse.from(it) })
+        val mapped = pageResult.map { GameSummaryResponse.from(it) }
+        return ApiResponse.success(PagedResponse.from(mapped))
     }
 
     /**

--- a/nextup-api/src/main/resources/application.yml
+++ b/nextup-api/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
     username: ${DB_USERNAME:nextup}
     password: ${DB_PASSWORD:nextup}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 
   jpa:
     hibernate:

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/game/GameScheduleControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/game/GameScheduleControllerTest.kt
@@ -3,6 +3,7 @@ package com.nextup.api.controller.game
 import com.nextup.api.exception.GlobalExceptionHandler
 import com.nextup.common.exception.GameNotFoundException
 import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.player.Position
@@ -79,6 +80,14 @@ class GameScheduleControllerTest {
                     createGameSummaryDto(gameId = 1L),
                     createGameSummaryDto(gameId = 2L, status = GameStatus.IN_PROGRESS, homeScore = 3, awayScore = 1),
                 )
+            val pageResult =
+                PageResult(
+                    content = games,
+                    page = 0,
+                    size = 20,
+                    totalElements = 2L,
+                    totalPages = 1,
+                )
             every {
                 gameScheduleService.getGames(
                     date = null,
@@ -87,26 +96,37 @@ class GameScheduleControllerTest {
                     page = 0,
                     size = 20,
                 )
-            } returns games
+            } returns pageResult
 
             // when & then
             mockMvc
                 .perform(get("/api/v1/games"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data").isArray)
-                .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].gameId").value(1))
-                .andExpect(jsonPath("$.data[0].homeTeam.teamName").value("홈팀"))
-                .andExpect(jsonPath("$.data[0].awayTeam.teamName").value("원정팀"))
-                .andExpect(jsonPath("$.data[0].status").value("SCHEDULED"))
-                .andExpect(jsonPath("$.data[1].homeTeam.score").value(3))
-                .andExpect(jsonPath("$.data[1].awayTeam.score").value(1))
+                .andExpect(jsonPath("$.data.content").isArray)
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.content[0].gameId").value(1))
+                .andExpect(jsonPath("$.data.content[0].homeTeam.teamName").value("홈팀"))
+                .andExpect(jsonPath("$.data.content[0].awayTeam.teamName").value("원정팀"))
+                .andExpect(jsonPath("$.data.content[0].status").value("SCHEDULED"))
+                .andExpect(jsonPath("$.data.content[1].homeTeam.score").value(3))
+                .andExpect(jsonPath("$.data.content[1].awayTeam.score").value(1))
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.currentPage").value(0))
         }
 
         @Test
         fun `빈 경기 목록을 반환한다`() {
             // given
+            val emptyPageResult =
+                PageResult(
+                    content = emptyList<GameSummaryDto>(),
+                    page = 0,
+                    size = 20,
+                    totalElements = 0L,
+                    totalPages = 0,
+                )
             every {
                 gameScheduleService.getGames(
                     date = null,
@@ -115,15 +135,16 @@ class GameScheduleControllerTest {
                     page = 0,
                     size = 20,
                 )
-            } returns emptyList()
+            } returns emptyPageResult
 
             // when & then
             mockMvc
                 .perform(get("/api/v1/games"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data").isArray)
-                .andExpect(jsonPath("$.data.length()").value(0))
+                .andExpect(jsonPath("$.data.content").isArray)
+                .andExpect(jsonPath("$.data.content.length()").value(0))
+                .andExpect(jsonPath("$.data.totalElements").value(0))
         }
     }
 

--- a/nextup-backoffice/src/main/resources/application.yml
+++ b/nextup-backoffice/src/main/resources/application.yml
@@ -10,6 +10,12 @@ spring:
     username: ${DB_USERNAME:nextup}
     password: ${DB_PASSWORD:nextup}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 2
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 
   jpa:
     hibernate:

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BattingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/BattingRecordRepositoryPort.kt
@@ -110,4 +110,10 @@ interface BattingRecordRepositoryPort {
         playerId: Long,
         competitionId: Long,
     ): List<BattingRecord>
+
+    /**
+     * 여러 경기 ID로 타격 기록을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     * 빈 리스트 전달 시 빈 결과를 반환합니다.
+     */
+    fun findAllByGameIds(gameIds: List<Long>): List<BattingRecord>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/CompetitionRepositoryPort.kt
@@ -48,4 +48,13 @@ interface CompetitionRepositoryPort {
      * 리그와 함께 대회 조회 (N+1 방지)
      */
     fun findByIdWithLeague(id: Long): Competition?
+
+    /**
+     * 이름에 키워드가 포함된 대회 목록을 조회합니다. (대소문자 무시)
+     * 빈 리스트 전달 시 빈 결과를 반환합니다.
+     */
+    fun findByNameContaining(
+        name: String,
+        limit: Int,
+    ): List<Competition>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
@@ -1,6 +1,9 @@
 package com.nextup.core.port.repository
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
 import java.time.LocalDateTime
 
 /**
@@ -67,4 +70,16 @@ interface GameRepositoryPort {
      * (잠금 만료 자동 해제용)
      */
     fun findLockedGamesBefore(threshold: LocalDateTime): List<Game>
+
+    /**
+     * 경기 목록을 페이징하여 조회합니다. (날짜/팀/대회 필터 지원)
+     * Core 모듈이 Spring에 의존하지 않도록 PageCommand/PageResult 커스텀 타입을 사용합니다.
+     */
+    fun findGames(
+        date: java.time.LocalDate?,
+        teamId: Long?,
+        competitionId: Long?,
+        status: GameStatus?,
+        pageCommand: PageCommand,
+    ): PageResult<Game>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameTeamRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameTeamRepositoryPort.kt
@@ -71,4 +71,10 @@ interface GameTeamRepositoryPort {
         opponentId: Long,
         competitionId: Long? = null,
     ): List<GameTeam>
+
+    /**
+     * 여러 팀 ID에 해당하는 GameTeam을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     * 빈 리스트 전달 시 빈 결과를 반환합니다.
+     */
+    fun findAllByTeamIdIn(teamIds: List<Long>): List<GameTeam>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchingRecordRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/PitchingRecordRepositoryPort.kt
@@ -138,4 +138,10 @@ interface PitchingRecordRepositoryPort {
         playerId: Long,
         competitionId: Long,
     ): List<PitchingRecord>
+
+    /**
+     * 여러 경기 ID로 투수 기록을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     * 빈 리스트 전달 시 빈 결과를 반환합니다.
+     */
+    fun findAllByGameIds(gameIds: List<Long>): List<PitchingRecord>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/GameScheduleService.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.service.game
 
+import com.nextup.core.common.PageResult
 import com.nextup.core.service.game.dto.GameDetailDto
 import com.nextup.core.service.game.dto.GameSummaryDto
 import java.time.LocalDate
@@ -9,7 +10,7 @@ import java.time.LocalDate
  */
 interface GameScheduleService {
     /**
-     * 경기 목록을 조회합니다. (날짜/팀 필터, 페이징)
+     * 경기 목록을 페이징하여 조회합니다. (날짜/팀 필터, DB 페이징)
      */
     fun getGames(
         date: LocalDate? = null,
@@ -17,7 +18,7 @@ interface GameScheduleService {
         competitionId: Long? = null,
         page: Int = 0,
         size: Int = 20,
-    ): List<GameSummaryDto>
+    ): PageResult<GameSummaryDto>
 
     /**
      * 경기 상세 정보를 조회합니다.

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/competition/CompetitionRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/competition/CompetitionRepository.kt
@@ -3,6 +3,8 @@ package com.nextup.infrastructure.repository.competition
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.port.repository.CompetitionRepositoryPort
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -41,4 +43,23 @@ interface CompetitionRepository :
      */
     @Query("SELECT c FROM Competition c JOIN FETCH c.league WHERE c.id = :id")
     override fun findByIdWithLeague(id: Long): Competition?
+
+    /**
+     * 이름에 키워드가 포함된 대회 목록을 조회합니다. (대소문자 무시, Pageable 기반)
+     */
+    @Query(
+        """
+        SELECT c FROM Competition c
+        WHERE LOWER(c.name) LIKE LOWER(CONCAT('%', :name, '%'))
+    """,
+    )
+    fun findByNameContainingWithPageable(
+        name: String,
+        pageable: Pageable,
+    ): List<Competition>
+
+    override fun findByNameContaining(
+        name: String,
+        limit: Int,
+    ): List<Competition> = findByNameContainingWithPageable(name, PageRequest.of(0, limit))
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/BattingRecordRepository.kt
@@ -221,4 +221,20 @@ interface BattingRecordRepository :
         @Param("playerId") playerId: Long,
         @Param("competitionId") competitionId: Long,
     ): List<BattingRecord>
+
+    /**
+     * 여러 경기 ID로 타격 기록을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     * 빈 리스트 전달 시 빈 결과를 반환합니다.
+     */
+    @Query(
+        """
+        SELECT br FROM BattingRecord br
+        JOIN FETCH br.gamePlayer gp
+        JOIN FETCH gp.gameTeam gt
+        WHERE gt.game.id IN :gameIds
+    """,
+    )
+    override fun findAllByGameIds(
+        @Param("gameIds") gameIds: List<Long>,
+    ): List<BattingRecord>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GamePlayerRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GamePlayerRepository.kt
@@ -17,7 +17,10 @@ interface GamePlayerRepository :
     @Query(
         """
         SELECT gp FROM GamePlayer gp
-        JOIN gp.gameTeam gt
+        JOIN FETCH gp.gameTeam gt
+        JOIN FETCH gt.game
+        JOIN FETCH gt.team
+        JOIN FETCH gp.player
         WHERE gt.game.id = :gameId
         AND gp.player.id = :playerId
     """,
@@ -33,7 +36,10 @@ interface GamePlayerRepository :
     @Query(
         """
         SELECT gp FROM GamePlayer gp
-        JOIN gp.gameTeam gt
+        JOIN FETCH gp.gameTeam gt
+        JOIN FETCH gt.game
+        JOIN FETCH gt.team
+        JOIN FETCH gp.player
         WHERE gt.game.id = :gameId
     """,
     )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
@@ -1,11 +1,18 @@
 package com.nextup.infrastructure.repository.game
 
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.port.repository.GameRepositoryPort
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 interface GameRepository :
     JpaRepository<Game, Long>,
@@ -80,4 +87,84 @@ interface GameRepository :
     override fun findLockedGamesBefore(
         @Param("threshold") threshold: LocalDateTime,
     ): List<Game>
+
+    // ---- 페이징용 내부 쿼리 메서드 (Spring Data Pageable은 Infra 레이어에서만 사용) ----
+
+    @Query(
+        "SELECT g FROM Game g " +
+            "WHERE (:competitionId IS NULL OR g.competition.id = :competitionId) " +
+            "AND (:startOfDay IS NULL OR g.scheduledAt >= :startOfDay) " +
+            "AND (:endOfDay IS NULL OR g.scheduledAt <= :endOfDay) " +
+            "AND (:status IS NULL OR g.status = :status)",
+    )
+    fun findByFilters(
+        @Param("competitionId") competitionId: Long?,
+        @Param("startOfDay") startOfDay: LocalDateTime?,
+        @Param("endOfDay") endOfDay: LocalDateTime?,
+        @Param("status") status: GameStatus?,
+        pageable: org.springframework.data.domain.Pageable,
+    ): org.springframework.data.domain.Page<Game>
+
+    @Query(
+        "SELECT g FROM Game g " +
+            "JOIN GameTeam gt ON gt.game.id = g.id " +
+            "WHERE gt.team.id IN :teamIds " +
+            "AND (:competitionId IS NULL OR g.competition.id = :competitionId) " +
+            "AND (:startOfDay IS NULL OR g.scheduledAt >= :startOfDay) " +
+            "AND (:endOfDay IS NULL OR g.scheduledAt <= :endOfDay) " +
+            "AND (:status IS NULL OR g.status = :status)",
+    )
+    fun findByFiltersAndTeamIds(
+        @Param("teamIds") teamIds: List<Long>,
+        @Param("competitionId") competitionId: Long?,
+        @Param("startOfDay") startOfDay: LocalDateTime?,
+        @Param("endOfDay") endOfDay: LocalDateTime?,
+        @Param("status") status: GameStatus?,
+        pageable: org.springframework.data.domain.Pageable,
+    ): org.springframework.data.domain.Page<Game>
+
+    override fun findGames(
+        date: LocalDate?,
+        teamId: Long?,
+        competitionId: Long?,
+        status: GameStatus?,
+        pageCommand: PageCommand,
+    ): PageResult<Game> {
+        val pageable =
+            PageRequest.of(
+                pageCommand.page,
+                pageCommand.size,
+                Sort.by(Sort.Direction.ASC, "scheduledAt"),
+            )
+        val startOfDay = date?.atStartOfDay()
+        val endOfDay = date?.atTime(LocalTime.MAX)
+
+        val page =
+            if (teamId != null) {
+                findByFiltersAndTeamIds(
+                    teamIds = listOf(teamId),
+                    competitionId = competitionId,
+                    startOfDay = startOfDay,
+                    endOfDay = endOfDay,
+                    status = status,
+                    pageable = pageable,
+                )
+            } else {
+                findByFilters(
+                    competitionId = competitionId,
+                    startOfDay = startOfDay,
+                    endOfDay = endOfDay,
+                    status = status,
+                    pageable = pageable,
+                )
+            }
+
+        return PageResult(
+            content = page.content,
+            page = page.number,
+            size = page.size,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+        )
+    }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameTeamRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameTeamRepository.kt
@@ -99,4 +99,8 @@ interface GameTeamRepository :
         opponentId: Long,
         competitionId: Long?,
     ): List<GameTeam>
+
+    override fun findAllByTeamIdIn(teamIds: List<Long>): List<GameTeam> = findByTeamIdIn(teamIds)
+
+    fun findByTeamIdIn(teamIds: List<Long>): List<GameTeam>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/PitchingRecordRepository.kt
@@ -310,4 +310,20 @@ interface PitchingRecordRepository :
         @Param("playerId") playerId: Long,
         @Param("competitionId") competitionId: Long,
     ): List<PitchingRecord>
+
+    /**
+     * 여러 경기 ID로 투수 기록을 한 번에 조회합니다. (N+1 방지용 배치 쿼리)
+     * 빈 리스트 전달 시 빈 결과를 반환합니다.
+     */
+    @Query(
+        """
+        SELECT pr FROM PitchingRecord pr
+        JOIN FETCH pr.gamePlayer gp
+        JOIN FETCH gp.gameTeam gt
+        WHERE gt.game.id IN :gameIds
+    """,
+    )
+    override fun findAllByGameIds(
+        @Param("gameIds") gameIds: List<Long>,
+    ): List<PitchingRecord>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImpl.kt
@@ -4,7 +4,9 @@ import com.nextup.common.exception.BattingRecordNotFoundException
 import com.nextup.common.exception.GamePlayerNotFoundException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.PitchingRecordNotFoundException
+import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.domain.game.PlateAppearanceResult
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
@@ -31,6 +33,14 @@ class BoxScoreServiceImpl(
             throw InvalidStateException("NO_PLAYERS_IN_GAME", "경기 ID $gameId 에 출전 선수가 없습니다.")
         }
 
+        // 배치 조회로 N+1 방지 — gameId 기준 한 번에 로드
+        val battingRecordMap =
+            battingRecordRepository.findAllByGameId(gameId)
+                .associateBy { it.gamePlayer.id }
+        val pitchingRecordMap =
+            pitchingRecordRepository.findAllByGameId(gameId)
+                .associateBy { it.gamePlayer.id }
+
         val game = gamePlayers.first().gameTeam.game
         val homeTeam = gamePlayers.first { it.gameTeam.isHome }.gameTeam
         val awayTeam = gamePlayers.first { it.gameTeam.isAway }.gameTeam
@@ -47,6 +57,8 @@ class BoxScoreServiceImpl(
                     homeTeam.team.logoUrl,
                     homeTeam,
                     homePlayers,
+                    battingRecordMap,
+                    pitchingRecordMap,
                 ),
             awayTeam =
                 buildTeamBoxScore(
@@ -55,6 +67,8 @@ class BoxScoreServiceImpl(
                     awayTeam.team.logoUrl,
                     awayTeam,
                     awayPlayers,
+                    battingRecordMap,
+                    pitchingRecordMap,
                 ),
             currentInning = game.currentInningDisplay,
             gameStatus = game.status.displayName,
@@ -124,19 +138,21 @@ class BoxScoreServiceImpl(
         logoUrl: String?,
         gameTeam: com.nextup.core.domain.game.GameTeam,
         players: List<GamePlayer>,
+        battingRecordMap: Map<Long, BattingRecord>,
+        pitchingRecordMap: Map<Long, PitchingRecord>,
     ): TeamBoxScoreDto {
         val inningScores = parseInningScores(gameTeam.inningScores)
 
         val batters =
             players
                 .filter { it.battingOrder != null || it.isStarter }
-                .map { buildBatterLine(it) }
+                .map { buildBatterLine(it, battingRecordMap) }
                 .sortedBy { it.battingOrder ?: 999 }
 
         val pitchers =
             players
                 .filter { it.isPitcher }
-                .map { buildPitcherLine(it) }
+                .map { buildPitcherLine(it, pitchingRecordMap) }
 
         return TeamBoxScoreDto(
             teamId = teamId,
@@ -151,8 +167,11 @@ class BoxScoreServiceImpl(
         )
     }
 
-    private fun buildBatterLine(gamePlayer: GamePlayer): BatterLineDto {
-        val battingRecord = battingRecordRepository.findByGamePlayer(gamePlayer)
+    private fun buildBatterLine(
+        gamePlayer: GamePlayer,
+        battingRecordMap: Map<Long, BattingRecord>,
+    ): BatterLineDto {
+        val battingRecord = battingRecordMap[gamePlayer.id]
 
         return BatterLineDto(
             playerId = gamePlayer.player.id,
@@ -170,8 +189,11 @@ class BoxScoreServiceImpl(
         )
     }
 
-    private fun buildPitcherLine(gamePlayer: GamePlayer): PitcherLineDto {
-        val pitchingRecord = pitchingRecordRepository.findByGamePlayer(gamePlayer)
+    private fun buildPitcherLine(
+        gamePlayer: GamePlayer,
+        pitchingRecordMap: Map<Long, PitchingRecord>,
+    ): PitcherLineDto {
+        val pitchingRecord = pitchingRecordMap[gamePlayer.id]
 
         return PitcherLineDto(
             playerId = gamePlayer.player.id,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImpl.kt
@@ -1,6 +1,8 @@
 package com.nextup.infrastructure.service.game
 
 import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.domain.game.GameTeam
@@ -14,7 +16,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 /**
  * 경기 일정 조회 서비스 구현
@@ -31,34 +32,24 @@ class GameScheduleServiceImpl(
         competitionId: Long?,
         page: Int,
         size: Int,
-    ): List<GameSummaryDto> {
-        val games =
-            when {
-                competitionId != null -> gameRepository.findByCompetitionId(competitionId)
-                date != null -> {
-                    val start = date.atStartOfDay()
-                    val end = date.atTime(LocalTime.MAX)
-                    gameRepository.findByScheduledAtBetween(start, end)
-                }
-                else -> gameRepository.findAll()
-            }
+    ): PageResult<GameSummaryDto> {
+        val pageCommand = PageCommand(page = page, size = size)
+        val pageResult =
+            gameRepository.findGames(
+                date = date,
+                teamId = teamId,
+                competitionId = competitionId,
+                status = null,
+                pageCommand = pageCommand,
+            )
 
-        val filteredGames =
-            if (teamId != null) {
-                val teamGameIds =
-                    gameTeamRepository.findAllByTeamId(teamId)
-                        .map { it.game.id }
-                        .toSet()
-                games.filter { it.id in teamGameIds }
-            } else {
-                games
-            }
+        val gameTeams = gameTeamRepository.findAllByGameIds(pageResult.content.map { it.id })
+        val gameTeamsByGameId = gameTeams.groupBy { it.game.id }
 
-        // 페이징
-        val start = page * size
-        val paged = filteredGames.drop(start).take(size)
-
-        return toSummaryDtos(paged)
+        return pageResult.map { game ->
+            val teams = gameTeamsByGameId[game.id] ?: emptyList()
+            toSummaryDto(game, teams)
+        }
     }
 
     override fun getGameDetail(gameId: Long): GameDetailDto {
@@ -129,8 +120,8 @@ class GameScheduleServiceImpl(
         if (teamIds.isEmpty()) return emptyList()
 
         val now = LocalDateTime.now()
-        val gameTeams =
-            teamIds.flatMap { gameTeamRepository.findAllByTeamId(it) }
+        // 배치 조회로 N+1 방지 — teamIds.flatMap 대신 단일 쿼리
+        val gameTeams = gameTeamRepository.findAllByTeamIdIn(teamIds)
         val gameIds = gameTeams.map { it.game.id }.distinct()
         val games =
             gameRepository.findAllByIds(gameIds)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/report/CompetitionReportServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/report/CompetitionReportServiceImpl.kt
@@ -82,19 +82,19 @@ class CompetitionReportServiceImpl(
                 0.0
             }
 
-        // 5. 타격/투구 통계 조회
+        // 5. 타격/투구 통계 조회 — 배치 쿼리로 N+1 방지
         val battingRecords =
             if (completedGameIds.isEmpty()) {
                 emptyList()
             } else {
-                completedGameIds.flatMap { battingRecordRepository.findAllByGameId(it) }
+                battingRecordRepository.findAllByGameIds(completedGameIds)
             }
 
         val pitchingRecords =
             if (completedGameIds.isEmpty()) {
                 emptyList()
             } else {
-                completedGameIds.flatMap { pitchingRecordRepository.findAllByGameId(it) }
+                pitchingRecordRepository.findAllByGameIds(completedGameIds)
             }
 
         val totalHomeRuns = battingRecords.sumOf { it.homeRuns }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/search/SearchServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/search/SearchServiceImpl.kt
@@ -68,9 +68,7 @@ class SearchServiceImpl(
 
         val competitions =
             competitionRepository
-                .findAll()
-                .filter { it.name.contains(keyword, ignoreCase = true) }
-                .take(limit)
+                .findByNameContaining(keyword, limit)
                 .map { competition ->
                     CompetitionSearchDto(
                         competitionId = competition.id,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/BoxScoreServiceImplTest.kt
@@ -118,10 +118,8 @@ class BoxScoreServiceImplTest {
             val awayPitchingRecord = PitchingRecord.create(awayGamePlayer, isStartingPitcher = true)
 
             every { gamePlayerRepository.findAllByGameId(1L) } returns listOf(homeGamePlayer, awayGamePlayer)
-            every { battingRecordRepository.findByGamePlayer(homeGamePlayer) } returns homeBattingRecord
-            every { battingRecordRepository.findByGamePlayer(awayGamePlayer) } returns null
-            every { pitchingRecordRepository.findByGamePlayer(homeGamePlayer) } returns null
-            every { pitchingRecordRepository.findByGamePlayer(awayGamePlayer) } returns awayPitchingRecord
+            every { battingRecordRepository.findAllByGameId(1L) } returns listOf(homeBattingRecord)
+            every { pitchingRecordRepository.findAllByGameId(1L) } returns listOf(awayPitchingRecord)
 
             // when
             val result = boxScoreService.getBoxScore(1L)
@@ -167,8 +165,8 @@ class BoxScoreServiceImplTest {
                 )
 
             every { gamePlayerRepository.findAllByGameId(1L) } returns listOf(homeGamePlayer, awayGamePlayer)
-            every { battingRecordRepository.findByGamePlayer(any()) } returns null
-            every { pitchingRecordRepository.findByGamePlayer(any()) } returns null
+            every { battingRecordRepository.findAllByGameId(1L) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(1L) } returns emptyList()
 
             // when
             val result = boxScoreService.getBoxScore(1L)
@@ -191,8 +189,8 @@ class BoxScoreServiceImplTest {
             val awayGp = GamePlayer(awayGameTeam, awayPlayer, Position.STARTING_PITCHER)
 
             every { gamePlayerRepository.findAllByGameId(1L) } returns listOf(gp1, gp2, gp3, awayGp)
-            every { battingRecordRepository.findByGamePlayer(any()) } returns null
-            every { pitchingRecordRepository.findByGamePlayer(any()) } returns null
+            every { battingRecordRepository.findAllByGameId(1L) } returns emptyList()
+            every { pitchingRecordRepository.findAllByGameId(1L) } returns emptyList()
 
             // when
             val result = boxScoreService.getBoxScore(1L)

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScheduleServiceImplTest.kt
@@ -1,6 +1,8 @@
 package com.nextup.infrastructure.service.game
 
 import com.nextup.common.exception.GameNotFoundException
+import com.nextup.core.common.PageCommand
+import com.nextup.core.common.PageResult
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameStatus
@@ -20,7 +22,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 @DisplayName("GameScheduleServiceImpl 테스트")
 class GameScheduleServiceImplTest {
@@ -45,8 +46,24 @@ class GameScheduleServiceImplTest {
             val competitionId = 1L
             val games = listOf(createGame(1L), createGame(2L))
             val gameTeams = listOf(createGameTeam(1L), createGameTeam(2L))
+            val pageResult =
+                PageResult(
+                    content = games,
+                    page = 0,
+                    size = 10,
+                    totalElements = 2L,
+                    totalPages = 1,
+                )
 
-            every { gameRepository.findByCompetitionId(competitionId) } returns games
+            every {
+                gameRepository.findGames(
+                    date = null,
+                    teamId = null,
+                    competitionId = competitionId,
+                    status = null,
+                    pageCommand = PageCommand(page = 0, size = 10),
+                )
+            } returns pageResult
             every { gameTeamRepository.findAllByGameIds(any()) } returns gameTeams
 
             // when
@@ -56,12 +73,12 @@ class GameScheduleServiceImplTest {
                     teamId = null,
                     competitionId = competitionId,
                     page = 0,
-                    size = 10
+                    size = 10,
                 )
 
             // then
-            assertThat(result).hasSize(2)
-            verify { gameRepository.findByCompetitionId(competitionId) }
+            assertThat(result.content).hasSize(2)
+            assertThat(result.totalElements).isEqualTo(2L)
         }
 
         @Test
@@ -69,20 +86,33 @@ class GameScheduleServiceImplTest {
         fun getGamesWithDate() {
             // given
             val date = LocalDate.of(2026, 2, 9)
-            val start = date.atStartOfDay()
-            val end = date.atTime(LocalTime.MAX)
             val games = listOf(createGame(1L))
             val gameTeams = listOf(createGameTeam(1L))
+            val pageResult =
+                PageResult(
+                    content = games,
+                    page = 0,
+                    size = 10,
+                    totalElements = 1L,
+                    totalPages = 1,
+                )
 
-            every { gameRepository.findByScheduledAtBetween(start, end) } returns games
+            every {
+                gameRepository.findGames(
+                    date = date,
+                    teamId = null,
+                    competitionId = null,
+                    status = null,
+                    pageCommand = PageCommand(page = 0, size = 10),
+                )
+            } returns pageResult
             every { gameTeamRepository.findAllByGameIds(any()) } returns gameTeams
 
             // when
             val result = service.getGames(date = date, teamId = null, competitionId = null, page = 0, size = 10)
 
             // then
-            assertThat(result).hasSize(1)
-            verify { gameRepository.findByScheduledAtBetween(start, end) }
+            assertThat(result.content).hasSize(1)
         }
 
         @Test
@@ -91,16 +121,31 @@ class GameScheduleServiceImplTest {
             // given
             val games = listOf(createGame(1L), createGame(2L), createGame(3L))
             val gameTeams = listOf(createGameTeam(1L), createGameTeam(2L), createGameTeam(3L))
+            val pageResult =
+                PageResult(
+                    content = games,
+                    page = 0,
+                    size = 10,
+                    totalElements = 3L,
+                    totalPages = 1,
+                )
 
-            every { gameRepository.findAll() } returns games
+            every {
+                gameRepository.findGames(
+                    date = null,
+                    teamId = null,
+                    competitionId = null,
+                    status = null,
+                    pageCommand = PageCommand(page = 0, size = 10),
+                )
+            } returns pageResult
             every { gameTeamRepository.findAllByGameIds(any()) } returns gameTeams
 
             // when
             val result = service.getGames(date = null, teamId = null, competitionId = null, page = 0, size = 10)
 
             // then
-            assertThat(result).hasSize(3)
-            verify { gameRepository.findAll() }
+            assertThat(result.content).hasSize(3)
         }
 
         @Test
@@ -108,55 +153,106 @@ class GameScheduleServiceImplTest {
         fun getGamesWithTeamIdFilter() {
             // given
             val teamId = 10L
-            val games = listOf(createGame(1L), createGame(2L), createGame(3L))
+            val games = listOf(createGame(1L), createGame(3L))
             val teamGames =
                 listOf(
                     createGameTeam(1L, teamId = teamId),
                     createGameTeam(3L, teamId = teamId),
                 )
+            val pageResult =
+                PageResult(
+                    content = games,
+                    page = 0,
+                    size = 10,
+                    totalElements = 2L,
+                    totalPages = 1,
+                )
 
-            every { gameRepository.findAll() } returns games
-            every { gameTeamRepository.findAllByTeamId(teamId) } returns teamGames
-            every { gameTeamRepository.findAllByGameIds(listOf(1L, 3L)) } returns teamGames
+            every {
+                gameRepository.findGames(
+                    date = null,
+                    teamId = teamId,
+                    competitionId = null,
+                    status = null,
+                    pageCommand = PageCommand(page = 0, size = 10),
+                )
+            } returns pageResult
+            every { gameTeamRepository.findAllByGameIds(any()) } returns teamGames
 
             // when
             val result = service.getGames(date = null, teamId = teamId, competitionId = null, page = 0, size = 10)
 
             // then
-            assertThat(result).hasSize(2)
-            assertThat(result.map { it.gameId }).containsExactlyInAnyOrder(1L, 3L)
-            verify { gameTeamRepository.findAllByTeamId(teamId) }
+            assertThat(result.content).hasSize(2)
+            assertThat(result.content.map { it.gameId }).containsExactlyInAnyOrder(1L, 3L)
         }
 
         @Test
         @DisplayName("페이징이 적용된다")
         fun getGamesWithPaging() {
             // given
-            val games = (1L..10L).map { createGame(it) }
-            val gameTeams = (1L..10L).map { createGameTeam(it) }
+            val games = (4L..6L).map { createGame(it) }
+            val gameTeams = (4L..6L).map { createGameTeam(it) }
+            val pageResult =
+                PageResult(
+                    content = games,
+                    page = 1,
+                    size = 3,
+                    totalElements = 10L,
+                    totalPages = 4,
+                )
 
-            every { gameRepository.findAll() } returns games
+            every {
+                gameRepository.findGames(
+                    date = null,
+                    teamId = null,
+                    competitionId = null,
+                    status = null,
+                    pageCommand = PageCommand(page = 1, size = 3),
+                )
+            } returns pageResult
             every { gameTeamRepository.findAllByGameIds(any()) } returns gameTeams
 
             // when
             val result = service.getGames(date = null, teamId = null, competitionId = null, page = 1, size = 3)
 
             // then
-            assertThat(result).hasSize(3)
-            assertThat(result.map { it.gameId }).containsExactly(4L, 5L, 6L)
+            assertThat(result.content).hasSize(3)
+            assertThat(result.content.map { it.gameId }).containsExactly(4L, 5L, 6L)
+            assertThat(result.totalElements).isEqualTo(10L)
         }
 
         @Test
         @DisplayName("빈 리스트를 반환한다")
         fun getGamesReturnsEmptyList() {
             // given
-            every { gameRepository.findAll() } returns emptyList()
+            val emptyPageResult =
+                PageResult(
+                    content = emptyList<Game>(),
+                    page = 0,
+                    size = 10,
+                    totalElements = 0L,
+                    totalPages = 0,
+                )
+
+            every {
+                gameRepository.findGames(
+                    date = null,
+                    teamId = null,
+                    competitionId = null,
+                    status = null,
+                    pageCommand = PageCommand(page = 0, size = 10),
+                )
+            } returns emptyPageResult
+
+            every { gameTeamRepository.findAllByGameIds(emptyList()) } returns emptyList()
 
             // when
             val result = service.getGames(date = null, teamId = null, competitionId = null, page = 0, size = 10)
 
             // then
-            assertThat(result).isEmpty()
+            assertThat(result.content).isEmpty()
+            assertThat(result.totalElements).isEqualTo(0L)
         }
     }
 
@@ -301,8 +397,8 @@ class GameScheduleServiceImplTest {
             val gameTeam1 = createGameTeam(10L, teamId = 1L)
             val gameTeam2 = createGameTeam(20L, teamId = 2L)
 
-            every { gameTeamRepository.findAllByTeamId(1L) } returns listOf(gameTeam1)
-            every { gameTeamRepository.findAllByTeamId(2L) } returns listOf(gameTeam2)
+            // findAllByTeamIdIn 배치 조회 사용
+            every { gameTeamRepository.findAllByTeamIdIn(teamIds) } returns listOf(gameTeam1, gameTeam2)
             every { gameRepository.findAllByIds(listOf(10L, 20L)) } returns listOf(game1, game2)
             every { gameTeamRepository.findAllByGameIds(listOf(10L, 20L)) } returns listOf(gameTeam1, gameTeam2)
 
@@ -313,6 +409,7 @@ class GameScheduleServiceImplTest {
             assertThat(result).hasSize(2)
             assertThat(result[0].gameId).isEqualTo(10L)
             assertThat(result[1].gameId).isEqualTo(20L)
+            verify { gameTeamRepository.findAllByTeamIdIn(teamIds) }
         }
 
         @Test
@@ -337,8 +434,7 @@ class GameScheduleServiceImplTest {
             val gameTeam1 = createGameTeam(10L, teamId = 1L, homeAway = HomeAway.HOME)
             val gameTeam2 = createGameTeam(10L, teamId = 2L, homeAway = HomeAway.AWAY)
 
-            every { gameTeamRepository.findAllByTeamId(1L) } returns listOf(gameTeam1)
-            every { gameTeamRepository.findAllByTeamId(2L) } returns listOf(gameTeam2)
+            every { gameTeamRepository.findAllByTeamIdIn(teamIds) } returns listOf(gameTeam1, gameTeam2)
             every { gameRepository.findAllByIds(listOf(10L)) } returns listOf(game)
             every { gameTeamRepository.findAllByGameIds(listOf(10L)) } returns listOf(gameTeam1, gameTeam2)
 
@@ -362,7 +458,7 @@ class GameScheduleServiceImplTest {
                 }
             val gameTeams = (1L..5L).map { createGameTeam(it, teamId = 1L) }
 
-            every { gameTeamRepository.findAllByTeamId(1L) } returns gameTeams
+            every { gameTeamRepository.findAllByTeamIdIn(teamIds) } returns gameTeams
             every { gameRepository.findAllByIds(any()) } returns games
             every { gameTeamRepository.findAllByGameIds(listOf(1L, 2L)) } returns gameTeams.take(2)
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/report/CompetitionReportServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/report/CompetitionReportServiceImplTest.kt
@@ -86,8 +86,8 @@ class CompetitionReportServiceImplTest {
         every { competitionRepository.findByIdOrNull(competitionId) } returns competition
         every { standingsService.getStandings(competitionId) } returns standingsDto
         every { gameRepository.findByCompetitionId(competitionId) } returns emptyList()
-        every { battingRecordRepository.findAllByGameId(any()) } returns emptyList()
-        every { pitchingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { battingRecordRepository.findAllByGameIds(any()) } returns emptyList()
+        every { pitchingRecordRepository.findAllByGameIds(any()) } returns emptyList()
         every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId) } returns emptyList()
 
         // when
@@ -203,8 +203,8 @@ class CompetitionReportServiceImplTest {
         every { gameRepository.findByCompetitionId(competitionId) } returns listOf(game1, game2)
         every { gameTeamRepository.findAllByGameIds(listOf(1L, 2L)) } returns
             listOf(gameTeam1, gameTeam2, gameTeam3, gameTeam4)
-        every { battingRecordRepository.findAllByGameId(any()) } returns emptyList()
-        every { pitchingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { battingRecordRepository.findAllByGameIds(any()) } returns emptyList()
+        every { pitchingRecordRepository.findAllByGameIds(any()) } returns emptyList()
         every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId) } returns
             listOf(gameTeam1, gameTeam2, gameTeam3, gameTeam4)
 
@@ -348,8 +348,8 @@ class CompetitionReportServiceImplTest {
         every { gameRepository.findByCompetitionId(competitionId) } returns
             listOf(game1, game2, game3, game4, game5)
         every { gameTeamRepository.findAllByGameIds(any()) } returns emptyList()
-        every { battingRecordRepository.findAllByGameId(any()) } returns emptyList()
-        every { pitchingRecordRepository.findAllByGameId(any()) } returns emptyList()
+        every { battingRecordRepository.findAllByGameIds(any()) } returns emptyList()
+        every { pitchingRecordRepository.findAllByGameIds(any()) } returns emptyList()
         every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId) } returns
             listOf(gameTeam1, gameTeam2, gameTeam3, gameTeam4, gameTeam5)
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/search/SearchServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/search/SearchServiceImplTest.kt
@@ -67,7 +67,7 @@ class SearchServiceImplTest {
             every {
                 teamRepository.findActiveTeamsByFilter(name = "홍", city = null)
             } returns listOf(team)
-            every { competitionRepository.findAll() } returns listOf(competition)
+            every { competitionRepository.findByNameContaining("홍", 5) } returns listOf(competition)
 
             // when
             val result = service.search("홍", 5)
@@ -102,7 +102,7 @@ class SearchServiceImplTest {
             every {
                 teamRepository.findActiveTeamsByFilter(name = "xyz", city = null)
             } returns emptyList()
-            every { competitionRepository.findAll() } returns emptyList()
+            every { competitionRepository.findByNameContaining("xyz", 5) } returns emptyList()
 
             val result = service.search("xyz", 5)
 
@@ -128,7 +128,7 @@ class SearchServiceImplTest {
             every {
                 teamRepository.findActiveTeamsByFilter(name = "선수", city = null)
             } returns emptyList()
-            every { competitionRepository.findAll() } returns emptyList()
+            every { competitionRepository.findByNameContaining("선수", 3) } returns emptyList()
 
             val result = service.search("선수", 3)
 
@@ -156,8 +156,8 @@ class SearchServiceImplTest {
                 teamRepository.findActiveTeamsByFilter(name = "봄", city = null)
             } returns emptyList()
             every {
-                competitionRepository.findAll()
-            } returns listOf(matchCompetition, nonMatchCompetition)
+                competitionRepository.findByNameContaining("봄", 5)
+            } returns listOf(matchCompetition)
 
             val result = service.search("봄", 5)
 
@@ -181,7 +181,7 @@ class SearchServiceImplTest {
             every {
                 teamRepository.findActiveTeamsByFilter(name = "spring", city = null)
             } returns emptyList()
-            every { competitionRepository.findAll() } returns listOf(competition)
+            every { competitionRepository.findByNameContaining("spring", 5) } returns listOf(competition)
 
             val result = service.search("spring", 5)
 
@@ -202,7 +202,7 @@ class SearchServiceImplTest {
             every {
                 teamRepository.findActiveTeamsByFilter(name = "테스트", city = null)
             } returns emptyList()
-            every { competitionRepository.findAll() } returns emptyList()
+            every { competitionRepository.findByNameContaining("테스트", 5) } returns emptyList()
 
             val result = service.search("테스트", 5)
 

--- a/nextup-scorer/src/main/resources/application.yml
+++ b/nextup-scorer/src/main/resources/application.yml
@@ -10,6 +10,12 @@ spring:
     username: ${DB_USERNAME:nextup}
     password: ${DB_PASSWORD:nextup}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 15
+      minimum-idle: 3
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary

>- Close #429

파괴적 기술 검토(#425)에서 발견된 CRITICAL 성능 이슈 해결. 동시 5명 박스스코어 조회 시 110쿼리 → 커넥션 풀 포화 문제를 3가지 영역에서 개선.

### CRITICAL-3: N+1 쿼리 해결
- **BoxScoreServiceImpl**: 선수별 개별 쿼리 → `findAllByGameId()` 배치 조회 + Map 기반 조회
- **CompetitionReportServiceImpl**: `flatMap` 루프 → `findAllByGameIds()` 단일 배치 호출
- **GameScheduleServiceImpl**: `teamIds.flatMap` → `findAllByTeamIdIn()` 배치 호출
- **GamePlayerRepository**: JOIN FETCH 추가 (`gameTeam`, `game`, `team`, `player`)

### CRITICAL-4: HikariCP 커넥션 풀 설정
| 모듈 | maximumPoolSize |
|------|----------------|
| api | 20 |
| scorer | 15 |
| backoffice | 5 |

### DB 레벨 페이징 전환
- **GameScheduleServiceImpl**: `findAll()` + 메모리 `drop/take` → `PageCommand`/`PageResult` DB 페이징
- **SearchServiceImpl**: `findAll().filter` → `findByNameContaining(keyword, limit)` DB 검색

## Tasks

- [x] Core Port에 배치 조회 메서드 추가 (5개 Port)
- [x] Infrastructure Repository에 배치 JPQL 구현
- [x] BoxScoreServiceImpl 배치 조회 전환
- [x] CompetitionReportServiceImpl flatMap → 배치 전환
- [x] GameScheduleServiceImpl N+1 해결 + DB 페이징
- [x] SearchServiceImpl 메모리 필터 → DB 검색
- [x] HikariCP 모듈별 설정 추가 (3개 모듈)
- [x] GameScheduleController 반환 타입 PagedResponse 변경
- [x] 테스트 mock 업데이트 및 전체 빌드 통과

## To Reviewer

- Core에서 `Pageable`(Spring Data) import 금지 규칙을 준수하여 `PageCommand`/`PageResult` 커스텀 타입 사용
- `CompetitionRepository.findByNameContaining()`은 JPQL `LIMIT` 미지원으로 `Pageable` 기반 내부 메서드 위임 방식 적용
- JOIN FETCH 대상은 모두 `@ManyToOne` 관계이므로 `MultipleBagFetchException` 위험 없음
- 기대 효과: 쿼리 80~95% 감소, 메모리 사용 90% 감소

## Screenshot

N/A (백엔드 성능 최적화)