### PR TITLE
fix(#409): WebSocket JWT 만료 후 세션 종료 처리 보강

### DIFF
--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketAuthInterceptor.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketAuthInterceptor.kt
@@ -19,16 +19,20 @@ import org.springframework.stereotype.Component
  * CONNECT 시 JWT 토큰을 검증하여 인증을 수행합니다.
  * SEND/SUBSCRIBE 시 기존 인증 정보의 토큰 만료 여부를 재검증합니다.
  * JWT 만료 시 STOMP ERROR를 발생시켜 연결을 해제합니다.
+ *
+ * 토큰 갱신: 클라이언트가 SEND/SUBSCRIBE 시 'Authorization' 네이티브 헤더에
+ * 새 토큰을 포함하면 세션 토큰을 갱신합니다.
  */
 @Component
 class WebSocketAuthInterceptor(
     private val jwtTokenProvider: JwtTokenProvider,
+    private val sessionRegistry: WebSocketSessionRegistry,
 ) : ChannelInterceptor {
     private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
         private const val BEARER_PREFIX = "Bearer "
-        private const val TOKEN_HEADER = "token"
+        internal const val TOKEN_HEADER = "token"
         private val COMMANDS_REQUIRING_AUTH =
             setOf(StompCommand.SEND, StompCommand.SUBSCRIBE)
     }
@@ -72,9 +76,40 @@ class WebSocketAuthInterceptor(
 
         // 세션 속성에 토큰 저장 (SEND/SUBSCRIBE에서 재검증용)
         accessor.sessionAttributes?.set(TOKEN_HEADER, token)
+
+        // 세션 레지스트리에 토큰 등록 (주기적 만료 검사용)
+        accessor.sessionId?.let { sessionId ->
+            sessionRegistry.registerToken(sessionId, token)
+        }
     }
 
     private fun handleAuthenticatedCommand(accessor: StompHeaderAccessor) {
+        // 토큰 갱신 시도: 클라이언트가 Authorization 헤더에 새 토큰을 보낸 경우
+        val refreshedToken =
+            accessor.getFirstNativeHeader("Authorization")
+                ?.removePrefix(BEARER_PREFIX)
+
+        if (refreshedToken != null && jwtTokenProvider.validateToken(refreshedToken) &&
+            jwtTokenProvider.isAccessToken(refreshedToken)
+        ) {
+            accessor.sessionAttributes?.set(TOKEN_HEADER, refreshedToken)
+            accessor.sessionId?.let { sessionId ->
+                sessionRegistry.updateToken(sessionId, refreshedToken)
+            }
+            // 인증 정보도 갱신
+            val userId = jwtTokenProvider.getUserId(refreshedToken)
+            val roles = jwtTokenProvider.getRoles(refreshedToken)
+            val authorities = roles.map { SimpleGrantedAuthority("ROLE_$it") }
+            accessor.user =
+                UsernamePasswordAuthenticationToken(userId, refreshedToken, authorities)
+            log.debug(
+                "WebSocket 토큰 갱신 완료: sessionId={}",
+                accessor.sessionId,
+            )
+            return
+        }
+
+        // 기존 토큰 만료 검증
         val token =
             accessor.sessionAttributes?.get(TOKEN_HEADER) as? String
                 ?: return
@@ -84,6 +119,7 @@ class WebSocketAuthInterceptor(
                 "WebSocket JWT 만료 감지, 세션 종료: sessionId={}",
                 accessor.sessionId,
             )
+            accessor.sessionId?.let { sessionRegistry.remove(it) }
             throw AuthenticationCredentialsNotFoundException(
                 "JWT 토큰이 만료되었습니다. 재연결이 필요합니다.",
             )

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketAuthInterceptor.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketAuthInterceptor.kt
@@ -89,7 +89,8 @@ class WebSocketAuthInterceptor(
             accessor.getFirstNativeHeader("Authorization")
                 ?.removePrefix(BEARER_PREFIX)
 
-        if (refreshedToken != null && jwtTokenProvider.validateToken(refreshedToken) &&
+        if (refreshedToken != null &&
+            jwtTokenProvider.validateToken(refreshedToken) &&
             jwtTokenProvider.isAccessToken(refreshedToken)
         ) {
             accessor.sessionAttributes?.set(TOKEN_HEADER, refreshedToken)

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketConfig.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketConfig.kt
@@ -7,27 +7,36 @@ import org.springframework.messaging.simp.config.ChannelRegistration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+import org.springframework.web.socket.CloseStatus
+import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration
+import org.springframework.web.socket.handler.WebSocketHandlerDecorator
+import org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory
 
 /**
  * WebSocket 설정
  *
  * 실시간 스코어보드 브로드캐스트를 위한 STOMP over WebSocket 설정
  * JWT 인증 필수, 허용된 도메인만 접근 가능
- * Heartbeat: 서버↔클라이언트 10초 간격
+ * Heartbeat: 서버<->클라이언트 10초 간격
+ * 세션 비활성 타임아웃: 35분 (JWT access token 만료 30분 + 버퍼 5분)
  */
 @Configuration
 @EnableWebSocketMessageBroker
 class WebSocketConfig(
     private val webSocketAuthInterceptor: WebSocketAuthInterceptor,
+    private val sessionRegistry: WebSocketSessionRegistry,
     @Value("\${app.websocket.allowed-origins:http://localhost:3000}")
     private val allowedOrigins: String,
 ) : WebSocketMessageBrokerConfigurer {
 
     companion object {
         private const val HEARTBEAT_INTERVAL_MS = 10000L
+        private const val SEND_BUFFER_SIZE_LIMIT = 512 * 1024
+        private const val SEND_TIME_LIMIT_MS = 20_000
     }
 
     @Bean
@@ -66,4 +75,33 @@ class WebSocketConfig(
     override fun configureClientInboundChannel(registration: ChannelRegistration) {
         registration.interceptors(webSocketAuthInterceptor)
     }
+
+    override fun configureWebSocketTransport(registration: WebSocketTransportRegistration) {
+        registration
+            .setSendBufferSizeLimit(SEND_BUFFER_SIZE_LIMIT)
+            .setSendTimeLimit(SEND_TIME_LIMIT_MS)
+            .addDecoratorFactory(sessionTrackingDecoratorFactory())
+    }
+
+    /**
+     * WebSocketSession 참조를 레지스트리에 등록/해제하는 데코레이터 팩토리.
+     * Transport 레벨에서 세션의 생명주기를 추적합니다.
+     */
+    private fun sessionTrackingDecoratorFactory(): WebSocketHandlerDecoratorFactory =
+        WebSocketHandlerDecoratorFactory { handler ->
+            object : WebSocketHandlerDecorator(handler) {
+                override fun afterConnectionEstablished(session: WebSocketSession) {
+                    sessionRegistry.registerSession(session)
+                    super.afterConnectionEstablished(session)
+                }
+
+                override fun afterConnectionClosed(
+                    session: WebSocketSession,
+                    closeStatus: CloseStatus,
+                ) {
+                    sessionRegistry.remove(session.id)
+                    super.afterConnectionClosed(session, closeStatus)
+                }
+            }
+        }
 }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketEventListener.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketEventListener.kt
@@ -12,11 +12,12 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent
  *
  * 클라이언트 연결/해제 이벤트를 처리합니다.
  * - 연결 시: 세션 정보 로깅
- * - 해제 시: 세션 정리 및 로깅
+ * - 해제 시: 세션 레지스트리에서 제거 및 로깅
  */
 @Component
-class WebSocketEventListener {
-
+class WebSocketEventListener(
+    private val sessionRegistry: WebSocketSessionRegistry,
+) {
     private val log = LoggerFactory.getLogger(WebSocketEventListener::class.java)
 
     @EventListener
@@ -32,6 +33,10 @@ class WebSocketEventListener {
         val accessor = StompHeaderAccessor.wrap(event.message)
         val sessionId = accessor.sessionId
         val user = accessor.user?.name ?: "anonymous"
+
+        // 세션 레지스트리에서 제거
+        sessionId?.let { sessionRegistry.remove(it) }
+
         log.info("WebSocket 해제: sessionId={}, user={}", sessionId, user)
     }
 }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketSessionExpirationScheduler.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketSessionExpirationScheduler.kt
@@ -1,0 +1,73 @@
+package com.nextup.scorer.config
+
+import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.CloseStatus
+
+/**
+ * WebSocket 세션 JWT 만료 스케줄러
+ *
+ * 주기적으로 활성 WebSocket 세션의 JWT 토큰 만료 여부를 검사합니다.
+ * 만료된 세션은 커스텀 CloseStatus(4401)로 연결을 해제합니다.
+ *
+ * 실행 주기: 60초 (fixedDelay)
+ * - SEND/SUBSCRIBE 없이 유휴 상태인 세션도 만료 감지 가능
+ * - 네트워크 비용 최소화를 위해 하트비트 주기(10초)보다 긴 간격 사용
+ */
+@Component
+class WebSocketSessionExpirationScheduler(
+    private val sessionRegistry: WebSocketSessionRegistry,
+    private val jwtTokenProvider: JwtTokenProvider,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val CHECK_INTERVAL_MS = 60_000L
+
+        /** JWT 만료로 인한 WebSocket 종료 코드 (4000번대는 애플리케이션 전용) */
+        val JWT_EXPIRED_CLOSE_STATUS =
+            CloseStatus(4401, "JWT 토큰이 만료되었습니다. 재연결이 필요합니다.")
+    }
+
+    @Scheduled(fixedDelay = CHECK_INTERVAL_MS)
+    fun checkExpiredSessions() {
+        val allTokens = sessionRegistry.getAllTokens()
+        if (allTokens.isEmpty()) {
+            return
+        }
+
+        var expiredCount = 0
+        for ((sessionId, token) in allTokens) {
+            if (!jwtTokenProvider.validateToken(token)) {
+                log.info("유휴 WebSocket 세션 JWT 만료 감지: sessionId={}", sessionId)
+                disconnectSession(sessionId)
+                expiredCount++
+            }
+        }
+
+        if (expiredCount > 0) {
+            log.info("만료된 WebSocket 세션 {}건 종료 처리 완료", expiredCount)
+        }
+    }
+
+    private fun disconnectSession(sessionId: String) {
+        try {
+            val session = sessionRegistry.getWebSocketSession(sessionId)
+            if (session != null && session.isOpen) {
+                session.close(JWT_EXPIRED_CLOSE_STATUS)
+                log.debug("WebSocket 세션 종료 완료: sessionId={}", sessionId)
+            }
+            sessionRegistry.remove(sessionId)
+        } catch (e: Exception) {
+            log.warn(
+                "WebSocket 세션 종료 실패: sessionId={}, error={}",
+                sessionId,
+                e.message,
+            )
+            // 종료에 실패해도 레지스트리에서는 제거
+            sessionRegistry.remove(sessionId)
+        }
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketSessionRegistry.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketSessionRegistry.kt
@@ -90,8 +90,7 @@ class WebSocketSessionRegistry {
      * @param sessionId WebSocket 세션 ID
      * @return WebSocketSession (없으면 null)
      */
-    fun getWebSocketSession(sessionId: String): WebSocketSession? =
-        webSocketSessions[sessionId]
+    fun getWebSocketSession(sessionId: String): WebSocketSession? = webSocketSessions[sessionId]
 
     /**
      * 등록된 세션 수를 반환합니다.

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketSessionRegistry.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/config/WebSocketSessionRegistry.kt
@@ -1,0 +1,100 @@
+package com.nextup.scorer.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.WebSocketSession
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * WebSocket 세션 레지스트리
+ *
+ * 활성 WebSocket 세션의 JWT 토큰 및 WebSocketSession 참조를 관리합니다.
+ * - CONNECT 시 토큰 등록
+ * - Transport 연결 시 WebSocketSession 등록
+ * - DISCONNECT 시 세션 제거
+ * - 토큰 갱신 시 세션 토큰 업데이트
+ * - 주기적 만료 검사를 위한 전체 세션 조회
+ *
+ * Thread-safe: ConcurrentHashMap 기반
+ */
+@Component
+class WebSocketSessionRegistry {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val tokens = ConcurrentHashMap<String, String>()
+    private val webSocketSessions = ConcurrentHashMap<String, WebSocketSession>()
+
+    /**
+     * 세션의 JWT 토큰을 등록합니다.
+     *
+     * @param sessionId WebSocket 세션 ID
+     * @param token JWT 토큰
+     */
+    fun registerToken(
+        sessionId: String,
+        token: String,
+    ) {
+        tokens[sessionId] = token
+        log.debug("WebSocket 세션 토큰 등록: sessionId={}", sessionId)
+    }
+
+    /**
+     * WebSocketSession 참조를 등록합니다.
+     *
+     * @param session WebSocketSession
+     */
+    fun registerSession(session: WebSocketSession) {
+        webSocketSessions[session.id] = session
+        log.debug("WebSocket 세션 참조 등록: sessionId={}", session.id)
+    }
+
+    /**
+     * 세션을 제거합니다.
+     *
+     * @param sessionId WebSocket 세션 ID
+     */
+    fun remove(sessionId: String) {
+        tokens.remove(sessionId)
+        webSocketSessions.remove(sessionId)
+        log.debug("WebSocket 세션 제거: sessionId={}", sessionId)
+    }
+
+    /**
+     * 세션의 토큰을 갱신합니다.
+     *
+     * @param sessionId WebSocket 세션 ID
+     * @param newToken 갱신된 JWT 토큰
+     * @return 세션이 존재하여 갱신에 성공하면 true
+     */
+    fun updateToken(
+        sessionId: String,
+        newToken: String,
+    ): Boolean {
+        val existed = tokens.replace(sessionId, newToken) != null
+        if (existed) {
+            log.debug("WebSocket 세션 토큰 갱신: sessionId={}", sessionId)
+        }
+        return existed
+    }
+
+    /**
+     * 등록된 모든 세션 토큰의 스냅샷을 반환합니다.
+     *
+     * @return sessionId -> token 맵의 불변 복사본
+     */
+    fun getAllTokens(): Map<String, String> = tokens.toMap()
+
+    /**
+     * 특정 세션의 WebSocketSession 참조를 반환합니다.
+     *
+     * @param sessionId WebSocket 세션 ID
+     * @return WebSocketSession (없으면 null)
+     */
+    fun getWebSocketSession(sessionId: String): WebSocketSession? =
+        webSocketSessions[sessionId]
+
+    /**
+     * 등록된 세션 수를 반환합니다.
+     */
+    fun sessionCount(): Int = tokens.size
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/config/WebSocketAuthInterceptorTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/config/WebSocketAuthInterceptorTest.kt
@@ -3,6 +3,7 @@ package com.nextup.scorer.config
 import com.nextup.infrastructure.security.jwt.JwtTokenProvider
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -18,12 +19,14 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 @DisplayName("WebSocketAuthInterceptor")
 class WebSocketAuthInterceptorTest {
     private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var sessionRegistry: WebSocketSessionRegistry
     private lateinit var interceptor: WebSocketAuthInterceptor
 
     @BeforeEach
     fun setUp() {
         jwtTokenProvider = mockk()
-        interceptor = WebSocketAuthInterceptor(jwtTokenProvider)
+        sessionRegistry = mockk(relaxed = true)
+        interceptor = WebSocketAuthInterceptor(jwtTokenProvider, sessionRegistry)
     }
 
     @Nested
@@ -73,6 +76,29 @@ class WebSocketAuthInterceptorTest {
             // then
             val auth = accessor.user as UsernamePasswordAuthenticationToken
             assertThat(auth.credentials).isEqualTo(token)
+        }
+
+        @Test
+        fun `should register token in session registry on CONNECT`() {
+            // given
+            val token = "valid-jwt-token"
+            val accessor = StompHeaderAccessor.create(StompCommand.CONNECT)
+            accessor.setLeaveMutable(true)
+            accessor.sessionId = "test-session-id"
+            accessor.sessionAttributes = mutableMapOf()
+            accessor.addNativeHeader("Authorization", "Bearer $token")
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            every { jwtTokenProvider.validateToken(token) } returns true
+            every { jwtTokenProvider.isAccessToken(token) } returns true
+            every { jwtTokenProvider.getUserId(token) } returns 1L
+            every { jwtTokenProvider.getRoles(token) } returns setOf("SCORER")
+
+            // when
+            interceptor.preSend(message, mockk())
+
+            // then
+            verify { sessionRegistry.registerToken("test-session-id", token) }
         }
 
         @Test
@@ -164,6 +190,27 @@ class WebSocketAuthInterceptorTest {
         }
 
         @Test
+        fun `should remove session from registry when token is expired`() {
+            // given
+            val token = "expired-token"
+            val sessionId = "test-session-id"
+            val accessor = StompHeaderAccessor.create(StompCommand.SEND)
+            accessor.destination = "/app/game/1/event"
+            accessor.sessionId = sessionId
+            accessor.sessionAttributes = mutableMapOf<String, Any>("token" to token)
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            every { jwtTokenProvider.validateToken(token) } returns false
+
+            // when & then
+            assertThatThrownBy {
+                interceptor.preSend(message, mockk())
+            }.isInstanceOf(AuthenticationCredentialsNotFoundException::class.java)
+
+            verify { sessionRegistry.remove(sessionId) }
+        }
+
+        @Test
         fun `should allow SEND when token is still valid`() {
             // given
             val token = "valid-token"
@@ -194,6 +241,104 @@ class WebSocketAuthInterceptorTest {
 
             // then
             assertThat(result).isNotNull
+        }
+    }
+
+    @Nested
+    @DisplayName("Token refresh on SEND/SUBSCRIBE")
+    inner class TokenRefresh {
+        @Test
+        fun `should refresh token when valid new token is provided in Authorization header`() {
+            // given
+            val oldToken = "old-valid-token"
+            val newToken = "new-valid-token"
+            val accessor = StompHeaderAccessor.create(StompCommand.SEND)
+            accessor.destination = "/app/game/1/event"
+            accessor.sessionAttributes = mutableMapOf<String, Any>("token" to oldToken)
+            accessor.addNativeHeader("Authorization", "Bearer $newToken")
+            accessor.setLeaveMutable(true)
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            every { jwtTokenProvider.validateToken(newToken) } returns true
+            every { jwtTokenProvider.isAccessToken(newToken) } returns true
+            every { jwtTokenProvider.getUserId(newToken) } returns 1L
+            every { jwtTokenProvider.getRoles(newToken) } returns setOf("SCORER")
+
+            // when
+            val result = interceptor.preSend(message, mockk())
+
+            // then
+            assertThat(result).isNotNull
+            assertThat(accessor.sessionAttributes?.get("token")).isEqualTo(newToken)
+            val auth = accessor.user as UsernamePasswordAuthenticationToken
+            assertThat(auth.principal).isEqualTo(1L)
+        }
+
+        @Test
+        fun `should update registry when token is refreshed`() {
+            // given
+            val oldToken = "old-valid-token"
+            val newToken = "new-valid-token"
+            val accessor = StompHeaderAccessor.create(StompCommand.SEND)
+            accessor.destination = "/app/game/1/event"
+            accessor.sessionId = "test-session-id"
+            accessor.sessionAttributes = mutableMapOf<String, Any>("token" to oldToken)
+            accessor.addNativeHeader("Authorization", "Bearer $newToken")
+            accessor.setLeaveMutable(true)
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            every { jwtTokenProvider.validateToken(newToken) } returns true
+            every { jwtTokenProvider.isAccessToken(newToken) } returns true
+            every { jwtTokenProvider.getUserId(newToken) } returns 1L
+            every { jwtTokenProvider.getRoles(newToken) } returns setOf("SCORER")
+
+            // when
+            interceptor.preSend(message, mockk())
+
+            // then
+            verify { sessionRegistry.updateToken("test-session-id", newToken) }
+        }
+
+        @Test
+        fun `should fall back to existing token validation when new token is invalid`() {
+            // given
+            val oldToken = "old-valid-token"
+            val invalidNewToken = "invalid-new-token"
+            val accessor = StompHeaderAccessor.create(StompCommand.SEND)
+            accessor.destination = "/app/game/1/event"
+            accessor.sessionAttributes = mutableMapOf<String, Any>("token" to oldToken)
+            accessor.addNativeHeader("Authorization", "Bearer $invalidNewToken")
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            every { jwtTokenProvider.validateToken(invalidNewToken) } returns false
+            every { jwtTokenProvider.validateToken(oldToken) } returns true
+
+            // when
+            val result = interceptor.preSend(message, mockk())
+
+            // then
+            assertThat(result).isNotNull
+        }
+
+        @Test
+        fun `should reject when both new and old tokens are expired`() {
+            // given
+            val oldToken = "expired-old-token"
+            val expiredNewToken = "expired-new-token"
+            val accessor = StompHeaderAccessor.create(StompCommand.SEND)
+            accessor.destination = "/app/game/1/event"
+            accessor.sessionAttributes = mutableMapOf<String, Any>("token" to oldToken)
+            accessor.addNativeHeader("Authorization", "Bearer $expiredNewToken")
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+
+            every { jwtTokenProvider.validateToken(expiredNewToken) } returns false
+            every { jwtTokenProvider.validateToken(oldToken) } returns false
+
+            // when & then
+            assertThatThrownBy {
+                interceptor.preSend(message, mockk())
+            }.isInstanceOf(AuthenticationCredentialsNotFoundException::class.java)
+                .hasMessageContaining("JWT 토큰이 만료되었습니다")
         }
     }
 

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/config/WebSocketEventListenerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/config/WebSocketEventListenerTest.kt
@@ -1,0 +1,43 @@
+package com.nextup.scorer.config
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.MessageBuilder
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+
+@DisplayName("WebSocketEventListener")
+class WebSocketEventListenerTest {
+    private lateinit var sessionRegistry: WebSocketSessionRegistry
+    private lateinit var listener: WebSocketEventListener
+
+    @BeforeEach
+    fun setUp() {
+        sessionRegistry = mockk(relaxed = true)
+        listener = WebSocketEventListener(sessionRegistry)
+    }
+
+    @Nested
+    @DisplayName("handleSessionDisconnect")
+    inner class HandleSessionDisconnect {
+        @Test
+        fun `should remove session from registry on disconnect`() {
+            // given
+            val accessor = StompHeaderAccessor.create(StompCommand.DISCONNECT)
+            accessor.sessionId = "test-session-id"
+            val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+            val event = SessionDisconnectEvent(this, message, "test-session-id", mockk())
+
+            // when
+            listener.handleSessionDisconnect(event)
+
+            // then
+            verify { sessionRegistry.remove("test-session-id") }
+        }
+    }
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/config/WebSocketSessionExpirationSchedulerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/config/WebSocketSessionExpirationSchedulerTest.kt
@@ -1,0 +1,165 @@
+package com.nextup.scorer.config
+
+import com.nextup.infrastructure.security.jwt.JwtTokenProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.web.socket.WebSocketSession
+
+@DisplayName("WebSocketSessionExpirationScheduler")
+class WebSocketSessionExpirationSchedulerTest {
+    private lateinit var sessionRegistry: WebSocketSessionRegistry
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var scheduler: WebSocketSessionExpirationScheduler
+
+    @BeforeEach
+    fun setUp() {
+        sessionRegistry = mockk(relaxed = true)
+        jwtTokenProvider = mockk()
+        scheduler =
+            WebSocketSessionExpirationScheduler(
+                sessionRegistry = sessionRegistry,
+                jwtTokenProvider = jwtTokenProvider,
+            )
+    }
+
+    @Nested
+    @DisplayName("checkExpiredSessions")
+    inner class CheckExpiredSessions {
+        @Test
+        fun `should do nothing when no sessions exist`() {
+            // given
+            every { sessionRegistry.getAllTokens() } returns emptyMap()
+
+            // when
+            scheduler.checkExpiredSessions()
+
+            // then
+            verify(exactly = 0) { sessionRegistry.remove(any()) }
+        }
+
+        @Test
+        fun `should disconnect session with expired token`() {
+            // given
+            val sessionId = "expired-session"
+            val expiredToken = "expired-token"
+            val mockSession = mockk<WebSocketSession>(relaxed = true)
+
+            every { sessionRegistry.getAllTokens() } returns mapOf(sessionId to expiredToken)
+            every { jwtTokenProvider.validateToken(expiredToken) } returns false
+            every { sessionRegistry.getWebSocketSession(sessionId) } returns mockSession
+            every { mockSession.isOpen } returns true
+
+            // when
+            scheduler.checkExpiredSessions()
+
+            // then
+            verify { mockSession.close(WebSocketSessionExpirationScheduler.JWT_EXPIRED_CLOSE_STATUS) }
+            verify { sessionRegistry.remove(sessionId) }
+        }
+
+        @Test
+        fun `should not disconnect session with valid token`() {
+            // given
+            val sessionId = "valid-session"
+            val validToken = "valid-token"
+
+            every { sessionRegistry.getAllTokens() } returns mapOf(sessionId to validToken)
+            every { jwtTokenProvider.validateToken(validToken) } returns true
+
+            // when
+            scheduler.checkExpiredSessions()
+
+            // then
+            verify(exactly = 0) { sessionRegistry.remove(any()) }
+        }
+
+        @Test
+        fun `should handle mixed valid and expired sessions`() {
+            // given
+            val validSessionId = "valid-session"
+            val expiredSessionId = "expired-session"
+            val validToken = "valid-token"
+            val expiredToken = "expired-token"
+            val mockSession = mockk<WebSocketSession>(relaxed = true)
+
+            every { sessionRegistry.getAllTokens() } returns
+                mapOf(
+                    validSessionId to validToken,
+                    expiredSessionId to expiredToken,
+                )
+            every { jwtTokenProvider.validateToken(validToken) } returns true
+            every { jwtTokenProvider.validateToken(expiredToken) } returns false
+            every { sessionRegistry.getWebSocketSession(expiredSessionId) } returns mockSession
+            every { mockSession.isOpen } returns true
+
+            // when
+            scheduler.checkExpiredSessions()
+
+            // then
+            verify(exactly = 1) { sessionRegistry.remove(expiredSessionId) }
+            verify(exactly = 0) { sessionRegistry.remove(validSessionId) }
+        }
+
+        @Test
+        fun `should handle already closed session gracefully`() {
+            // given
+            val sessionId = "closed-session"
+            val expiredToken = "expired-token"
+            val mockSession = mockk<WebSocketSession>(relaxed = true)
+
+            every { sessionRegistry.getAllTokens() } returns mapOf(sessionId to expiredToken)
+            every { jwtTokenProvider.validateToken(expiredToken) } returns false
+            every { sessionRegistry.getWebSocketSession(sessionId) } returns mockSession
+            every { mockSession.isOpen } returns false
+
+            // when
+            scheduler.checkExpiredSessions()
+
+            // then
+            verify(exactly = 0) { mockSession.close(any()) }
+            verify { sessionRegistry.remove(sessionId) }
+        }
+
+        @Test
+        fun `should handle null WebSocketSession gracefully`() {
+            // given
+            val sessionId = "null-session"
+            val expiredToken = "expired-token"
+
+            every { sessionRegistry.getAllTokens() } returns mapOf(sessionId to expiredToken)
+            every { jwtTokenProvider.validateToken(expiredToken) } returns false
+            every { sessionRegistry.getWebSocketSession(sessionId) } returns null
+
+            // when
+            scheduler.checkExpiredSessions()
+
+            // then
+            verify { sessionRegistry.remove(sessionId) }
+        }
+
+        @Test
+        fun `should still remove session from registry when close throws exception`() {
+            // given
+            val sessionId = "error-session"
+            val expiredToken = "expired-token"
+            val mockSession = mockk<WebSocketSession>(relaxed = true)
+
+            every { sessionRegistry.getAllTokens() } returns mapOf(sessionId to expiredToken)
+            every { jwtTokenProvider.validateToken(expiredToken) } returns false
+            every { sessionRegistry.getWebSocketSession(sessionId) } returns mockSession
+            every { mockSession.isOpen } returns true
+            every { mockSession.close(any()) } throws RuntimeException("Connection reset")
+
+            // when
+            scheduler.checkExpiredSessions()
+
+            // then
+            verify { sessionRegistry.remove(sessionId) }
+        }
+    }
+}

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/config/WebSocketSessionRegistryTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/config/WebSocketSessionRegistryTest.kt
@@ -1,0 +1,172 @@
+package com.nextup.scorer.config
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.web.socket.WebSocketSession
+
+@DisplayName("WebSocketSessionRegistry")
+class WebSocketSessionRegistryTest {
+    private lateinit var registry: WebSocketSessionRegistry
+
+    @BeforeEach
+    fun setUp() {
+        registry = WebSocketSessionRegistry()
+    }
+
+    @Nested
+    @DisplayName("registerToken")
+    inner class RegisterToken {
+        @Test
+        fun `should register token for session`() {
+            // given
+            val sessionId = "session-1"
+            val token = "jwt-token-1"
+
+            // when
+            registry.registerToken(sessionId, token)
+
+            // then
+            val tokens = registry.getAllTokens()
+            assertThat(tokens).containsEntry(sessionId, token)
+            assertThat(registry.sessionCount()).isEqualTo(1)
+        }
+
+        @Test
+        fun `should overwrite token when registering same session`() {
+            // given
+            val sessionId = "session-1"
+            registry.registerToken(sessionId, "old-token")
+
+            // when
+            registry.registerToken(sessionId, "new-token")
+
+            // then
+            val tokens = registry.getAllTokens()
+            assertThat(tokens[sessionId]).isEqualTo("new-token")
+            assertThat(registry.sessionCount()).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    @DisplayName("registerSession")
+    inner class RegisterSession {
+        @Test
+        fun `should register WebSocketSession reference`() {
+            // given
+            val session = mockk<WebSocketSession>()
+            every { session.id } returns "session-1"
+
+            // when
+            registry.registerSession(session)
+
+            // then
+            assertThat(registry.getWebSocketSession("session-1")).isSameAs(session)
+        }
+    }
+
+    @Nested
+    @DisplayName("remove")
+    inner class Remove {
+        @Test
+        fun `should remove both token and session reference`() {
+            // given
+            val sessionId = "session-1"
+            registry.registerToken(sessionId, "jwt-token")
+            val session = mockk<WebSocketSession>()
+            every { session.id } returns sessionId
+            registry.registerSession(session)
+
+            // when
+            registry.remove(sessionId)
+
+            // then
+            assertThat(registry.getAllTokens()).doesNotContainKey(sessionId)
+            assertThat(registry.getWebSocketSession(sessionId)).isNull()
+            assertThat(registry.sessionCount()).isEqualTo(0)
+        }
+
+        @Test
+        fun `should do nothing when removing non-existent session`() {
+            // when
+            registry.remove("non-existent")
+
+            // then
+            assertThat(registry.sessionCount()).isEqualTo(0)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateToken")
+    inner class UpdateToken {
+        @Test
+        fun `should update token and return true when session exists`() {
+            // given
+            val sessionId = "session-1"
+            registry.registerToken(sessionId, "old-token")
+
+            // when
+            val result = registry.updateToken(sessionId, "new-token")
+
+            // then
+            assertThat(result).isTrue()
+            assertThat(registry.getAllTokens()[sessionId]).isEqualTo("new-token")
+        }
+
+        @Test
+        fun `should return false when session does not exist`() {
+            // when
+            val result = registry.updateToken("non-existent", "new-token")
+
+            // then
+            assertThat(result).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllTokens")
+    inner class GetAllTokens {
+        @Test
+        fun `should return immutable snapshot of all tokens`() {
+            // given
+            registry.registerToken("session-1", "token-1")
+            registry.registerToken("session-2", "token-2")
+
+            // when
+            val tokens = registry.getAllTokens()
+
+            // then
+            assertThat(tokens).hasSize(2)
+            assertThat(tokens).containsEntry("session-1", "token-1")
+            assertThat(tokens).containsEntry("session-2", "token-2")
+        }
+
+        @Test
+        fun `should return empty map when no sessions registered`() {
+            // when
+            val tokens = registry.getAllTokens()
+
+            // then
+            assertThat(tokens).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("sessionCount")
+    inner class SessionCount {
+        @Test
+        fun `should return correct count`() {
+            // given
+            registry.registerToken("session-1", "token-1")
+            registry.registerToken("session-2", "token-2")
+            registry.registerToken("session-3", "token-3")
+
+            // when & then
+            assertThat(registry.sessionCount()).isEqualTo(3)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- Close #409

WebSocket JWT 만료 시 유휴 상태(SEND/SUBSCRIBE 없이 연결만 유지)인 세션이 만료된 토큰으로도 유지되는 문제를 보강합니다.

주기적 토큰 만료 검사 스케줄러, 토큰 갱신 메커니즘, 세션 레지스트리를 추가하여 유휴 세션의 JWT 만료를 감지하고 안전하게 종료합니다.

## Tasks

- [x] `WebSocketSessionRegistry` 추가 — ConcurrentHashMap 기반 세션-토큰 매핑 및 WebSocketSession 참조 관리
- [x] `WebSocketSessionExpirationScheduler` 추가 — 60초 주기 JWT 만료 검사, 만료 세션 CloseStatus(4401)로 종료
- [x] `WebSocketAuthInterceptor` 토큰 갱신 메커니즘 — SEND/SUBSCRIBE 시 Authorization 헤더로 새 토큰 전달 지원
- [x] `WebSocketConfig` transport 데코레이터 — WebSocketSession 참조 자동 등록/해제, 전송 버퍼 설정
- [x] `WebSocketEventListener` 세션 레지스트리 연동 — DISCONNECT 시 레지스트리 정리
- [x] 단위 테스트 추가 (WebSocketSessionRegistryTest, WebSocketSessionExpirationSchedulerTest, WebSocketEventListenerTest)
- [x] 기존 WebSocketAuthInterceptorTest 보강 (토큰 갱신, 세션 레지스트리 연동 테스트)

## To Reviewer

### 아키텍처 결정

1. **세션 레지스트리 설계**: `ConcurrentHashMap` 두 개로 토큰 매핑(`sessionId → token`)과 WebSocketSession 참조(`sessionId → WebSocketSession`)를 분리 관리합니다. 토큰은 STOMP 인터셉터 레벨(CONNECT)에서, WebSocketSession 참조는 Transport 레벨(데코레이터)에서 등록됩니다.

2. **만료 검사 주기 60초**: 하트비트(10초)보다 긴 간격으로 네트워크 비용을 최소화하면서도, JWT access token 만료(30분) 대비 충분히 빠른 감지가 가능합니다.

3. **CloseStatus 4401**: WebSocket 표준의 4000번대 애플리케이션 전용 코드를 사용하여 클라이언트가 JWT 만료로 인한 종료임을 구분할 수 있습니다.

4. **토큰 갱신**: 클라이언트가 SEND/SUBSCRIBE 시 `Authorization` 네이티브 헤더에 새 토큰을 포함하면, 세션 속성과 레지스트리의 토큰을 갱신합니다. 별도 STOMP 커맨드 없이 기존 메시지 흐름에 토큰 갱신을 통합했습니다.

### 주의사항

- `@Scheduled`는 `nextup-infrastructure`의 `SchedulingConfig`(`@EnableScheduling`)을 통해 활성화됩니다
- scorer 모듈의 `@SpringBootApplication(scanBasePackages = ["com.nextup"])`이 infrastructure 빈을 스캔합니다