### PR TITLE
feat(#402): 팀 자체 일정 관리 API — Hexagonal 리팩토링 + 인가 보강

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamScheduleController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/team/TeamScheduleController.kt
@@ -8,6 +8,8 @@ import com.nextup.core.service.team.TeamScheduleService
 import jakarta.validation.Valid
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -31,13 +33,15 @@ class TeamScheduleController(
     private val teamScheduleService: TeamScheduleService,
 ) {
     /**
-     * 팀 일정을 생성합니다.
+     * 팀 일정을 생성합니다. 매니저 이상 권한이 필요합니다.
      */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun createSchedule(
         @PathVariable teamId: Long,
         @Valid @RequestBody request: CreateTeamScheduleRequest,
+        @AuthenticationPrincipal userId: Long,
     ): ApiResponse<TeamScheduleResponse> {
         val schedule =
             teamScheduleService.create(
@@ -90,13 +94,15 @@ class TeamScheduleController(
     }
 
     /**
-     * 팀 일정을 수정합니다.
+     * 팀 일정을 수정합니다. 매니저 이상 권한이 필요합니다.
      */
     @PatchMapping("/{scheduleId}")
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun updateSchedule(
         @PathVariable teamId: Long,
         @PathVariable scheduleId: Long,
         @Valid @RequestBody request: UpdateTeamScheduleRequest,
+        @AuthenticationPrincipal userId: Long,
     ): ApiResponse<TeamScheduleResponse> {
         val schedule =
             teamScheduleService.update(
@@ -112,13 +118,15 @@ class TeamScheduleController(
     }
 
     /**
-     * 팀 일정을 삭제합니다.
+     * 팀 일정을 삭제합니다. 매니저 이상 권한이 필요합니다.
      */
     @DeleteMapping("/{scheduleId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
     fun deleteSchedule(
         @PathVariable teamId: Long,
         @PathVariable scheduleId: Long,
+        @AuthenticationPrincipal userId: Long,
     ): ApiResponse<Unit> {
         teamScheduleService.delete(scheduleId)
         return ApiResponse.success(Unit)

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamScheduleControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/team/TeamScheduleControllerTest.kt
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -47,11 +50,15 @@ class TeamScheduleControllerTest {
         objectMapper =
             jacksonObjectMapper().registerModule(JavaTimeModule())
 
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(1L, null, emptyList())
+
         val controller = TeamScheduleController(teamScheduleService)
         mockMvc =
             MockMvcBuilders
                 .standaloneSetup(controller)
                 .setControllerAdvice(GlobalExceptionHandler())
+                .setCustomArgumentResolvers(AuthenticationPrincipalArgumentResolver())
                 .build()
 
         every { mockTeam.id } returns teamId

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamScheduleService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamScheduleService.kt
@@ -1,30 +1,19 @@
 package com.nextup.core.service.team
 
-import com.nextup.common.exception.TeamNotFoundException
-import com.nextup.common.exception.TeamScheduleNotFoundException
 import com.nextup.core.domain.team.TeamSchedule
 import com.nextup.core.domain.team.TeamScheduleType
-import com.nextup.core.port.repository.TeamRepositoryPort
-import com.nextup.core.port.repository.TeamScheduleRepositoryPort
-import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 /**
- * 팀 일정 서비스
+ * 팀 일정 서비스 (Inbound Port)
  *
- * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ * 팀 자체 일정(연습, 이벤트, 모임 등) CRUD 유스케이스를 정의합니다.
+ * 구현체는 nextup-infrastructure의 TeamScheduleServiceImpl입니다.
  */
-@Service
-@Transactional(readOnly = true)
-class TeamScheduleService(
-    private val teamScheduleRepository: TeamScheduleRepositoryPort,
-    private val teamRepository: TeamRepositoryPort,
-) {
+interface TeamScheduleService {
     /**
      * 팀 일정을 생성합니다.
      */
-    @Transactional
     fun create(
         teamId: Long,
         title: String,
@@ -33,34 +22,12 @@ class TeamScheduleService(
         startAt: LocalDateTime,
         endAt: LocalDateTime?,
         location: String?,
-    ): TeamSchedule {
-        val team =
-            teamRepository.findByIdOrNull(teamId)
-                ?: throw TeamNotFoundException(teamId)
-
-        val schedule =
-            TeamSchedule.create(
-                team = team,
-                title = title,
-                description = description,
-                scheduleType = scheduleType,
-                startAt = startAt,
-                endAt = endAt,
-                location = location,
-            )
-
-        return teamScheduleRepository.save(schedule)
-    }
+    ): TeamSchedule
 
     /**
      * 팀 일정 목록을 조회합니다.
      */
-    fun getByTeamId(teamId: Long): List<TeamSchedule> {
-        teamRepository.findByIdOrNull(teamId)
-            ?: throw TeamNotFoundException(teamId)
-
-        return teamScheduleRepository.findByTeamId(teamId)
-    }
+    fun getByTeamId(teamId: Long): List<TeamSchedule>
 
     /**
      * 팀 일정 목록을 기간으로 필터링하여 조회합니다.
@@ -69,24 +36,16 @@ class TeamScheduleService(
         teamId: Long,
         from: LocalDateTime,
         to: LocalDateTime,
-    ): List<TeamSchedule> {
-        teamRepository.findByIdOrNull(teamId)
-            ?: throw TeamNotFoundException(teamId)
-
-        return teamScheduleRepository.findByTeamIdAndDateRange(teamId, from, to)
-    }
+    ): List<TeamSchedule>
 
     /**
      * ID로 팀 일정을 조회합니다.
      */
-    fun getById(id: Long): TeamSchedule =
-        teamScheduleRepository.findByIdOrNull(id)
-            ?: throw TeamScheduleNotFoundException(id)
+    fun getById(id: Long): TeamSchedule
 
     /**
      * 팀 일정을 수정합니다.
      */
-    @Transactional
     fun update(
         id: Long,
         title: String? = null,
@@ -95,25 +54,10 @@ class TeamScheduleService(
         startAt: LocalDateTime? = null,
         endAt: LocalDateTime? = null,
         location: String? = null,
-    ): TeamSchedule {
-        val schedule = getById(id)
-        schedule.update(
-            title = title,
-            description = description,
-            scheduleType = scheduleType,
-            startAt = startAt,
-            endAt = endAt,
-            location = location,
-        )
-        return schedule
-    }
+    ): TeamSchedule
 
     /**
      * 팀 일정을 삭제합니다.
      */
-    @Transactional
-    fun delete(id: Long) {
-        val schedule = getById(id)
-        teamScheduleRepository.deleteById(schedule.id)
-    }
+    fun delete(id: Long)
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/team/TeamScheduleServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/team/TeamScheduleServiceTest.kt
@@ -1,219 +1,24 @@
 package com.nextup.core.service.team
 
-import com.nextup.common.exception.TeamNotFoundException
-import com.nextup.common.exception.TeamScheduleNotFoundException
-import com.nextup.core.domain.team.Team
-import com.nextup.core.domain.team.TeamSchedule
-import com.nextup.core.domain.team.TeamScheduleType
-import com.nextup.core.port.repository.TeamRepositoryPort
-import com.nextup.core.port.repository.TeamScheduleRepositoryPort
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import java.time.LocalDateTime
 
-@DisplayName("TeamScheduleService")
+/**
+ * TeamScheduleService 인터페이스 계약 테스트
+ *
+ * 구현체(TeamScheduleServiceImpl) 테스트는
+ * nextup-infrastructure 모듈의 TeamScheduleServiceImplTest에서 수행합니다.
+ */
+@DisplayName("TeamScheduleService 인터페이스")
 class TeamScheduleServiceTest {
-    private lateinit var teamScheduleRepository: TeamScheduleRepositoryPort
-    private lateinit var teamRepository: TeamRepositoryPort
-    private lateinit var service: TeamScheduleService
+    @Test
+    fun `인터페이스는 필요한 메서드를 모두 정의한다`() {
+        // TeamScheduleService 인터페이스가 올바르게 정의되어 있는지 컴파일 타임 검증
+        val methods = TeamScheduleService::class.java.declaredMethods.map { it.name }.toSet()
 
-    private lateinit var mockTeam: Team
-
-    @BeforeEach
-    fun setUp() {
-        teamScheduleRepository = mockk()
-        teamRepository = mockk()
-        service =
-            TeamScheduleService(
-                teamScheduleRepository = teamScheduleRepository,
-                teamRepository = teamRepository,
-            )
-
-        mockTeam = mockk(relaxed = true)
-    }
-
-    @Nested
-    @DisplayName("create - 팀 일정 생성")
-    inner class CreateTest {
-        @Test
-        fun `팀이 존재하면 일정을 생성하고 저장한다`() {
-            // given
-            val teamId = 1L
-            val startAt = LocalDateTime.now().plusDays(1)
-            val schedule =
-                TeamSchedule.create(
-                    team = mockTeam,
-                    title = "연습",
-                    scheduleType = TeamScheduleType.PRACTICE,
-                    startAt = startAt,
-                )
-            every { teamRepository.findByIdOrNull(teamId) } returns mockTeam
-            every { teamScheduleRepository.save(any()) } returns schedule
-
-            // when
-            val result =
-                service.create(
-                    teamId = teamId,
-                    title = "연습",
-                    description = null,
-                    scheduleType = TeamScheduleType.PRACTICE,
-                    startAt = startAt,
-                    endAt = null,
-                    location = null,
-                )
-
-            // then
-            assertThat(result).isNotNull
-            assertThat(result.title).isEqualTo("연습")
-            verify(exactly = 1) { teamScheduleRepository.save(any()) }
-        }
-
-        @Test
-        fun `팀이 존재하지 않으면 TeamNotFoundException을 던진다`() {
-            // given
-            val teamId = 999L
-            every { teamRepository.findByIdOrNull(teamId) } returns null
-
-            // when & then
-            assertThrows<TeamNotFoundException> {
-                service.create(
-                    teamId = teamId,
-                    title = "연습",
-                    description = null,
-                    scheduleType = TeamScheduleType.PRACTICE,
-                    startAt = LocalDateTime.now().plusDays(1),
-                    endAt = null,
-                    location = null,
-                )
-            }
-            verify(exactly = 0) { teamScheduleRepository.save(any()) }
-        }
-    }
-
-    @Nested
-    @DisplayName("getByTeamId - 팀 일정 목록 조회")
-    inner class GetByTeamIdTest {
-        @Test
-        fun `팀이 존재하면 해당 팀의 일정 목록을 반환한다`() {
-            // given
-            val teamId = 1L
-            val startAt = LocalDateTime.now().plusDays(1)
-            val schedules =
-                listOf(
-                    TeamSchedule.create(
-                        team = mockTeam,
-                        title = "연습",
-                        scheduleType = TeamScheduleType.PRACTICE,
-                        startAt = startAt,
-                    ),
-                    TeamSchedule.create(
-                        team = mockTeam,
-                        title = "모임",
-                        scheduleType = TeamScheduleType.MEETING,
-                        startAt = startAt.plusDays(1),
-                    ),
-                )
-            every { teamRepository.findByIdOrNull(teamId) } returns mockTeam
-            every { teamScheduleRepository.findByTeamId(teamId) } returns schedules
-
-            // when
-            val result = service.getByTeamId(teamId)
-
-            // then
-            assertThat(result).hasSize(2)
-            assertThat(result[0].title).isEqualTo("연습")
-            assertThat(result[1].title).isEqualTo("모임")
-        }
-
-        @Test
-        fun `팀이 존재하지 않으면 TeamNotFoundException을 던진다`() {
-            // given
-            val teamId = 999L
-            every { teamRepository.findByIdOrNull(teamId) } returns null
-
-            // when & then
-            assertThrows<TeamNotFoundException> {
-                service.getByTeamId(teamId)
-            }
-        }
-    }
-
-    @Nested
-    @DisplayName("getById - ID로 팀 일정 조회")
-    inner class GetByIdTest {
-        @Test
-        fun `존재하지 않는 ID이면 TeamScheduleNotFoundException을 던진다`() {
-            // given
-            val scheduleId = 999L
-            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns null
-
-            // when & then
-            assertThrows<TeamScheduleNotFoundException> {
-                service.getById(scheduleId)
-            }
-        }
-    }
-
-    @Nested
-    @DisplayName("update - 팀 일정 수정")
-    inner class UpdateTest {
-        @Test
-        fun `존재하는 일정을 수정한다`() {
-            // given
-            val scheduleId = 1L
-            val startAt = LocalDateTime.now().plusDays(1)
-            val schedule =
-                TeamSchedule.create(
-                    team = mockTeam,
-                    title = "연습",
-                    scheduleType = TeamScheduleType.PRACTICE,
-                    startAt = startAt,
-                )
-            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns schedule
-
-            // when
-            val result =
-                service.update(
-                    id = scheduleId,
-                    title = "정기 연습",
-                    scheduleType = TeamScheduleType.PRACTICE,
-                )
-
-            // then
-            assertThat(result.title).isEqualTo("정기 연습")
-        }
-    }
-
-    @Nested
-    @DisplayName("delete - 팀 일정 삭제")
-    inner class DeleteTest {
-        @Test
-        fun `존재하는 일정을 삭제한다`() {
-            // given
-            val scheduleId = 1L
-            val startAt = LocalDateTime.now().plusDays(1)
-            val schedule =
-                TeamSchedule.create(
-                    team = mockTeam,
-                    title = "연습",
-                    scheduleType = TeamScheduleType.PRACTICE,
-                    startAt = startAt,
-                )
-            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns schedule
-            every { teamScheduleRepository.deleteById(schedule.id) } returns Unit
-
-            // when
-            service.delete(scheduleId)
-
-            // then
-            verify(exactly = 1) { teamScheduleRepository.deleteById(schedule.id) }
-        }
+        assertThat(methods).containsAll(
+            listOf("create", "getByTeamId", "getByTeamIdAndDateRange", "getById", "update", "delete"),
+        )
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamScheduleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamScheduleServiceImpl.kt
@@ -1,0 +1,102 @@
+package com.nextup.infrastructure.service.team
+
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.common.exception.TeamScheduleNotFoundException
+import com.nextup.core.domain.team.TeamSchedule
+import com.nextup.core.domain.team.TeamScheduleType
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.port.repository.TeamScheduleRepositoryPort
+import com.nextup.core.service.team.TeamScheduleService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * 팀 일정 서비스 구현체
+ *
+ * 비즈니스 로직은 Entity에 위임하고, 서비스는 조율(orchestration)만 수행합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class TeamScheduleServiceImpl(
+    private val teamScheduleRepository: TeamScheduleRepositoryPort,
+    private val teamRepository: TeamRepositoryPort,
+) : TeamScheduleService {
+    @Transactional
+    override fun create(
+        teamId: Long,
+        title: String,
+        description: String?,
+        scheduleType: TeamScheduleType,
+        startAt: LocalDateTime,
+        endAt: LocalDateTime?,
+        location: String?,
+    ): TeamSchedule {
+        val team =
+            teamRepository.findByIdOrNull(teamId)
+                ?: throw TeamNotFoundException(teamId)
+
+        val schedule =
+            TeamSchedule.create(
+                team = team,
+                title = title,
+                description = description,
+                scheduleType = scheduleType,
+                startAt = startAt,
+                endAt = endAt,
+                location = location,
+            )
+
+        return teamScheduleRepository.save(schedule)
+    }
+
+    override fun getByTeamId(teamId: Long): List<TeamSchedule> {
+        teamRepository.findByIdOrNull(teamId)
+            ?: throw TeamNotFoundException(teamId)
+
+        return teamScheduleRepository.findByTeamId(teamId)
+    }
+
+    override fun getByTeamIdAndDateRange(
+        teamId: Long,
+        from: LocalDateTime,
+        to: LocalDateTime,
+    ): List<TeamSchedule> {
+        teamRepository.findByIdOrNull(teamId)
+            ?: throw TeamNotFoundException(teamId)
+
+        return teamScheduleRepository.findByTeamIdAndDateRange(teamId, from, to)
+    }
+
+    override fun getById(id: Long): TeamSchedule =
+        teamScheduleRepository.findByIdOrNull(id)
+            ?: throw TeamScheduleNotFoundException(id)
+
+    @Transactional
+    override fun update(
+        id: Long,
+        title: String?,
+        description: String?,
+        scheduleType: TeamScheduleType?,
+        startAt: LocalDateTime?,
+        endAt: LocalDateTime?,
+        location: String?,
+    ): TeamSchedule {
+        val schedule = getById(id)
+        schedule.update(
+            title = title,
+            description = description,
+            scheduleType = scheduleType,
+            startAt = startAt,
+            endAt = endAt,
+            location = location,
+        )
+        return schedule
+    }
+
+    @Transactional
+    override fun delete(id: Long) {
+        val schedule = getById(id)
+        teamScheduleRepository.deleteById(schedule.id)
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamScheduleServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/team/TeamScheduleServiceImplTest.kt
@@ -1,0 +1,305 @@
+package com.nextup.infrastructure.service.team
+
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.common.exception.TeamScheduleNotFoundException
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.team.TeamSchedule
+import com.nextup.core.domain.team.TeamScheduleType
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.port.repository.TeamScheduleRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+@DisplayName("TeamScheduleServiceImpl")
+class TeamScheduleServiceImplTest {
+    private lateinit var teamScheduleRepository: TeamScheduleRepositoryPort
+    private lateinit var teamRepository: TeamRepositoryPort
+    private lateinit var service: TeamScheduleServiceImpl
+
+    private lateinit var mockTeam: Team
+
+    @BeforeEach
+    fun setUp() {
+        teamScheduleRepository = mockk()
+        teamRepository = mockk()
+        service =
+            TeamScheduleServiceImpl(
+                teamScheduleRepository = teamScheduleRepository,
+                teamRepository = teamRepository,
+            )
+
+        mockTeam = mockk(relaxed = true)
+    }
+
+    @Nested
+    @DisplayName("create - 팀 일정 생성")
+    inner class CreateTest {
+        @Test
+        fun `팀이 존재하면 일정을 생성하고 저장한다`() {
+            // given
+            val teamId = 1L
+            val startAt = LocalDateTime.now().plusDays(1)
+            val schedule =
+                TeamSchedule.create(
+                    team = mockTeam,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = startAt,
+                )
+            every { teamRepository.findByIdOrNull(teamId) } returns mockTeam
+            every { teamScheduleRepository.save(any()) } returns schedule
+
+            // when
+            val result =
+                service.create(
+                    teamId = teamId,
+                    title = "연습",
+                    description = null,
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = startAt,
+                    endAt = null,
+                    location = null,
+                )
+
+            // then
+            assertThat(result).isNotNull
+            assertThat(result.title).isEqualTo("연습")
+            verify(exactly = 1) { teamScheduleRepository.save(any()) }
+        }
+
+        @Test
+        fun `팀이 존재하지 않으면 TeamNotFoundException을 던진다`() {
+            // given
+            val teamId = 999L
+            every { teamRepository.findByIdOrNull(teamId) } returns null
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                service.create(
+                    teamId = teamId,
+                    title = "연습",
+                    description = null,
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = LocalDateTime.now().plusDays(1),
+                    endAt = null,
+                    location = null,
+                )
+            }
+            verify(exactly = 0) { teamScheduleRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("getByTeamId - 팀 일정 목록 조회")
+    inner class GetByTeamIdTest {
+        @Test
+        fun `팀이 존재하면 해당 팀의 일정 목록을 반환한다`() {
+            // given
+            val teamId = 1L
+            val startAt = LocalDateTime.now().plusDays(1)
+            val schedules =
+                listOf(
+                    TeamSchedule.create(
+                        team = mockTeam,
+                        title = "연습",
+                        scheduleType = TeamScheduleType.PRACTICE,
+                        startAt = startAt,
+                    ),
+                    TeamSchedule.create(
+                        team = mockTeam,
+                        title = "모임",
+                        scheduleType = TeamScheduleType.MEETING,
+                        startAt = startAt.plusDays(1),
+                    ),
+                )
+            every { teamRepository.findByIdOrNull(teamId) } returns mockTeam
+            every { teamScheduleRepository.findByTeamId(teamId) } returns schedules
+
+            // when
+            val result = service.getByTeamId(teamId)
+
+            // then
+            assertThat(result).hasSize(2)
+            assertThat(result[0].title).isEqualTo("연습")
+            assertThat(result[1].title).isEqualTo("모임")
+        }
+
+        @Test
+        fun `팀이 존재하지 않으면 TeamNotFoundException을 던진다`() {
+            // given
+            val teamId = 999L
+            every { teamRepository.findByIdOrNull(teamId) } returns null
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                service.getByTeamId(teamId)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getByTeamIdAndDateRange - 기간 필터 조회")
+    inner class GetByTeamIdAndDateRangeTest {
+        @Test
+        fun `팀이 존재하면 기간 내 일정을 반환한다`() {
+            // given
+            val teamId = 1L
+            val from = LocalDateTime.of(2026, 3, 1, 0, 0)
+            val to = LocalDateTime.of(2026, 3, 31, 23, 59)
+            val schedule =
+                TeamSchedule.create(
+                    team = mockTeam,
+                    title = "3월 연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = LocalDateTime.of(2026, 3, 15, 10, 0),
+                )
+            every { teamRepository.findByIdOrNull(teamId) } returns mockTeam
+            every { teamScheduleRepository.findByTeamIdAndDateRange(teamId, from, to) } returns listOf(schedule)
+
+            // when
+            val result = service.getByTeamIdAndDateRange(teamId, from, to)
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].title).isEqualTo("3월 연습")
+        }
+
+        @Test
+        fun `팀이 존재하지 않으면 TeamNotFoundException을 던진다`() {
+            // given
+            val teamId = 999L
+            val from = LocalDateTime.of(2026, 3, 1, 0, 0)
+            val to = LocalDateTime.of(2026, 3, 31, 23, 59)
+            every { teamRepository.findByIdOrNull(teamId) } returns null
+
+            // when & then
+            assertThrows<TeamNotFoundException> {
+                service.getByTeamIdAndDateRange(teamId, from, to)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getById - ID로 팀 일정 조회")
+    inner class GetByIdTest {
+        @Test
+        fun `존재하는 ID이면 일정을 반환한다`() {
+            // given
+            val scheduleId = 1L
+            val schedule =
+                TeamSchedule.create(
+                    team = mockTeam,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = LocalDateTime.now().plusDays(1),
+                )
+            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns schedule
+
+            // when
+            val result = service.getById(scheduleId)
+
+            // then
+            assertThat(result.title).isEqualTo("연습")
+        }
+
+        @Test
+        fun `존재하지 않는 ID이면 TeamScheduleNotFoundException을 던진다`() {
+            // given
+            val scheduleId = 999L
+            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns null
+
+            // when & then
+            assertThrows<TeamScheduleNotFoundException> {
+                service.getById(scheduleId)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("update - 팀 일정 수정")
+    inner class UpdateTest {
+        @Test
+        fun `존재하는 일정을 수정한다`() {
+            // given
+            val scheduleId = 1L
+            val startAt = LocalDateTime.now().plusDays(1)
+            val schedule =
+                TeamSchedule.create(
+                    team = mockTeam,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = startAt,
+                )
+            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns schedule
+
+            // when
+            val result =
+                service.update(
+                    id = scheduleId,
+                    title = "정기 연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                )
+
+            // then
+            assertThat(result.title).isEqualTo("정기 연습")
+        }
+
+        @Test
+        fun `존재하지 않는 일정을 수정하면 TeamScheduleNotFoundException을 던진다`() {
+            // given
+            val scheduleId = 999L
+            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns null
+
+            // when & then
+            assertThrows<TeamScheduleNotFoundException> {
+                service.update(id = scheduleId, title = "수정")
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("delete - 팀 일정 삭제")
+    inner class DeleteTest {
+        @Test
+        fun `존재하는 일정을 삭제한다`() {
+            // given
+            val scheduleId = 1L
+            val startAt = LocalDateTime.now().plusDays(1)
+            val schedule =
+                TeamSchedule.create(
+                    team = mockTeam,
+                    title = "연습",
+                    scheduleType = TeamScheduleType.PRACTICE,
+                    startAt = startAt,
+                )
+            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns schedule
+            every { teamScheduleRepository.deleteById(schedule.id) } returns Unit
+
+            // when
+            service.delete(scheduleId)
+
+            // then
+            verify(exactly = 1) { teamScheduleRepository.deleteById(schedule.id) }
+        }
+
+        @Test
+        fun `존재하지 않는 일정을 삭제하면 TeamScheduleNotFoundException을 던진다`() {
+            // given
+            val scheduleId = 999L
+            every { teamScheduleRepository.findByIdOrNull(scheduleId) } returns null
+
+            // when & then
+            assertThrows<TeamScheduleNotFoundException> {
+                service.delete(scheduleId)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- Close #402

기존 develop 브랜치에 이미 존재하던 팀 자체 일정 관리 코드(TeamSchedule 엔티티, Controller, DTO, Repository, 마이그레이션)를 Hexagonal Architecture 규칙에 맞게 리팩토링하고, 보안 인가를 보강합니다.

### 주요 변경 사항

1. **Service Interface/Impl 분리 (Hexagonal Architecture 준수)**
   - `TeamScheduleService`를 core 모듈의 **interface**로 변환 (Inbound Port)
   - `TeamScheduleServiceImpl`을 infrastructure 모듈에 생성 (Outbound Adapter)
   - 기존에 core에 `@Service`/`@Transactional`이 있던 위반 사항 해소

2. **인가(Authorization) 보강**
   - POST/PATCH/DELETE 엔드포인트에 `@PreAuthorize("@teamSecurity.isOwnerOrManager()")` 추가
   - `@AuthenticationPrincipal userId: Long` 파라미터 추가로 IDOR 취약점 방지
   - 이슈 완료 조건 "팀 멤버 권한 검증 (매니저 이상만 생성/수정/삭제)" 충족

3. **테스트 이동**
   - ServiceImpl 테스트를 infrastructure 모듈로 이동
   - 기간 필터 조회, 존재하지 않는 일정 예외 등 추가 테스트 케이스 보강

## Tasks

- [x] `TeamScheduleService` → interface (core) + `TeamScheduleServiceImpl` (infra) 분리
- [x] Controller mutating 엔드포인트에 `@PreAuthorize` + `@AuthenticationPrincipal` 추가
- [x] ServiceImpl 단위 테스트 (infrastructure 모듈)
- [x] Core 인터페이스 계약 테스트
- [x] verify-authorization 규칙 준수 확인
- [x] verify-entity-leak 규칙 준수 확인
- [x] verify-api-response 규칙 준수 확인
- [x] verify-url-prefix 규칙 준수 확인
- [x] verify-repository-injection 규칙 준수 확인

## To Reviewer

- 기존 develop에 이미 존재하던 TeamSchedule 관련 코드(Entity, DTO, Repository, Migration V037)는 변경하지 않았습니다
- 이 PR의 핵심은 **아키텍처 규칙 위반 수정**(Service가 core에 concrete class로 존재)과 **보안 인가 추가**입니다
- 로컬 빌드가 시스템 메모리 부족으로 Gradle 데몬이 크래시하여 수행되지 못했습니다. CI에서 빌드 확인 부탁드립니다