### PR TITLE
feat(#391): 수비 기록 필드 보강 — 포수 도루 저지/허용 + correctField 확장

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/FieldingRecord.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/FieldingRecord.kt
@@ -86,6 +86,20 @@ class FieldingRecord(
     var passedBalls: Int = 0
         protected set
 
+    /**
+     * 도루 저지(CS, Caught Stealing) - 포수가 도루를 저지한 횟수 (포수 전용)
+     */
+    @Column(name = "caught_stealing", nullable = false)
+    var caughtStealing: Int = 0
+        protected set
+
+    /**
+     * 도루 허용(SB Allowed) - 포수가 도루를 허용한 횟수 (포수 전용)
+     */
+    @Column(name = "stolen_bases_allowed", nullable = false)
+    var stolenBasesAllowed: Int = 0
+        protected set
+
     // Calculated properties
 
     /**
@@ -151,6 +165,20 @@ class FieldingRecord(
     }
 
     /**
+     * 도루 저지(CS)를 기록합니다 (포수 전용).
+     */
+    fun recordCaughtStealing() {
+        caughtStealing++
+    }
+
+    /**
+     * 도루 허용(SB Allowed)을 기록합니다 (포수 전용).
+     */
+    fun recordStolenBaseAllowed() {
+        stolenBasesAllowed++
+    }
+
+    /**
      * 자살(PO)을 취소합니다 (Undo용).
      */
     fun revertPutOut() {
@@ -199,6 +227,22 @@ class FieldingRecord(
     }
 
     /**
+     * 도루 저지(CS)를 취소합니다 (Undo용).
+     */
+    fun revertCaughtStealing() {
+        require(caughtStealing > 0) { "취소할 도루 저지 기록이 없습니다." }
+        caughtStealing--
+    }
+
+    /**
+     * 도루 허용(SB Allowed)을 취소합니다 (Undo용).
+     */
+    fun revertStolenBaseAllowed() {
+        require(stolenBasesAllowed > 0) { "취소할 도루 허용 기록이 없습니다." }
+        stolenBasesAllowed--
+    }
+
+    /**
      * 기록 유효성을 검증합니다.
      */
     fun validate() {
@@ -208,6 +252,8 @@ class FieldingRecord(
         require(doublePlays >= 0) { "병살 관여($doublePlays)는 음수일 수 없습니다." }
         require(triplePlays >= 0) { "삼중살 관여($triplePlays)는 음수일 수 없습니다." }
         require(passedBalls >= 0) { "포일($passedBalls)은 음수일 수 없습니다." }
+        require(caughtStealing >= 0) { "도루 저지($caughtStealing)는 음수일 수 없습니다." }
+        require(stolenBasesAllowed >= 0) { "도루 허용($stolenBasesAllowed)은 음수일 수 없습니다." }
     }
 
     /**
@@ -233,7 +279,10 @@ class FieldingRecord(
                 "assists" -> assists.also { assists = intValue }
                 "errors" -> errors.also { errors = intValue }
                 "doublePlays" -> doublePlays.also { doublePlays = intValue }
+                "triplePlays" -> triplePlays.also { triplePlays = intValue }
                 "passedBalls" -> passedBalls.also { passedBalls = intValue }
+                "caughtStealing" -> caughtStealing.also { caughtStealing = intValue }
+                "stolenBasesAllowed" -> stolenBasesAllowed.also { stolenBasesAllowed = intValue }
                 else -> throw IllegalArgumentException("유효하지 않은 수비 기록 필드입니다: $fieldName")
             }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerFieldingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/CareerFieldingStats.kt
@@ -74,6 +74,18 @@ class CareerFieldingStats(
     var passedBalls: Int = 0
         protected set
 
+    @Column(name = "triple_plays", nullable = false)
+    var triplePlays: Int = 0
+        protected set
+
+    @Column(name = "caught_stealing", nullable = false)
+    var caughtStealing: Int = 0
+        protected set
+
+    @Column(name = "stolen_bases_allowed", nullable = false)
+    var stolenBasesAllowed: Int = 0
+        protected set
+
     // Calculated properties
 
     /**
@@ -106,6 +118,9 @@ class CareerFieldingStats(
         errors += record.errors
         doublePlays += record.doublePlays
         passedBalls += record.passedBalls
+        triplePlays += record.triplePlays
+        caughtStealing += record.caughtStealing
+        stolenBasesAllowed += record.stolenBasesAllowed
     }
 
     /**
@@ -119,6 +134,9 @@ class CareerFieldingStats(
         errors = maxOf(0, errors - record.errors)
         doublePlays = maxOf(0, doublePlays - record.doublePlays)
         passedBalls = maxOf(0, passedBalls - record.passedBalls)
+        triplePlays = maxOf(0, triplePlays - record.triplePlays)
+        caughtStealing = maxOf(0, caughtStealing - record.caughtStealing)
+        stolenBasesAllowed = maxOf(0, stolenBasesAllowed - record.stolenBasesAllowed)
     }
 
     /**
@@ -144,6 +162,9 @@ class CareerFieldingStats(
             "errors" -> errors = maxOf(0, errors + delta)
             "doublePlays" -> doublePlays = maxOf(0, doublePlays + delta)
             "passedBalls" -> passedBalls = maxOf(0, passedBalls + delta)
+            "triplePlays" -> triplePlays = maxOf(0, triplePlays + delta)
+            "caughtStealing" -> caughtStealing = maxOf(0, caughtStealing + delta)
+            "stolenBasesAllowed" -> stolenBasesAllowed = maxOf(0, stolenBasesAllowed + delta)
             else -> throw IllegalArgumentException("유효하지 않은 통산 수비 통계 필드입니다: $fieldName")
         }
         validate()
@@ -173,6 +194,15 @@ class CareerFieldingStats(
         }
         if (passedBalls < 0) {
             throw StatsValidationException("포일($passedBalls)은 음수일 수 없습니다.")
+        }
+        if (triplePlays < 0) {
+            throw StatsValidationException("삼중살 관여($triplePlays)는 음수일 수 없습니다.")
+        }
+        if (caughtStealing < 0) {
+            throw StatsValidationException("도루 저지($caughtStealing)는 음수일 수 없습니다.")
+        }
+        if (stolenBasesAllowed < 0) {
+            throw StatsValidationException("도루 허용($stolenBasesAllowed)은 음수일 수 없습니다.")
         }
     }
 

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonFieldingStats.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/stats/SeasonFieldingStats.kt
@@ -82,6 +82,18 @@ class SeasonFieldingStats(
     var passedBalls: Int = 0
         protected set
 
+    @Column(name = "triple_plays", nullable = false)
+    var triplePlays: Int = 0
+        protected set
+
+    @Column(name = "caught_stealing", nullable = false)
+    var caughtStealing: Int = 0
+        protected set
+
+    @Column(name = "stolen_bases_allowed", nullable = false)
+    var stolenBasesAllowed: Int = 0
+        protected set
+
     // Calculated properties
 
     /**
@@ -114,6 +126,9 @@ class SeasonFieldingStats(
         errors += record.errors
         doublePlays += record.doublePlays
         passedBalls += record.passedBalls
+        triplePlays += record.triplePlays
+        caughtStealing += record.caughtStealing
+        stolenBasesAllowed += record.stolenBasesAllowed
     }
 
     /**
@@ -126,6 +141,9 @@ class SeasonFieldingStats(
         errors -= record.errors
         doublePlays -= record.doublePlays
         passedBalls -= record.passedBalls
+        triplePlays -= record.triplePlays
+        caughtStealing -= record.caughtStealing
+        stolenBasesAllowed -= record.stolenBasesAllowed
         validate()
     }
 
@@ -145,6 +163,9 @@ class SeasonFieldingStats(
             "errors" -> errors = maxOf(0, errors + delta)
             "doublePlays" -> doublePlays = maxOf(0, doublePlays + delta)
             "passedBalls" -> passedBalls = maxOf(0, passedBalls + delta)
+            "triplePlays" -> triplePlays = maxOf(0, triplePlays + delta)
+            "caughtStealing" -> caughtStealing = maxOf(0, caughtStealing + delta)
+            "stolenBasesAllowed" -> stolenBasesAllowed = maxOf(0, stolenBasesAllowed + delta)
             else -> throw IllegalArgumentException("유효하지 않은 시즌 수비 통계 필드입니다: $fieldName")
         }
         validate()
@@ -171,6 +192,15 @@ class SeasonFieldingStats(
         }
         if (passedBalls < 0) {
             throw StatsValidationException("포일($passedBalls)은 음수일 수 없습니다.")
+        }
+        if (triplePlays < 0) {
+            throw StatsValidationException("삼중살 관여($triplePlays)는 음수일 수 없습니다.")
+        }
+        if (caughtStealing < 0) {
+            throw StatsValidationException("도루 저지($caughtStealing)는 음수일 수 없습니다.")
+        }
+        if (stolenBasesAllowed < 0) {
+            throw StatsValidationException("도루 허용($stolenBasesAllowed)은 음수일 수 없습니다.")
         }
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/FieldingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/FieldingRecordTest.kt
@@ -30,7 +30,10 @@ class FieldingRecordTest {
             assertThat(fieldingRecord.assists).isEqualTo(0)
             assertThat(fieldingRecord.errors).isEqualTo(0)
             assertThat(fieldingRecord.doublePlays).isEqualTo(0)
+            assertThat(fieldingRecord.triplePlays).isEqualTo(0)
             assertThat(fieldingRecord.passedBalls).isEqualTo(0)
+            assertThat(fieldingRecord.caughtStealing).isEqualTo(0)
+            assertThat(fieldingRecord.stolenBasesAllowed).isEqualTo(0)
         }
 
         @Test
@@ -440,6 +443,141 @@ class FieldingRecordTest {
                 fieldingRecord.correctField("putOuts", "-1")
             }.isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("정정 값은 0 이상이어야 합니다")
+        }
+
+        @Test
+        fun `triplePlays 필드를 정정할 수 있다`() {
+            fieldingRecord.recordTriplePlay()
+            val oldValue = fieldingRecord.correctField("triplePlays", "3")
+            assertThat(oldValue).isEqualTo("1")
+            assertThat(fieldingRecord.triplePlays).isEqualTo(3)
+        }
+
+        @Test
+        fun `caughtStealing 필드를 정정할 수 있다`() {
+            val oldValue = fieldingRecord.correctField("caughtStealing", "5")
+            assertThat(oldValue).isEqualTo("0")
+            assertThat(fieldingRecord.caughtStealing).isEqualTo(5)
+        }
+
+        @Test
+        fun `stolenBasesAllowed 필드를 정정할 수 있다`() {
+            val oldValue = fieldingRecord.correctField("stolenBasesAllowed", "7")
+            assertThat(oldValue).isEqualTo("0")
+            assertThat(fieldingRecord.stolenBasesAllowed).isEqualTo(7)
+        }
+    }
+
+    @Nested
+    @DisplayName("도루 저지(CS) 기록 - 포수 전용")
+    inner class RecordCaughtStealingTest {
+        @Test
+        fun `도루 저지를 기록하면 caughtStealing이 1 증가한다`() {
+            // when
+            fieldingRecord.recordCaughtStealing()
+
+            // then
+            assertThat(fieldingRecord.caughtStealing).isEqualTo(1)
+        }
+
+        @Test
+        fun `도루 저지를 여러 번 기록하면 누적된다`() {
+            // when
+            repeat(3) { fieldingRecord.recordCaughtStealing() }
+
+            // then
+            assertThat(fieldingRecord.caughtStealing).isEqualTo(3)
+        }
+    }
+
+    @Nested
+    @DisplayName("도루 허용(SB Allowed) 기록 - 포수 전용")
+    inner class RecordStolenBaseAllowedTest {
+        @Test
+        fun `도루 허용을 기록하면 stolenBasesAllowed가 1 증가한다`() {
+            // when
+            fieldingRecord.recordStolenBaseAllowed()
+
+            // then
+            assertThat(fieldingRecord.stolenBasesAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `도루 허용을 여러 번 기록하면 누적된다`() {
+            // when
+            repeat(4) { fieldingRecord.recordStolenBaseAllowed() }
+
+            // then
+            assertThat(fieldingRecord.stolenBasesAllowed).isEqualTo(4)
+        }
+    }
+
+    @Nested
+    @DisplayName("도루 저지/허용 Undo")
+    inner class RevertCatcherFieldsTest {
+        @Test
+        fun `도루 저지를 취소하면 caughtStealing이 1 감소한다`() {
+            // given
+            fieldingRecord.recordCaughtStealing()
+
+            // when
+            fieldingRecord.revertCaughtStealing()
+
+            // then
+            assertThat(fieldingRecord.caughtStealing).isEqualTo(0)
+        }
+
+        @Test
+        fun `도루 저지 기록이 없는 상태에서 취소하면 예외가 발생한다`() {
+            assertThatThrownBy { fieldingRecord.revertCaughtStealing() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("취소할 도루 저지 기록이 없습니다")
+        }
+
+        @Test
+        fun `도루 허용을 취소하면 stolenBasesAllowed가 1 감소한다`() {
+            // given
+            fieldingRecord.recordStolenBaseAllowed()
+
+            // when
+            fieldingRecord.revertStolenBaseAllowed()
+
+            // then
+            assertThat(fieldingRecord.stolenBasesAllowed).isEqualTo(0)
+        }
+
+        @Test
+        fun `도루 허용 기록이 없는 상태에서 취소하면 예외가 발생한다`() {
+            assertThatThrownBy { fieldingRecord.revertStolenBaseAllowed() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("취소할 도루 허용 기록이 없습니다")
+        }
+    }
+
+    @Nested
+    @DisplayName("도루 저지/허용 validate 검증")
+    inner class CatcherFieldsValidateTest {
+        @Test
+        fun `도루 저지와 도루 허용이 포함된 상태에서 validate는 예외를 발생시키지 않는다`() {
+            // given
+            fieldingRecord.recordCaughtStealing()
+            fieldingRecord.recordStolenBaseAllowed()
+
+            // when & then (no exception)
+            fieldingRecord.validate()
+            assertThat(fieldingRecord.caughtStealing).isEqualTo(1)
+            assertThat(fieldingRecord.stolenBasesAllowed).isEqualTo(1)
+        }
+
+        @Test
+        fun `도루 저지와 도루 허용은 수비 기회에 포함되지 않는다`() {
+            // given
+            fieldingRecord.recordCaughtStealing()
+            fieldingRecord.recordStolenBaseAllowed()
+            fieldingRecord.recordPutOut()
+
+            // then: totalChances = putOuts + assists + errors = 1
+            assertThat(fieldingRecord.totalChances).isEqualTo(1)
         }
     }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerFieldingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/CareerFieldingStatsTest.kt
@@ -24,6 +24,28 @@ class CareerFieldingStatsTest {
         careerFieldingStats = CareerFieldingStats.create(player)
     }
 
+    private fun createFieldingRecordMock(
+        putOuts: Int = 0,
+        assists: Int = 0,
+        errors: Int = 0,
+        doublePlays: Int = 0,
+        passedBalls: Int = 0,
+        triplePlays: Int = 0,
+        caughtStealing: Int = 0,
+        stolenBasesAllowed: Int = 0,
+    ): FieldingRecord {
+        val record = mockk<FieldingRecord>()
+        every { record.putOuts } returns putOuts
+        every { record.assists } returns assists
+        every { record.errors } returns errors
+        every { record.doublePlays } returns doublePlays
+        every { record.passedBalls } returns passedBalls
+        every { record.triplePlays } returns triplePlays
+        every { record.caughtStealing } returns caughtStealing
+        every { record.stolenBasesAllowed } returns stolenBasesAllowed
+        return record
+    }
+
     @Nested
     @DisplayName("생성")
     inner class CreateTest {
@@ -36,6 +58,9 @@ class CareerFieldingStatsTest {
             assertThat(careerFieldingStats.errors).isEqualTo(0)
             assertThat(careerFieldingStats.doublePlays).isEqualTo(0)
             assertThat(careerFieldingStats.passedBalls).isEqualTo(0)
+            assertThat(careerFieldingStats.triplePlays).isEqualTo(0)
+            assertThat(careerFieldingStats.caughtStealing).isEqualTo(0)
+            assertThat(careerFieldingStats.stolenBasesAllowed).isEqualTo(0)
         }
 
         @Test
@@ -66,12 +91,14 @@ class CareerFieldingStatsTest {
         @Test
         fun `addGameRecord 호출 시 gamesPlayed가 1 증가하고 수비 기록이 누적된다`() {
             // given
-            val record = mockk<FieldingRecord>()
-            every { record.putOuts } returns 5
-            every { record.assists } returns 3
-            every { record.errors } returns 1
-            every { record.doublePlays } returns 2
-            every { record.passedBalls } returns 1
+            val record =
+                createFieldingRecordMock(
+                    putOuts = 5,
+                    assists = 3,
+                    errors = 1,
+                    doublePlays = 2,
+                    passedBalls = 1,
+                )
 
             // when
             careerFieldingStats.addGameRecord(record)
@@ -88,19 +115,14 @@ class CareerFieldingStatsTest {
         @Test
         fun `여러 경기 기록을 누적하면 합산된다`() {
             // given
-            val record1 = mockk<FieldingRecord>()
-            every { record1.putOuts } returns 3
-            every { record1.assists } returns 1
-            every { record1.errors } returns 0
-            every { record1.doublePlays } returns 0
-            every { record1.passedBalls } returns 0
-
-            val record2 = mockk<FieldingRecord>()
-            every { record2.putOuts } returns 4
-            every { record2.assists } returns 2
-            every { record2.errors } returns 1
-            every { record2.doublePlays } returns 1
-            every { record2.passedBalls } returns 0
+            val record1 = createFieldingRecordMock(putOuts = 3, assists = 1)
+            val record2 =
+                createFieldingRecordMock(
+                    putOuts = 4,
+                    assists = 2,
+                    errors = 1,
+                    doublePlays = 1,
+                )
 
             // when
             careerFieldingStats.addGameRecord(record1)
@@ -121,12 +143,14 @@ class CareerFieldingStatsTest {
         @Test
         fun `revertGameRecord 호출 시 gamesPlayed가 1 감소하고 수비 기록이 차감된다`() {
             // given
-            val record = mockk<FieldingRecord>()
-            every { record.putOuts } returns 5
-            every { record.assists } returns 3
-            every { record.errors } returns 1
-            every { record.doublePlays } returns 2
-            every { record.passedBalls } returns 1
+            val record =
+                createFieldingRecordMock(
+                    putOuts = 5,
+                    assists = 3,
+                    errors = 1,
+                    doublePlays = 2,
+                    passedBalls = 1,
+                )
 
             careerFieldingStats.addGameRecord(record)
             assertThat(careerFieldingStats.gamesPlayed).isEqualTo(1)
@@ -146,12 +170,14 @@ class CareerFieldingStatsTest {
         @Test
         fun `초기 상태에서 revertGameRecord를 호출해도 음수가 되지 않는다`() {
             // given
-            val record = mockk<FieldingRecord>()
-            every { record.putOuts } returns 5
-            every { record.assists } returns 3
-            every { record.errors } returns 1
-            every { record.doublePlays } returns 2
-            every { record.passedBalls } returns 1
+            val record =
+                createFieldingRecordMock(
+                    putOuts = 5,
+                    assists = 3,
+                    errors = 1,
+                    doublePlays = 2,
+                    passedBalls = 1,
+                )
 
             // when
             careerFieldingStats.revertGameRecord(record)
@@ -168,19 +194,8 @@ class CareerFieldingStatsTest {
         @Test
         fun `여러 경기 중 하나를 롤백하면 나머지만 남는다`() {
             // given
-            val record1 = mockk<FieldingRecord>()
-            every { record1.putOuts } returns 3
-            every { record1.assists } returns 1
-            every { record1.errors } returns 0
-            every { record1.doublePlays } returns 0
-            every { record1.passedBalls } returns 0
-
-            val record2 = mockk<FieldingRecord>()
-            every { record2.putOuts } returns 4
-            every { record2.assists } returns 2
-            every { record2.errors } returns 1
-            every { record2.doublePlays } returns 1
-            every { record2.passedBalls } returns 0
+            val record1 = createFieldingRecordMock(putOuts = 3, assists = 1)
+            val record2 = createFieldingRecordMock(putOuts = 4, assists = 2, errors = 1, doublePlays = 1)
 
             careerFieldingStats.addGameRecord(record1)
             careerFieldingStats.addGameRecord(record2)
@@ -209,12 +224,7 @@ class CareerFieldingStatsTest {
         @Test
         fun `수비 기회는 자살 + 보살 + 실책이다`() {
             // given
-            val record = mockk<FieldingRecord>()
-            every { record.putOuts } returns 5
-            every { record.assists } returns 3
-            every { record.errors } returns 2
-            every { record.doublePlays } returns 0
-            every { record.passedBalls } returns 0
+            val record = createFieldingRecordMock(putOuts = 5, assists = 3, errors = 2)
 
             careerFieldingStats.addGameRecord(record)
 
@@ -234,12 +244,7 @@ class CareerFieldingStatsTest {
         @Test
         fun `수비 기회가 있으면 수비율을 반환한다`() {
             // given: PO=9, A=3, E=1 -> TC=13, FPCT=12/13
-            val record = mockk<FieldingRecord>()
-            every { record.putOuts } returns 9
-            every { record.assists } returns 3
-            every { record.errors } returns 1
-            every { record.doublePlays } returns 0
-            every { record.passedBalls } returns 0
+            val record = createFieldingRecordMock(putOuts = 9, assists = 3, errors = 1)
 
             careerFieldingStats.addGameRecord(record)
 
@@ -250,12 +255,7 @@ class CareerFieldingStatsTest {
         @Test
         fun `실책이 없으면 수비율은 1이다`() {
             // given: PO=5, A=3, E=0 -> TC=8, FPCT=8/8=1.000
-            val record = mockk<FieldingRecord>()
-            every { record.putOuts } returns 5
-            every { record.assists } returns 3
-            every { record.errors } returns 0
-            every { record.doublePlays } returns 0
-            every { record.passedBalls } returns 0
+            val record = createFieldingRecordMock(putOuts = 5, assists = 3)
 
             careerFieldingStats.addGameRecord(record)
 
@@ -267,12 +267,7 @@ class CareerFieldingStatsTest {
         @Test
         fun `수비율은 소수점 3자리로 계산된다`() {
             // given: PO=2, A=1, E=1 -> TC=4, FPCT=3/4=0.750
-            val record = mockk<FieldingRecord>()
-            every { record.putOuts } returns 2
-            every { record.assists } returns 1
-            every { record.errors } returns 1
-            every { record.doublePlays } returns 0
-            every { record.passedBalls } returns 0
+            val record = createFieldingRecordMock(putOuts = 2, assists = 1, errors = 1)
 
             careerFieldingStats.addGameRecord(record)
 
@@ -288,12 +283,7 @@ class CareerFieldingStatsTest {
         @Test
         fun `정상 상태에서 validate는 예외를 발생시키지 않는다`() {
             // given: 정상 상태
-            val record = mockk<FieldingRecord>()
-            every { record.putOuts } returns 3
-            every { record.assists } returns 1
-            every { record.errors } returns 0
-            every { record.doublePlays } returns 0
-            every { record.passedBalls } returns 0
+            val record = createFieldingRecordMock(putOuts = 3, assists = 1)
             careerFieldingStats.addGameRecord(record)
             careerFieldingStats.addSeason()
 
@@ -351,6 +341,27 @@ class CareerFieldingStatsTest {
         @Test
         fun `passedBalls가 음수이면 StatsValidationException이 발생한다`() {
             setFieldDirectly(careerFieldingStats, "passedBalls", -1)
+            assertThatThrownBy { careerFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `triplePlays가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(careerFieldingStats, "triplePlays", -1)
+            assertThatThrownBy { careerFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `caughtStealing이 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(careerFieldingStats, "caughtStealing", -1)
+            assertThatThrownBy { careerFieldingStats.validate() }
+                .isInstanceOf(StatsValidationException::class.java)
+        }
+
+        @Test
+        fun `stolenBasesAllowed가 음수이면 StatsValidationException이 발생한다`() {
+            setFieldDirectly(careerFieldingStats, "stolenBasesAllowed", -1)
             assertThatThrownBy { careerFieldingStats.validate() }
                 .isInstanceOf(StatsValidationException::class.java)
         }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonFieldingStatsRevertGameRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonFieldingStatsRevertGameRecordTest.kt
@@ -31,6 +31,9 @@ class SeasonFieldingStatsRevertGameRecordTest {
         errors: Int = 0,
         doublePlays: Int = 0,
         passedBalls: Int = 0,
+        triplePlays: Int = 0,
+        caughtStealing: Int = 0,
+        stolenBasesAllowed: Int = 0,
     ): FieldingRecord {
         val record = mockk<FieldingRecord>()
         every { record.putOuts } returns putOuts
@@ -38,6 +41,9 @@ class SeasonFieldingStatsRevertGameRecordTest {
         every { record.errors } returns errors
         every { record.doublePlays } returns doublePlays
         every { record.passedBalls } returns passedBalls
+        every { record.triplePlays } returns triplePlays
+        every { record.caughtStealing } returns caughtStealing
+        every { record.stolenBasesAllowed } returns stolenBasesAllowed
         return record
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonFieldingStatsTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/stats/SeasonFieldingStatsTest.kt
@@ -69,6 +69,9 @@ class SeasonFieldingStatsTest {
             every { record.errors } returns 1
             every { record.doublePlays } returns 1
             every { record.passedBalls } returns 0
+            every { record.triplePlays } returns 0
+            every { record.caughtStealing } returns 0
+            every { record.stolenBasesAllowed } returns 0
 
             // when
             seasonFieldingStats.addGameRecord(record)
@@ -91,6 +94,9 @@ class SeasonFieldingStatsTest {
             every { record1.errors } returns 0
             every { record1.doublePlays } returns 0
             every { record1.passedBalls } returns 0
+            every { record1.triplePlays } returns 0
+            every { record1.caughtStealing } returns 0
+            every { record1.stolenBasesAllowed } returns 0
 
             val record2 = mockk<FieldingRecord>()
             every { record2.putOuts } returns 3
@@ -98,6 +104,9 @@ class SeasonFieldingStatsTest {
             every { record2.errors } returns 1
             every { record2.doublePlays } returns 1
             every { record2.passedBalls } returns 1
+            every { record2.triplePlays } returns 0
+            every { record2.caughtStealing } returns 0
+            every { record2.stolenBasesAllowed } returns 0
 
             // when
             seasonFieldingStats.addGameRecord(record1)
@@ -128,6 +137,9 @@ class SeasonFieldingStatsTest {
             every { record.errors } returns 1
             every { record.doublePlays } returns 0
             every { record.passedBalls } returns 0
+            every { record.triplePlays } returns 0
+            every { record.caughtStealing } returns 0
+            every { record.stolenBasesAllowed } returns 0
 
             seasonFieldingStats.addGameRecord(record)
 
@@ -145,6 +157,9 @@ class SeasonFieldingStatsTest {
             every { record.errors } returns 0
             every { record.doublePlays } returns 0
             every { record.passedBalls } returns 0
+            every { record.triplePlays } returns 0
+            every { record.caughtStealing } returns 0
+            every { record.stolenBasesAllowed } returns 0
 
             seasonFieldingStats.addGameRecord(record)
 
@@ -162,6 +177,9 @@ class SeasonFieldingStatsTest {
             every { record.errors } returns 1
             every { record.doublePlays } returns 0
             every { record.passedBalls } returns 0
+            every { record.triplePlays } returns 0
+            every { record.caughtStealing } returns 0
+            every { record.stolenBasesAllowed } returns 0
 
             seasonFieldingStats.addGameRecord(record)
 
@@ -182,6 +200,9 @@ class SeasonFieldingStatsTest {
             every { record.errors } returns 0
             every { record.doublePlays } returns 0
             every { record.passedBalls } returns 0
+            every { record.triplePlays } returns 0
+            every { record.caughtStealing } returns 0
+            every { record.stolenBasesAllowed } returns 0
             seasonFieldingStats.addGameRecord(record)
 
             seasonFieldingStats.validate()

--- a/nextup-infrastructure/src/main/resources/db/migration/V047__add_catcher_stealing_fields_to_fielding_records.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V047__add_catcher_stealing_fields_to_fielding_records.sql
@@ -1,0 +1,12 @@
+-- M-6: fielding_records 테이블에 포수용 도루 저지/허용 컬럼 추가
+ALTER TABLE fielding_records ADD COLUMN caught_stealing INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE fielding_records ADD COLUMN stolen_bases_allowed INTEGER NOT NULL DEFAULT 0;
+
+-- 시즌/통산 수비 통계 테이블에 삼중살/도루 저지/도루 허용 컬럼 추가
+ALTER TABLE season_fielding_stats ADD COLUMN triple_plays INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE season_fielding_stats ADD COLUMN caught_stealing INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE season_fielding_stats ADD COLUMN stolen_bases_allowed INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE career_fielding_stats ADD COLUMN triple_plays INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE career_fielding_stats ADD COLUMN caught_stealing INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE career_fielding_stats ADD COLUMN stolen_bases_allowed INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

>- Close #391

FieldingRecord에 포수 전용 도루 저지(caughtStealing)/도루 허용(stolenBasesAllowed) 필드를 추가하고, correctField() 메서드에 triplePlays 및 새 포수 필드 정정 지원을 추가합니다. 시즌/통산 수비 통계(SeasonFieldingStats, CareerFieldingStats)에도 동일 필드를 반영하여 기록 누적/롤백/정정/검증이 일관되게 동작합니다.

## Tasks

- [x] FieldingRecord에 caughtStealing, stolenBasesAllowed 필드 및 도메인 메서드 추가
- [x] FieldingRecord.correctField()에 triplePlays, caughtStealing, stolenBasesAllowed 정정 지원
- [x] FieldingRecord.validate()에 새 필드 음수 검증 추가
- [x] SeasonFieldingStats에 triplePlays, caughtStealing, stolenBasesAllowed 필드 추가
- [x] CareerFieldingStats에 triplePlays, caughtStealing, stolenBasesAllowed 필드 추가
- [x] addGameRecord/revertGameRecord/applyFieldCorrection/validate에 새 필드 반영
- [x] V047 DB 마이그레이션 스크립트 작성 (fielding_records, season/career_fielding_stats)
- [x] FieldingRecordTest 단위 테스트 추가 (기록/취소/정정/검증)
- [x] CareerFieldingStatsTest, SeasonFieldingStatsTest 모크 업데이트
- [x] `./gradlew clean build` 성공

## To Reviewer

- 기존 triplePlays 필드는 이미 FieldingRecord에 존재했으나, correctField()에서 누락되어 있었습니다. 이번 PR에서 함께 보완했습니다.
- PitchingRecord의 stolenBasesAllowed/runnersCaughtStealing/pickoffs 필드는 이전 PR에서 이미 구현 완료되어 있어 별도 변경 없습니다.
- 시즌/통산 수비 통계 테이블에도 triplePlays가 누락되어 있었으므로, V047 마이그레이션에서 함께 추가했습니다.
- 포수 전용 필드(caughtStealing, stolenBasesAllowed, passedBalls)는 포지션 구분 없이 FieldingRecord에 공통으로 존재하며, 실제 기록은 포수 포지션일 때만 사용됩니다.