### PR TITLE
fix(#387): 투수 기록 정확도 보완 — 타이브레이크 주자 책임투수 + 패전 판정

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/Game.kt
@@ -235,6 +235,7 @@ class Game private constructor(
             gameState.setupTiebreaker(
                 firstRunnerId = tiebreakerFirstRunnerId,
                 secondRunnerId = tiebreakerSecondRunnerId,
+                responsiblePitcherId = gameState.currentPitcherId,
             )
             return TiebreakerResult.TIEBREAKER_APPLIED
         }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameState.kt
@@ -316,19 +316,26 @@ class GameState(
      *
      * 사회인 야구 타이브레이크 규칙에 따라 이닝 시작 시 자동으로
      * 1루와 2루에 주자를 배치합니다.
-     * 배치된 주자의 담당 투수 ID는 현재 투수(currentPitcherId)로 설정됩니다.
+     *
+     * 타이브레이크 주자가 득점하면 해당 실점/자책점은 [responsiblePitcherId]에게
+     * 귀속됩니다. 호출 시 반드시 현재 등판 중인 투수의 ID를 전달해야
+     * 자책점 추적이 정확하게 이루어집니다.
      *
      * @param firstRunnerId  1루에 배치할 주자 GamePlayer ID (null 허용)
      * @param secondRunnerId 2루에 배치할 주자 GamePlayer ID (null 허용)
+     * @param responsiblePitcherId 타이브레이크 주자의 책임투수 ID.
+     *        null이면 [currentPitcherId]를 사용합니다.
      */
     fun setupTiebreaker(
         firstRunnerId: Long? = null,
         secondRunnerId: Long? = null,
+        responsiblePitcherId: Long? = null,
     ) {
+        val pitcherId = responsiblePitcherId ?: currentPitcherId
         runnerOnFirstId = firstRunnerId
-        runnerOnFirstPitcherId = if (firstRunnerId != null) currentPitcherId else null
+        runnerOnFirstPitcherId = if (firstRunnerId != null) pitcherId else null
         runnerOnSecondId = secondRunnerId
-        runnerOnSecondPitcherId = if (secondRunnerId != null) currentPitcherId else null
+        runnerOnSecondPitcherId = if (secondRunnerId != null) pitcherId else null
         runnerOnThirdId = null
         runnerOnThirdPitcherId = null
     }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/PitchingRecord.kt
@@ -401,10 +401,14 @@ class PitchingRecord(
 
     /**
      * 패배 결정을 부여합니다.
+     *
+     * 블론세이브(BLOWN_SAVE)가 이미 부여된 투수에게도 패전을 부여할 수 있습니다.
+     * 야구 규칙상 세이브 상황에서 역전을 허용한 투수는 블론세이브와 패전을 동시에
+     * 기록할 수 있으며, 이 경우 패전(LOSS)이 최종 결정으로 기록됩니다.
      */
     fun assignLoss() {
-        require(decision == PitchingDecision.NONE) {
-            "이미 다른 결정이 부여된 투수입니다."
+        require(decision == PitchingDecision.NONE || decision == PitchingDecision.BLOWN_SAVE) {
+            "이미 다른 결정이 부여된 투수입니다: $decision"
         }
         this.decision = PitchingDecision.LOSS
     }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/PitchingDecisionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/PitchingDecisionService.kt
@@ -223,10 +223,10 @@ class PitchingDecisionService {
         // 블론세이브를 먼저 처리: 리드를 잃은 시점의 투수에게 BS 부여 (LOSS보다 우선)
         assignBlownSaves(loserRecords, winnerInningScores, loserInningScores)
 
-        // 패전 투수 결정: BS가 이미 부여된 투수는 LOSS에서 제외
+        // 패전 투수 결정: BS가 부여된 투수도 LOSS를 받을 수 있음 (야구 규칙: BS+L 동시 기록)
         val losingPitcher = findLosingPitcher(loserRecords, winnerInningScores, loserInningScores)
         losingPitcher?.let {
-            if (it.decision == PitchingDecision.NONE) {
+            if (it.decision == PitchingDecision.NONE || it.decision == PitchingDecision.BLOWN_SAVE) {
                 it.assignLoss()
             }
         }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameStateTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GameStateTest.kt
@@ -1082,4 +1082,88 @@ class GameStateTest {
         assertThat(gameState.wasDhReleased).isTrue()
         assertThat(gameState.outs).isEqualTo(0)
     }
+
+    // ── Tiebreaker Responsible Pitcher Tests ──────────────────────────────────
+
+    @Test
+    fun `setupTiebreaker should use currentPitcherId when responsiblePitcherId is null`() {
+        // given
+        val gameState = GameState(currentPitcherId = 50L)
+
+        // when
+        gameState.setupTiebreaker(firstRunnerId = 10L, secondRunnerId = 20L)
+
+        // then
+        assertThat(gameState.runnerOnFirstPitcherId).isEqualTo(50L)
+        assertThat(gameState.runnerOnSecondPitcherId).isEqualTo(50L)
+    }
+
+    @Test
+    fun `setupTiebreaker should use explicit responsiblePitcherId when provided`() {
+        // given
+        val gameState = GameState(currentPitcherId = 50L)
+
+        // when
+        gameState.setupTiebreaker(
+            firstRunnerId = 10L,
+            secondRunnerId = 20L,
+            responsiblePitcherId = 77L,
+        )
+
+        // then - responsiblePitcherId(77) overrides currentPitcherId(50)
+        assertThat(gameState.runnerOnFirstPitcherId).isEqualTo(77L)
+        assertThat(gameState.runnerOnSecondPitcherId).isEqualTo(77L)
+    }
+
+    @Test
+    fun `setupTiebreaker should set null pitcher ids when runners are null`() {
+        // given
+        val gameState = GameState(currentPitcherId = 50L)
+
+        // when
+        gameState.setupTiebreaker(
+            firstRunnerId = null,
+            secondRunnerId = null,
+            responsiblePitcherId = 77L,
+        )
+
+        // then - no runners, so no pitcher ids
+        assertThat(gameState.runnerOnFirstPitcherId).isNull()
+        assertThat(gameState.runnerOnSecondPitcherId).isNull()
+    }
+
+    @Test
+    fun `setupTiebreaker should clear third base runner and pitcher id`() {
+        // given
+        val gameState = GameState(currentPitcherId = 50L)
+        gameState.setRunner(Base.THIRD, 99L)
+        assertThat(gameState.runnerOnThirdId).isEqualTo(99L)
+        assertThat(gameState.runnerOnThirdPitcherId).isEqualTo(50L)
+
+        // when
+        gameState.setupTiebreaker(
+            firstRunnerId = 10L,
+            secondRunnerId = 20L,
+            responsiblePitcherId = 77L,
+        )
+
+        // then
+        assertThat(gameState.runnerOnThirdId).isNull()
+        assertThat(gameState.runnerOnThirdPitcherId).isNull()
+    }
+
+    @Test
+    fun `setupTiebreaker with null currentPitcherId and no responsiblePitcherId results in null pitcher ids`() {
+        // given - currentPitcherId is null (edge case)
+        val gameState = GameState(currentPitcherId = null)
+
+        // when
+        gameState.setupTiebreaker(firstRunnerId = 10L, secondRunnerId = 20L)
+
+        // then - pitcherId falls back to currentPitcherId which is null
+        assertThat(gameState.runnerOnFirstId).isEqualTo(10L)
+        assertThat(gameState.runnerOnFirstPitcherId).isNull()
+        assertThat(gameState.runnerOnSecondId).isEqualTo(20L)
+        assertThat(gameState.runnerOnSecondPitcherId).isNull()
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -631,6 +631,17 @@ class PitchingRecordTest {
         }
 
         @Test
+        fun `이미 승리 결정이 있는 투수에게 패배를 부여하면 예외가 발생한다`() {
+            // given
+            pitchingRecord.assignWin()
+
+            // when & then
+            assertThatThrownBy { pitchingRecord.assignLoss() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이미 다른 결정이 부여된 투수입니다")
+        }
+
+        @Test
         fun `이미 패배 결정이 있는 투수에게 세이브를 부여하면 예외가 발생한다`() {
             // given
             pitchingRecord.assignLoss()

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -618,6 +618,19 @@ class PitchingRecordTest {
         }
 
         @Test
+        fun `블론세이브 상태에서 패배 결정을 부여하면 LOSS로 전환된다`() {
+            // given: 구원투수에게 먼저 블론세이브 부여
+            pitchingRecord.assignBlownSave()
+            assertThat(pitchingRecord.decision).isEqualTo(PitchingDecision.BLOWN_SAVE)
+
+            // when: 패전 부여 (야구 규칙: BS+L 동시 기록 가능)
+            pitchingRecord.assignLoss()
+
+            // then
+            assertThat(pitchingRecord.decision).isEqualTo(PitchingDecision.LOSS)
+        }
+
+        @Test
         fun `이미 패배 결정이 있는 투수에게 세이브를 부여하면 예외가 발생한다`() {
             // given
             pitchingRecord.assignLoss()

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/PitchingDecisionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/PitchingDecisionServiceTest.kt
@@ -705,6 +705,34 @@ class PitchingDecisionServiceTest {
             // 야구 규칙: BS와 L은 동시 기록 가능하며, 최종 결정은 LOSS
             assertThat(loserRelief.decision).isEqualTo(PitchingDecision.LOSS)
         }
+
+        @Test
+        fun `블론세이브 투수가 패전 투수와 동일하면 BLOWN_SAVE에서 LOSS로 전환된다`() {
+            // given: 패배팀이 1회에 1점 리드 후, 구원 투수가 2회부터 등판하여 역전 허용
+            // 패팀: 1,0,0,0,0,0,0,0,0 = 1
+            // 승팀: 0,2,0,0,0,0,0,0,0 = 2 (2회에 역전)
+            val loserStarter =
+                makeRecord(isStarter = true, outs = 3, runsAllowed = 0) // 1회
+            val loserRelief =
+                makeRecord(isStarter = false, outs = 24, runsAllowed = 2) // 2~9회 (역전 허용)
+
+            val winnerTeam = makeGameTeam("0,2,0,0,0,0,0,0,0", 2)
+            val loserTeam = makeGameTeam("1,0,0,0,0,0,0,0,0", 1)
+
+            // when
+            service.assignDecisions(
+                winnerTeamRecords = emptyList(),
+                loserTeamRecords = listOf(loserStarter, loserRelief),
+                winnerGameTeam = winnerTeam,
+                loserGameTeam = loserTeam,
+                gameRules = gameRules,
+            )
+
+            // then: loserRelief는 먼저 BS를 받은 뒤, 결승점 허용으로 LOSS 부여
+            // BS 상태에서 assignLoss() 호출 → BLOWN_SAVE 분기 커버
+            assertThat(loserRelief.decision).isEqualTo(PitchingDecision.LOSS)
+            assertThat(loserStarter.decision).isEqualTo(PitchingDecision.NONE)
+        }
     }
 
     // ────────────────────────────────────────────────────────────

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/PitchingDecisionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/PitchingDecisionServiceTest.kt
@@ -682,7 +682,7 @@ class PitchingDecisionServiceTest {
     inner class BlownSaveTest {
 
         @Test
-        fun `패배팀 구원 투수가 리드 상황 등판 후 역전 허용 시 블론세이브`() {
+        fun `패배팀 구원 투수가 리드 상황 등판 후 역전 허용 시 블론세이브 후 패전으로 전환`() {
             // given: 패배팀이 3회까지 리드했다가 4회에 역전 허용
             // 패팀: 2,0,0,0,0,0,0,0,0 (2점 리드 후 역전 당함)
             // 승팀: 0,0,0,3,0,0,0,0,0 (4회에 역전)
@@ -701,8 +701,9 @@ class PitchingDecisionServiceTest {
                 gameRules = gameRules,
             )
 
-            // then: 역전 허용 시점(4회)의 투수인 loserRelief에게 블론세이브
-            assertThat(loserRelief.decision).isEqualTo(PitchingDecision.BLOWN_SAVE)
+            // then: 역전 허용 시점(4회)의 투수인 loserRelief에게 블론세이브 + 패전
+            // 야구 규칙: BS와 L은 동시 기록 가능하며, 최종 결정은 LOSS
+            assertThat(loserRelief.decision).isEqualTo(PitchingDecision.LOSS)
         }
     }
 
@@ -1107,6 +1108,142 @@ class PitchingDecisionServiceTest {
             // then: winningRelief가 WIN, closerRelief는 SAVE 조건 불충족이므로 NONE
             assertThat(winningRelief.decision).isEqualTo(PitchingDecision.WIN)
             assertThat(closerRelief.decision).isEqualTo(PitchingDecision.NONE)
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // 시소 게임 (리드 교차) 결승점 판정 — M-2
+    // ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("시소 게임 결승점 판정")
+    inner class SeesawGameGoAheadRunTest {
+
+        @Test
+        fun `시소 게임에서 최종 역전 이닝의 투수에게 패전 부여`() {
+            // given: 리드가 두 번 바뀌는 시소 게임
+            // 승팀(원정): 2,0,0,0,0,3,0,0,0 = 5
+            // 패팀(홈):   0,0,3,0,0,0,0,0,0 = 3
+            // 누적: 승 2,2,2,2,2,5,5,5,5 / 패 0,0,3,3,3,3,3,3,3
+            // 1회: 2>0 && 0<=0 → decisionInning=1
+            // 3회: 2<3 → skip
+            // 6회: 5>3 && 2<=3 → decisionInning=6 (최종 역전)
+            val loserStarter =
+                makeRecord(isStarter = true, outs = 15, runsAllowed = 2) // 1~5회
+            val loserRelief =
+                makeRecord(isStarter = false, outs = 12, runsAllowed = 3) // 6~9회 (결승점 허용)
+
+            val winnerTeam = makeGameTeam("2,0,0,0,0,3,0,0,0", 5)
+            val loserTeam = makeGameTeam("0,0,3,0,0,0,0,0,0", 3)
+
+            // when
+            service.assignDecisions(
+                winnerTeamRecords = emptyList(),
+                loserTeamRecords = listOf(loserStarter, loserRelief),
+                winnerGameTeam = winnerTeam,
+                loserGameTeam = loserTeam,
+                gameRules = gameRules,
+            )
+
+            // then: 6회 결승점 → 6~9회 담당 loserRelief에게 패전
+            assertThat(loserRelief.decision).isEqualTo(PitchingDecision.LOSS)
+            assertThat(loserStarter.decision).isEqualTo(PitchingDecision.NONE)
+        }
+
+        @Test
+        fun `세 번 리드가 바뀌는 시소 게임에서 최종 역전 투수에게 패전`() {
+            // given: 리드 교차 3회
+            // 승팀: 1,0,0,2,0,0,0,0,2 = 5
+            // 패팀: 0,0,2,0,0,1,0,0,0 = 3
+            // 누적: 승 1,1,1,3,3,3,3,3,5 / 패 0,0,2,2,2,3,3,3,3
+            // 1회: 1>0 && 0<=0 → decisionInning=1
+            // 3회: 1<2 → skip
+            // 4회: 3>2 && 1<=2 → decisionInning=4
+            // 6회: 3<=3 → skip (동점)
+            // 9회: 5>3 && 3<=3 → decisionInning=9
+            val loserStarter =
+                makeRecord(isStarter = true, outs = 9, runsAllowed = 1) // 1~3회
+            val loserRelief1 =
+                makeRecord(isStarter = false, outs = 9, runsAllowed = 2) // 4~6회
+            val loserRelief2 =
+                makeRecord(isStarter = false, outs = 9, runsAllowed = 2) // 7~9회 (최종 결승점)
+
+            val winnerTeam = makeGameTeam("1,0,0,2,0,0,0,0,2", 5)
+            val loserTeam = makeGameTeam("0,0,2,0,0,1,0,0,0", 3)
+
+            // when
+            service.assignDecisions(
+                winnerTeamRecords = emptyList(),
+                loserTeamRecords = listOf(loserStarter, loserRelief1, loserRelief2),
+                winnerGameTeam = winnerTeam,
+                loserGameTeam = loserTeam,
+                gameRules = gameRules,
+            )
+
+            // then: 9회 결승점 → 7~9회 담당 loserRelief2에게 패전
+            assertThat(loserRelief2.decision).isEqualTo(PitchingDecision.LOSS)
+            assertThat(loserStarter.decision).isEqualTo(PitchingDecision.NONE)
+            assertThat(loserRelief1.decision).isEqualTo(PitchingDecision.NONE)
+        }
+
+        @Test
+        fun `승리팀이 처음부터 리드를 한 번도 놓치지 않은 경우 1회 투수에게 패전`() {
+            // given: 승팀이 1회에 리드 잡고 끝까지 유지
+            // 승팀: 3,0,0,0,0,0,0,0,0 = 3
+            // 패팀: 0,0,0,1,0,0,0,0,0 = 1
+            // 누적: 승 3,3,3,3,3,3,3,3,3 / 패 0,0,0,1,1,1,1,1,1
+            // 1회: 3>0 && 0<=0 → decisionInning=1
+            // 이후 prevW > prevL 이므로 갱신 없음
+            val loserStarter =
+                makeRecord(isStarter = true, outs = 27, runsAllowed = 3) // 완투
+
+            val winnerTeam = makeGameTeam("3,0,0,0,0,0,0,0,0", 3)
+            val loserTeam = makeGameTeam("0,0,0,1,0,0,0,0,0", 1)
+
+            // when
+            service.assignDecisions(
+                winnerTeamRecords = emptyList(),
+                loserTeamRecords = listOf(loserStarter),
+                winnerGameTeam = winnerTeam,
+                loserGameTeam = loserTeam,
+                gameRules = gameRules,
+            )
+
+            // then: 1회 결승점 → 완투한 선발에게 패전
+            assertThat(loserStarter.decision).isEqualTo(PitchingDecision.LOSS)
+        }
+
+        @Test
+        fun `동점에서 역전한 뒤 추가 득점이 있어도 결승점 이닝은 최초 역전 이닝`() {
+            // given: 동점에서 4회에 역전, 7회에 추가 득점
+            // 승팀: 0,0,0,2,0,0,3,0,0 = 5
+            // 패팀: 0,0,0,0,0,0,0,0,0 = 0
+            // 누적: 승 0,0,0,2,2,2,5,5,5 / 패 0,0,0,0,0,0,0,0,0
+            // 4회: 2>0 && 0<=0 → decisionInning=4
+            // 7회: 5>0 && 2>0 → prevW > prevL → 갱신 없음
+            val loserStarter =
+                makeRecord(isStarter = true, outs = 9, runsAllowed = 0) // 1~3회
+            val loserRelief1 =
+                makeRecord(isStarter = false, outs = 9, runsAllowed = 2) // 4~6회 (결승점)
+            val loserRelief2 =
+                makeRecord(isStarter = false, outs = 9, runsAllowed = 3) // 7~9회 (추가 실점)
+
+            val winnerTeam = makeGameTeam("0,0,0,2,0,0,3,0,0", 5)
+            val loserTeam = makeGameTeam("0,0,0,0,0,0,0,0,0", 0)
+
+            // when
+            service.assignDecisions(
+                winnerTeamRecords = emptyList(),
+                loserTeamRecords = listOf(loserStarter, loserRelief1, loserRelief2),
+                winnerGameTeam = winnerTeam,
+                loserGameTeam = loserTeam,
+                gameRules = gameRules,
+            )
+
+            // then: 4회 결승점 → 4~6회 담당 loserRelief1에게 패전
+            assertThat(loserRelief1.decision).isEqualTo(PitchingDecision.LOSS)
+            assertThat(loserStarter.decision).isEqualTo(PitchingDecision.NONE)
+            assertThat(loserRelief2.decision).isEqualTo(PitchingDecision.NONE)
         }
     }
 }


### PR DESCRIPTION
## Summary

>- Close #387

타이브레이크 주자의 책임투수(responsiblePitcherId) 미설정 및 패전 투수 "결승점" 판정 로직 부정확 문제를 수정합니다.

### M-1: 타이브레이크 주자 책임투수 설정
- `GameState.setupTiebreaker()`에 `responsiblePitcherId: Long?` 파라미터 추가
- null이면 기존과 동일하게 `currentPitcherId`를 사용하여 하위 호환 유지
- `Game.advanceInning()`에서 `gameState.currentPitcherId`를 명시적으로 전달하여 책임투수 추적 정확도 보장

### M-2: 패전 투수 결승점 판정 정확화
- `PitchingRecord.assignLoss()`가 `BLOWN_SAVE` 상태에서도 `LOSS` 부여 가능하도록 수정
- 야구 규칙상 세이브 상황에서 역전을 허용한 투수는 BS+L 동시 기록 가능, 최종 결정은 LOSS
- `PitchingDecisionService`에서 BS 투수에게도 패전 부여 로직 추가
- 시소 게임(리드 교차)에서 최종 역전 이닝의 투수에게 정확히 패전 부여

## Tasks

- [x] `GameState.setupTiebreaker()`에 `responsiblePitcherId` 파라미터 추가
- [x] `Game.advanceInning()`에서 명시적 `responsiblePitcherId` 전달
- [x] `PitchingRecord.assignLoss()`에서 `BLOWN_SAVE` → `LOSS` 전환 허용
- [x] `PitchingDecisionService`에서 BS+L 동시 기록 지원
- [x] 타이브레이크 책임투수 단위 테스트 추가 (5개)
- [x] 시소 게임 결승점 시나리오 단위 테스트 추가 (4개)
- [x] `./gradlew clean build` 성공 (2966+ tests, 0 failures)

## To Reviewer

- **하위 호환성**: `setupTiebreaker()`의 `responsiblePitcherId`는 기본값 `null`이므로 기존 호출부 변경 불필요
- **BS+L 동시 기록**: 야구 규칙에 따라 블론세이브 투수가 결승점 허용 투수일 경우 LOSS가 최종 결정으로 덮어씁니다. 기존 `BLOWN_SAVE`만 기록되던 것이 `LOSS`로 변경되는 동작 변경입니다.
- 변경 범위는 `nextup-core` 모듈에 한정되며, DB 마이그레이션은 불필요합니다.