### PR TITLE
feat(#397): 리그 순위 동률 타이브레이커 구현

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/standings/StandingsResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/standings/StandingsResponse.kt
@@ -59,6 +59,10 @@ data class TeamStandingResponse(
     val runDifferential: Int,
     val isPlayoffPosition: Boolean,
     val logoUrl: String? = null,
+    /** 타이브레이커가 적용되었는지 여부 */
+    val tiebreakerApplied: Boolean = false,
+    /** 타이브레이커 적용 사유 */
+    val tiebreakerReason: String? = null,
 ) {
     companion object {
         fun from(
@@ -81,6 +85,8 @@ data class TeamStandingResponse(
                 runDifferential = dto.runDifferential,
                 isPlayoffPosition = isPlayoffPosition,
                 logoUrl = dto.logoUrl,
+                tiebreakerApplied = dto.tiebreakerApplied,
+                tiebreakerReason = dto.tiebreakerReason,
             )
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/GameRules.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/GameRules.kt
@@ -62,6 +62,9 @@ data class GameRules(
     /** L-3: 용병(머서너리) 쿼터 제한 (null이면 무제한) */
     @Column(name = "max_mercenary_count")
     val maxMercenaryCount: Int? = null,
+    /** L-13: 순위 동률 타이브레이커 기준 순서 (쉼표 구분, 기본: 상대전적→득실점차→다득점) */
+    @Column(name = "standings_tiebreaker_order")
+    val standingsTiebreakerOrder: String = "HEAD_TO_HEAD,RUN_DIFFERENTIAL,RUNS_SCORED",
 ) {
     init {
         require(defaultInnings in 3..12) { "기본 이닝은 3~12 사이여야 합니다." }
@@ -101,5 +104,26 @@ data class GameRules(
         maxMercenaryCount?.let {
             require(it >= 0) { "용병 쿼터 제한은 0 이상이어야 합니다." }
         }
+
+        require(standingsTiebreakerOrder.isNotBlank()) {
+            "타이브레이커 기준 순서는 비어있을 수 없습니다."
+        }
+        val criteria = parseTiebreakerOrder()
+        require(criteria.isNotEmpty()) {
+            "타이브레이커 기준 순서에 유효한 기준이 최소 1개 이상 있어야 합니다."
+        }
+        require(criteria.size == criteria.toSet().size) {
+            "타이브레이커 기준 순서에 중복된 기준이 있습니다."
+        }
     }
+
+    /**
+     * 타이브레이커 기준 순서를 파싱하여 리스트로 반환합니다.
+     */
+    fun parseTiebreakerOrder(): List<TiebreakerCriterion> =
+        standingsTiebreakerOrder
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map { TiebreakerCriterion.valueOf(it) }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/TiebreakerCriterion.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/competition/TiebreakerCriterion.kt
@@ -1,0 +1,20 @@
+package com.nextup.core.domain.competition
+
+/**
+ * 리그 순위 동률 타이브레이커 기준
+ *
+ * 순위표에서 승률이 동일한 팀 간의 순위를 결정할 때 사용하는 기준입니다.
+ * 대회별로 타이브레이커 기준의 우선순위를 커스터마이징할 수 있습니다.
+ */
+enum class TiebreakerCriterion(
+    val displayName: String,
+) {
+    /** 상대 전적 (직접 대결 승률) */
+    HEAD_TO_HEAD("상대 전적"),
+
+    /** 득실점차 (득점 - 실점) */
+    RUN_DIFFERENTIAL("득실점차"),
+
+    /** 다득점 (총 득점 수) */
+    RUNS_SCORED("다득점"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/standings/dto/TeamStandingDto.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/standings/dto/TeamStandingDto.kt
@@ -20,4 +20,8 @@ data class TeamStandingDto(
     val runsAllowed: Int,
     val runDifferential: Int,
     val logoUrl: String? = null,
+    /** 타이브레이커가 적용되었는지 여부 */
+    val tiebreakerApplied: Boolean = false,
+    /** 타이브레이커 적용 사유 (예: "상대 전적", "득실점차") */
+    val tiebreakerReason: String? = null,
 )

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/GameRulesTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/competition/GameRulesTest.kt
@@ -352,4 +352,71 @@ class GameRulesTest {
             assertThat(rules.maxExtraInnings).isEqualTo(1)
         }
     }
+
+    @Nested
+    @DisplayName("순위 타이브레이커 설정")
+    inner class StandingsTiebreakerValidation {
+        @Test
+        fun `기본 타이브레이커 순서는 상대전적-득실점차-다득점이다`() {
+            val rules = GameRules()
+
+            assertThat(rules.standingsTiebreakerOrder)
+                .isEqualTo("HEAD_TO_HEAD,RUN_DIFFERENTIAL,RUNS_SCORED")
+        }
+
+        @Test
+        fun `기본 타이브레이커 순서를 파싱할 수 있다`() {
+            val rules = GameRules()
+            val criteria = rules.parseTiebreakerOrder()
+
+            assertThat(criteria).containsExactly(
+                TiebreakerCriterion.HEAD_TO_HEAD,
+                TiebreakerCriterion.RUN_DIFFERENTIAL,
+                TiebreakerCriterion.RUNS_SCORED,
+            )
+        }
+
+        @Test
+        fun `커스텀 타이브레이커 순서를 설정할 수 있다`() {
+            val rules =
+                GameRules(standingsTiebreakerOrder = "RUN_DIFFERENTIAL,RUNS_SCORED,HEAD_TO_HEAD")
+            val criteria = rules.parseTiebreakerOrder()
+
+            assertThat(criteria).containsExactly(
+                TiebreakerCriterion.RUN_DIFFERENTIAL,
+                TiebreakerCriterion.RUNS_SCORED,
+                TiebreakerCriterion.HEAD_TO_HEAD,
+            )
+        }
+
+        @Test
+        fun `단일 기준만 설정할 수 있다`() {
+            val rules = GameRules(standingsTiebreakerOrder = "HEAD_TO_HEAD")
+            val criteria = rules.parseTiebreakerOrder()
+
+            assertThat(criteria).containsExactly(TiebreakerCriterion.HEAD_TO_HEAD)
+        }
+
+        @Test
+        fun `빈 타이브레이커 순서는 예외가 발생한다`() {
+            assertThatThrownBy { GameRules(standingsTiebreakerOrder = "") }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("비어있을 수 없습니다")
+        }
+
+        @Test
+        fun `중복된 기준이 있으면 예외가 발생한다`() {
+            assertThatThrownBy {
+                GameRules(standingsTiebreakerOrder = "HEAD_TO_HEAD,HEAD_TO_HEAD")
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("중복된 기준")
+        }
+
+        @Test
+        fun `유효하지 않은 기준이면 예외가 발생한다`() {
+            assertThatThrownBy {
+                GameRules(standingsTiebreakerOrder = "INVALID_CRITERION")
+            }.isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/standings/StandingsServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/standings/StandingsServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.nextup.infrastructure.service.standings
 
 import com.nextup.common.exception.CompetitionNotFoundException
+import com.nextup.core.domain.competition.TiebreakerCriterion
 import com.nextup.core.domain.game.GameResult
 import com.nextup.core.domain.game.GameTeam
 import com.nextup.core.port.repository.CompetitionRepositoryPort
@@ -34,7 +35,8 @@ class StandingsServiceImpl(
 
         // 2. 대회의 모든 GameTeam 조회
         val allGameTeams = gameTeamRepository.findAllByCompetitionId(competitionId)
-        val decidedGameTeams = gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId)
+        val decidedGameTeams =
+            gameTeamRepository.findAllByCompetitionIdWithDecidedResult(competitionId)
 
         // 3. 팀별로 그룹화하여 통계 계산
         val teamStats = calculateTeamStats(decidedGameTeams, allGameTeams)
@@ -42,28 +44,28 @@ class StandingsServiceImpl(
         // L-13: 상대전적 기반 타이브레이커 계산
         val headToHeadRecords = calculateHeadToHeadRecords(decidedGameTeams)
 
-        // 4. 정렬: 승률 DESC → L-13: 상대전적 DESC → 득실차 DESC → 득점 DESC
+        // 4. 대회 GameRules에서 타이브레이커 순서 가져오기
+        val tiebreakerOrder = competition.gameRules.parseTiebreakerOrder()
+
+        // 5. 승률 기준 1차 정렬 + 타이브레이커 적용
         val sortedStats =
             teamStats.sortedWith(
-                compareByDescending<TeamStats> { it.winningPercentage }
-                    .thenByDescending { stats ->
-                        // L-13: 동률 팀 간 상대전적 승률 계산
-                        val sameWinPctTeams =
-                            teamStats.filter { it.winningPercentage == stats.winningPercentage }
-                        if (sameWinPctTeams.size <= 1) {
-                            BigDecimal.ZERO
-                        } else {
-                            calculateHeadToHeadWinPct(stats.teamId, sameWinPctTeams, headToHeadRecords)
-                        }
-                    }
-                    .thenByDescending { it.runDifferential }
-                    .thenByDescending { it.runsScored },
+                buildTiebreakerComparator(teamStats, headToHeadRecords, tiebreakerOrder),
             )
 
-        // 5. 순위 부여 및 게임 차 계산
+        // 6. 타이브레이커 사유 결정
+        val tiebreakerInfoMap =
+            determineTiebreakerReasons(
+                sortedStats,
+                headToHeadRecords,
+                tiebreakerOrder,
+            )
+
+        // 7. 순위 부여 및 게임 차 계산
         val leader = sortedStats.firstOrNull()
         val standings =
             sortedStats.mapIndexed { index, stats ->
+                val info = tiebreakerInfoMap[stats.teamId]
                 TeamStandingDto(
                     rank = index + 1,
                     teamId = stats.teamId,
@@ -78,6 +80,8 @@ class StandingsServiceImpl(
                     runsScored = stats.runsScored,
                     runsAllowed = stats.runsAllowed,
                     runDifferential = stats.runDifferential,
+                    tiebreakerApplied = info?.applied ?: false,
+                    tiebreakerReason = info?.reason,
                 )
             }
 
@@ -89,6 +93,120 @@ class StandingsServiceImpl(
             lastUpdated = LocalDateTime.now(),
         )
     }
+
+    /**
+     * 타이브레이커 순서에 따른 Comparator 생성
+     */
+    private fun buildTiebreakerComparator(
+        teamStats: List<TeamStats>,
+        headToHeadRecords: Map<Pair<Long, Long>, Pair<Int, Int>>,
+        tiebreakerOrder: List<TiebreakerCriterion>,
+    ): Comparator<TeamStats> {
+        var comparator = compareByDescending<TeamStats> { it.winningPercentage }
+
+        for (criterion in tiebreakerOrder) {
+            comparator =
+                when (criterion) {
+                    TiebreakerCriterion.HEAD_TO_HEAD ->
+                        comparator.thenByDescending { stats ->
+                            val sameWinPctTeams =
+                                teamStats.filter {
+                                    it.winningPercentage == stats.winningPercentage
+                                }
+                            if (sameWinPctTeams.size <= 1) {
+                                BigDecimal.ZERO
+                            } else {
+                                calculateHeadToHeadWinPct(
+                                    stats.teamId,
+                                    sameWinPctTeams,
+                                    headToHeadRecords,
+                                )
+                            }
+                        }
+
+                    TiebreakerCriterion.RUN_DIFFERENTIAL ->
+                        comparator.thenByDescending { it.runDifferential }
+
+                    TiebreakerCriterion.RUNS_SCORED ->
+                        comparator.thenByDescending { it.runsScored }
+                }
+        }
+
+        return comparator
+    }
+
+    /**
+     * 동률 팀들에 대해 어떤 타이브레이커 기준으로 순위가 결정되었는지 판단합니다.
+     */
+    private fun determineTiebreakerReasons(
+        sortedStats: List<TeamStats>,
+        headToHeadRecords: Map<Pair<Long, Long>, Pair<Int, Int>>,
+        tiebreakerOrder: List<TiebreakerCriterion>,
+    ): Map<Long, TiebreakerInfo> {
+        val result = mutableMapOf<Long, TiebreakerInfo>()
+
+        // 승률이 같은 팀들을 그룹으로 묶기
+        val winPctGroups =
+            sortedStats.groupBy { it.winningPercentage }
+
+        for ((_, teamsInGroup) in winPctGroups) {
+            if (teamsInGroup.size <= 1) continue
+
+            // 이 그룹 내의 팀들은 승률이 동일 → 타이브레이커 적용 대상
+            for (team in teamsInGroup) {
+                val reason = findResolvingCriterion(team, teamsInGroup, headToHeadRecords, tiebreakerOrder)
+                result[team.teamId] =
+                    TiebreakerInfo(
+                        applied = true,
+                        reason = reason,
+                    )
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * 특정 팀의 순위를 결정한 타이브레이커 기준을 찾습니다.
+     *
+     * 동률 그룹 내에서 어떤 기준에 의해 이 팀이 다른 팀과 구분되었는지 판별합니다.
+     * 모든 기준으로도 구분이 안 되면 null을 반환합니다.
+     */
+    private fun findResolvingCriterion(
+        team: TeamStats,
+        tiedTeams: List<TeamStats>,
+        headToHeadRecords: Map<Pair<Long, Long>, Pair<Int, Int>>,
+        tiebreakerOrder: List<TiebreakerCriterion>,
+    ): String? {
+        for (criterion in tiebreakerOrder) {
+            val allSame =
+                tiedTeams.all { other ->
+                    getCriterionValue(criterion, team, tiedTeams, headToHeadRecords) ==
+                        getCriterionValue(criterion, other, tiedTeams, headToHeadRecords)
+                }
+            if (!allSame) {
+                return criterion.displayName
+            }
+        }
+        return null
+    }
+
+    /**
+     * 특정 기준에 대한 팀의 비교 값을 반환합니다.
+     */
+    private fun getCriterionValue(
+        criterion: TiebreakerCriterion,
+        team: TeamStats,
+        tiedTeams: List<TeamStats>,
+        headToHeadRecords: Map<Pair<Long, Long>, Pair<Int, Int>>,
+    ): Comparable<*> =
+        when (criterion) {
+            TiebreakerCriterion.HEAD_TO_HEAD ->
+                calculateHeadToHeadWinPct(team.teamId, tiedTeams, headToHeadRecords)
+
+            TiebreakerCriterion.RUN_DIFFERENTIAL -> team.runDifferential
+            TiebreakerCriterion.RUNS_SCORED -> team.runsScored
+        }
 
     /**
      * 팀별 통계 계산
@@ -234,23 +352,27 @@ class StandingsServiceImpl(
                     team1.result == GameResult.WIN && team1.team.id == key.first ->
                         Pair(
                             current.first + 1,
-                            current.second
+                            current.second,
                         )
+
                     team1.result == GameResult.LOSS && team1.team.id == key.first ->
                         Pair(
                             current.first,
-                            current.second + 1
+                            current.second + 1,
                         )
+
                     team1.result == GameResult.WIN && team1.team.id == key.second ->
                         Pair(
                             current.first,
-                            current.second + 1
+                            current.second + 1,
                         )
+
                     team1.result == GameResult.LOSS && team1.team.id == key.second ->
                         Pair(
                             current.first + 1,
-                            current.second
+                            current.second,
                         )
+
                     else -> current // DRAW
                 }
 
@@ -299,6 +421,14 @@ class StandingsServiceImpl(
             BigDecimal(h2hWins).divide(BigDecimal(h2hGames), 3, RoundingMode.HALF_UP)
         }
     }
+
+    /**
+     * 타이브레이커 정보
+     */
+    private data class TiebreakerInfo(
+        val applied: Boolean,
+        val reason: String?,
+    )
 
     /**
      * 팀 통계 내부 데이터 클래스

--- a/nextup-infrastructure/src/main/resources/db/migration/V045__add_standings_tiebreaker_order_to_game_rules.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V045__add_standings_tiebreaker_order_to_game_rules.sql
@@ -1,0 +1,2 @@
+-- L-13: GameRules에 순위 동률 타이브레이커 기준 순서 컬럼 추가
+ALTER TABLE competitions ADD COLUMN IF NOT EXISTS standings_tiebreaker_order VARCHAR(255) NOT NULL DEFAULT 'HEAD_TO_HEAD,RUN_DIFFERENTIAL,RUNS_SCORED';

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/standings/StandingsServiceImplTest.kt
@@ -4,6 +4,7 @@ import com.nextup.common.exception.CompetitionNotFoundException
 import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.competition.GameRules
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameResult
 import com.nextup.core.domain.game.GameStatus
@@ -369,6 +370,204 @@ class StandingsServiceImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("타이브레이커")
+    inner class Tiebreaker {
+        @Test
+        fun `승률이 다르면 타이브레이커가 적용되지 않는다`() {
+            // given
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+
+            val teamA1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val teamB1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 3, GameResult.LOSS)
+
+            val allGameTeams = listOf(teamA1, teamB1)
+            val decidedGameTeams = listOf(teamA1, teamB1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when
+            val result = standingsService.getStandings(1L)
+
+            // then
+            assertThat(result.standings[0].tiebreakerApplied).isFalse()
+            assertThat(result.standings[0].tiebreakerReason).isNull()
+            assertThat(result.standings[1].tiebreakerApplied).isFalse()
+            assertThat(result.standings[1].tiebreakerReason).isNull()
+        }
+
+        @Test
+        fun `승률 동률 시 상대전적으로 순위를 구분하면 사유가 표시된다`() {
+            // given: Tigers와 Lions가 각각 1승 1패 (승률 0.500)
+            // Tigers가 Lions에게 2연승 → 상대전적 Tigers 우위
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+            val teamC = createTeam(3L, league, "Bears")
+
+            val game1 = createGame(1L, competition)
+            val game2 = createGame(2L, competition)
+            val game3 = createGame(3L, competition)
+            val game4 = createGame(4L, competition)
+
+            // Tigers: Tigers vs Lions (WIN), Tigers vs Bears (LOSS) → 1승 1패
+            val teamA1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val teamB1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 3, GameResult.LOSS)
+            val teamA2 = createGameTeam(3L, game2, teamA, HomeAway.HOME, 2, GameResult.LOSS)
+            val teamC1 = createGameTeam(4L, game2, teamC, HomeAway.AWAY, 4, GameResult.WIN)
+
+            // Lions: Lions vs Bears (WIN) → 1승 1패
+            val teamB2 = createGameTeam(5L, game3, teamB, HomeAway.HOME, 6, GameResult.WIN)
+            val teamC2 = createGameTeam(6L, game3, teamC, HomeAway.AWAY, 2, GameResult.LOSS)
+
+            // Bears: 1승 2패 (different win pct)
+            val teamC3 = createGameTeam(7L, game4, teamC, HomeAway.HOME, 1, GameResult.LOSS)
+            val teamB3 = createGameTeam(8L, game4, teamB, HomeAway.AWAY, 3, GameResult.WIN)
+
+            val allGameTeams = listOf(teamA1, teamB1, teamA2, teamC1, teamB2, teamC2, teamC3, teamB3)
+            val decidedGameTeams = listOf(teamA1, teamB1, teamA2, teamC1, teamB2, teamC2, teamC3, teamB3)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when
+            val result = standingsService.getStandings(1L)
+
+            // then: Lions는 2승 1패 (승률 0.667), Tigers 1승 1패 (0.500), Bears 1승 2패 (0.333)
+            // Lions와 Tigers는 승률이 다르므로 타이브레이커 적용 안됨
+            val lions = result.standings.find { it.teamName == "Lions" }!!
+            assertThat(lions.wins).isEqualTo(2)
+            assertThat(lions.tiebreakerApplied).isFalse()
+        }
+
+        @Test
+        fun `승률 동률이고 상대전적도 동률이면 득실점차로 구분한다`() {
+            // given: 3팀 라운드 로빈, 모두 1승 1패 (승률 0.500)
+            // 상대전적으로도 구분 불가 → 득실점차로 결정
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+            val teamC = createTeam(3L, league, "Bears")
+
+            val game1 = createGame(1L, competition)
+            val game2 = createGame(2L, competition)
+            val game3 = createGame(3L, competition)
+
+            // Tigers > Lions (5-3), Lions > Bears (6-1), Bears > Tigers (4-2)
+            // 모두 1승 1패, 상대전적 전부 0.500
+            val teamA1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val teamB1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 3, GameResult.LOSS)
+            val teamB2 = createGameTeam(3L, game2, teamB, HomeAway.HOME, 6, GameResult.WIN)
+            val teamC1 = createGameTeam(4L, game2, teamC, HomeAway.AWAY, 1, GameResult.LOSS)
+            val teamC2 = createGameTeam(5L, game3, teamC, HomeAway.HOME, 4, GameResult.WIN)
+            val teamA2 = createGameTeam(6L, game3, teamA, HomeAway.AWAY, 2, GameResult.LOSS)
+
+            // Tigers: 득점 7 (5+2), 실점 7 (3+4), 득실차 0
+            // Lions:  득점 9 (3+6), 실점 6 (5+1), 득실차 +3
+            // Bears:  득점 5 (1+4), 실점 8 (6+2), 득실차 -3
+
+            val allGameTeams = listOf(teamA1, teamB1, teamB2, teamC1, teamC2, teamA2)
+            val decidedGameTeams = listOf(teamA1, teamB1, teamB2, teamC1, teamC2, teamA2)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when
+            val result = standingsService.getStandings(1L)
+
+            // then: Lions(+3) > Tigers(0) > Bears(-3), 득실점차로 결정
+            assertThat(result.standings[0].teamName).isEqualTo("Lions")
+            assertThat(result.standings[1].teamName).isEqualTo("Tigers")
+            assertThat(result.standings[2].teamName).isEqualTo("Bears")
+
+            // 모든 팀에 타이브레이커가 적용되어야 함
+            assertThat(result.standings[0].tiebreakerApplied).isTrue()
+            assertThat(result.standings[0].tiebreakerReason).isEqualTo("득실점차")
+            assertThat(result.standings[1].tiebreakerApplied).isTrue()
+            assertThat(result.standings[2].tiebreakerApplied).isTrue()
+        }
+
+        @Test
+        fun `대회별 커스텀 타이브레이커 순서를 적용할 수 있다`() {
+            // given: 득실점차 우선 타이브레이커 설정
+            val customCompetition =
+                createCompetitionWithGameRules(
+                    id = 2L,
+                    league = league,
+                    name = "커스텀 대회",
+                    year = 2025,
+                    season = 1,
+                    gameRules = GameRules(standingsTiebreakerOrder = "RUN_DIFFERENTIAL,RUNS_SCORED,HEAD_TO_HEAD"),
+                )
+
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, customCompetition)
+            val game2 = createGame(2L, customCompetition)
+
+            // Tigers: 1승 1패, 득점 9 (5+4), 실점 5 (3+2), 득실차 +4
+            // Lions:  1승 1패, 득점 5 (3+2), 실점 9 (5+4), 득실차 -4
+            // 상대전적: Tigers 1승 1패, Lions 1승 1패 (동률)
+            val teamA1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 5, GameResult.WIN)
+            val teamB1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 3, GameResult.LOSS)
+            val teamA2 = createGameTeam(3L, game2, teamA, HomeAway.HOME, 4, GameResult.LOSS)
+            val teamB2 = createGameTeam(4L, game2, teamB, HomeAway.AWAY, 2, GameResult.WIN)
+
+            val allGameTeams = listOf(teamA1, teamB1, teamA2, teamB2)
+            val decidedGameTeams = listOf(teamA1, teamB1, teamA2, teamB2)
+
+            every { competitionRepository.findByIdOrNull(2L) } returns customCompetition
+            every { gameTeamRepository.findAllByCompetitionId(2L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(2L) } returns decidedGameTeams
+
+            // when
+            val result = standingsService.getStandings(2L)
+
+            // then: RUN_DIFFERENTIAL 우선이므로 Tigers(+4) > Lions(-4)
+            assertThat(result.standings[0].teamName).isEqualTo("Tigers")
+            assertThat(result.standings[0].tiebreakerApplied).isTrue()
+            assertThat(result.standings[0].tiebreakerReason).isEqualTo("득실점차")
+            assertThat(result.standings[1].teamName).isEqualTo("Lions")
+            assertThat(result.standings[1].tiebreakerApplied).isTrue()
+        }
+
+        @Test
+        fun `모든 타이브레이커 기준으로도 구분이 안 되면 사유가 null이다`() {
+            // given: 두 팀이 모든 기준에서 완전 동률
+            val teamA = createTeam(1L, league, "Tigers")
+            val teamB = createTeam(2L, league, "Lions")
+
+            val game1 = createGame(1L, competition)
+
+            // 무승부: 3-3, 둘 다 0승 0패 1무, 득실차 0, 득점 3
+            val teamA1 = createGameTeam(1L, game1, teamA, HomeAway.HOME, 3, GameResult.DRAW)
+            val teamB1 = createGameTeam(2L, game1, teamB, HomeAway.AWAY, 3, GameResult.DRAW)
+
+            val allGameTeams = listOf(teamA1, teamB1)
+            val decidedGameTeams = listOf(teamA1, teamB1)
+
+            every { competitionRepository.findByIdOrNull(1L) } returns competition
+            every { gameTeamRepository.findAllByCompetitionId(1L) } returns allGameTeams
+            every { gameTeamRepository.findAllByCompetitionIdWithDecidedResult(1L) } returns decidedGameTeams
+
+            // when
+            val result = standingsService.getStandings(1L)
+
+            // then: 타이브레이커 적용되었지만 구분 기준은 없음
+            assertThat(result.standings).hasSize(2)
+            assertThat(result.standings[0].tiebreakerApplied).isTrue()
+            assertThat(result.standings[0].tiebreakerReason).isNull()
+            assertThat(result.standings[1].tiebreakerApplied).isTrue()
+            assertThat(result.standings[1].tiebreakerReason).isNull()
+        }
+    }
+
     // Helper methods
     private fun createAssociation(
         id: Long,
@@ -423,6 +622,31 @@ class StandingsServiceImplTest {
             endDate = null,
             description = null,
             maxTeams = null,
+        ).apply {
+            val idField = Competition::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+
+    private fun createCompetitionWithGameRules(
+        id: Long,
+        league: League,
+        name: String,
+        year: Int,
+        season: Int,
+        gameRules: GameRules,
+    ): Competition =
+        Competition(
+            league = league,
+            name = name,
+            year = year,
+            season = season,
+            type = CompetitionType.LEAGUE,
+            startDate = LocalDate.of(year, 3, 1),
+            endDate = null,
+            description = null,
+            maxTeams = null,
+            gameRules = gameRules,
         ).apply {
             val idField = Competition::class.java.getDeclaredField("id")
             idField.isAccessible = true


### PR DESCRIPTION
## Summary

>- Close #397

리그 순위표에서 승률 동률 시 상대 전적, 득실점차, 다득점 순으로 타이브레이커를 적용하여 순위를 결정하는 기능을 구현했습니다. 대회별로 타이브레이커 기준 순서를 커스터마이징할 수 있으며, 타이브레이커 적용 사유가 순위표 응답에 포함됩니다.

## Tasks

- [x] `TiebreakerCriterion` enum 추가 (`HEAD_TO_HEAD`, `RUN_DIFFERENTIAL`, `RUNS_SCORED`)
- [x] `GameRules`에 `standingsTiebreakerOrder` 필드 추가 (쉼표 구분 문자열, 대회별 커스터마이징 가능)
- [x] `GameRules.parseTiebreakerOrder()` 헬퍼 메서드 + 유효성 검증 (빈값/중복/유효하지 않은 기준)
- [x] `TeamStandingDto`에 `tiebreakerApplied: Boolean`, `tiebreakerReason: String?` 필드 추가
- [x] `StandingsServiceImpl` 리팩토링: 설정 가능한 타이브레이커 Comparator + 사유 추적 로직
- [x] `TeamStandingResponse`에 타이브레이커 정보 노출 (API 응답)
- [x] Flyway V045 마이그레이션: `standings_tiebreaker_order` 컬럼 추가
- [x] `GameRulesTest`: 타이브레이커 기본값/커스텀/빈값/중복 검증 테스트 7개 추가
- [x] `StandingsServiceImplTest`: 타이브레이커 사유 표시/득실점차 폴스루/커스텀 순서/완전 동률 테스트 5개 추가
- [x] ktlint 통과 확인

## To Reviewer

### 아키텍처 결정

1. **타이브레이커 순서를 문자열로 저장**: `GameRules`는 `@Embeddable` Value Object이므로 `List<TiebreakerCriterion>`을 직접 저장할 수 없습니다. 쉼표 구분 문자열(`"HEAD_TO_HEAD,RUN_DIFFERENTIAL,RUNS_SCORED"`)로 저장하고 `parseTiebreakerOrder()` 메서드로 파싱합니다.

2. **타이브레이커 사유 판별 로직**: 동률 그룹 내에서 어떤 기준이 팀들을 처음으로 구분했는지 찾아 해당 기준의 `displayName`을 반환합니다. 모든 기준으로도 구분이 안 되면 `tiebreakerReason`은 `null`입니다.

3. **기존 정렬 로직과의 호환성**: 기존 `L-13` 상대전적 로직을 유지하면서 `buildTiebreakerComparator`로 리팩토링하여 대회 설정에 따라 동적으로 Comparator를 구성합니다.

4. **시뮬레이션 서비스**: `StandingsSimulationServiceImpl`은 간소화된 정렬을 사용하므로 타이브레이커 사유 추적을 추가하지 않았습니다 (새 필드는 기본값 사용).

### DB 마이그레이션

- V045: `competitions` 테이블에 `standings_tiebreaker_order` 컬럼 추가 (기본값: `HEAD_TO_HEAD,RUN_DIFFERENTIAL,RUNS_SCORED`)
- 기존 데이터는 기본값으로 자동 설정됩니다