### PR TITLE
feat(#388): 낫아웃 삼진 시즌 통계 실시간 갱신 누락 수정

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
@@ -266,7 +266,9 @@ class SeasonBattingStats(
             PlateAppearanceResult.WALK -> walks++
             PlateAppearanceResult.INTENTIONAL_WALK -> intentionalWalks++
             PlateAppearanceResult.HIT_BY_PITCH -> hitByPitch++
-            PlateAppearanceResult.STRIKEOUT -> strikeouts++
+            PlateAppearanceResult.STRIKEOUT,
+            PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD,
+            -> strikeouts++
             PlateAppearanceResult.SACRIFICE_BUNT -> sacrificeBunts++
             PlateAppearanceResult.SACRIFICE_FLY -> sacrificeFlies++
             else -> Unit
@@ -299,7 +301,9 @@ class SeasonBattingStats(
             PlateAppearanceResult.WALK -> if (walks > 0) walks--
             PlateAppearanceResult.INTENTIONAL_WALK -> if (intentionalWalks > 0) intentionalWalks--
             PlateAppearanceResult.HIT_BY_PITCH -> if (hitByPitch > 0) hitByPitch--
-            PlateAppearanceResult.STRIKEOUT -> if (strikeouts > 0) strikeouts--
+            PlateAppearanceResult.STRIKEOUT,
+            PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD,
+            -> if (strikeouts > 0) strikeouts--
             PlateAppearanceResult.SACRIFICE_BUNT -> if (sacrificeBunts > 0) sacrificeBunts--
             PlateAppearanceResult.SACRIFICE_FLY -> if (sacrificeFlies > 0) sacrificeFlies--
             else -> Unit

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
@@ -360,7 +360,9 @@ class SeasonPitchingStats(
                 hitsAllowed++
                 homeRunsAllowed++
             }
-            PlateAppearanceResult.STRIKEOUT -> {
+            PlateAppearanceResult.STRIKEOUT,
+            PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD,
+            -> {
                 strikeouts++
             }
             PlateAppearanceResult.WALK,
@@ -396,7 +398,9 @@ class SeasonPitchingStats(
                 if (hitsAllowed > 0) hitsAllowed--
                 if (homeRunsAllowed > 0) homeRunsAllowed--
             }
-            PlateAppearanceResult.STRIKEOUT -> {
+            PlateAppearanceResult.STRIKEOUT,
+            PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD,
+            -> {
                 if (strikeouts > 0) strikeouts--
             }
             PlateAppearanceResult.WALK,

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonBattingStatsLiveUpdateTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonBattingStatsLiveUpdateTest.kt
@@ -141,6 +141,16 @@ class SeasonBattingStatsLiveUpdateTest {
         }
 
         @Test
+        fun `낫아웃 삼진 기록 시 타석, 타수, 삼진 증가 (안타 아님)`() {
+            stats.applyLiveUpdate(PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD)
+
+            assertThat(stats.plateAppearances).isEqualTo(1)
+            assertThat(stats.atBats).isEqualTo(1)
+            assertThat(stats.hits).isZero
+            assertThat(stats.strikeouts).isEqualTo(1)
+        }
+
+        @Test
         fun `여러 타석 결과 누적 시 통계가 올바르게 집계됨`() {
             // 4타수 2안타 (단타, 홈런), 1볼넷, 1삼진
             stats.applyLiveUpdate(PlateAppearanceResult.SINGLE)
@@ -215,6 +225,16 @@ class SeasonBattingStatsLiveUpdateTest {
         fun `삼진 역산 시 타석, 타수, 삼진 감소`() {
             stats.applyLiveUpdate(PlateAppearanceResult.STRIKEOUT)
             stats.revertLiveUpdate(PlateAppearanceResult.STRIKEOUT)
+
+            assertThat(stats.plateAppearances).isZero
+            assertThat(stats.atBats).isZero
+            assertThat(stats.strikeouts).isZero
+        }
+
+        @Test
+        fun `낫아웃 삼진 역산 시 타석, 타수, 삼진 감소`() {
+            stats.applyLiveUpdate(PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD)
+            stats.revertLiveUpdate(PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD)
 
             assertThat(stats.plateAppearances).isZero
             assertThat(stats.atBats).isZero

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonPitchingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonPitchingStatsTest.kt
@@ -686,6 +686,19 @@ class SeasonPitchingStatsTest {
         }
 
         @Test
+        fun `낫아웃 삼진 결과를 반영하면 탈삼진이 증가한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+
+            // when
+            stats.applyLiveUpdate(PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD)
+
+            // then
+            assertThat(stats.battersFaced).isEqualTo(1)
+            assertThat(stats.strikeouts).isEqualTo(1)
+        }
+
+        @Test
         fun `볼넷 결과를 반영하면 볼넷허용이 증가한다`() {
             // given
             val stats = SeasonPitchingStats.create(testPlayer, 2024)
@@ -779,6 +792,19 @@ class SeasonPitchingStatsTest {
 
             // when
             stats.revertLiveUpdate(PlateAppearanceResult.STRIKEOUT)
+
+            // then
+            assertThat(stats.strikeouts).isZero
+        }
+
+        @Test
+        fun `낫아웃 삼진 역산 시 삼진이 감소한다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2024)
+            stats.applyLiveUpdate(PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD)
+
+            // when
+            stats.revertLiveUpdate(PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD)
 
             // then
             assertThat(stats.strikeouts).isZero


### PR DESCRIPTION
## Summary

>- Close #388

SeasonBattingStats와 SeasonPitchingStats의 `applyLiveUpdate`/`revertLiveUpdate` 메서드에서 `STRIKEOUT_DROPPED_THIRD`(낫아웃 삼진)가 삼진으로 카운트되지 않던 버그를 수정합니다.

`PlateAppearanceResult.STRIKEOUT_DROPPED_THIRD` enum 값과 `BattingRecord`/`PitchingRecord`의 처리는 이미 구현되어 있었으나, 시즌 통계 실시간 갱신 메서드에서만 누락되어 있었습니다.

## Tasks

- [x] `SeasonBattingStats.applyLiveUpdate()` — `STRIKEOUT_DROPPED_THIRD` 시 삼진 카운트 추가
- [x] `SeasonBattingStats.revertLiveUpdate()` — `STRIKEOUT_DROPPED_THIRD` 시 삼진 카운트 역산 추가
- [x] `SeasonPitchingStats.applyLiveUpdate()` — `STRIKEOUT_DROPPED_THIRD` 시 탈삼진 카운트 추가
- [x] `SeasonPitchingStats.revertLiveUpdate()` — `STRIKEOUT_DROPPED_THIRD` 시 탈삼진 카운트 역산 추가
- [x] 단위 테스트 4개 추가 (apply/revert x batting/pitching)
- [x] `./gradlew clean build` 성공 (87 tasks, all passed)

## To Reviewer

- 변경 범위는 `nextup-core` 모듈에 한정됩니다 (의존성 규칙 준수).
- `PlateAppearanceResult` enum, `BattingRecord`, `PitchingRecord`는 이미 `STRIKEOUT_DROPPED_THIRD`를 올바르게 처리하고 있었습니다. 이번 수정은 시즌 통계 실시간 갱신 메서드(`applyLiveUpdate`/`revertLiveUpdate`)에서만 누락된 분기를 추가한 것입니다.
- 야구 규칙상 낫아웃 삼진은 삼진 기록이 유지(투수 탈삼진 + 타자 삼진)되면서 타자가 출루하는 특수 케이스이므로, `STRIKEOUT`과 동일한 통계 처리가 정확합니다.

## Screenshot

_(백엔드 작업이므로 해당 없음)_