### PR TITLE
feat(#404): 기록 정정 요청 워크플로우 인가 보강 + 테스트 커버리지 확대

### DIFF
--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/correction/CorrectionRequestAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/correction/CorrectionRequestAdminController.kt
@@ -6,6 +6,7 @@ import com.nextup.backoffice.dto.correction.RejectCorrectionRequestDto
 import com.nextup.common.dto.ApiResponse
 import com.nextup.core.service.game.correction.CorrectionRequestService
 import jakarta.validation.Valid
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController
  */
 @RestController
 @RequestMapping("/api/backoffice/corrections")
+@PreAuthorize("hasRole('ADMIN')")
 class CorrectionRequestAdminController(
     private val correctionRequestService: CorrectionRequestService,
 ) {

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/game/correction/CorrectionRequestServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/game/correction/CorrectionRequestServiceTest.kt
@@ -1,6 +1,7 @@
 package com.nextup.core.service.game.correction
 
 import com.nextup.common.exception.CorrectionRequestNotFoundException
+import com.nextup.common.exception.InvalidStateException
 import com.nextup.core.domain.game.CorrectionRequest
 import com.nextup.core.domain.game.CorrectionRequestStatus
 import com.nextup.core.domain.game.CorrectionType
@@ -52,6 +53,17 @@ class CorrectionRequestServiceTest {
             fieldName = "strikeOuts",
             newValue = "5",
             reason = "기록 오류",
+        )
+
+    private fun createFieldingRequest(): CorrectionRequest =
+        CorrectionRequest.create(
+            gameId = 1L,
+            requesterUserId = 1L,
+            correctionType = CorrectionType.FIELDING,
+            targetRecordId = 3L,
+            fieldName = "errors",
+            newValue = "1",
+            reason = "수비 기록 오류",
         )
 
     @Nested
@@ -159,6 +171,61 @@ class CorrectionRequestServiceTest {
                 )
             }
         }
+
+        @Test
+        fun `FIELDING 타입 정정 요청을 승인하고 수비 기록을 정정한다`() {
+            // given
+            val requestId = 3L
+            val reviewerUserId = 10L
+            val request = createFieldingRequest()
+            every { correctionRequestRepository.findByIdOrNull(requestId) } returns request
+            every {
+                recordCorrectionService.correctFieldingRecord(any(), any(), any())
+            } returns mockk(relaxed = true)
+
+            // when
+            val result =
+                service.approve(
+                    requestId = requestId,
+                    reviewerUserId = reviewerUserId,
+                    comment = "승인합니다",
+                )
+
+            // then
+            assertThat(result.status).isEqualTo(CorrectionRequestStatus.APPROVED)
+            assertThat(result.reviewerUserId).isEqualTo(reviewerUserId)
+            verify(exactly = 1) {
+                recordCorrectionService.correctFieldingRecord(
+                    gameId = 1L,
+                    recordId = 3L,
+                    request =
+                        FieldingCorrectionRequest(
+                            adminUserId = reviewerUserId,
+                            fieldName = "errors",
+                            newValue = "1",
+                            reason = "수비 기록 오류",
+                        ),
+                )
+            }
+        }
+
+        @Test
+        fun `이미 승인된 요청을 승인하면 InvalidStateException이 발생한다`() {
+            // given
+            val requestId = 1L
+            val request = createBattingRequest()
+            request.approve(reviewerUserId = 99L)
+            every { correctionRequestRepository.findByIdOrNull(requestId) } returns request
+
+            // when & then
+            assertThrows<InvalidStateException> {
+                service.approve(
+                    requestId = requestId,
+                    reviewerUserId = 10L,
+                    comment = "재승인 시도",
+                )
+            }
+        }
     }
 
     @Nested
@@ -184,6 +251,24 @@ class CorrectionRequestServiceTest {
             assertThat(result.status).isEqualTo(CorrectionRequestStatus.REJECTED)
             assertThat(result.reviewerUserId).isEqualTo(reviewerUserId)
             assertThat(result.reviewComment).isEqualTo("근거가 부족합니다")
+        }
+
+        @Test
+        fun `이미 승인된 요청을 반려하면 InvalidStateException이 발생한다`() {
+            // given
+            val requestId = 1L
+            val request = createBattingRequest()
+            request.approve(reviewerUserId = 99L)
+            every { correctionRequestRepository.findByIdOrNull(requestId) } returns request
+
+            // when & then
+            assertThrows<InvalidStateException> {
+                service.reject(
+                    requestId = requestId,
+                    reviewerUserId = 10L,
+                    comment = "반려 시도",
+                )
+            }
         }
     }
 

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/correction/CorrectionRequestScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/correction/CorrectionRequestScorerController.kt
@@ -6,6 +6,7 @@ import com.nextup.scorer.dto.correction.CorrectionRequestResponse
 import com.nextup.scorer.dto.correction.CreateCorrectionRequestDto
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -28,6 +29,7 @@ class CorrectionRequestScorerController(
     /**
      * 기록 정정 요청을 생성합니다.
      */
+    @PreAuthorize("isAuthenticated()")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun createCorrectionRequest(


### PR DESCRIPTION
## Summary

>- Close #404

기록 정정 요청→승인 워크플로우의 보안 인가(Authorization) 규칙 위반을 수정하고 테스트 커버리지를 보강합니다.

기존 구현에서 Scorer POST 엔드포인트와 Backoffice PATCH 엔드포인트에 `@PreAuthorize`가 누락되어 있었으며, CorrectionRequestService의 FIELDING 타입 승인 분기와 비정상 상태 전이 분기에 대한 테스트가 없었습니다.

## Tasks

- [x] Scorer `CorrectionRequestScorerController` POST에 `@PreAuthorize("isAuthenticated()")` 추가
- [x] Backoffice `CorrectionRequestAdminController` 클래스 레벨에 `@PreAuthorize("hasRole('ADMIN')")` 추가
- [x] `CorrectionRequestServiceTest`에 FIELDING 타입 승인 테스트 추가
- [x] `CorrectionRequestServiceTest`에 이미 승인된 요청 재승인 시 `InvalidStateException` 테스트 추가
- [x] `CorrectionRequestServiceTest`에 이미 승인된 요청 반려 시 `InvalidStateException` 테스트 추가

## To Reviewer

- Scorer 모듈의 `@PreAuthorize` 패턴은 기존 `GameScorerController`의 `isAuthenticated()` 방식을 따랐습니다
- Backoffice 모듈의 `@PreAuthorize` 패턴은 기존 `AuditLogAdminController`의 클래스 레벨 `hasRole('ADMIN')` 방식을 따랐습니다
- 메모리 제약으로 인해 전체 빌드 완료가 어려웠으나, 개별 모듈 컴파일 및 core/backoffice/api/infrastructure 테스트 모두 통과 확인했습니다