### PR TITLE
fix(#394): DH 해제 시 타순 인원 검증 로직 추가

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
@@ -2,6 +2,7 @@ package com.nextup.core.domain.game
 
 import com.nextup.common.exception.DuplicatePlayerInLineupException
 import com.nextup.common.exception.InvalidDhRuleException
+import com.nextup.common.exception.InvalidGameStateException
 import com.nextup.common.exception.InvalidLineupBattingOrderCountException
 import com.nextup.common.exception.MercenaryQuotaExceededException
 import com.nextup.common.exception.NoCatcherInLineupException
@@ -126,6 +127,27 @@ object LineupValidator {
 
     /** 타순에 필요한 선수 수 */
     private const val REQUIRED_BATTING_ORDER_COUNT = 9
+
+    /**
+     * DH 해제 후 현재 출전 중인 선수들의 타순 인원을 검증합니다.
+     *
+     * DH 해제 시 DH 선수가 퇴장하고 투수가 타순에 편입되므로,
+     * 활성 타순 인원이 정확히 9명(투수 포함)이어야 합니다.
+     * 투수가 DH의 타순을 이어받으므로 총 타순 인원은 9명으로 유지됩니다.
+     *
+     * @param currentlyPlayingPlayers 현재 출전 중인 선수 목록 (해당 팀의 선수만)
+     * @throws InvalidGameStateException 타순 인원이 올바르지 않은 경우
+     */
+    fun validatePostDhReleaseBattingOrder(currentlyPlayingPlayers: List<GamePlayer>) {
+        val battersInOrder =
+            currentlyPlayingPlayers.filter { it.isCurrentlyPlaying && it.battingOrder != null }
+        if (battersInOrder.size != REQUIRED_BATTING_ORDER_COUNT) {
+            throw InvalidGameStateException(
+                "DH 해제 후 타순 인원이 올바르지 않습니다. " +
+                    "예상: ${REQUIRED_BATTING_ORDER_COUNT}명, 현재: ${battersInOrder.size}명",
+            )
+        }
+    }
 
     /**
      * 참석(ATTENDING) 선수만 라인업에 포함되었는지 검증

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
@@ -2,6 +2,7 @@ package com.nextup.core.domain.game
 
 import com.nextup.common.exception.DuplicatePlayerInLineupException
 import com.nextup.common.exception.InvalidDhRuleException
+import com.nextup.common.exception.InvalidGameStateException
 import com.nextup.common.exception.NoCatcherInLineupException
 import com.nextup.common.exception.NonAttendingPlayerInLineupException
 import com.nextup.common.exception.UnregisteredPlayerInLineupException
@@ -12,6 +13,7 @@ import com.nextup.core.domain.player.Player
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.team.Team
 import com.nextup.core.domain.user.User
+import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -379,6 +381,112 @@ class LineupValidatorTest {
         // when & then
         assertThatCode {
             LineupValidator.validateLeagueRegisteredPlayers(entries, registeredPlayerIds)
+        }.doesNotThrowAnyException()
+    }
+
+    // ========== Post-DH Release Batting Order Validation Tests ==========
+
+    @Test
+    fun `should pass post-DH release validation with 9 batters in order`() {
+        // given: DH 해제 후 투수 포함 9명이 타순에 있는 상태
+        val gameTeam = mockk<GameTeam>(relaxed = true)
+        val players =
+            (1..8).map { order ->
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = createPlayer("야수$order", Position.CATCHER, order.toLong()),
+                    position = Position.CATCHER,
+                    battingOrder = order,
+                )
+            } +
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = createPlayer("투수", Position.STARTING_PITCHER, 9L),
+                    position = Position.STARTING_PITCHER,
+                    battingOrder = 9,
+                )
+
+        // when & then
+        assertThatCode {
+            LineupValidator.validatePostDhReleaseBattingOrder(players)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should fail post-DH release validation with 8 batters in order`() {
+        // given: DH 해제 후 투수가 타순을 할당받지 못해 8명만 타순에 있는 상태
+        val gameTeam = mockk<GameTeam>(relaxed = true)
+        val players =
+            (1..8).map { order ->
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = createPlayer("야수$order", Position.CATCHER, order.toLong()),
+                    position = Position.CATCHER,
+                    battingOrder = order,
+                )
+            } +
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = createPlayer("투수", Position.STARTING_PITCHER, 9L),
+                    position = Position.STARTING_PITCHER,
+                    battingOrder = null, // 투수에게 타순이 할당되지 않음
+                )
+
+        // when & then
+        val exception =
+            assertThrows<InvalidGameStateException> {
+                LineupValidator.validatePostDhReleaseBattingOrder(players)
+            }
+        assert(exception.message?.contains("8명") == true)
+    }
+
+    @Test
+    fun `should fail post-DH release validation with 10 batters in order`() {
+        // given: 잘못된 상태로 10명이 타순에 있는 경우
+        val gameTeam = mockk<GameTeam>(relaxed = true)
+        val players =
+            (1..10).map { order ->
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = createPlayer("선수$order", Position.CATCHER, order.toLong()),
+                    position = Position.CATCHER,
+                    battingOrder = order,
+                )
+            }
+
+        // when & then
+        val exception =
+            assertThrows<InvalidGameStateException> {
+                LineupValidator.validatePostDhReleaseBattingOrder(players)
+            }
+        assert(exception.message?.contains("10명") == true)
+    }
+
+    @Test
+    fun `should only count currently playing players in post-DH release validation`() {
+        // given: 퇴장한 선수는 카운트에서 제외
+        val gameTeam = mockk<GameTeam>(relaxed = true)
+        val activePlayers =
+            (1..9).map { order ->
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = createPlayer("야수$order", Position.CATCHER, order.toLong()),
+                    position = Position.CATCHER,
+                    battingOrder = order,
+                )
+            }
+        val exitedPlayer =
+            GamePlayer.createStarter(
+                gameTeam = gameTeam,
+                player = createPlayer("퇴장선수", Position.LEFT_FIELD, 10L),
+                position = Position.LEFT_FIELD,
+                battingOrder = 5,
+            )
+        exitedPlayer.exitGame(3)
+
+        // when & then: 퇴장한 선수(isCurrentlyPlaying=false)는 제외되므로 9명으로 통과
+        assertThatCode {
+            LineupValidator.validatePostDhReleaseBattingOrder(activePlayers + exitedPlayer)
         }.doesNotThrowAnyException()
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameSubstitutionServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameSubstitutionServiceImpl.kt
@@ -8,6 +8,7 @@ import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.LineupValidator
 import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.player.PositionCategory
@@ -92,9 +93,27 @@ class GameSubstitutionServiceImpl(
 
         val dhReleaseRequired = outgoingPlayer.isDhReleaseRequired(incomingPlayer)
         if (dhReleaseRequired) {
+            val dhBattingOrder = outgoingPlayer.battingOrder
             outgoingPlayer.releaseDH()
             game.gameState.wasDhReleased = true
             gamePlayerRepository.save(outgoingPlayer)
+
+            // DH 해제 시 현재 투수에게 DH의 타순을 할당
+            val currentPitcherId = game.gameState.currentPitcherId
+            if (currentPitcherId != null && dhBattingOrder != null) {
+                val currentPitcher = gamePlayerRepository.findByIdOrNull(currentPitcherId)
+                if (currentPitcher != null &&
+                    currentPitcher.isCurrentlyPlaying &&
+                    currentPitcher.battingOrder == null) {
+                    currentPitcher.changeBattingOrder(dhBattingOrder)
+                    gamePlayerRepository.save(currentPitcher)
+                    log.debug(
+                        "DH 해제 - 투수에게 DH 타순 할당 (pitcherId={}, battingOrder={})",
+                        currentPitcherId,
+                        dhBattingOrder,
+                    )
+                }
+            }
         }
 
         // M-10: 투수 교체 시 이전 투수의 이닝 마감 처리
@@ -128,6 +147,20 @@ class GameSubstitutionServiceImpl(
 
         // M-11: 교체 선수 기록 자동 생성
         createRecordsForSubstitute(incomingPlayer)
+
+        // M-7: DH 해제 후 타순 인원 검증
+        if (dhReleaseRequired) {
+            val teamPlayers =
+                gamePlayerRepository.findCurrentlyPlayingByGameId(gameId)
+                    .filter { it.gameTeam.id == outgoingPlayer.gameTeam.id }
+            LineupValidator.validatePostDhReleaseBattingOrder(teamPlayers)
+            log.debug(
+                "DH 해제 후 타순 인원 검증 통과 (gameId={}, teamId={}, battersInOrder={})",
+                gameId,
+                outgoingPlayer.gameTeam.id,
+                teamPlayers.count { it.battingOrder != null },
+            )
+        }
 
         // C2: 투수 교체 시 currentPitcherId 갱신
         if (request.newPosition.category == PositionCategory.PITCHER) {

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
@@ -315,6 +315,10 @@ class GameScorerServiceSubstitutionTest {
             every { gamePlayerRepository.save(any()) } answers { firstArg() }
             every { gameRepository.save(any()) } answers { firstArg() }
 
+            // DH 해제 후 타순 인원 검증을 위한 mock: 투수(타순4) 포함 9명 반환
+            val teamPlayers = createNinePlayerTeam(dhPlayer.gameTeam, includeReliefPitcherWithOrder = 4)
+            every { gamePlayerRepository.findCurrentlyPlayingByGameId(1L) } returns teamPlayers
+
             val savedEvent = mockk<GameEvent>(relaxed = true)
             every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
             every { gameEventRepository.save(any()) } returns savedEvent
@@ -386,6 +390,10 @@ class GameScorerServiceSubstitutionTest {
             every { gamePlayerRepository.findByIdOrNull(20L) } returns reliefPitcher
             every { gamePlayerRepository.save(any()) } answers { firstArg() }
             every { gameRepository.save(any()) } answers { firstArg() }
+
+            // DH 해제 후 타순 인원 검증을 위한 mock: 투수(타순4) 포함 9명 반환
+            val teamPlayers = createNinePlayerTeam(dhPlayer.gameTeam, includeReliefPitcherWithOrder = 4)
+            every { gamePlayerRepository.findCurrentlyPlayingByGameId(1L) } returns teamPlayers
 
             var capturedEvent: GameEvent? = null
             every { gameEventRepository.save(any()) } answers {
@@ -552,5 +560,45 @@ class GameScorerServiceSubstitutionTest {
             f.set(this, id)
             setAsDesignatedHitter(pitcherOrder = 9)
         }
+    }
+
+    /**
+     * DH 해제 후 타순 인원 검증용 9인 팀 목록 생성.
+     * 투수 포함 9명이 타순에 배치된 상태를 시뮬레이션합니다.
+     */
+    private fun createNinePlayerTeam(
+        gameTeam: com.nextup.core.domain.game.GameTeam,
+        includeReliefPitcherWithOrder: Int,
+    ): List<GamePlayer> {
+        val positions =
+            listOf(
+                Position.CATCHER,
+                Position.FIRST_BASE,
+                Position.SECOND_BASE,
+                Position.THIRD_BASE,
+                Position.SHORTSTOP,
+                Position.LEFT_FIELD,
+                Position.CENTER_FIELD,
+                Position.RIGHT_FIELD,
+            )
+        val fieldPlayers =
+            positions.mapIndexed { index, pos ->
+                val order = if (index + 1 >= includeReliefPitcherWithOrder) index + 2 else index + 1
+                val p = mockk<com.nextup.core.domain.player.Player>(relaxed = true)
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = p,
+                    position = pos,
+                    battingOrder = order,
+                )
+            }
+        val pitcher =
+            GamePlayer.createStarter(
+                gameTeam = gameTeam,
+                player = mockk<com.nextup.core.domain.player.Player>(relaxed = true),
+                position = Position.RELIEF_PITCHER,
+                battingOrder = includeReliefPitcherWithOrder,
+            )
+        return fieldPlayers + pitcher
     }
 }


### PR DESCRIPTION
## Summary

>- Close #394

DH(지명타자) 해제 후 타순 인원 무결성을 보장하기 위한 검증 로직을 추가합니다.

- `LineupValidator`에 `validatePostDhReleaseBattingOrder()` 메서드 추가하여 DH 해제 후 활성 타순 인원이 정확히 9명인지 검증
- `GameSubstitutionServiceImpl`에서 DH 해제 시 현재 투수에게 DH의 타순을 자동 할당하고, 교체 완료 후 타순 인원 검증 호출
- DH 재지정 방지 로직(`wasDhReleased` 플래그)은 기존에 이미 구현되어 있음을 확인

## Tasks

- [x] `LineupValidator`에 DH 해제 후 타순 인원 검증 메서드 추가
- [x] `GameSubstitutionServiceImpl`에서 DH 해제 시 투수 타순 할당 로직 추가
- [x] `GameSubstitutionServiceImpl`에서 DH 해제 후 검증 호출
- [x] DH 재지정 방지 (`wasDhReleased` 플래그) 확인 — 기존 구현 완료
- [x] 단위 테스트 추가 (`LineupValidatorTest`, `GameScorerServiceSubstitutionTest`)
- [x] `./gradlew clean build` 성공 (1244 tests passed)

## To Reviewer

- `wasDhReleased` 플래그와 DH 재지정 방지 로직은 `GameState`, `GameSubstitutionServiceImpl`, `GamePositionChangeServiceImpl`에 이미 구현되어 있었습니다.
- 이 PR의 핵심은 DH 해제 후 **타순 인원 검증**과 **투수 타순 자동 할당**입니다:
  1. DH 해제 시 현재 투수(타순 없음)에게 DH의 기존 타순을 할당
  2. 교체 완료 후 `LineupValidator.validatePostDhReleaseBattingOrder()`로 활성 타순 인원 9명 검증
- `LineupValidator`의 새 메서드는 `GamePlayer` 리스트를 받아 `isCurrentlyPlaying && battingOrder != null` 조건으로 필터링하므로, 퇴장한 선수는 자동 제외됩니다.