### PR TITLE
feat(#392): 시즌 통계 아카이브/확정 메커니즘

### DIFF
--- a/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminController.kt
+++ b/nextup-backoffice/src/main/kotlin/com/nextup/backoffice/controller/competition/CompetitionAdminController.kt
@@ -10,6 +10,7 @@ import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.service.competition.CompetitionService
 import com.nextup.core.service.competition.SeasonTransitionService
 import com.nextup.core.service.competition.dto.NextSeasonPreparationResult
+import com.nextup.core.service.competition.dto.SeasonArchiveResult
 import com.nextup.core.service.competition.dto.SeasonSummaryDto
 import com.nextup.core.service.competition.dto.TeamWithdrawalResult
 import jakarta.validation.Valid
@@ -212,6 +213,34 @@ class CompetitionAdminController(
                 description = request.description,
                 maxTeams = request.maxTeams,
             )
+        return ApiResponse.success(result)
+    }
+
+    /**
+     * 완료된 대회의 시즌 통계를 확정(아카이브)합니다.
+     *
+     * 해당 대회 연도의 모든 시즌 통계를 frozen 상태로 전환하여
+     * 기록 정정을 불가능하게 합니다.
+     */
+    @PostMapping("/{id}/archive")
+    fun archiveSeason(
+        @PathVariable id: Long,
+    ): ApiResponse<SeasonArchiveResult> {
+        val result = seasonTransitionService.archiveSeason(id)
+        return ApiResponse.success(result)
+    }
+
+    /**
+     * 시즌 통계 확정(아카이브)을 해제합니다.
+     *
+     * 공식 항의 등 특수한 경우 관리자가 아카이브를 해제하여
+     * 기록 정정이 가능하도록 합니다.
+     */
+    @PostMapping("/{id}/unarchive")
+    fun unarchiveSeason(
+        @PathVariable id: Long,
+    ): ApiResponse<SeasonArchiveResult> {
+        val result = seasonTransitionService.unarchiveSeason(id)
         return ApiResponse.success(result)
     }
 }

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/StatsExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/StatsExceptions.kt
@@ -58,3 +58,10 @@ class PlayerNotFoundException(
 class StatsValidationException(
     message: String,
 ) : InvalidStateException("STATS_VALIDATION_ERROR", message)
+
+/**
+ * 확정(frozen)된 시즌 통계를 수정하려 할 때 발생하는 예외
+ */
+class FrozenStatsException(
+    message: String = "확정된 시즌 통계는 수정할 수 없습니다.",
+) : InvalidStateException("FROZEN_STATS", message)

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonBattingStats.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.domain.stats
 
+import com.nextup.common.exception.FrozenStatsException
 import com.nextup.common.exception.StatsValidationException
 import com.nextup.core.common.BaseTimeEntity
 import com.nextup.core.domain.game.BattingRecord
@@ -220,6 +221,7 @@ class SeasonBattingStats(
      * 경기 타격 기록을 누적합니다.
      */
     fun addGameRecord(record: BattingRecord) {
+        requireNotFinalized()
         gamesPlayed++
         plateAppearances += record.plateAppearances
         atBats += record.atBats
@@ -246,6 +248,7 @@ class SeasonBattingStats(
      * 이벤트 기반으로 호출되며, 경기 종료 전에도 통계가 반영됩니다.
      */
     fun applyLiveUpdate(result: PlateAppearanceResult) {
+        requireNotFinalized()
         plateAppearances++
 
         if (result.isAtBat) {
@@ -279,6 +282,7 @@ class SeasonBattingStats(
      * 이벤트 기반으로 호출되며, applyLiveUpdate의 역연산입니다.
      */
     fun revertLiveUpdate(result: PlateAppearanceResult) {
+        requireNotFinalized()
         if (plateAppearances > 0) plateAppearances--
 
         if (result.isAtBat && atBats > 0) {
@@ -314,6 +318,7 @@ class SeasonBattingStats(
      * 음수 방지를 위해 각 항목은 0 미만으로 내려가지 않습니다.
      */
     fun revertGameRecord(record: BattingRecord) {
+        requireNotFinalized()
         gamesPlayed = maxOf(0, gamesPlayed - 1)
         plateAppearances = maxOf(0, plateAppearances - record.plateAppearances)
         atBats = maxOf(0, atBats - record.atBats)
@@ -342,8 +347,9 @@ class SeasonBattingStats(
      */
     fun applyFieldCorrection(
         fieldName: String,
-        delta: Int
+        delta: Int,
     ) {
+        requireNotFinalized()
         when (fieldName) {
             "plateAppearances" -> plateAppearances = maxOf(0, plateAppearances + delta)
             "atBats" -> atBats = maxOf(0, atBats + delta)
@@ -430,6 +436,15 @@ class SeasonBattingStats(
             mismatches.add("타수: 시즌통계=$atBats, BoxScore합산=$totalAtBats")
         }
         return mismatches
+    }
+
+    /**
+     * 확정된 통계의 수정을 방지하는 가드 메서드.
+     */
+    private fun requireNotFinalized() {
+        if (isFinalized) {
+            throw FrozenStatsException()
+        }
     }
 
     companion object {

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonFieldingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonFieldingStats.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.domain.stats
 
+import com.nextup.common.exception.FrozenStatsException
 import com.nextup.common.exception.StatsValidationException
 import com.nextup.core.common.BaseTimeEntity
 import com.nextup.core.domain.game.FieldingRecord
@@ -82,6 +83,11 @@ class SeasonFieldingStats(
     var passedBalls: Int = 0
         protected set
 
+    /** L-8: 시즌 통계 확정 여부 (확정 후에는 수정 불가) */
+    @Column(name = "is_finalized", nullable = false)
+    var isFinalized: Boolean = false
+        protected set
+
     // Calculated properties
 
     /**
@@ -108,6 +114,7 @@ class SeasonFieldingStats(
      * 경기 수비 기록을 누적합니다.
      */
     fun addGameRecord(record: FieldingRecord) {
+        requireNotFinalized()
         gamesPlayed++
         putOuts += record.putOuts
         assists += record.assists
@@ -120,6 +127,7 @@ class SeasonFieldingStats(
      * 경기 수비 기록을 롤백합니다 (경기 취소 시).
      */
     fun revertGameRecord(record: FieldingRecord) {
+        requireNotFinalized()
         gamesPlayed--
         putOuts -= record.putOuts
         assists -= record.assists
@@ -139,6 +147,7 @@ class SeasonFieldingStats(
         fieldName: String,
         delta: Int,
     ) {
+        requireNotFinalized()
         when (fieldName) {
             "putOuts" -> putOuts = maxOf(0, putOuts + delta)
             "assists" -> assists = maxOf(0, assists + delta)
@@ -171,6 +180,34 @@ class SeasonFieldingStats(
         }
         if (passedBalls < 0) {
             throw StatsValidationException("포일($passedBalls)은 음수일 수 없습니다.")
+        }
+    }
+
+    /**
+     * L-8: 시즌 통계를 확정합니다.
+     *
+     * 확정된 통계는 추가 갱신이 불가합니다.
+     */
+    fun finalize() {
+        require(!isFinalized) { "이미 확정된 시즌 통계입니다." }
+        validate()
+        this.isFinalized = true
+    }
+
+    /**
+     * L-8: 시즌 통계 확정을 해제합니다 (관리자용).
+     */
+    fun unfinalize() {
+        require(isFinalized) { "확정되지 않은 시즌 통계입니다." }
+        this.isFinalized = false
+    }
+
+    /**
+     * 확정된 통계의 수정을 방지하는 가드 메서드.
+     */
+    private fun requireNotFinalized() {
+        if (isFinalized) {
+            throw FrozenStatsException()
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonPitchingStats.kt
@@ -1,5 +1,6 @@
 package com.nextup.core.domain.stats
 
+import com.nextup.common.exception.FrozenStatsException
 import com.nextup.common.exception.StatsValidationException
 import com.nextup.core.common.BaseTimeEntity
 import com.nextup.core.domain.game.PitchingRecord
@@ -264,6 +265,7 @@ class SeasonPitchingStats(
      * 경기 투수 기록을 누적합니다.
      */
     fun addGameRecord(record: PitchingRecord) {
+        requireNotFinalized()
         gamesPlayed++
         if (record.isStartingPitcher) {
             gamesStarted++
@@ -307,6 +309,7 @@ class SeasonPitchingStats(
      * 음수 방지를 위해 각 항목은 0 미만으로 내려가지 않습니다.
      */
     fun revertGameRecord(record: PitchingRecord) {
+        requireNotFinalized()
         gamesPlayed = maxOf(0, gamesPlayed - 1)
         if (record.isStartingPitcher) {
             gamesStarted = maxOf(0, gamesStarted - 1)
@@ -347,6 +350,7 @@ class SeasonPitchingStats(
      * 대면 타자 수, 피안타, 삼진, 볼넷, 사구, 피홈런을 갱신합니다.
      */
     fun applyLiveUpdate(result: PlateAppearanceResult) {
+        requireNotFinalized()
         battersFaced++
 
         when (result) {
@@ -383,6 +387,7 @@ class SeasonPitchingStats(
      * 이벤트 기반으로 호출되며, applyLiveUpdate의 역연산입니다.
      */
     fun revertLiveUpdate(result: PlateAppearanceResult) {
+        requireNotFinalized()
         if (battersFaced > 0) battersFaced--
 
         when (result) {
@@ -440,8 +445,9 @@ class SeasonPitchingStats(
      */
     fun applyFieldCorrection(
         fieldName: String,
-        delta: Int
+        delta: Int,
     ) {
+        requireNotFinalized()
         when (fieldName) {
             "inningsPitchedOuts" -> inningsPitchedOuts = maxOf(0, inningsPitchedOuts + delta)
             "earnedRuns" -> earnedRuns = maxOf(0, earnedRuns + delta)
@@ -476,6 +482,15 @@ class SeasonPitchingStats(
         }
         if (pitchesThrown != null && strikesThrown != null && strikesThrown!! > pitchesThrown!!) {
             throw StatsValidationException("스트라이크 수($strikesThrown)가 총 투구 수($pitchesThrown)보다 클 수 없습니다.")
+        }
+    }
+
+    /**
+     * 확정된 통계의 수정을 방지하는 가드 메서드.
+     */
+    private fun requireNotFinalized() {
+        if (isFinalized) {
+            throw FrozenStatsException()
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/competition/SeasonTransitionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/competition/SeasonTransitionService.kt
@@ -7,7 +7,11 @@ import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import com.nextup.core.service.competition.dto.NextSeasonPreparationResult
+import com.nextup.core.service.competition.dto.SeasonArchiveResult
 import com.nextup.core.service.competition.dto.SeasonSummaryDto
 import com.nextup.core.service.standings.StandingsService
 import org.springframework.stereotype.Service
@@ -26,6 +30,9 @@ class SeasonTransitionService(
     private val competitionPlayerRepository: CompetitionPlayerRepositoryPort,
     private val standingsService: StandingsService,
     private val competitionService: CompetitionService,
+    private val seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort,
+    private val seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort,
+    private val seasonFieldingStatsRepository: SeasonFieldingStatsRepositoryPort,
 ) {
     /**
      * 완료된 대회의 시즌 요약을 조회합니다.
@@ -143,6 +150,101 @@ class SeasonTransitionService(
             registeredTeamCount = registeredTeamIds.size,
             registeredPlayerCount = newRegistrations.size,
             skippedPlayerCount = skippedCount,
+        )
+    }
+
+    /**
+     * L-8: 완료된 대회의 시즌 통계를 확정(아카이브)합니다.
+     *
+     * 해당 대회 연도의 모든 시즌 타격/투수/수비 통계를 frozen 상태로 전환합니다.
+     * 확정된 통계는 기록 정정 시 reject 처리됩니다.
+     */
+    @Transactional
+    fun archiveSeason(competitionId: Long): SeasonArchiveResult {
+        val competition =
+            competitionRepository.findByIdWithLeague(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        if (competition.status != CompetitionStatus.COMPLETED) {
+            throw InvalidCompetitionStateException(
+                "시즌 아카이브는 완료된 대회에서만 가능합니다.",
+            )
+        }
+
+        val year = competition.year
+
+        val battingStats = seasonBattingStatsRepository.findAllByYear(year)
+        val pitchingStats = seasonPitchingStatsRepository.findAllByYear(year)
+        val fieldingStats = seasonFieldingStatsRepository.findAllByYear(year)
+
+        var battingFinalized = 0
+        var pitchingFinalized = 0
+        var fieldingFinalized = 0
+
+        battingStats.filter { !it.isFinalized }.forEach {
+            it.finalize()
+            battingFinalized++
+        }
+        pitchingStats.filter { !it.isFinalized }.forEach {
+            it.finalize()
+            pitchingFinalized++
+        }
+        fieldingStats.filter { !it.isFinalized }.forEach {
+            it.finalize()
+            fieldingFinalized++
+        }
+
+        return SeasonArchiveResult(
+            competitionId = competitionId,
+            competitionName = competition.name,
+            year = year,
+            battingStatsFinalized = battingFinalized,
+            pitchingStatsFinalized = pitchingFinalized,
+            fieldingStatsFinalized = fieldingFinalized,
+        )
+    }
+
+    /**
+     * L-8: 시즌 통계 확정을 해제합니다 (관리자 전용).
+     *
+     * 공식 항의 등 특수한 경우 관리자가 아카이브를 해제하여 정정이 가능하도록 합니다.
+     */
+    @Transactional
+    fun unarchiveSeason(competitionId: Long): SeasonArchiveResult {
+        val competition =
+            competitionRepository.findByIdWithLeague(competitionId)
+                ?: throw CompetitionNotFoundException(competitionId)
+
+        val year = competition.year
+
+        val battingStats = seasonBattingStatsRepository.findAllByYear(year)
+        val pitchingStats = seasonPitchingStatsRepository.findAllByYear(year)
+        val fieldingStats = seasonFieldingStatsRepository.findAllByYear(year)
+
+        var battingUnfinalized = 0
+        var pitchingUnfinalized = 0
+        var fieldingUnfinalized = 0
+
+        battingStats.filter { it.isFinalized }.forEach {
+            it.unfinalize()
+            battingUnfinalized++
+        }
+        pitchingStats.filter { it.isFinalized }.forEach {
+            it.unfinalize()
+            pitchingUnfinalized++
+        }
+        fieldingStats.filter { it.isFinalized }.forEach {
+            it.unfinalize()
+            fieldingUnfinalized++
+        }
+
+        return SeasonArchiveResult(
+            competitionId = competitionId,
+            competitionName = competition.name,
+            year = year,
+            battingStatsFinalized = battingUnfinalized,
+            pitchingStatsFinalized = pitchingUnfinalized,
+            fieldingStatsFinalized = fieldingUnfinalized,
         )
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/competition/dto/SeasonArchiveResult.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/competition/dto/SeasonArchiveResult.kt
@@ -1,0 +1,16 @@
+package com.nextup.core.service.competition.dto
+
+/**
+ * 시즌 통계 아카이브/해제 결과 DTO
+ */
+data class SeasonArchiveResult(
+    val competitionId: Long,
+    val competitionName: String,
+    val year: Int,
+    val battingStatsFinalized: Int,
+    val pitchingStatsFinalized: Int,
+    val fieldingStatsFinalized: Int,
+) {
+    val totalStatsFinalized: Int
+        get() = battingStatsFinalized + pitchingStatsFinalized + fieldingStatsFinalized
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonStatsArchiveTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonStatsArchiveTest.kt
@@ -1,0 +1,240 @@
+package com.nextup.core.domain.stats
+
+import com.nextup.common.exception.FrozenStatsException
+import com.nextup.core.domain.game.FieldingRecord
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.PlateAppearanceResult
+import com.nextup.core.domain.player.BattingHand
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * L-8: 시즌 통계 아카이브/확정 메커니즘 - Frozen Guard 테스트
+ *
+ * 확정된(frozen) 시즌 통계에 대한 수정 시도가 FrozenStatsException을 던지는지 검증합니다.
+ */
+@DisplayName("시즌 통계 아카이브/확정 — Frozen Guard 테스트")
+class SeasonStatsArchiveTest {
+    private val testPlayer =
+        Player(
+            name = "홍길동",
+            primaryPosition = Position.CATCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+            id = 1L,
+        )
+
+    // === SeasonBattingStats Frozen Guard ===
+
+    @Nested
+    @DisplayName("SeasonBattingStats — 확정된 통계 수정 거부")
+    inner class BattingStatsFrozenGuard {
+        @Test
+        fun `확정된 타격 통계에 applyLiveUpdate 시 FrozenStatsException`() {
+            // given
+            val stats = SeasonBattingStats.create(testPlayer, 2026)
+            stats.finalize()
+
+            // when & then
+            assertThatThrownBy { stats.applyLiveUpdate(PlateAppearanceResult.SINGLE) }
+                .isInstanceOf(FrozenStatsException::class.java)
+        }
+
+        @Test
+        fun `확정된 타격 통계에 revertLiveUpdate 시 FrozenStatsException`() {
+            // given
+            val stats = SeasonBattingStats.create(testPlayer, 2026)
+            stats.finalize()
+
+            // when & then
+            assertThatThrownBy { stats.revertLiveUpdate(PlateAppearanceResult.SINGLE) }
+                .isInstanceOf(FrozenStatsException::class.java)
+        }
+
+        @Test
+        fun `확정된 타격 통계에 applyFieldCorrection 시 FrozenStatsException`() {
+            // given
+            val stats = SeasonBattingStats.create(testPlayer, 2026)
+            stats.finalize()
+
+            // when & then
+            assertThatThrownBy { stats.applyFieldCorrection("hits", 1) }
+                .isInstanceOf(FrozenStatsException::class.java)
+        }
+
+        @Test
+        fun `확정 해제 후에는 수정이 가능하다`() {
+            // given
+            val stats = SeasonBattingStats.create(testPlayer, 2026)
+            stats.finalize()
+            stats.unfinalize()
+
+            // when & then (예외 없이 통과)
+            stats.applyLiveUpdate(PlateAppearanceResult.SINGLE)
+            assertThat(stats.hits).isEqualTo(1)
+        }
+    }
+
+    // === SeasonPitchingStats Frozen Guard ===
+
+    @Nested
+    @DisplayName("SeasonPitchingStats — 확정된 통계 수정 거부")
+    inner class PitchingStatsFrozenGuard {
+        @Test
+        fun `확정된 투수 통계에 applyLiveUpdate 시 FrozenStatsException`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2026)
+            stats.finalize()
+
+            // when & then
+            assertThatThrownBy { stats.applyLiveUpdate(PlateAppearanceResult.STRIKEOUT) }
+                .isInstanceOf(FrozenStatsException::class.java)
+        }
+
+        @Test
+        fun `확정된 투수 통계에 revertLiveUpdate 시 FrozenStatsException`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2026)
+            stats.finalize()
+
+            // when & then
+            assertThatThrownBy { stats.revertLiveUpdate(PlateAppearanceResult.STRIKEOUT) }
+                .isInstanceOf(FrozenStatsException::class.java)
+        }
+
+        @Test
+        fun `확정된 투수 통계에 applyFieldCorrection 시 FrozenStatsException`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2026)
+            stats.finalize()
+
+            // when & then
+            assertThatThrownBy { stats.applyFieldCorrection("strikeouts", 1) }
+                .isInstanceOf(FrozenStatsException::class.java)
+        }
+
+        @Test
+        fun `확정 해제 후에는 수정이 가능하다`() {
+            // given
+            val stats = SeasonPitchingStats.create(testPlayer, 2026)
+            stats.finalize()
+            stats.unfinalize()
+
+            // when & then (예외 없이 통과)
+            stats.applyLiveUpdate(PlateAppearanceResult.STRIKEOUT)
+            assertThat(stats.strikeouts).isEqualTo(1)
+        }
+    }
+
+    // === SeasonFieldingStats Finalize/Unfinalize + Frozen Guard ===
+
+    @Nested
+    @DisplayName("SeasonFieldingStats — 확정/해제 및 수정 거부")
+    inner class FieldingStatsFinalizeAndFrozenGuard {
+        @Test
+        fun `수비 통계를 확정할 수 있다`() {
+            // given
+            val stats = SeasonFieldingStats.create(testPlayer, 2026)
+
+            // when
+            stats.finalize()
+
+            // then
+            assertThat(stats.isFinalized).isTrue()
+        }
+
+        @Test
+        fun `이미 확정된 수비 통계를 다시 확정하면 예외가 발생한다`() {
+            // given
+            val stats = SeasonFieldingStats.create(testPlayer, 2026)
+            stats.finalize()
+
+            // when & then
+            assertThatThrownBy { stats.finalize() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이미 확정")
+        }
+
+        @Test
+        fun `확정된 수비 통계를 해제할 수 있다`() {
+            // given
+            val stats = SeasonFieldingStats.create(testPlayer, 2026)
+            stats.finalize()
+
+            // when
+            stats.unfinalize()
+
+            // then
+            assertThat(stats.isFinalized).isFalse()
+        }
+
+        @Test
+        fun `확정되지 않은 수비 통계를 해제하면 예외가 발생한다`() {
+            // given
+            val stats = SeasonFieldingStats.create(testPlayer, 2026)
+
+            // when & then
+            assertThatThrownBy { stats.unfinalize() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("확정되지 않은")
+        }
+
+        @Test
+        fun `확정된 수비 통계에 addGameRecord 시 FrozenStatsException`() {
+            // given
+            val stats = SeasonFieldingStats.create(testPlayer, 2026)
+            stats.finalize()
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val record = FieldingRecord.create(gamePlayer)
+
+            // when & then
+            assertThatThrownBy { stats.addGameRecord(record) }
+                .isInstanceOf(FrozenStatsException::class.java)
+        }
+
+        @Test
+        fun `확정된 수비 통계에 revertGameRecord 시 FrozenStatsException`() {
+            // given
+            val stats = SeasonFieldingStats.create(testPlayer, 2026)
+            stats.finalize()
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val record = FieldingRecord.create(gamePlayer)
+
+            // when & then
+            assertThatThrownBy { stats.revertGameRecord(record) }
+                .isInstanceOf(FrozenStatsException::class.java)
+        }
+
+        @Test
+        fun `확정된 수비 통계에 applyFieldCorrection 시 FrozenStatsException`() {
+            // given
+            val stats = SeasonFieldingStats.create(testPlayer, 2026)
+            stats.finalize()
+
+            // when & then
+            assertThatThrownBy { stats.applyFieldCorrection("putOuts", 1) }
+                .isInstanceOf(FrozenStatsException::class.java)
+        }
+
+        @Test
+        fun `확정 해제 후에는 수정이 가능하다`() {
+            // given
+            val stats = SeasonFieldingStats.create(testPlayer, 2026)
+            stats.finalize()
+            stats.unfinalize()
+            val gamePlayer = mockk<GamePlayer>(relaxed = true)
+            val record = FieldingRecord.create(gamePlayer)
+
+            // when & then (예외 없이 통과)
+            stats.addGameRecord(record)
+            assertThat(stats.gamesPlayed).isEqualTo(1)
+        }
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/competition/SeasonTransitionServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/competition/SeasonTransitionServiceTest.kt
@@ -9,11 +9,19 @@ import com.nextup.core.domain.competition.CompetitionPlayerStatus
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.league.League
+import com.nextup.core.domain.player.BattingHand
 import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.ThrowingHand
+import com.nextup.core.domain.stats.SeasonBattingStats
+import com.nextup.core.domain.stats.SeasonFieldingStats
+import com.nextup.core.domain.stats.SeasonPitchingStats
 import com.nextup.core.domain.team.Team
 import com.nextup.core.port.repository.CompetitionPlayerRepositoryPort
 import com.nextup.core.port.repository.CompetitionRepositoryPort
+import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
+import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import com.nextup.core.service.standings.StandingsService
 import com.nextup.core.service.standings.dto.StandingsDto
 import com.nextup.core.service.standings.dto.TeamStandingDto
@@ -36,6 +44,9 @@ class SeasonTransitionServiceTest {
     private lateinit var competitionPlayerRepository: CompetitionPlayerRepositoryPort
     private lateinit var standingsService: StandingsService
     private lateinit var competitionService: CompetitionService
+    private lateinit var seasonBattingStatsRepository: SeasonBattingStatsRepositoryPort
+    private lateinit var seasonPitchingStatsRepository: SeasonPitchingStatsRepositoryPort
+    private lateinit var seasonFieldingStatsRepository: SeasonFieldingStatsRepositoryPort
     private lateinit var seasonTransitionService: SeasonTransitionService
 
     @BeforeEach
@@ -44,12 +55,18 @@ class SeasonTransitionServiceTest {
         competitionPlayerRepository = mockk()
         standingsService = mockk()
         competitionService = mockk()
+        seasonBattingStatsRepository = mockk()
+        seasonPitchingStatsRepository = mockk()
+        seasonFieldingStatsRepository = mockk()
         seasonTransitionService =
             SeasonTransitionService(
                 competitionRepository,
                 competitionPlayerRepository,
                 standingsService,
                 competitionService,
+                seasonBattingStatsRepository,
+                seasonPitchingStatsRepository,
+                seasonFieldingStatsRepository,
             )
     }
 
@@ -232,7 +249,166 @@ class SeasonTransitionServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("archiveSeason")
+    inner class ArchiveSeason {
+        @Test
+        fun `should finalize all season stats for the competition year`() {
+            // given
+            val competition = createCompletedCompetition(1L)
+            val player1 = createPlayerWithHands(1L, "선수1")
+            val player2 = createPlayerWithHands(2L, "선수2")
+
+            val battingStats =
+                listOf(
+                    SeasonBattingStats.create(player1, 2025),
+                    SeasonBattingStats.create(player2, 2025),
+                )
+            val pitchingStats = listOf(SeasonPitchingStats.create(player1, 2025))
+            val fieldingStats = listOf(SeasonFieldingStats.create(player1, 2025))
+
+            every { competitionRepository.findByIdWithLeague(1L) } returns competition
+            every { seasonBattingStatsRepository.findAllByYear(2025) } returns battingStats
+            every { seasonPitchingStatsRepository.findAllByYear(2025) } returns pitchingStats
+            every { seasonFieldingStatsRepository.findAllByYear(2025) } returns fieldingStats
+
+            // when
+            val result = seasonTransitionService.archiveSeason(1L)
+
+            // then
+            assertThat(result.competitionId).isEqualTo(1L)
+            assertThat(result.year).isEqualTo(2025)
+            assertThat(result.battingStatsFinalized).isEqualTo(2)
+            assertThat(result.pitchingStatsFinalized).isEqualTo(1)
+            assertThat(result.fieldingStatsFinalized).isEqualTo(1)
+            assertThat(result.totalStatsFinalized).isEqualTo(4)
+
+            battingStats.forEach { assertThat(it.isFinalized).isTrue() }
+            pitchingStats.forEach { assertThat(it.isFinalized).isTrue() }
+            fieldingStats.forEach { assertThat(it.isFinalized).isTrue() }
+        }
+
+        @Test
+        fun `should skip already finalized stats`() {
+            // given
+            val competition = createCompletedCompetition(1L)
+            val player = createPlayerWithHands(1L, "선수1")
+
+            val alreadyFinalized = SeasonBattingStats.create(player, 2025).apply { finalize() }
+            val notFinalized = SeasonBattingStats.create(player, 2025, teamId = 2L)
+
+            every { competitionRepository.findByIdWithLeague(1L) } returns competition
+            every { seasonBattingStatsRepository.findAllByYear(2025) } returns listOf(alreadyFinalized, notFinalized)
+            every { seasonPitchingStatsRepository.findAllByYear(2025) } returns emptyList()
+            every { seasonFieldingStatsRepository.findAllByYear(2025) } returns emptyList()
+
+            // when
+            val result = seasonTransitionService.archiveSeason(1L)
+
+            // then
+            assertThat(result.battingStatsFinalized).isEqualTo(1) // 1개만 새로 확정
+        }
+
+        @Test
+        fun `should throw exception when competition is not completed`() {
+            // given
+            val competition = createInProgressCompetition(1L)
+            every { competitionRepository.findByIdWithLeague(1L) } returns competition
+
+            // when & then
+            assertThatThrownBy { seasonTransitionService.archiveSeason(1L) }
+                .isInstanceOf(InvalidCompetitionStateException::class.java)
+        }
+
+        @Test
+        fun `should throw exception when competition not found`() {
+            // given
+            every { competitionRepository.findByIdWithLeague(999L) } returns null
+
+            // when & then
+            assertThatThrownBy { seasonTransitionService.archiveSeason(999L) }
+                .isInstanceOf(CompetitionNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("unarchiveSeason")
+    inner class UnarchiveSeason {
+        @Test
+        fun `should unfinalize all finalized season stats for the competition year`() {
+            // given
+            val competition = createCompletedCompetition(1L)
+            val player = createPlayerWithHands(1L, "선수1")
+
+            val battingStats =
+                listOf(SeasonBattingStats.create(player, 2025).apply { finalize() })
+            val pitchingStats =
+                listOf(SeasonPitchingStats.create(player, 2025).apply { finalize() })
+            val fieldingStats =
+                listOf(SeasonFieldingStats.create(player, 2025).apply { finalize() })
+
+            every { competitionRepository.findByIdWithLeague(1L) } returns competition
+            every { seasonBattingStatsRepository.findAllByYear(2025) } returns battingStats
+            every { seasonPitchingStatsRepository.findAllByYear(2025) } returns pitchingStats
+            every { seasonFieldingStatsRepository.findAllByYear(2025) } returns fieldingStats
+
+            // when
+            val result = seasonTransitionService.unarchiveSeason(1L)
+
+            // then
+            assertThat(result.competitionId).isEqualTo(1L)
+            assertThat(result.battingStatsFinalized).isEqualTo(1)
+            assertThat(result.pitchingStatsFinalized).isEqualTo(1)
+            assertThat(result.fieldingStatsFinalized).isEqualTo(1)
+
+            battingStats.forEach { assertThat(it.isFinalized).isFalse() }
+            pitchingStats.forEach { assertThat(it.isFinalized).isFalse() }
+            fieldingStats.forEach { assertThat(it.isFinalized).isFalse() }
+        }
+
+        @Test
+        fun `should skip stats that are not finalized`() {
+            // given
+            val competition = createCompletedCompetition(1L)
+            val player = createPlayerWithHands(1L, "선수1")
+
+            val notFinalized = SeasonBattingStats.create(player, 2025)
+
+            every { competitionRepository.findByIdWithLeague(1L) } returns competition
+            every { seasonBattingStatsRepository.findAllByYear(2025) } returns listOf(notFinalized)
+            every { seasonPitchingStatsRepository.findAllByYear(2025) } returns emptyList()
+            every { seasonFieldingStatsRepository.findAllByYear(2025) } returns emptyList()
+
+            // when
+            val result = seasonTransitionService.unarchiveSeason(1L)
+
+            // then
+            assertThat(result.battingStatsFinalized).isEqualTo(0)
+        }
+
+        @Test
+        fun `should throw exception when competition not found`() {
+            // given
+            every { competitionRepository.findByIdWithLeague(999L) } returns null
+
+            // when & then
+            assertThatThrownBy { seasonTransitionService.unarchiveSeason(999L) }
+                .isInstanceOf(CompetitionNotFoundException::class.java)
+        }
+    }
+
     // --- Helper methods ---
+
+    private fun createPlayerWithHands(
+        id: Long,
+        name: String,
+    ): Player =
+        Player(
+            name = name,
+            primaryPosition = Position.STARTING_PITCHER,
+            throwingHand = ThrowingHand.RIGHT,
+            battingHand = BattingHand.RIGHT,
+        ).apply { setId(this, id) }
 
     private fun createCompletedCompetition(id: Long): Competition {
         val league = createLeague()

--- a/nextup-infrastructure/src/main/resources/db/migration/V047__add_is_finalized_to_season_fielding_stats.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V047__add_is_finalized_to_season_fielding_stats.sql
@@ -1,0 +1,4 @@
+-- V047: L-8 시즌 통계 아카이브 메커니즘 - season_fielding_stats에 is_finalized 컬럼 추가
+-- season_batting_stats, season_pitching_stats는 V042에서 이미 추가됨
+
+ALTER TABLE season_fielding_stats ADD COLUMN is_finalized BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary

>- Close #392

시즌 종료 후 통계가 수정 가능한 상태로 유지되는 문제를 해결하기 위한 시즌 통계 아카이브/확정 기능을 구현합니다. 3개 시즌 통계 엔티티(타격/투수/수비)에 frozen guard를 적용하여, 확정된 통계에 대한 기록 정정을 원천 차단합니다. 관리자는 backoffice API를 통해 아카이브/해제를 수행할 수 있습니다.

## Tasks

- [x] `FrozenStatsException` 커스텀 예외 추가 (nextup-common)
- [x] `SeasonFieldingStats`에 `isFinalized` / `finalize()` / `unfinalize()` 추가
- [x] 3개 SeasonStats 엔티티에 frozen guard 적용 — 확정된 통계 수정 시 `FrozenStatsException` 발생
  - `addGameRecord()`, `revertGameRecord()`, `applyLiveUpdate()`, `revertLiveUpdate()`, `applyFieldCorrection()`
- [x] `SeasonTransitionService`에 `archiveSeason()` / `unarchiveSeason()` 메서드 추가
- [x] `SeasonArchiveResult` DTO 생성
- [x] `CompetitionAdminController`에 `POST /{id}/archive`, `POST /{id}/unarchive` 엔드포인트 추가
- [x] V047 Flyway 마이그레이션 — `season_fielding_stats`에 `is_finalized` 컬럼 추가
- [x] Frozen guard 단위 테스트 (3개 엔티티 x finalize/unfinalize/guard)
- [x] `SeasonTransitionService` archive/unarchive 단위 테스트
- [x] `./gradlew clean build` 성공

## To Reviewer

- `SeasonBattingStats`와 `SeasonPitchingStats`는 V042에서 이미 `is_finalized` 컬럼이 추가되었고, 엔티티에도 `finalize()`/`unfinalize()` 메서드가 존재했습니다. 이번 PR에서는 **누락된 `SeasonFieldingStats`에 동일 필드를 추가**하고, **3개 엔티티 모두에 frozen guard(수정 차단)를 적용**한 것이 핵심입니다.
- `archiveSeason()`은 대회의 `year`로 해당 연도의 모든 시즌 통계를 일괄 확정합니다. 같은 연도에 여러 대회가 있을 경우 모두 영향을 받으므로, 향후 대회별 분리가 필요하면 별도 이슈로 처리할 수 있습니다.
- backoffice SecurityConfig에서 `.hasRole("ADMIN")`이 전역 적용되므로 개별 `@PreAuthorize`는 생략했습니다.