### PR TITLE
feat(#403): 이미지 업로드 API 구현

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/controller/image/ImageController.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/controller/image/ImageController.kt
@@ -1,0 +1,106 @@
+package com.nextup.api.controller.image
+
+import com.nextup.api.dto.image.ImageUploadResponse
+import com.nextup.common.dto.ApiResponse
+import com.nextup.common.exception.EmptyImageFileException
+import com.nextup.core.service.image.ImageUploadService
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * 이미지 업로드 API Controller (일반 사용자용)
+ *
+ * - POST /api/v1/images/upload : 범용 이미지 업로드
+ * - PUT /api/v1/teams/{teamId}/logo : 팀 로고 설정
+ * - PUT /api/v1/players/me/profile-image : 선수 프로필 이미지 설정
+ */
+@RestController
+@RequestMapping("/api/v1")
+class ImageController(
+    private val imageUploadService: ImageUploadService,
+) {
+    /**
+     * 범용 이미지를 업로드합니다.
+     *
+     * POST /api/v1/images/upload
+     */
+    @PostMapping("/images/upload", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @PreAuthorize("isAuthenticated()")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun uploadImage(
+        @RequestParam("file") file: MultipartFile,
+        @RequestParam(required = false, defaultValue = "general") directory: String,
+        @AuthenticationPrincipal userId: Long,
+    ): ApiResponse<ImageUploadResponse> {
+        validateMultipartFile(file)
+        val imageUrl =
+            imageUploadService.uploadImage(
+                directory = directory,
+                originalFileName = file.originalFilename ?: "image.png",
+                content = file.bytes,
+                contentType = file.contentType ?: "image/png",
+            )
+        return ApiResponse.success(ImageUploadResponse(imageUrl))
+    }
+
+    /**
+     * 팀 로고를 업로드합니다. 팀 OWNER 또는 MANAGER만 가능합니다.
+     *
+     * PUT /api/v1/teams/{teamId}/logo
+     */
+    @PutMapping("/teams/{teamId}/logo", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @PreAuthorize("@teamSecurity.isOwnerOrManager(#teamId, authentication.principal)")
+    fun uploadTeamLogo(
+        @PathVariable teamId: Long,
+        @RequestParam("file") file: MultipartFile,
+        @AuthenticationPrincipal userId: Long,
+    ): ApiResponse<ImageUploadResponse> {
+        validateMultipartFile(file)
+        val imageUrl =
+            imageUploadService.uploadTeamLogo(
+                teamId = teamId,
+                originalFileName = file.originalFilename ?: "logo.png",
+                content = file.bytes,
+                contentType = file.contentType ?: "image/png",
+            )
+        return ApiResponse.success(ImageUploadResponse(imageUrl))
+    }
+
+    /**
+     * 선수 프로필 이미지를 업로드합니다. 인증된 사용자 본인의 프로필만 변경 가능합니다.
+     *
+     * PUT /api/v1/players/me/profile-image
+     */
+    @PutMapping("/players/me/profile-image", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @PreAuthorize("isAuthenticated()")
+    fun uploadPlayerProfileImage(
+        @RequestParam("file") file: MultipartFile,
+        @AuthenticationPrincipal userId: Long,
+    ): ApiResponse<ImageUploadResponse> {
+        validateMultipartFile(file)
+        val imageUrl =
+            imageUploadService.uploadPlayerProfileImage(
+                userId = userId,
+                originalFileName = file.originalFilename ?: "profile.png",
+                content = file.bytes,
+                contentType = file.contentType ?: "image/png",
+            )
+        return ApiResponse.success(ImageUploadResponse(imageUrl))
+    }
+
+    private fun validateMultipartFile(file: MultipartFile) {
+        if (file.isEmpty) {
+            throw EmptyImageFileException()
+        }
+    }
+}

--- a/nextup-api/src/main/kotlin/com/nextup/api/dto/image/ImageUploadResponse.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/dto/image/ImageUploadResponse.kt
@@ -1,0 +1,8 @@
+package com.nextup.api.dto.image
+
+/**
+ * 이미지 업로드 응답 DTO
+ */
+data class ImageUploadResponse(
+    val imageUrl: String,
+)

--- a/nextup-api/src/main/resources/application.yml
+++ b/nextup-api/src/main/resources/application.yml
@@ -23,6 +23,11 @@ spring:
         default_batch_fetch_size: 100
     open-in-view: false
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 10MB
+
   jackson:
     property-naming-strategy: SNAKE_CASE
     default-property-inclusion: non_null

--- a/nextup-api/src/test/kotlin/com/nextup/api/controller/image/ImageControllerTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/controller/image/ImageControllerTest.kt
@@ -1,0 +1,187 @@
+package com.nextup.api.controller.image
+
+import com.nextup.common.exception.EmptyImageFileException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.common.exception.UnsupportedImageFormatException
+import com.nextup.core.service.image.ImageUploadService
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockMultipartFile
+
+@DisplayName("ImageController")
+class ImageControllerTest {
+    private lateinit var imageUploadService: ImageUploadService
+    private lateinit var controller: ImageController
+
+    @BeforeEach
+    fun setUp() {
+        imageUploadService = mockk()
+        controller = ImageController(imageUploadService)
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/images/upload")
+    inner class UploadImage {
+        @Test
+        @DisplayName("이미지를 성공적으로 업로드한다")
+        fun uploadSuccess() {
+            // given
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "test.png",
+                    "image/png",
+                    ByteArray(1024) { 0xFF.toByte() },
+                )
+            every {
+                imageUploadService.uploadImage(
+                    directory = "general",
+                    originalFileName = "test.png",
+                    content = any(),
+                    contentType = "image/png",
+                )
+            } returns "/images/general/uuid.png"
+
+            // when
+            val response = controller.uploadImage(file, "general", 100L)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.imageUrl).isEqualTo("/images/general/uuid.png")
+        }
+
+        @Test
+        @DisplayName("빈 파일은 EmptyImageFileException을 발생시킨다")
+        fun uploadEmptyFile() {
+            val emptyFile =
+                MockMultipartFile(
+                    "file",
+                    "empty.png",
+                    "image/png",
+                    ByteArray(0),
+                )
+
+            assertThatThrownBy {
+                controller.uploadImage(emptyFile, "general", 100L)
+            }.isInstanceOf(EmptyImageFileException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/teams/{teamId}/logo")
+    inner class UploadTeamLogo {
+        @Test
+        @DisplayName("팀 로고를 성공적으로 업로드한다")
+        fun uploadTeamLogoSuccess() {
+            // given
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "logo.jpg",
+                    "image/jpeg",
+                    ByteArray(1024) { 0xFF.toByte() },
+                )
+            every {
+                imageUploadService.uploadTeamLogo(
+                    teamId = 1L,
+                    originalFileName = "logo.jpg",
+                    content = any(),
+                    contentType = "image/jpeg",
+                )
+            } returns "/images/teams/uuid.jpg"
+
+            // when
+            val response = controller.uploadTeamLogo(1L, file, 100L)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.imageUrl).isEqualTo("/images/teams/uuid.jpg")
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 팀이면 예외가 전파된다")
+        fun teamNotFound() {
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "logo.png",
+                    "image/png",
+                    ByteArray(100) { 0xFF.toByte() },
+                )
+            every {
+                imageUploadService.uploadTeamLogo(
+                    teamId = 999L,
+                    originalFileName = "logo.png",
+                    content = any(),
+                    contentType = "image/png",
+                )
+            } throws TeamNotFoundException(999L)
+
+            assertThatThrownBy {
+                controller.uploadTeamLogo(999L, file, 100L)
+            }.isInstanceOf(TeamNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/players/me/profile-image")
+    inner class UploadPlayerProfileImage {
+        @Test
+        @DisplayName("선수 프로필 이미지를 성공적으로 업로드한다")
+        fun uploadProfileSuccess() {
+            // given
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "profile.webp",
+                    "image/webp",
+                    ByteArray(1024) { 0xFF.toByte() },
+                )
+            every {
+                imageUploadService.uploadPlayerProfileImage(
+                    userId = 100L,
+                    originalFileName = "profile.webp",
+                    content = any(),
+                    contentType = "image/webp",
+                )
+            } returns "/images/players/uuid.webp"
+
+            // when
+            val response = controller.uploadPlayerProfileImage(file, 100L)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.imageUrl).isEqualTo("/images/players/uuid.webp")
+        }
+
+        @Test
+        @DisplayName("서비스에서 예외가 발생하면 전파된다")
+        fun serviceExceptionPropagates() {
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "test.gif",
+                    "image/gif",
+                    ByteArray(100) { 0xFF.toByte() },
+                )
+            every {
+                imageUploadService.uploadPlayerProfileImage(
+                    userId = 100L,
+                    originalFileName = "test.gif",
+                    content = any(),
+                    contentType = "image/gif",
+                )
+            } throws UnsupportedImageFormatException("image/gif")
+
+            assertThatThrownBy {
+                controller.uploadPlayerProfileImage(file, 100L)
+            }.isInstanceOf(UnsupportedImageFormatException::class.java)
+        }
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/image/ImageAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/image/ImageAdminController.kt
@@ -1,0 +1,73 @@
+package com.nextup.backoffice.controller.image
+
+import com.nextup.backoffice.dto.image.ImageUploadAdminResponse
+import com.nextup.common.dto.ApiResponse
+import com.nextup.common.exception.EmptyImageFileException
+import com.nextup.core.service.image.ImageUploadService
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * 이미지 관리 API Controller (관리자용)
+ *
+ * - PUT /api/backoffice/leagues/{leagueId}/logo : 리그 로고 설정
+ * - PUT /api/backoffice/associations/{associationId}/logo : 협회 로고 설정
+ */
+@RestController
+@RequestMapping("/api/backoffice")
+class ImageAdminController(
+    private val imageUploadService: ImageUploadService,
+) {
+    /**
+     * 리그 로고를 업로드합니다.
+     *
+     * PUT /api/backoffice/leagues/{leagueId}/logo
+     */
+    @PutMapping("/leagues/{leagueId}/logo", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun uploadLeagueLogo(
+        @PathVariable leagueId: Long,
+        @RequestParam("file") file: MultipartFile,
+    ): ApiResponse<ImageUploadAdminResponse> {
+        validateMultipartFile(file)
+        val imageUrl =
+            imageUploadService.uploadLeagueLogo(
+                leagueId = leagueId,
+                originalFileName = file.originalFilename ?: "logo.png",
+                content = file.bytes,
+                contentType = file.contentType ?: "image/png",
+            )
+        return ApiResponse.success(ImageUploadAdminResponse(imageUrl))
+    }
+
+    /**
+     * 협회 로고를 업로드합니다.
+     *
+     * PUT /api/backoffice/associations/{associationId}/logo
+     */
+    @PutMapping("/associations/{associationId}/logo", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun uploadAssociationLogo(
+        @PathVariable associationId: Long,
+        @RequestParam("file") file: MultipartFile,
+    ): ApiResponse<ImageUploadAdminResponse> {
+        validateMultipartFile(file)
+        val imageUrl =
+            imageUploadService.uploadAssociationLogo(
+                associationId = associationId,
+                originalFileName = file.originalFilename ?: "logo.png",
+                content = file.bytes,
+                contentType = file.contentType ?: "image/png",
+            )
+        return ApiResponse.success(ImageUploadAdminResponse(imageUrl))
+    }
+
+    private fun validateMultipartFile(file: MultipartFile) {
+        if (file.isEmpty) {
+            throw EmptyImageFileException()
+        }
+    }
+}

--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/image/ImageUploadAdminResponse.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/dto/image/ImageUploadAdminResponse.kt
@@ -1,0 +1,8 @@
+package com.nextup.backoffice.dto.image
+
+/**
+ * 이미지 업로드 관리자 응답 DTO
+ */
+data class ImageUploadAdminResponse(
+    val imageUrl: String,
+)

--- a/nextup-backoffice/src/main/resources/application.yml
+++ b/nextup-backoffice/src/main/resources/application.yml
@@ -26,6 +26,11 @@ spring:
         default_batch_fetch_size: 100
     open-in-view: false
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 10MB
+
   jackson:
     property-naming-strategy: SNAKE_CASE
     default-property-inclusion: non_null

--- a/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/image/ImageAdminControllerTest.kt
+++ b/nextup-backoffice/src/test/kotlin/com/nextup/backoffice/controller/image/ImageAdminControllerTest.kt
@@ -1,0 +1,155 @@
+package com.nextup.backoffice.controller.image
+
+import com.nextup.common.exception.AssociationNotFoundException
+import com.nextup.common.exception.EmptyImageFileException
+import com.nextup.common.exception.LeagueNotFoundException
+import com.nextup.core.service.image.ImageUploadService
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockMultipartFile
+
+@DisplayName("ImageAdminController")
+class ImageAdminControllerTest {
+    private lateinit var imageUploadService: ImageUploadService
+    private lateinit var controller: ImageAdminController
+
+    @BeforeEach
+    fun setUp() {
+        imageUploadService = mockk()
+        controller = ImageAdminController(imageUploadService)
+    }
+
+    @Nested
+    @DisplayName("PUT /api/backoffice/leagues/{leagueId}/logo")
+    inner class UploadLeagueLogo {
+        @Test
+        @DisplayName("리그 로고를 성공적으로 업로드한다")
+        fun uploadLeagueLogoSuccess() {
+            // given
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "logo.png",
+                    "image/png",
+                    ByteArray(1024) { 0xFF.toByte() },
+                )
+            every {
+                imageUploadService.uploadLeagueLogo(
+                    leagueId = 1L,
+                    originalFileName = "logo.png",
+                    content = any(),
+                    contentType = "image/png",
+                )
+            } returns "/images/leagues/uuid.png"
+
+            // when
+            val response = controller.uploadLeagueLogo(1L, file)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.imageUrl).isEqualTo("/images/leagues/uuid.png")
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리그이면 예외가 전파된다")
+        fun leagueNotFound() {
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "logo.png",
+                    "image/png",
+                    ByteArray(100) { 0xFF.toByte() },
+                )
+            every {
+                imageUploadService.uploadLeagueLogo(
+                    leagueId = 999L,
+                    originalFileName = "logo.png",
+                    content = any(),
+                    contentType = "image/png",
+                )
+            } throws LeagueNotFoundException(999L)
+
+            assertThatThrownBy {
+                controller.uploadLeagueLogo(999L, file)
+            }.isInstanceOf(LeagueNotFoundException::class.java)
+        }
+
+        @Test
+        @DisplayName("빈 파일은 EmptyImageFileException을 발생시킨다")
+        fun emptyFile() {
+            val emptyFile =
+                MockMultipartFile(
+                    "file",
+                    "empty.png",
+                    "image/png",
+                    ByteArray(0),
+                )
+
+            assertThatThrownBy {
+                controller.uploadLeagueLogo(1L, emptyFile)
+            }.isInstanceOf(EmptyImageFileException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/backoffice/associations/{associationId}/logo")
+    inner class UploadAssociationLogo {
+        @Test
+        @DisplayName("협회 로고를 성공적으로 업로드한다")
+        fun uploadAssociationLogoSuccess() {
+            // given
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "logo.jpg",
+                    "image/jpeg",
+                    ByteArray(1024) { 0xFF.toByte() },
+                )
+            every {
+                imageUploadService.uploadAssociationLogo(
+                    associationId = 1L,
+                    originalFileName = "logo.jpg",
+                    content = any(),
+                    contentType = "image/jpeg",
+                )
+            } returns "/images/associations/uuid.jpg"
+
+            // when
+            val response = controller.uploadAssociationLogo(1L, file)
+
+            // then
+            assertThat(response.success).isTrue()
+            assertThat(response.data?.imageUrl).isEqualTo("/images/associations/uuid.jpg")
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 협회이면 예외가 전파된다")
+        fun associationNotFound() {
+            val file =
+                MockMultipartFile(
+                    "file",
+                    "logo.png",
+                    "image/png",
+                    ByteArray(100) { 0xFF.toByte() },
+                )
+            every {
+                imageUploadService.uploadAssociationLogo(
+                    associationId = 999L,
+                    originalFileName = "logo.png",
+                    content = any(),
+                    contentType = "image/png",
+                )
+            } throws AssociationNotFoundException(999L)
+
+            assertThatThrownBy {
+                controller.uploadAssociationLogo(999L, file)
+            }.isInstanceOf(AssociationNotFoundException::class.java)
+        }
+    }
+}

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/ImageExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/ImageExceptions.kt
@@ -1,0 +1,41 @@
+package com.nextup.common.exception
+
+/**
+ * 이미지 업로드 시 유효하지 않은 파일 형식일 때 발생하는 예외
+ */
+class UnsupportedImageFormatException(
+    contentType: String?,
+) : InvalidInputException(
+        "UNSUPPORTED_IMAGE_FORMAT",
+        "지원하지 않는 이미지 형식입니다: $contentType (허용: JPEG, PNG, WebP)",
+    )
+
+/**
+ * 이미지 파일 크기가 제한을 초과할 때 발생하는 예외
+ */
+class ImageFileSizeExceededException(
+    fileSize: Long,
+    maxSize: Long,
+) : InvalidInputException(
+        "IMAGE_FILE_SIZE_EXCEEDED",
+        "이미지 파일 크기가 제한을 초과합니다: ${fileSize / 1024}KB (최대: ${maxSize / 1024}KB)",
+    )
+
+/**
+ * 이미지 파일이 비어있을 때 발생하는 예외
+ */
+class EmptyImageFileException :
+    InvalidInputException(
+        "EMPTY_IMAGE_FILE",
+        "이미지 파일이 비어있습니다.",
+    )
+
+/**
+ * 이미지 저장에 실패했을 때 발생하는 예외
+ */
+class ImageStorageException(
+    message: String,
+) : BusinessException(
+        "IMAGE_STORAGE_FAILED",
+        message,
+    )

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/service/ImageStoragePort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/service/ImageStoragePort.kt
@@ -1,0 +1,31 @@
+package com.nextup.core.port.service
+
+/**
+ * 이미지 저장소 포트 인터페이스
+ *
+ * Infrastructure 계층에서 실제 저장소(로컬 파일시스템, S3 등)를 사용하여 구현합니다.
+ */
+interface ImageStoragePort {
+    /**
+     * 이미지를 저장하고 접근 가능한 URL을 반환합니다.
+     *
+     * @param directory 저장 디렉토리 (예: "teams", "players", "leagues", "associations")
+     * @param fileName 저장할 파일명 (확장자 포함)
+     * @param content 파일 바이트 배열
+     * @param contentType MIME 타입 (예: "image/png")
+     * @return 저장된 이미지의 접근 URL
+     */
+    fun store(
+        directory: String,
+        fileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String
+
+    /**
+     * 저장된 이미지를 삭제합니다.
+     *
+     * @param imageUrl 삭제할 이미지 URL
+     */
+    fun delete(imageUrl: String)
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/image/ImageUploadService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/image/ImageUploadService.kt
@@ -1,0 +1,89 @@
+package com.nextup.core.service.image
+
+/**
+ * 이미지 업로드 서비스 인터페이스
+ *
+ * 이미지 업로드, 엔티티 로고/프로필 이미지 설정 등의 유스케이스를 정의합니다.
+ * Infrastructure 계층에서 구현합니다.
+ */
+interface ImageUploadService {
+    /**
+     * 범용 이미지를 업로드합니다.
+     *
+     * @param directory 저장 디렉토리 카테고리
+     * @param originalFileName 원본 파일명
+     * @param content 파일 바이트 배열
+     * @param contentType MIME 타입
+     * @return 저장된 이미지 URL
+     */
+    fun uploadImage(
+        directory: String,
+        originalFileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String
+
+    /**
+     * 팀 로고를 업로드하고 팀에 설정합니다.
+     *
+     * @param teamId 팀 ID
+     * @param originalFileName 원본 파일명
+     * @param content 파일 바이트 배열
+     * @param contentType MIME 타입
+     * @return 저장된 이미지 URL
+     */
+    fun uploadTeamLogo(
+        teamId: Long,
+        originalFileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String
+
+    /**
+     * 선수 프로필 이미지를 업로드하고 설정합니다.
+     *
+     * @param userId 인증된 사용자 ID
+     * @param originalFileName 원본 파일명
+     * @param content 파일 바이트 배열
+     * @param contentType MIME 타입
+     * @return 저장된 이미지 URL
+     */
+    fun uploadPlayerProfileImage(
+        userId: Long,
+        originalFileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String
+
+    /**
+     * 리그 로고를 업로드하고 설정합니다.
+     *
+     * @param leagueId 리그 ID
+     * @param originalFileName 원본 파일명
+     * @param content 파일 바이트 배열
+     * @param contentType MIME 타입
+     * @return 저장된 이미지 URL
+     */
+    fun uploadLeagueLogo(
+        leagueId: Long,
+        originalFileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String
+
+    /**
+     * 협회 로고를 업로드하고 설정합니다.
+     *
+     * @param associationId 협회 ID
+     * @param originalFileName 원본 파일명
+     * @param content 파일 바이트 배열
+     * @param contentType MIME 타입
+     * @return 저장된 이미지 URL
+     */
+    fun uploadAssociationLogo(
+        associationId: Long,
+        originalFileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/ImageUploadConfig.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/ImageUploadConfig.kt
@@ -1,0 +1,13 @@
+package com.nextup.infrastructure.config
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+/**
+ * 이미지 업로드 설정
+ *
+ * ImageUploadProperties를 빈으로 등록합니다.
+ */
+@Configuration
+@EnableConfigurationProperties(ImageUploadProperties::class)
+class ImageUploadConfig

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/ImageUploadProperties.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/ImageUploadProperties.kt
@@ -1,0 +1,25 @@
+package com.nextup.infrastructure.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * 이미지 업로드 설정 프로퍼티
+ *
+ * application.yml에서 `image.upload.*` 프로퍼티를 바인딩합니다.
+ */
+@ConfigurationProperties(prefix = "image.upload")
+data class ImageUploadProperties(
+    /** 최대 파일 크기 (바이트, 기본 5MB) */
+    val maxFileSize: Long = 5 * 1024 * 1024,
+    /** 허용 MIME 타입 목록 */
+    val allowedContentTypes: Set<String> =
+        setOf(
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+        ),
+    /** 로컬 저장 경로 */
+    val storagePath: String = "uploads/images",
+    /** 이미지 서빙 기본 URL */
+    val baseUrl: String = "/images",
+)

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/image/ImageUploadServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/image/ImageUploadServiceImpl.kt
@@ -1,0 +1,185 @@
+package com.nextup.infrastructure.service.image
+
+import com.nextup.common.exception.AssociationNotFoundException
+import com.nextup.common.exception.EmptyImageFileException
+import com.nextup.common.exception.ImageFileSizeExceededException
+import com.nextup.common.exception.LeagueNotFoundException
+import com.nextup.common.exception.PlayerNotLinkedException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.common.exception.UnsupportedImageFormatException
+import com.nextup.common.exception.UserNotFoundException
+import com.nextup.core.port.repository.AssociationRepositoryPort
+import com.nextup.core.port.repository.LeagueRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.port.repository.UserRepositoryPort
+import com.nextup.core.port.service.ImageStoragePort
+import com.nextup.core.service.image.ImageUploadService
+import com.nextup.infrastructure.config.ImageUploadProperties
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+/**
+ * 이미지 업로드 서비스 구현체
+ *
+ * 파일 검증(크기, MIME 타입) 후 저장소에 저장하고,
+ * 엔티티의 logoUrl/profileImageUrl 필드를 업데이트합니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class ImageUploadServiceImpl(
+    private val imageStoragePort: ImageStoragePort,
+    private val properties: ImageUploadProperties,
+    private val teamRepository: TeamRepositoryPort,
+    private val playerRepository: PlayerRepositoryPort,
+    private val userRepository: UserRepositoryPort,
+    private val leagueRepository: LeagueRepositoryPort,
+    private val associationRepository: AssociationRepositoryPort,
+) : ImageUploadService {
+    override fun uploadImage(
+        directory: String,
+        originalFileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String {
+        validateImage(content, contentType)
+        val storedFileName = generateFileName(originalFileName)
+        return imageStoragePort.store(directory, storedFileName, content, contentType)
+    }
+
+    @Transactional
+    override fun uploadTeamLogo(
+        teamId: Long,
+        originalFileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String {
+        validateImage(content, contentType)
+
+        val team =
+            teamRepository.findByIdOrNull(teamId)
+                ?: throw TeamNotFoundException(teamId)
+
+        val oldLogoUrl = team.logoUrl
+        val storedFileName = generateFileName(originalFileName)
+        val imageUrl = imageStoragePort.store("teams", storedFileName, content, contentType)
+
+        team.updateInfo(logoUrl = imageUrl)
+        teamRepository.save(team)
+
+        oldLogoUrl?.let { deleteOldImageSafely(it) }
+
+        return imageUrl
+    }
+
+    @Transactional
+    override fun uploadPlayerProfileImage(
+        userId: Long,
+        originalFileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String {
+        validateImage(content, contentType)
+
+        val user =
+            userRepository.findByIdOrNull(userId)
+                ?: throw UserNotFoundException(userId)
+
+        val player =
+            user.player
+                ?: throw PlayerNotLinkedException(userId)
+
+        val oldImageUrl = player.profileImageUrl
+        val storedFileName = generateFileName(originalFileName)
+        val imageUrl = imageStoragePort.store("players", storedFileName, content, contentType)
+
+        player.updateProfile(imageUrl)
+        playerRepository.save(player)
+
+        oldImageUrl?.let { deleteOldImageSafely(it) }
+
+        return imageUrl
+    }
+
+    @Transactional
+    override fun uploadLeagueLogo(
+        leagueId: Long,
+        originalFileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String {
+        validateImage(content, contentType)
+
+        val league =
+            leagueRepository.findByIdOrNull(leagueId)
+                ?: throw LeagueNotFoundException(leagueId)
+
+        val oldLogoUrl = league.logoUrl
+        val storedFileName = generateFileName(originalFileName)
+        val imageUrl = imageStoragePort.store("leagues", storedFileName, content, contentType)
+
+        league.updateInfo(logoUrl = imageUrl)
+        leagueRepository.save(league)
+
+        oldLogoUrl?.let { deleteOldImageSafely(it) }
+
+        return imageUrl
+    }
+
+    @Transactional
+    override fun uploadAssociationLogo(
+        associationId: Long,
+        originalFileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String {
+        validateImage(content, contentType)
+
+        val association =
+            associationRepository.findByIdOrNull(associationId)
+                ?: throw AssociationNotFoundException(associationId)
+
+        val oldLogoUrl = association.logoUrl
+        val storedFileName = generateFileName(originalFileName)
+        val imageUrl = imageStoragePort.store("associations", storedFileName, content, contentType)
+
+        association.updateInfo(logoUrl = imageUrl)
+        associationRepository.save(association)
+
+        oldLogoUrl?.let { deleteOldImageSafely(it) }
+
+        return imageUrl
+    }
+
+    private fun validateImage(
+        content: ByteArray,
+        contentType: String,
+    ) {
+        if (content.isEmpty()) {
+            throw EmptyImageFileException()
+        }
+        if (content.size.toLong() > properties.maxFileSize) {
+            throw ImageFileSizeExceededException(content.size.toLong(), properties.maxFileSize)
+        }
+        if (contentType !in properties.allowedContentTypes) {
+            throw UnsupportedImageFormatException(contentType)
+        }
+    }
+
+    private fun generateFileName(originalFileName: String): String {
+        val extension =
+            originalFileName.substringAfterLast('.', "png").lowercase()
+        return "${UUID.randomUUID()}.$extension"
+    }
+
+    private fun deleteOldImageSafely(imageUrl: String) {
+        try {
+            imageStoragePort.delete(imageUrl)
+        } catch (e: Exception) {
+            // 기존 이미지 삭제 실패는 무시 (로깅만)
+            org.slf4j.LoggerFactory.getLogger(javaClass)
+                .warn("기존 이미지 삭제 실패 (무시): {}", imageUrl, e)
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/storage/LocalImageStorageAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/storage/LocalImageStorageAdapter.kt
@@ -1,0 +1,66 @@
+package com.nextup.infrastructure.storage
+
+import com.nextup.common.exception.ImageStorageException
+import com.nextup.core.port.service.ImageStoragePort
+import com.nextup.infrastructure.config.ImageUploadProperties
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption
+
+/**
+ * 로컬 파일시스템 기반 이미지 저장소 어댑터
+ *
+ * 개발 환경용 구현체입니다. 운영 환경에서는 S3/MinIO 기반 구현체로 교체합니다.
+ */
+@Component
+class LocalImageStorageAdapter(
+    private val properties: ImageUploadProperties,
+) : ImageStoragePort {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun store(
+        directory: String,
+        fileName: String,
+        content: ByteArray,
+        contentType: String,
+    ): String {
+        try {
+            val dirPath: Path = Paths.get(properties.storagePath, directory)
+            Files.createDirectories(dirPath)
+
+            val filePath = dirPath.resolve(fileName)
+            Files.write(
+                filePath,
+                content,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+            )
+
+            log.info("이미지 저장 완료: {} ({} bytes)", filePath, content.size)
+            return "${properties.baseUrl}/$directory/$fileName"
+        } catch (e: Exception) {
+            log.error("이미지 저장 실패: {}/{}", directory, fileName, e)
+            throw ImageStorageException("이미지 저장에 실패했습니다: ${e.message}")
+        }
+    }
+
+    override fun delete(imageUrl: String) {
+        try {
+            val relativePath = imageUrl.removePrefix(properties.baseUrl).trimStart('/')
+            val filePath = Paths.get(properties.storagePath, relativePath)
+
+            if (Files.exists(filePath)) {
+                Files.delete(filePath)
+                log.info("이미지 삭제 완료: {}", filePath)
+            } else {
+                log.warn("삭제할 이미지 파일이 존재하지 않습니다: {}", filePath)
+            }
+        } catch (e: Exception) {
+            log.error("이미지 삭제 실패: {}", imageUrl, e)
+            throw ImageStorageException("이미지 삭제에 실패했습니다: ${e.message}")
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/image/ImageUploadServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/image/ImageUploadServiceImplTest.kt
@@ -1,0 +1,311 @@
+package com.nextup.infrastructure.service.image
+
+import com.nextup.common.exception.AssociationNotFoundException
+import com.nextup.common.exception.EmptyImageFileException
+import com.nextup.common.exception.ImageFileSizeExceededException
+import com.nextup.common.exception.LeagueNotFoundException
+import com.nextup.common.exception.PlayerNotLinkedException
+import com.nextup.common.exception.TeamNotFoundException
+import com.nextup.common.exception.UnsupportedImageFormatException
+import com.nextup.common.exception.UserNotFoundException
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.team.Team
+import com.nextup.core.domain.user.User
+import com.nextup.core.port.repository.AssociationRepositoryPort
+import com.nextup.core.port.repository.LeagueRepositoryPort
+import com.nextup.core.port.repository.PlayerRepositoryPort
+import com.nextup.core.port.repository.TeamRepositoryPort
+import com.nextup.core.port.repository.UserRepositoryPort
+import com.nextup.core.port.service.ImageStoragePort
+import com.nextup.infrastructure.config.ImageUploadProperties
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("ImageUploadServiceImpl")
+class ImageUploadServiceImplTest {
+    private val imageStoragePort: ImageStoragePort = mockk()
+    private val teamRepository: TeamRepositoryPort = mockk()
+    private val playerRepository: PlayerRepositoryPort = mockk()
+    private val userRepository: UserRepositoryPort = mockk()
+    private val leagueRepository: LeagueRepositoryPort = mockk()
+    private val associationRepository: AssociationRepositoryPort = mockk()
+
+    private val properties =
+        ImageUploadProperties(
+            maxFileSize = 5 * 1024 * 1024,
+            allowedContentTypes = setOf("image/jpeg", "image/png", "image/webp"),
+            storagePath = "uploads/images",
+            baseUrl = "/images",
+        )
+
+    private lateinit var service: ImageUploadServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        service =
+            ImageUploadServiceImpl(
+                imageStoragePort = imageStoragePort,
+                properties = properties,
+                teamRepository = teamRepository,
+                playerRepository = playerRepository,
+                userRepository = userRepository,
+                leagueRepository = leagueRepository,
+                associationRepository = associationRepository,
+            )
+    }
+
+    @Nested
+    @DisplayName("uploadImage")
+    inner class UploadImage {
+        @Test
+        @DisplayName("범용 이미지를 성공적으로 업로드한다")
+        fun uploadImageSuccess() {
+            // given
+            val content = ByteArray(1024) { 0xFF.toByte() }
+            every { imageStoragePort.store("general", any(), content, "image/png") } returns "/images/general/test.png"
+
+            // when
+            val result = service.uploadImage("general", "test.png", content, "image/png")
+
+            // then
+            assertThat(result).isEqualTo("/images/general/test.png")
+            verify { imageStoragePort.store("general", any(), content, "image/png") }
+        }
+
+        @Test
+        @DisplayName("빈 파일은 EmptyImageFileException을 발생시킨다")
+        fun uploadEmptyImage() {
+            assertThatThrownBy {
+                service.uploadImage("general", "test.png", ByteArray(0), "image/png")
+            }.isInstanceOf(EmptyImageFileException::class.java)
+        }
+
+        @Test
+        @DisplayName("파일 크기 초과 시 ImageFileSizeExceededException을 발생시킨다")
+        fun uploadOversizedImage() {
+            val oversized = ByteArray(6 * 1024 * 1024) { 0xFF.toByte() }
+            assertThatThrownBy {
+                service.uploadImage("general", "big.png", oversized, "image/png")
+            }.isInstanceOf(ImageFileSizeExceededException::class.java)
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 MIME 타입은 UnsupportedImageFormatException을 발생시킨다")
+        fun uploadUnsupportedFormat() {
+            val content = ByteArray(100) { 0xFF.toByte() }
+            assertThatThrownBy {
+                service.uploadImage("general", "test.gif", content, "image/gif")
+            }.isInstanceOf(UnsupportedImageFormatException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("uploadTeamLogo")
+    inner class UploadTeamLogo {
+        @Test
+        @DisplayName("팀 로고를 성공적으로 업로드한다")
+        fun uploadTeamLogoSuccess() {
+            // given
+            val content = ByteArray(1024) { 0xFF.toByte() }
+            val team =
+                mockk<Team> {
+                    every { logoUrl } returns null
+                    every { primaryColor } returns null
+                    every { secondaryColor } returns null
+                    every { updateInfo(any(), any(), any()) } returns Unit
+                }
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamRepository.save(team) } returns team
+            every { imageStoragePort.store("teams", any(), content, "image/jpeg") } returns "/images/teams/uuid.jpg"
+
+            // when
+            val result = service.uploadTeamLogo(1L, "logo.jpg", content, "image/jpeg")
+
+            // then
+            assertThat(result).isEqualTo("/images/teams/uuid.jpg")
+            verify { team.updateInfo(any(), any(), any()) }
+            verify { teamRepository.save(team) }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 팀이면 TeamNotFoundException을 발생시킨다")
+        fun uploadTeamLogoNotFound() {
+            val content = ByteArray(100) { 0xFF.toByte() }
+            every { teamRepository.findByIdOrNull(999L) } returns null
+
+            assertThatThrownBy {
+                service.uploadTeamLogo(999L, "logo.png", content, "image/png")
+            }.isInstanceOf(TeamNotFoundException::class.java)
+        }
+
+        @Test
+        @DisplayName("기존 로고가 있으면 삭제 후 새 로고를 설정한다")
+        fun uploadTeamLogoReplacesOld() {
+            // given
+            val content = ByteArray(1024) { 0xFF.toByte() }
+            val team =
+                mockk<Team> {
+                    every { logoUrl } returns "/images/teams/old.png"
+                    every { primaryColor } returns null
+                    every { secondaryColor } returns null
+                    every { updateInfo(any(), any(), any()) } returns Unit
+                }
+            every { teamRepository.findByIdOrNull(1L) } returns team
+            every { teamRepository.save(team) } returns team
+            every { imageStoragePort.store("teams", any(), content, "image/png") } returns "/images/teams/new.png"
+            justRun { imageStoragePort.delete("/images/teams/old.png") }
+
+            // when
+            val result = service.uploadTeamLogo(1L, "logo.png", content, "image/png")
+
+            // then
+            assertThat(result).isEqualTo("/images/teams/new.png")
+            verify { imageStoragePort.delete("/images/teams/old.png") }
+        }
+    }
+
+    @Nested
+    @DisplayName("uploadPlayerProfileImage")
+    inner class UploadPlayerProfileImage {
+        @Test
+        @DisplayName("선수 프로필 이미지를 성공적으로 업로드한다")
+        fun uploadPlayerProfileSuccess() {
+            // given
+            val content = ByteArray(1024) { 0xFF.toByte() }
+            val player =
+                mockk<Player> {
+                    every { profileImageUrl } returns null
+                    every { updateProfile(any()) } returns Unit
+                }
+            val user =
+                mockk<User> {
+                    every { this@mockk.player } returns player
+                }
+            every { userRepository.findByIdOrNull(100L) } returns user
+            every { playerRepository.save(player) } returns player
+            every { imageStoragePort.store("players", any(), content, "image/png") } returns "/images/players/uuid.png"
+
+            // when
+            val result = service.uploadPlayerProfileImage(100L, "profile.png", content, "image/png")
+
+            // then
+            assertThat(result).isEqualTo("/images/players/uuid.png")
+            verify { player.updateProfile("/images/players/uuid.png") }
+        }
+
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 UserNotFoundException을 발생시킨다")
+        fun userNotFound() {
+            val content = ByteArray(100) { 0xFF.toByte() }
+            every { userRepository.findByIdOrNull(999L) } returns null
+
+            assertThatThrownBy {
+                service.uploadPlayerProfileImage(999L, "profile.png", content, "image/png")
+            }.isInstanceOf(UserNotFoundException::class.java)
+        }
+
+        @Test
+        @DisplayName("연결된 선수가 없으면 PlayerNotLinkedException을 발생시킨다")
+        fun playerNotLinked() {
+            val content = ByteArray(100) { 0xFF.toByte() }
+            val user =
+                mockk<User> {
+                    every { player } returns null
+                }
+            every { userRepository.findByIdOrNull(100L) } returns user
+
+            assertThatThrownBy {
+                service.uploadPlayerProfileImage(100L, "profile.png", content, "image/png")
+            }.isInstanceOf(PlayerNotLinkedException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("uploadLeagueLogo")
+    inner class UploadLeagueLogo {
+        @Test
+        @DisplayName("리그 로고를 성공적으로 업로드한다")
+        fun uploadLeagueLogoSuccess() {
+            // given
+            val content = ByteArray(1024) { 0xFF.toByte() }
+            val league =
+                mockk<League> {
+                    every { logoUrl } returns null
+                    every { description } returns null
+                    every { updateInfo(any(), any()) } returns Unit
+                }
+            every { leagueRepository.findByIdOrNull(1L) } returns league
+            every { leagueRepository.save(league) } returns league
+            every { imageStoragePort.store("leagues", any(), content, "image/png") } returns "/images/leagues/uuid.png"
+
+            // when
+            val result = service.uploadLeagueLogo(1L, "logo.png", content, "image/png")
+
+            // then
+            assertThat(result).isEqualTo("/images/leagues/uuid.png")
+            verify { league.updateInfo(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리그이면 LeagueNotFoundException을 발생시킨다")
+        fun leagueNotFound() {
+            val content = ByteArray(100) { 0xFF.toByte() }
+            every { leagueRepository.findByIdOrNull(999L) } returns null
+
+            assertThatThrownBy {
+                service.uploadLeagueLogo(999L, "logo.png", content, "image/png")
+            }.isInstanceOf(LeagueNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("uploadAssociationLogo")
+    inner class UploadAssociationLogo {
+        @Test
+        @DisplayName("협회 로고를 성공적으로 업로드한다")
+        fun uploadAssociationLogoSuccess() {
+            // given
+            val content = ByteArray(1024) { 0xFF.toByte() }
+            val association =
+                mockk<Association> {
+                    every { logoUrl } returns null
+                    every { description } returns null
+                    every { websiteUrl } returns null
+                    every { updateInfo(any(), any(), any()) } returns Unit
+                }
+            every { associationRepository.findByIdOrNull(1L) } returns association
+            every { associationRepository.save(association) } returns association
+            every {
+                imageStoragePort.store("associations", any(), content, "image/png")
+            } returns "/images/associations/uuid.png"
+
+            // when
+            val result = service.uploadAssociationLogo(1L, "logo.png", content, "image/png")
+
+            // then
+            assertThat(result).isEqualTo("/images/associations/uuid.png")
+            verify { association.updateInfo(any(), any(), any()) }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 협회이면 AssociationNotFoundException을 발생시킨다")
+        fun associationNotFound() {
+            val content = ByteArray(100) { 0xFF.toByte() }
+            every { associationRepository.findByIdOrNull(999L) } returns null
+
+            assertThatThrownBy {
+                service.uploadAssociationLogo(999L, "logo.png", content, "image/png")
+            }.isInstanceOf(AssociationNotFoundException::class.java)
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/storage/LocalImageStorageAdapterTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/storage/LocalImageStorageAdapterTest.kt
@@ -1,0 +1,106 @@
+package com.nextup.infrastructure.storage
+
+import com.nextup.infrastructure.config.ImageUploadProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+@DisplayName("LocalImageStorageAdapter")
+class LocalImageStorageAdapterTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var adapter: LocalImageStorageAdapter
+    private lateinit var properties: ImageUploadProperties
+
+    @BeforeEach
+    fun setUp() {
+        properties =
+            ImageUploadProperties(
+                storagePath = tempDir.toString(),
+                baseUrl = "/images",
+            )
+        adapter = LocalImageStorageAdapter(properties)
+    }
+
+    @Nested
+    @DisplayName("store")
+    inner class Store {
+        @Test
+        @DisplayName("이미지를 성공적으로 저장하고 URL을 반환한다")
+        fun storeSuccess() {
+            // given
+            val content = "fake image data".toByteArray()
+
+            // when
+            val url = adapter.store("teams", "test.png", content, "image/png")
+
+            // then
+            assertThat(url).isEqualTo("/images/teams/test.png")
+            val storedFile = tempDir.resolve("teams").resolve("test.png")
+            assertThat(Files.exists(storedFile)).isTrue()
+            assertThat(Files.readAllBytes(storedFile)).isEqualTo(content)
+        }
+
+        @Test
+        @DisplayName("하위 디렉토리를 자동 생성한다")
+        fun createsDirectories() {
+            // given
+            val content = "data".toByteArray()
+
+            // when
+            adapter.store("players", "profile.jpg", content, "image/jpeg")
+
+            // then
+            assertThat(Files.isDirectory(tempDir.resolve("players"))).isTrue()
+        }
+
+        @Test
+        @DisplayName("동일 파일명으로 저장 시 덮어쓴다")
+        fun overwritesExisting() {
+            // given
+            val originalContent = "original".toByteArray()
+            val newContent = "updated".toByteArray()
+
+            // when
+            adapter.store("teams", "logo.png", originalContent, "image/png")
+            adapter.store("teams", "logo.png", newContent, "image/png")
+
+            // then
+            val storedFile = tempDir.resolve("teams").resolve("logo.png")
+            assertThat(Files.readAllBytes(storedFile)).isEqualTo(newContent)
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    inner class Delete {
+        @Test
+        @DisplayName("존재하는 이미지를 삭제한다")
+        fun deleteExisting() {
+            // given
+            val content = "data".toByteArray()
+            adapter.store("teams", "delete-me.png", content, "image/png")
+            val filePath = tempDir.resolve("teams").resolve("delete-me.png")
+            assertThat(Files.exists(filePath)).isTrue()
+
+            // when
+            adapter.delete("/images/teams/delete-me.png")
+
+            // then
+            assertThat(Files.exists(filePath)).isFalse()
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이미지 삭제는 예외를 발생시키지 않는다")
+        fun deleteNonExisting() {
+            // when & then (no exception)
+            adapter.delete("/images/teams/nonexistent.png")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- Close #403

팀 로고, 선수 프로필 사진, 리그/협회 로고를 업로드할 수 있는 이미지 업로드 API를 구현했습니다.
Hexagonal Architecture(Port & Adapter) 패턴에 따라 Core에 인터페이스를 정의하고, Infrastructure에 로컬 파일시스템 기반 구현체를 제공합니다. 운영 환경에서는 S3/MinIO 어댑터로 교체 가능합니다.

## Tasks

- [x] `ImageStoragePort` 포트 인터페이스 정의 (nextup-core)
- [x] `ImageUploadService` 서비스 인터페이스 정의 (nextup-core)
- [x] `ImageUploadProperties` 설정 프로퍼티 (nextup-infrastructure)
- [x] `LocalImageStorageAdapter` 로컬 파일시스템 어댑터 (nextup-infrastructure)
- [x] `ImageUploadServiceImpl` 서비스 구현체 (nextup-infrastructure)
- [x] `ImageController` API 컨트롤러 (nextup-api)
  - `POST /api/v1/images/upload` — 범용 이미지 업로드
  - `PUT /api/v1/teams/{teamId}/logo` — 팀 로고 설정
  - `PUT /api/v1/players/me/profile-image` — 선수 프로필 이미지 설정
- [x] `ImageAdminController` 백오피스 컨트롤러 (nextup-backoffice)
  - `PUT /api/backoffice/leagues/{leagueId}/logo` — 리그 로고 설정
  - `PUT /api/backoffice/associations/{associationId}/logo` — 협회 로고 설정
- [x] 커스텀 예외 클래스 (ImageExceptions.kt)
- [x] Multipart 설정 (application.yml)
- [x] 단위 테스트 (서비스 14건 + 스토리지 5건 + API 컨트롤러 7건 + 백오피스 컨트롤러 5건)
- [x] `./gradlew build` 성공 (컴파일 + 테스트 + ktlint)

## To Reviewer

### 아키텍처 결정사항

1. **Port & Adapter 패턴**: `ImageStoragePort`(Core)를 `LocalImageStorageAdapter`(Infrastructure)가 구현하여, 추후 S3/MinIO로 교체 시 어댑터만 변경하면 됩니다.

2. **파일 검증**: MIME 타입(JPEG/PNG/WebP) + 파일 크기(5MB) 이중 검증을 `ImageUploadServiceImpl`에서 수행합니다.

3. **기존 이미지 교체**: 새 이미지 업로드 시 기존 이미지를 삭제합니다. 삭제 실패는 로깅만 하고 진행합니다(새 이미지 저장이 더 중요).

4. **보안**: 모든 mutating 엔드포인트에 `@PreAuthorize` 적용. 팀 로고는 `@teamSecurity.isOwnerOrManager`, 선수 프로필은 `@AuthenticationPrincipal`에서 userId 도출.

5. **Backoffice 엔드포인트**: 리그/협회 로고는 관리자 전용이므로 backoffice 모듈에 배치. SecurityConfig에서 관리자 인증이 처리됩니다.