### PR TITLE
fix(#430): lockForScorer 비관적 락 전환 + StatsEventListener @Retryable 전환

### DIFF
--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/BusinessException.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/BusinessException.kt
@@ -39,3 +39,11 @@ open class ForbiddenException(
     code: String,
     message: String,
 ) : BusinessException(code, message)
+
+/**
+ * 리소스 충돌(동시성 경쟁)이 발생했을 때 사용하는 예외 (HTTP 409)
+ */
+open class ConflictException(
+    code: String,
+    message: String,
+) : BusinessException(code, message)

--- a/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
+++ b/nextup-common/src/main/kotlin/com/nextup/common/exception/RecordExceptions.kt
@@ -74,12 +74,12 @@ class NoEventToUndoException :
     )
 
 /**
- * 다른 기록원이 이미 경기를 잠금한 상태에서 기록을 시도할 때 발생하는 예외
+ * 다른 기록원이 이미 경기를 잠금한 상태에서 기록을 시도할 때 발생하는 예외 (HTTP 409)
  */
 class GameAlreadyLockedException(
     gameId: Long,
     lockedByScorerId: Long,
-) : InvalidStateException(
+) : ConflictException(
         "GAME_ALREADY_LOCKED",
         "Game $gameId is already locked by scorer $lockedByScorerId",
     )

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
@@ -66,6 +66,13 @@ interface GameRepositoryPort {
     ): List<Int>
 
     /**
+     * 비관적 락(SELECT ... FOR UPDATE)으로 Game을 조회합니다.
+     * 동시 잠금 경쟁을 DB 레벨에서 직렬화하여 OptimisticLockingFailureException 대신
+     * 대기 후 순차 처리합니다.
+     */
+    fun findByIdForUpdate(id: Long): Game?
+
+    /**
      * 기록원이 잠금한 경기 중 lockedAt이 threshold 이전인 경기를 조회합니다.
      * (잠금 만료 자동 해제용)
      */

--- a/nextup-infrastructure/build.gradle.kts
+++ b/nextup-infrastructure/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
     // Spring AOP (for AuditLog aspect)
     implementation("org.springframework.boot:spring-boot-starter-aop")
 
+    // Spring Retry (for @Retryable on event listeners)
+    implementation("org.springframework.retry:spring-retry")
+
     // Rate Limiting
     implementation("com.bucket4j:bucket4j-core:8.10.1")
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/RetryConfig.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/RetryConfig.kt
@@ -1,0 +1,8 @@
+package com.nextup.infrastructure.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.retry.annotation.EnableRetry
+
+@Configuration
+@EnableRetry
+class RetryConfig

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/exception/BaseExceptionHandler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/exception/BaseExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.nextup.infrastructure.exception
 
 import com.nextup.common.dto.ApiResponse
 import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.ConflictException
 import com.nextup.common.exception.NotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -28,6 +29,14 @@ abstract class BaseExceptionHandler {
         log.warn("NotFoundException: code={}, message={}", ex.code, ex.message)
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
+            .body(ApiResponse.error(ex.code, ex.message))
+    }
+
+    @ExceptionHandler(ConflictException::class)
+    fun handleConflictException(ex: ConflictException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn("ConflictException: code={}, message={}", ex.code, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
             .body(ApiResponse.error(ex.code, ex.message))
     }
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
@@ -12,9 +12,11 @@ import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import com.nextup.infrastructure.config.CacheConfig
-import com.nextup.infrastructure.listener.StatsEventListener.Companion.retryOnOptimisticLock
 import org.slf4j.LoggerFactory
 import org.springframework.cache.CacheManager
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -57,13 +59,16 @@ class GameCancelEventListener(
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+        retryFor = [ObjectOptimisticLockingFailureException::class],
+        maxAttempts = 3,
+        backoff = Backoff(delay = 100),
+    )
     fun onGameCancelled(event: GameCancelledEvent) {
         val gameId = event.gameId
         logger.info("경기 취소 스탯 롤백 시작 (gameId={})", gameId)
 
-        retryOnOptimisticLock("onGameCancelled(gameId=$gameId)") {
-            rollbackStats(gameId)
-        }
+        rollbackStats(gameId)
 
         evictStandingsCache(gameId)
     }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
@@ -16,6 +16,9 @@ import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import com.nextup.infrastructure.config.CacheConfig
 import org.slf4j.LoggerFactory
 import org.springframework.cache.CacheManager
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -49,6 +52,11 @@ class RecordCorrectionEventListener(
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+        retryFor = [ObjectOptimisticLockingFailureException::class],
+        maxAttempts = 3,
+        backoff = Backoff(delay = 100),
+    )
     fun onRecordCorrected(event: RecordCorrectedEvent) {
         val delta = parseDeltaSafely(event.newValue, event.oldValue)
         if (delta == 0) {
@@ -71,15 +79,13 @@ class RecordCorrectionEventListener(
             delta,
         )
 
-        StatsEventListener.retryOnOptimisticLock("onRecordCorrected(playerId=${event.playerId})") {
-            when (event.correctionType) {
-                CorrectionType.BATTING ->
-                    applyBattingCorrection(event.gameId, event.playerId, year, event.fieldName, delta)
-                CorrectionType.PITCHING ->
-                    applyPitchingCorrection(event.playerId, year, event.fieldName, delta)
-                CorrectionType.FIELDING ->
-                    applyFieldingCorrection(event.playerId, year, event.fieldName, delta)
-            }
+        when (event.correctionType) {
+            CorrectionType.BATTING ->
+                applyBattingCorrection(event.gameId, event.playerId, year, event.fieldName, delta)
+            CorrectionType.PITCHING ->
+                applyPitchingCorrection(event.playerId, year, event.fieldName, delta)
+            CorrectionType.FIELDING ->
+                applyFieldingCorrection(event.playerId, year, event.fieldName, delta)
         }
 
         logger.info(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StatsEventListener.kt
@@ -25,6 +25,8 @@ import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
 import org.slf4j.LoggerFactory
 import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -39,7 +41,8 @@ import org.springframework.transaction.event.TransactionalEventListener
  * Infrastructure 계층에 위치하여 Core의 Port를 통해 데이터에 접근합니다.
  *
  * Optimistic Locking(@Version) 기반 동시성 제어를 적용하여
- * Lost Update를 방지합니다. 충돌 시 최대 3회 재시도합니다.
+ * Lost Update를 방지합니다. 충돌 시 @Retryable로 메서드 레벨에서
+ * 최대 3회 재시도하며, 각 재시도마다 새 트랜잭션(REQUIRES_NEW)에서 실행됩니다.
  */
 @Component
 class StatsEventListener(
@@ -62,26 +65,29 @@ class StatsEventListener(
      *
      * 해당 선수의 시즌 타격 통계와 투수의 시즌 투수 통계를 실시간으로 갱신합니다.
      * 시즌 통계가 없는 경우 자동으로 생성합니다.
-     * Optimistic Locking 충돌 시 최대 3회 재시도합니다.
+     * Optimistic Locking 충돌 시 @Retryable로 최대 3회 재시도합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+        retryFor = [ObjectOptimisticLockingFailureException::class],
+        maxAttempts = 3,
+        backoff = Backoff(delay = 100),
+    )
     fun onPlateAppearanceRecorded(event: PlateAppearanceRecordedEvent) {
         val year = resolveYear(event.gameId)
 
-        retryOnOptimisticLock("onPlateAppearanceRecorded") {
-            val stats = findOrCreateSeasonBattingStats(event.playerId, year)
+        val stats = findOrCreateSeasonBattingStats(event.playerId, year)
 
-            stats.applyLiveUpdate(event.result)
-            seasonBattingStatsRepository.save(stats)
+        stats.applyLiveUpdate(event.result)
+        seasonBattingStatsRepository.save(stats)
 
-            logger.debug(
-                "실시간 타격 통계 갱신 완료 (playerId={}, year={}, result={})",
-                event.playerId,
-                year,
-                event.result,
-            )
-        }
+        logger.debug(
+            "실시간 타격 통계 갱신 완료 (playerId={}, year={}, result={})",
+            event.playerId,
+            year,
+            event.result,
+        )
 
         // 투수 통계 실시간 갱신
         val pitchingStats =
@@ -129,26 +135,29 @@ class StatsEventListener(
      *
      * 해당 선수의 시즌 타격 통계와 투수의 시즌 투수 통계를 역산합니다.
      * 시즌 통계가 없는 경우 자동으로 생성한 뒤 역산합니다.
-     * Optimistic Locking 충돌 시 최대 3회 재시도합니다.
+     * Optimistic Locking 충돌 시 @Retryable로 최대 3회 재시도합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+        retryFor = [ObjectOptimisticLockingFailureException::class],
+        maxAttempts = 3,
+        backoff = Backoff(delay = 100),
+    )
     fun onPlateAppearanceUndone(event: PlateAppearanceUndoneEvent) {
         val year = resolveYear(event.gameId)
 
-        retryOnOptimisticLock("onPlateAppearanceUndone") {
-            val stats = findOrCreateSeasonBattingStats(event.playerId, year)
+        val stats = findOrCreateSeasonBattingStats(event.playerId, year)
 
-            stats.revertLiveUpdate(event.result)
-            seasonBattingStatsRepository.save(stats)
+        stats.revertLiveUpdate(event.result)
+        seasonBattingStatsRepository.save(stats)
 
-            logger.debug(
-                "실시간 타격 통계 역산 완료 (playerId={}, year={}, result={})",
-                event.playerId,
-                year,
-                event.result,
-            )
-        }
+        logger.debug(
+            "실시간 타격 통계 역산 완료 (playerId={}, year={}, result={})",
+            event.playerId,
+            year,
+            event.result,
+        )
 
         // 투수 통계 역산
         val pitchingStats =
@@ -186,10 +195,15 @@ class StatsEventListener(
      * 1. 투수 스탯: isFirstSeasonRecord 확인 → SeasonPitchingStats 갱신 → CareerPitchingStats 갱신
      * 2. 타자 스탯: isFirstSeasonRecord 확인 → CareerBattingStats 갱신
      *
-     * 각 선수별 갱신에 Optimistic Locking 재시도를 적용합니다.
+     * Optimistic Locking 충돌 시 @Retryable로 최대 3회 재시도합니다.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+        retryFor = [ObjectOptimisticLockingFailureException::class],
+        maxAttempts = 3,
+        backoff = Backoff(delay = 100),
+    )
     fun onGameResultConfirmed(event: GameResultConfirmedEvent) {
         val gameId = event.gameId
         val year = resolveYear(gameId)
@@ -205,35 +219,33 @@ class StatsEventListener(
             val player = pitchingRecord.gamePlayer.player
             val playerId = player.id
 
-            retryOnOptimisticLock("onGameResultConfirmed-pitching(playerId=$playerId)") {
-                val existingSeasonPitching =
-                    seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year)
-                val isFirstPitchingSeason = existingSeasonPitching == null
+            val existingSeasonPitching =
+                seasonPitchingStatsRepository.findByPlayerIdAndYear(playerId, year)
+            val isFirstPitchingSeason = existingSeasonPitching == null
 
-                // SeasonPitchingStats 갱신
-                val seasonPitchingStats =
-                    existingSeasonPitching ?: SeasonPitchingStats.create(player = player, year = year)
-                seasonPitchingStats.addGameRecord(pitchingRecord)
-                seasonPitchingStatsRepository.save(seasonPitchingStats)
+            // SeasonPitchingStats 갱신
+            val seasonPitchingStats =
+                existingSeasonPitching ?: SeasonPitchingStats.create(player = player, year = year)
+            seasonPitchingStats.addGameRecord(pitchingRecord)
+            seasonPitchingStatsRepository.save(seasonPitchingStats)
 
-                // CareerPitchingStats 갱신
-                val careerPitchingStats =
-                    careerPitchingStatsRepository.findByPlayerId(playerId)
-                        ?: CareerPitchingStats.create(player = player)
+            // CareerPitchingStats 갱신
+            val careerPitchingStats =
+                careerPitchingStatsRepository.findByPlayerId(playerId)
+                    ?: CareerPitchingStats.create(player = player)
 
-                if (isFirstPitchingSeason) {
-                    careerPitchingStats.addSeason()
-                }
-                careerPitchingStats.addGameRecord(pitchingRecord)
-                careerPitchingStatsRepository.save(careerPitchingStats)
-
-                logger.debug(
-                    "투수 통계 갱신 완료 (playerId={}, year={}, isFirstSeason={})",
-                    playerId,
-                    year,
-                    isFirstPitchingSeason,
-                )
+            if (isFirstPitchingSeason) {
+                careerPitchingStats.addSeason()
             }
+            careerPitchingStats.addGameRecord(pitchingRecord)
+            careerPitchingStatsRepository.save(careerPitchingStats)
+
+            logger.debug(
+                "투수 통계 갱신 완료 (playerId={}, year={}, isFirstSeason={})",
+                playerId,
+                year,
+                isFirstPitchingSeason,
+            )
         }
 
         // 커리어 타격 스탯 집계: CareerBattingStats
@@ -243,26 +255,24 @@ class StatsEventListener(
             val player = battingRecord.gamePlayer.player
             val playerId = player.id
 
-            retryOnOptimisticLock("onGameResultConfirmed-batting(playerId=$playerId)") {
-                val isFirstBattingSeason =
-                    seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year) == null
+            val isFirstBattingSeason =
+                seasonBattingStatsRepository.findByPlayerIdAndYear(playerId, year) == null
 
-                val careerBattingStats =
-                    careerBattingStatsRepository.findByPlayerId(playerId)
-                        ?: CareerBattingStats.create(player = player)
+            val careerBattingStats =
+                careerBattingStatsRepository.findByPlayerId(playerId)
+                    ?: CareerBattingStats.create(player = player)
 
-                if (isFirstBattingSeason) {
-                    careerBattingStats.addSeason()
-                }
-                careerBattingStats.addGameRecord(battingRecord)
-                careerBattingStatsRepository.save(careerBattingStats)
-
-                logger.debug(
-                    "커리어 타격 통계 갱신 완료 (playerId={}, isFirstSeason={})",
-                    playerId,
-                    isFirstBattingSeason,
-                )
+            if (isFirstBattingSeason) {
+                careerBattingStats.addSeason()
             }
+            careerBattingStats.addGameRecord(battingRecord)
+            careerBattingStatsRepository.save(careerBattingStats)
+
+            logger.debug(
+                "커리어 타격 통계 갱신 완료 (playerId={}, isFirstSeason={})",
+                playerId,
+                isFirstBattingSeason,
+            )
         }
 
         // 수비 스탯 집계: SeasonFieldingStats + CareerFieldingStats
@@ -271,35 +281,33 @@ class StatsEventListener(
             val player = fieldingRecord.gamePlayer.player
             val playerId = player.id
 
-            retryOnOptimisticLock("onGameResultConfirmed-fielding(playerId=$playerId)") {
-                val existingSeasonFielding =
-                    seasonFieldingStatsRepository.findByPlayerIdAndYear(playerId, year)
-                val isFirstFieldingSeason = existingSeasonFielding == null
+            val existingSeasonFielding =
+                seasonFieldingStatsRepository.findByPlayerIdAndYear(playerId, year)
+            val isFirstFieldingSeason = existingSeasonFielding == null
 
-                // SeasonFieldingStats 갱신
-                val seasonFieldingStats =
-                    existingSeasonFielding ?: SeasonFieldingStats.create(player = player, year = year)
-                seasonFieldingStats.addGameRecord(fieldingRecord)
-                seasonFieldingStatsRepository.save(seasonFieldingStats)
+            // SeasonFieldingStats 갱신
+            val seasonFieldingStats =
+                existingSeasonFielding ?: SeasonFieldingStats.create(player = player, year = year)
+            seasonFieldingStats.addGameRecord(fieldingRecord)
+            seasonFieldingStatsRepository.save(seasonFieldingStats)
 
-                // CareerFieldingStats 갱신
-                val careerFieldingStats =
-                    careerFieldingStatsRepository.findByPlayerId(playerId)
-                        ?: CareerFieldingStats.create(player = player)
+            // CareerFieldingStats 갱신
+            val careerFieldingStats =
+                careerFieldingStatsRepository.findByPlayerId(playerId)
+                    ?: CareerFieldingStats.create(player = player)
 
-                if (isFirstFieldingSeason) {
-                    careerFieldingStats.addSeason()
-                }
-                careerFieldingStats.addGameRecord(fieldingRecord)
-                careerFieldingStatsRepository.save(careerFieldingStats)
-
-                logger.debug(
-                    "수비 통계 갱신 완료 (playerId={}, year={}, isFirstSeason={})",
-                    playerId,
-                    year,
-                    isFirstFieldingSeason,
-                )
+            if (isFirstFieldingSeason) {
+                careerFieldingStats.addSeason()
             }
+            careerFieldingStats.addGameRecord(fieldingRecord)
+            careerFieldingStatsRepository.save(careerFieldingStats)
+
+            logger.debug(
+                "수비 통계 갱신 완료 (playerId={}, year={}, isFirstSeason={})",
+                playerId,
+                year,
+                isFirstFieldingSeason,
+            )
         }
 
         logger.info(
@@ -341,43 +349,5 @@ class StatsEventListener(
             gameRepository.findByIdOrNull(gameId)
                 ?: throw GameNotFoundException(gameId)
         return game.scheduledAt.year
-    }
-
-    companion object {
-        private const val MAX_RETRIES = 3
-        private val log = LoggerFactory.getLogger(StatsEventListener::class.java)
-
-        /**
-         * Optimistic Locking 충돌 시 재시도하는 헬퍼 메서드.
-         *
-         * @param operationName 로깅용 작업명
-         * @param action 재시도할 작업
-         */
-        internal fun retryOnOptimisticLock(
-            operationName: String,
-            action: () -> Unit,
-        ) {
-            var lastException: ObjectOptimisticLockingFailureException? = null
-            for (attempt in 1..MAX_RETRIES) {
-                try {
-                    action()
-                    return
-                } catch (ex: ObjectOptimisticLockingFailureException) {
-                    lastException = ex
-                    log.warn(
-                        "Optimistic Locking 충돌 발생 - 재시도 {}/{} (operation={})",
-                        attempt,
-                        MAX_RETRIES,
-                        operationName,
-                    )
-                }
-            }
-            log.error(
-                "Optimistic Locking 재시도 초과 (operation={}, maxRetries={})",
-                operationName,
-                MAX_RETRIES,
-            )
-            throw lastException!!
-        }
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
@@ -5,9 +5,11 @@ import com.nextup.core.common.PageResult
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameStatus
 import com.nextup.core.port.repository.GameRepositoryPort
+import jakarta.persistence.LockModeType
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
@@ -18,6 +20,14 @@ interface GameRepository :
     JpaRepository<Game, Long>,
     GameRepositoryPort {
     override fun findByIdOrNull(id: Long): Game? = findById(id).orElse(null)
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT g FROM Game g WHERE g.id = :id")
+    fun findByIdWithPessimisticLock(
+        @Param("id") id: Long,
+    ): Game?
+
+    override fun findByIdForUpdate(id: Long): Game? = findByIdWithPessimisticLock(id)
 
     @Query("SELECT g FROM Game g WHERE g.id IN :ids")
     override fun findAllByIds(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImpl.kt
@@ -389,7 +389,9 @@ class GameLifecycleServiceImpl(
         gameId: Long,
         scorerId: Long,
     ): Game {
-        val game = findGame(gameId)
+        val game =
+            gameRepository.findByIdForUpdate(gameId)
+                ?: throw GameNotFoundException(gameId)
         game.lockForScorer(scorerId)
         return gameRepository.save(game)
     }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/exception/BaseExceptionHandlerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/exception/BaseExceptionHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.nextup.infrastructure.exception
 
+import com.nextup.common.exception.ConflictException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -19,6 +20,20 @@ class BaseExceptionHandlerTest {
     @BeforeEach
     fun setUp() {
         handler = TestExceptionHandler()
+    }
+
+    @Test
+    fun `should handle ConflictException and return 409`() {
+        // given
+        val exception = ConflictException("GAME_ALREADY_LOCKED", "Game 1 is already locked by scorer 2")
+
+        // when
+        val response = handler.handleConflictException(exception)
+
+        // then
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
+        assertThat(response.body?.success).isFalse()
+        assertThat(response.body?.error?.code).isEqualTo("GAME_ALREADY_LOCKED")
     }
 
     @Test

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
@@ -701,42 +701,12 @@ class RecordCorrectionEventListenerTest {
     }
 
     @Nested
-    @DisplayName("Optimistic Locking 재시도")
-    inner class OptimisticLockingRetry {
+    @DisplayName("@Retryable - Optimistic Locking 재시도 설정 검증")
+    inner class RetryableConfiguration {
         @Test
-        fun `기록 정정 시 OptimisticLocking 충돌이 발생하면 재시도하여 성공`() {
-            // given
-            val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
-            seasonStats.applyFieldCorrection("plateAppearances", 15)
-            seasonStats.applyFieldCorrection("atBats", 12)
-            seasonStats.applyFieldCorrection("hits", 10)
-
-            every { seasonBattingStatsRepository.findByPlayerIdAndYear(1L, 2024) } returns seasonStats
-            // 첫 번째 save 시 충돌, 두 번째에 성공
-            every { seasonBattingStatsRepository.save(any()) } throws
-                ObjectOptimisticLockingFailureException("conflict", null) andThen seasonStats
-            every { careerBattingStatsRepository.findByPlayerId(1L) } returns null
-
-            val event =
-                RecordCorrectedEvent(
-                    gameId = 10L,
-                    correctionType = CorrectionType.BATTING,
-                    playerId = 1L,
-                    fieldName = "hits",
-                    oldValue = "2",
-                    newValue = "3",
-                )
-
-            // when
-            listener.onRecordCorrected(event)
-
-            // then: 2번 호출됨 (1번 실패 + 1번 성공)
-            verify(exactly = 2) { seasonBattingStatsRepository.save(any()) }
-        }
-
-        @Test
-        fun `재시도 횟수 초과 시 예외가 전파됨`() {
-            // given
+        fun `OptimisticLockingFailureException 발생 시 직접 호출에서는 예외 전파됨`() {
+            // NOTE: @Retryable은 Spring AOP 프록시를 통해서만 동작합니다.
+            // 직접 호출 시에는 재시도 없이 예외가 그대로 전파됩니다.
             val seasonStats = SeasonBattingStats.create(testPlayer, 2024)
             seasonStats.applyFieldCorrection("walks", 10)
 
@@ -755,7 +725,7 @@ class RecordCorrectionEventListenerTest {
                     newValue = "3",
                 )
 
-            // when & then
+            // when & then: 직접 호출이므로 @Retryable 없이 예외 전파
             assertThrows<ObjectOptimisticLockingFailureException> {
                 listener.onRecordCorrected(event)
             }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StatsEventListenerTest.kt
@@ -1006,76 +1006,19 @@ class StatsEventListenerTest {
     }
 
     @Nested
-    @DisplayName("retryOnOptimisticLock - Optimistic Locking 재시도")
-    inner class RetryOnOptimisticLock {
+    @DisplayName("@Retryable - Optimistic Locking 재시도 설정 검증")
+    inner class RetryableConfiguration {
         @Test
-        fun `OptimisticLockingFailureException 발생 시 재시도 후 성공`() {
-            // given
-            var callCount = 0
-
-            // when
-            StatsEventListener.retryOnOptimisticLock("test") {
-                callCount++
-                if (callCount < 3) {
-                    throw ObjectOptimisticLockingFailureException("test", null)
-                }
-            }
-
-            // then: 3번째에 성공
-            assertThat(callCount).isEqualTo(3)
-        }
-
-        @Test
-        fun `재시도 횟수 초과 시 예외 전파`() {
-            // given & when & then
-            assertThrows<ObjectOptimisticLockingFailureException> {
-                StatsEventListener.retryOnOptimisticLock("test") {
-                    throw ObjectOptimisticLockingFailureException("test", null)
-                }
-            }
-        }
-
-        @Test
-        fun `첫 시도에 성공하면 한 번만 호출됨`() {
-            // given
-            var callCount = 0
-
-            // when
-            StatsEventListener.retryOnOptimisticLock("test") {
-                callCount++
-            }
-
-            // then
-            assertThat(callCount).isEqualTo(1)
-        }
-
-        @Test
-        fun `OptimisticLockingFailureException이 아닌 예외는 즉시 전파`() {
-            // given
-            var callCount = 0
-
-            // when & then
-            assertThrows<IllegalStateException> {
-                StatsEventListener.retryOnOptimisticLock("test") {
-                    callCount++
-                    throw IllegalStateException("다른 예외")
-                }
-            }
-
-            // then: 재시도 없이 1회만 호출
-            assertThat(callCount).isEqualTo(1)
-        }
-
-        @Test
-        fun `타석 기록 이벤트에서 OptimisticLocking 충돌 시 재시도하여 성공`() {
-            // given
+        fun `OptimisticLockingFailureException 발생 시 직접 호출에서는 예외 전파됨`() {
+            // NOTE: @Retryable은 Spring AOP 프록시를 통해서만 동작합니다.
+            // 직접 호출 시에는 재시도 없이 예외가 그대로 전파됩니다.
+            // 이 테스트는 재시도 없이 예외가 올바르게 전파되는지 확인합니다.
             val stats = SeasonBattingStats.create(testPlayer, 2024)
             every {
                 seasonBattingStatsRepository.findByPlayerIdAndYear(testPlayer.id, 2024)
             } returns stats
-            // 첫 번째 save 시 충돌, 두 번째에 성공
             every { seasonBattingStatsRepository.save(any()) } throws
-                ObjectOptimisticLockingFailureException("conflict", null) andThen stats
+                ObjectOptimisticLockingFailureException("conflict", null)
             every {
                 seasonPitchingStatsRepository.findByPlayerIdAndYear(testPitcher.id, 2024)
             } returns null
@@ -1088,11 +1031,10 @@ class StatsEventListenerTest {
                     result = PlateAppearanceResult.SINGLE,
                 )
 
-            // when
-            listener.onPlateAppearanceRecorded(event)
-
-            // then: 2번 호출됨 (1번 실패 + 1번 성공)
-            verify(exactly = 2) { seasonBattingStatsRepository.save(any()) }
+            // when & then: 직접 호출이므로 @Retryable 없이 예외 전파
+            assertThrows<ObjectOptimisticLockingFailureException> {
+                listener.onPlateAppearanceRecorded(event)
+            }
         }
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplLockTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameLifecycleServiceImplLockTest.kt
@@ -72,14 +72,14 @@ class GameLifecycleServiceImplLockTest {
     @DisplayName("lockGame")
     inner class LockGameTest {
         @Test
-        @DisplayName("경기를 잠금하고 저장된 Game을 반환한다")
+        @DisplayName("경기를 비관적 락으로 잠금하고 저장된 Game을 반환한다")
         fun locksGameAndReturnsSaved() {
             // given
             val gameId = 1L
             val scorerId = 100L
             val game = createGame(gameId, GameStatus.SCHEDULED)
 
-            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gameRepository.findByIdForUpdate(gameId) } returns game
             every { gameRepository.save(any()) } answers { firstArg() }
 
             // when
@@ -87,7 +87,7 @@ class GameLifecycleServiceImplLockTest {
 
             // then
             assertThat(result.scorerId).isEqualTo(scorerId)
-            verify(exactly = 1) { gameRepository.findByIdOrNull(gameId) }
+            verify(exactly = 1) { gameRepository.findByIdForUpdate(gameId) }
             verify(exactly = 1) { gameRepository.save(any()) }
         }
 
@@ -96,7 +96,7 @@ class GameLifecycleServiceImplLockTest {
         fun throwsWhenGameNotFound() {
             // given
             val gameId = 999L
-            every { gameRepository.findByIdOrNull(gameId) } returns null
+            every { gameRepository.findByIdForUpdate(gameId) } returns null
 
             // when & then
             assertThatThrownBy { service.lockGame(gameId, 100L) }

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/exception/GlobalExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.nextup.scorer.exception
 
 import com.nextup.common.dto.ApiResponse
 import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.ConflictException
 import com.nextup.common.exception.ForbiddenException
 import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.InvalidStateException
@@ -35,6 +36,7 @@ class GlobalExceptionHandler : BaseExceptionHandler() {
         val status =
             when (ex) {
                 is NotFoundException -> HttpStatus.NOT_FOUND
+                is ConflictException -> HttpStatus.CONFLICT
                 is ForbiddenException -> HttpStatus.FORBIDDEN
                 is InvalidStateException -> HttpStatus.BAD_REQUEST
                 is InvalidInputException -> HttpStatus.BAD_REQUEST

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/exception/GlobalExceptionHandlerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/exception/GlobalExceptionHandlerTest.kt
@@ -1,6 +1,7 @@
 package com.nextup.scorer.exception
 
 import com.nextup.common.exception.BusinessException
+import com.nextup.common.exception.ConflictException
 import com.nextup.common.exception.InvalidInputException
 import com.nextup.common.exception.InvalidStateException
 import com.nextup.common.exception.NotFoundException
@@ -69,6 +70,20 @@ class GlobalExceptionHandlerTest {
             assertThat(response.body?.success).isFalse()
             assertThat(response.body?.error?.code).isEqualTo("INVALID_INPUT")
             assertThat(response.body?.error?.message).isEqualTo("Invalid input")
+        }
+
+        @Test
+        fun `should return 409 for ConflictException`() {
+            // given
+            val exception = object : ConflictException("GAME_ALREADY_LOCKED", "Game already locked") {}
+
+            // when
+            val response = handler.handleBusinessException(exception)
+
+            // then
+            assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
+            assertThat(response.body?.success).isFalse()
+            assertThat(response.body?.error?.code).isEqualTo("GAME_ALREADY_LOCKED")
         }
 
         @Test


### PR DESCRIPTION
## Summary

>- Close #430

파괴적 기술 검토(#425)에서 발견된 CRITICAL-5, CRITICAL-6 정합성 이슈를 수정합니다.

### CRITICAL-5: lockForScorer 낙관적 락 → 비관적 락
- 두 기록원이 동시에 잠금 시도 시 `OptimisticLockingFailureException` → 500 에러가 발생하던 문제
- `@Lock(PESSIMISTIC_WRITE)` SELECT FOR UPDATE로 전환하여 DB 레벨에서 직렬화
- `GameAlreadyLockedException`을 `ConflictException`(409)으로 변경하여 적절한 HTTP 응답 반환

### CRITICAL-6: StatsEventListener 재시도 로직 미작동 수정
- `@Transactional(REQUIRES_NEW)` 내부 for 루프 재시도는 EntityManager 오염으로 실질적으로 죽은 코드
- `retryOnOptimisticLock` 헬퍼를 제거하고 `@Retryable` 메서드 레벨로 전환
- 각 재시도마다 새 트랜잭션에서 실행되어 실제로 재시도가 동작

## Tasks

- [x] `ConflictException` 기본 클래스 추가 (common)
- [x] `GameAlreadyLockedException` → `ConflictException` 상속 전환
- [x] `GameRepositoryPort.findByIdForUpdate()` 추가 (core)
- [x] `GameRepository`에 `@Lock(PESSIMISTIC_WRITE)` 구현 (infra)
- [x] `GameLifecycleServiceImpl.lockGame()`에서 비관적 락 조회 사용
- [x] `BaseExceptionHandler`에 `ConflictException` → 409 핸들러 추가
- [x] scorer `GlobalExceptionHandler`에 `ConflictException` → 409 매핑 추가
- [x] `spring-retry` 의존성 추가 + `@EnableRetry` 설정
- [x] `StatsEventListener`에서 `retryOnOptimisticLock` 제거, `@Retryable` 적용
- [x] `GameCancelEventListener`에서 `retryOnOptimisticLock` 제거, `@Retryable` 적용
- [x] `RecordCorrectionEventListener`에서 `retryOnOptimisticLock` 제거, `@Retryable` 적용
- [x] 테스트 갱신 (Lock 테스트, Retry 테스트, ExceptionHandler 테스트)
- [x] 빌드 & 전체 테스트 통과

## To Reviewer

- **CRITICAL-5**: 성능 영향은 경기당 1회 호출이므로 무시 가능합니다. SELECT FOR UPDATE는 트랜잭션 종료까지만 락을 유지합니다.
- **CRITICAL-6**: `@Retryable`은 Spring AOP 프록시를 통해 동작하므로, 단위 테스트에서는 직접 호출 시 재시도가 발생하지 않습니다. 통합 테스트에서 프록시 기반 재시도를 검증할 수 있습니다.
- `retryOnOptimisticLock`을 사용하던 3개 리스너(StatsEventListener, GameCancelEventListener, RecordCorrectionEventListener)를 모두 `@Retryable`로 전환했습니다.