### PR TITLE
feat(#393): 경기 시간/투구수 제한 경고 WebSocket 알림

### DIFF
--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/PlateAppearanceRecordServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/PlateAppearanceRecordServiceImpl.kt
@@ -8,6 +8,8 @@ import com.nextup.core.domain.event.GameResultConfirmedEvent
 import com.nextup.core.domain.event.PitchCountWarningEvent
 import com.nextup.core.domain.event.PitchCountWarningType
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
+import com.nextup.core.domain.event.TimeLimitWarningEvent
+import com.nextup.core.domain.event.TimeLimitWarningType
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.domain.game.GamePlayer
@@ -16,6 +18,7 @@ import com.nextup.core.domain.game.GameTeam
 import com.nextup.core.domain.game.HomeAway
 import com.nextup.core.domain.game.PitchCountStatus
 import com.nextup.core.domain.game.PlateAppearanceResult
+import com.nextup.core.domain.game.TimeLimitStatus
 import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
@@ -30,6 +33,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 /**
  * 타석 결과 기록 서비스 구현
@@ -170,6 +174,7 @@ class PlateAppearanceRecordServiceImpl(
 
         if (!walkOff) {
             detectPitchCountWarning(savedGame, pitcher, warnings)
+            detectTimeLimitWarning(savedGame, warnings)
         }
 
         return PlateAppearanceRecordResult(game = savedGame, warnings = warnings)
@@ -264,6 +269,64 @@ class PlateAppearanceRecordServiceImpl(
                         pitchesThrown = pitchesThrown,
                         pitchCountLimit = limit,
                         warningType = PitchCountWarningType.APPROACHING_LIMIT,
+                    ),
+                )
+            }
+        }
+    }
+
+    /**
+     * 경기 시간 제한 경고를 감지합니다 (M-5).
+     *
+     * 경기 시작 시각 기반으로 현재 경과 시간을 체크하여
+     * 시간 제한 임박 또는 도달 시 TimeLimitWarningEvent를 발행합니다.
+     */
+    private fun detectTimeLimitWarning(
+        game: Game,
+        warnings: MutableList<String>,
+    ) {
+        val now = LocalDateTime.now()
+        val status = game.checkTimeLimitStatus(now) ?: return
+        val startedAt = game.startedAt ?: return
+        val timeLimitMinutes = game.competition.gameRules.timeLimitMinutes ?: return
+        val elapsedMinutes =
+            java.time.Duration.between(startedAt, now).toMinutes()
+
+        when (status) {
+            TimeLimitStatus.LIMIT_REACHED -> {
+                log.warn(
+                    "시간 제한 경고: 경기(ID: {}) 경과 시간 {}분 — 제한({}분) 도달",
+                    game.id,
+                    elapsedMinutes,
+                    timeLimitMinutes,
+                )
+                warnings.add(
+                    "시간 제한 경고: 경기 시간 제한(${timeLimitMinutes}분)에 도달했습니다" +
+                        "(경과 시간: ${elapsedMinutes}분).",
+                )
+                eventPublisher.publishEvent(
+                    TimeLimitWarningEvent(
+                        gameId = game.id,
+                        startedAt = startedAt.atZone(java.time.ZoneId.systemDefault()).toInstant(),
+                        timeLimitMinutes = timeLimitMinutes,
+                        elapsedMinutes = elapsedMinutes,
+                        warningType = TimeLimitWarningType.LIMIT_REACHED,
+                    ),
+                )
+            }
+            TimeLimitStatus.APPROACHING_LIMIT -> {
+                val remaining = timeLimitMinutes - elapsedMinutes
+                warnings.add(
+                    "시간 제한 주의: 경기 시간 제한에 임박했습니다. " +
+                        "남은 시간: ${remaining}분 (제한: ${timeLimitMinutes}분, 경과: ${elapsedMinutes}분).",
+                )
+                eventPublisher.publishEvent(
+                    TimeLimitWarningEvent(
+                        gameId = game.id,
+                        startedAt = startedAt.atZone(java.time.ZoneId.systemDefault()).toInstant(),
+                        timeLimitMinutes = timeLimitMinutes,
+                        elapsedMinutes = elapsedMinutes,
+                        warningType = TimeLimitWarningType.APPROACHING_LIMIT,
                     ),
                 )
             }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/PlateAppearanceRecordServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/PlateAppearanceRecordServiceImplTest.kt
@@ -6,6 +6,8 @@ import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
 import com.nextup.core.domain.competition.GameRules
 import com.nextup.core.domain.event.GameResultConfirmedEvent
+import com.nextup.core.domain.event.TimeLimitWarningEvent
+import com.nextup.core.domain.event.TimeLimitWarningType
 import com.nextup.core.domain.game.Base
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GamePlayer
@@ -399,6 +401,162 @@ class PlateAppearanceRecordServiceImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("시간 제한 경고 감지 (M-5)")
+    inner class TimeLimitWarningDetection {
+
+        @Test
+        @DisplayName("시간 제한 도달 시 TimeLimitWarningEvent(LIMIT_REACHED) 발행")
+        fun timeLimitReachedPublishesEvent() {
+            // given: 120분 제한, 시작 125분 전 → 제한 도달
+            val game =
+                createGameWithTimeLimit(
+                    id = 1L,
+                    currentInning = 5,
+                    isTopInning = true,
+                    timeLimitMinutes = 120,
+                    startedAt = LocalDateTime.now().minusMinutes(125),
+                )
+            val batter = createGamePlayer(10L, playerId = 100L, battingOrder = 1)
+            val pitcher = createGamePlayer(20L, playerId = 200L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                )
+
+            // when
+            val result = service.recordPlateAppearance(1L, request, 999L)
+
+            // then
+            val timeLimitEvents =
+                publishedEvents.filterIsInstance<TimeLimitWarningEvent>()
+            assertThat(timeLimitEvents).hasSize(1)
+            assertThat(timeLimitEvents[0].warningType)
+                .isEqualTo(TimeLimitWarningType.LIMIT_REACHED)
+            assertThat(result.warnings).anyMatch { it.contains("시간 제한 경고") }
+        }
+
+        @Test
+        @DisplayName("시간 제한 임박 시 TimeLimitWarningEvent(APPROACHING_LIMIT) 발행")
+        fun timeLimitApproachingPublishesEvent() {
+            // given: 120분 제한, 시작 112분 전 → 임박 (10분 이하 남음)
+            val game =
+                createGameWithTimeLimit(
+                    id = 1L,
+                    currentInning = 5,
+                    isTopInning = true,
+                    timeLimitMinutes = 120,
+                    startedAt = LocalDateTime.now().minusMinutes(112),
+                )
+            val batter = createGamePlayer(10L, playerId = 100L, battingOrder = 1)
+            val pitcher = createGamePlayer(20L, playerId = 200L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                )
+
+            // when
+            val result = service.recordPlateAppearance(1L, request, 999L)
+
+            // then
+            val timeLimitEvents =
+                publishedEvents.filterIsInstance<TimeLimitWarningEvent>()
+            assertThat(timeLimitEvents).hasSize(1)
+            assertThat(timeLimitEvents[0].warningType)
+                .isEqualTo(TimeLimitWarningType.APPROACHING_LIMIT)
+            assertThat(result.warnings).anyMatch { it.contains("시간 제한 주의") }
+        }
+
+        @Test
+        @DisplayName("시간 제한이 없는 경기에서는 경고 이벤트 미발행")
+        fun noTimeLimitNoEvent() {
+            // given: 시간 제한 없음 (기본 GameRules)
+            val game = createGame(1L, currentInning = 5, isTopInning = true)
+            val batter = createGamePlayer(10L, playerId = 100L, battingOrder = 1)
+            val pitcher = createGamePlayer(20L, playerId = 200L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                )
+
+            // when
+            service.recordPlateAppearance(1L, request, 999L)
+
+            // then
+            val timeLimitEvents =
+                publishedEvents.filterIsInstance<TimeLimitWarningEvent>()
+            assertThat(timeLimitEvents).isEmpty()
+        }
+
+        @Test
+        @DisplayName("시간 제한 정상 범위면 경고 이벤트 미발행")
+        fun withinTimeLimitNoEvent() {
+            // given: 120분 제한, 시작 60분 전 → 정상 범위
+            val game =
+                createGameWithTimeLimit(
+                    id = 1L,
+                    currentInning = 3,
+                    isTopInning = true,
+                    timeLimitMinutes = 120,
+                    startedAt = LocalDateTime.now().minusMinutes(60),
+                )
+            val batter = createGamePlayer(10L, playerId = 100L, battingOrder = 1)
+            val pitcher = createGamePlayer(20L, playerId = 200L)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns batter
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns pitcher
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            val request =
+                PlateAppearanceRequest(
+                    batterId = 10L,
+                    pitcherId = 20L,
+                    result = PlateAppearanceResult.STRIKEOUT,
+                    runnerMovements = emptyList(),
+                    rbis = 0,
+                )
+
+            // when
+            service.recordPlateAppearance(1L, request, 999L)
+
+            // then
+            val timeLimitEvents =
+                publishedEvents.filterIsInstance<TimeLimitWarningEvent>()
+            assertThat(timeLimitEvents).isEmpty()
+        }
+    }
+
     // Helper methods
 
     private fun createGamePlayer(
@@ -479,6 +637,73 @@ class PlateAppearanceRecordServiceImplTest {
             currentInning = currentInning,
             isTopInning = isTopInning,
             totalInnings = totalInnings,
+            gameState = GameState(),
+            scorerId = 999L,
+            id = id,
+        )
+    }
+
+    private fun createGameWithTimeLimit(
+        id: Long,
+        currentInning: Int = 1,
+        isTopInning: Boolean = true,
+        totalInnings: Int = 9,
+        timeLimitMinutes: Int,
+        startedAt: LocalDateTime,
+    ): Game {
+        val association =
+            Association(
+                name = "서울시야구협회",
+                region = "서울",
+            ).also { setEntityId(it, 1L) }
+        val league =
+            League(
+                association = association,
+                name = "1부 리그",
+                foundedYear = 2020,
+            ).also { setEntityId(it, 1L) }
+        val competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                status = CompetitionStatus.IN_PROGRESS,
+                gameRules =
+                    GameRules(
+                        defaultInnings = totalInnings,
+                        timeLimitMinutes = timeLimitMinutes,
+                    ),
+            ).also { setEntityId(it, 1L) }
+        val homeTeam =
+            Team(
+                league = league,
+                name = "홈팀",
+                city = "서울",
+                foundedYear = 2020,
+                id = 1L,
+            )
+        val awayTeam =
+            Team(
+                league = league,
+                name = "원정팀",
+                city = "부산",
+                foundedYear = 2020,
+                id = 2L,
+            )
+
+        return Game.createForTest(
+            competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            status = GameStatus.IN_PROGRESS,
+            currentInning = currentInning,
+            isTopInning = isTopInning,
+            totalInnings = totalInnings,
+            startedAt = startedAt,
             gameState = GameState(),
             scorerId = 999L,
             id = id,

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/websocket/WarningMessage.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/websocket/WarningMessage.kt
@@ -1,0 +1,41 @@
+package com.nextup.scorer.dto.websocket
+
+import java.time.Instant
+
+/**
+ * 경기 경고 메시지 DTO
+ *
+ * 경기 시간 제한, 투구수 제한 등 경고 알림을 기록원에게 실시간으로 브로드캐스트합니다.
+ * Topic: /topic/games/{gameId}/warnings
+ */
+data class WarningMessage(
+    val gameId: Long,
+    val warningType: WarningType,
+    val severity: WarningSeverity,
+    val title: String,
+    val message: String,
+    val details: Map<String, Any?>,
+    val timestamp: Instant,
+)
+
+/**
+ * 경고 유형
+ */
+enum class WarningType {
+    /** 시간 제한 경고 */
+    TIME_LIMIT,
+
+    /** 투구수 제한 경고 */
+    PITCH_COUNT,
+}
+
+/**
+ * 경고 심각도
+ */
+enum class WarningSeverity {
+    /** 주의 — 제한에 임박 */
+    WARNING,
+
+    /** 위험 — 제한 도달 */
+    CRITICAL,
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/listener/GameBroadcastEventListener.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/listener/GameBroadcastEventListener.kt
@@ -3,10 +3,14 @@ package com.nextup.scorer.listener
 import com.nextup.core.domain.event.GameEndedEvent
 import com.nextup.core.domain.event.GameStartedEvent
 import com.nextup.core.domain.event.HalfInningAdvancedEvent
+import com.nextup.core.domain.event.PitchCountWarningEvent
+import com.nextup.core.domain.event.PitchCountWarningType
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlayerSubstitutedEvent
 import com.nextup.core.domain.event.PositionChangedEvent
 import com.nextup.core.domain.event.RecordCorrectedEvent
+import com.nextup.core.domain.event.TimeLimitWarningEvent
+import com.nextup.core.domain.event.TimeLimitWarningType
 import com.nextup.core.domain.game.HomeAway
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
@@ -19,6 +23,9 @@ import com.nextup.scorer.dto.websocket.PlayerBriefDto
 import com.nextup.scorer.dto.websocket.RunnersDto
 import com.nextup.scorer.dto.websocket.ScoreboardMessage
 import com.nextup.scorer.dto.websocket.TeamScoreDto
+import com.nextup.scorer.dto.websocket.WarningMessage
+import com.nextup.scorer.dto.websocket.WarningSeverity
+import com.nextup.scorer.dto.websocket.WarningType
 import com.nextup.scorer.service.websocket.GameBroadcastService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -319,6 +326,120 @@ class GameBroadcastEventListener(
             )
         } catch (ex: Exception) {
             log.error("RecordCorrectedEvent 브로드캐스트 실패 (gameId={}): {}", event.gameId, ex.message, ex)
+        }
+    }
+
+    /**
+     * 투구수 제한 경고 이벤트를 처리합니다.
+     *
+     * broadcastWarning(PITCH_COUNT)
+     * LIMIT_REACHED 시 투수 교체 권고 메시지를 포함합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onPitchCountWarning(event: PitchCountWarningEvent) {
+        try {
+            val severity =
+                when (event.warningType) {
+                    PitchCountWarningType.LIMIT_REACHED -> WarningSeverity.CRITICAL
+                    PitchCountWarningType.APPROACHING_LIMIT -> WarningSeverity.WARNING
+                }
+            val title = event.warningType.displayName
+            val message =
+                when (event.warningType) {
+                    PitchCountWarningType.LIMIT_REACHED ->
+                        "투수가 투구 수 제한(${event.pitchCountLimit}구)에 도달했습니다" +
+                            "(현재 ${event.pitchesThrown}구). 투수 교체를 권고합니다."
+                    PitchCountWarningType.APPROACHING_LIMIT ->
+                        "투수가 ${event.pitchesThrown}구를 던졌습니다. " +
+                            "제한(${event.pitchCountLimit}구)까지 ${event.remainingPitches}구 남았습니다."
+                }
+            val details =
+                mapOf(
+                    "gamePlayerId" to event.gamePlayerId,
+                    "playerId" to event.playerId,
+                    "pitchesThrown" to event.pitchesThrown,
+                    "pitchCountLimit" to event.pitchCountLimit,
+                    "remainingPitches" to event.remainingPitches,
+                    "isSubstitutionRecommended" to event.isSubstitutionRecommended,
+                )
+
+            val warningMessage =
+                WarningMessage(
+                    gameId = event.gameId,
+                    warningType = WarningType.PITCH_COUNT,
+                    severity = severity,
+                    title = title,
+                    message = message,
+                    details = details,
+                    timestamp = Instant.now(),
+                )
+            gameBroadcastService.broadcastWarning(event.gameId, warningMessage)
+
+            log.debug(
+                "투구수 경고 브로드캐스트 완료 (gameId={}, pitchesThrown={}, limit={}, type={})",
+                event.gameId,
+                event.pitchesThrown,
+                event.pitchCountLimit,
+                event.warningType,
+            )
+        } catch (ex: Exception) {
+            log.error("PitchCountWarningEvent 브로드캐스트 실패 (gameId={}): {}", event.gameId, ex.message, ex)
+        }
+    }
+
+    /**
+     * 시간 제한 경고 이벤트를 처리합니다.
+     *
+     * broadcastWarning(TIME_LIMIT)
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onTimeLimitWarning(event: TimeLimitWarningEvent) {
+        try {
+            val severity =
+                when (event.warningType) {
+                    TimeLimitWarningType.LIMIT_REACHED -> WarningSeverity.CRITICAL
+                    TimeLimitWarningType.APPROACHING_LIMIT -> WarningSeverity.WARNING
+                }
+            val title = event.warningType.displayName
+            val message =
+                when (event.warningType) {
+                    TimeLimitWarningType.LIMIT_REACHED ->
+                        "경기 시간 제한(${event.timeLimitMinutes}분)에 도달했습니다" +
+                            "(경과 시간: ${event.elapsedMinutes}분)."
+                    TimeLimitWarningType.APPROACHING_LIMIT ->
+                        "경기 시간 제한에 임박했습니다. " +
+                            "남은 시간: ${event.remainingMinutes}분 " +
+                            "(제한: ${event.timeLimitMinutes}분, 경과: ${event.elapsedMinutes}분)."
+                }
+            val details =
+                mapOf<String, Any?>(
+                    "startedAt" to event.startedAt.toString(),
+                    "timeLimitMinutes" to event.timeLimitMinutes,
+                    "elapsedMinutes" to event.elapsedMinutes,
+                    "remainingMinutes" to event.remainingMinutes,
+                )
+
+            val warningMessage =
+                WarningMessage(
+                    gameId = event.gameId,
+                    warningType = WarningType.TIME_LIMIT,
+                    severity = severity,
+                    title = title,
+                    message = message,
+                    details = details,
+                    timestamp = Instant.now(),
+                )
+            gameBroadcastService.broadcastWarning(event.gameId, warningMessage)
+
+            log.debug(
+                "시간 제한 경고 브로드캐스트 완료 (gameId={}, elapsed={}분, limit={}분, type={})",
+                event.gameId,
+                event.elapsedMinutes,
+                event.timeLimitMinutes,
+                event.warningType,
+            )
+        } catch (ex: Exception) {
+            log.error("TimeLimitWarningEvent 브로드캐스트 실패 (gameId={}): {}", event.gameId, ex.message, ex)
         }
     }
 

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/service/websocket/GameBroadcastService.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/service/websocket/GameBroadcastService.kt
@@ -3,6 +3,7 @@ package com.nextup.scorer.service.websocket
 import com.nextup.scorer.dto.websocket.GameEventMessage
 import com.nextup.scorer.dto.websocket.GameStateMessage
 import com.nextup.scorer.dto.websocket.ScoreboardMessage
+import com.nextup.scorer.dto.websocket.WarningMessage
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 
@@ -61,6 +62,24 @@ class GameBroadcastService(
         messagingTemplate.convertAndSend(
             "/topic/games/$gameId/state",
             state
+        )
+    }
+
+    /**
+     * 경기 경고를 브로드캐스트합니다.
+     *
+     * 시간 제한, 투구수 제한 등 경고 알림을 기록원에게 전송합니다.
+     *
+     * @param gameId 경기 ID
+     * @param warning 경고 메시지
+     */
+    fun broadcastWarning(
+        gameId: Long,
+        warning: WarningMessage,
+    ) {
+        messagingTemplate.convertAndSend(
+            "/topic/games/$gameId/warnings",
+            warning,
         )
     }
 }

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/listener/GameBroadcastEventListenerTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/listener/GameBroadcastEventListenerTest.kt
@@ -3,9 +3,13 @@ package com.nextup.scorer.listener
 import com.nextup.core.domain.event.GameEndedEvent
 import com.nextup.core.domain.event.GameStartedEvent
 import com.nextup.core.domain.event.HalfInningAdvancedEvent
+import com.nextup.core.domain.event.PitchCountWarningEvent
+import com.nextup.core.domain.event.PitchCountWarningType
 import com.nextup.core.domain.event.PlateAppearanceRecordedEvent
 import com.nextup.core.domain.event.PlayerSubstitutedEvent
 import com.nextup.core.domain.event.RecordCorrectedEvent
+import com.nextup.core.domain.event.TimeLimitWarningEvent
+import com.nextup.core.domain.event.TimeLimitWarningType
 import com.nextup.core.domain.game.CorrectionType
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
@@ -26,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.Instant
 
 @DisplayName("GameBroadcastEventListener 테스트")
 class GameBroadcastEventListenerTest {
@@ -475,6 +480,141 @@ class GameBroadcastEventListenerTest {
             // then
             verify(exactly = 0) { gameBroadcastService.broadcastState(any(), any()) }
             verify(exactly = 0) { gameBroadcastService.broadcastScoreboard(any(), any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("onPitchCountWarning - 투구수 제한 경고 이벤트")
+    inner class OnPitchCountWarning {
+
+        @Test
+        @DisplayName("LIMIT_REACHED 시 broadcastWarning 호출")
+        fun `투구수 제한 도달 시 경고 브로드캐스트`() {
+            // given
+            val event =
+                PitchCountWarningEvent(
+                    gameId = GAME_ID,
+                    gamePlayerId = 50L,
+                    playerId = 100L,
+                    pitchesThrown = 105,
+                    pitchCountLimit = 100,
+                    warningType = PitchCountWarningType.LIMIT_REACHED,
+                )
+
+            // when
+            listener.onPitchCountWarning(event)
+
+            // then
+            verify(exactly = 1) { gameBroadcastService.broadcastWarning(eq(GAME_ID), any()) }
+        }
+
+        @Test
+        @DisplayName("APPROACHING_LIMIT 시 broadcastWarning 호출")
+        fun `투구수 제한 임박 시 경고 브로드캐스트`() {
+            // given
+            val event =
+                PitchCountWarningEvent(
+                    gameId = GAME_ID,
+                    gamePlayerId = 50L,
+                    playerId = 100L,
+                    pitchesThrown = 92,
+                    pitchCountLimit = 100,
+                    warningType = PitchCountWarningType.APPROACHING_LIMIT,
+                )
+
+            // when
+            listener.onPitchCountWarning(event)
+
+            // then
+            verify(exactly = 1) { gameBroadcastService.broadcastWarning(eq(GAME_ID), any()) }
+        }
+
+        @Test
+        @DisplayName("broadcastWarning 실패 시 예외를 삼킴")
+        fun `브로드캐스트 실패 시 예외 전파 없음`() {
+            // given
+            every {
+                gameBroadcastService.broadcastWarning(any(), any())
+            } throws RuntimeException("WebSocket 전송 실패")
+
+            val event =
+                PitchCountWarningEvent(
+                    gameId = GAME_ID,
+                    gamePlayerId = 50L,
+                    playerId = 100L,
+                    pitchesThrown = 105,
+                    pitchCountLimit = 100,
+                    warningType = PitchCountWarningType.LIMIT_REACHED,
+                )
+
+            // when & then - 예외가 전파되지 않음
+            listener.onPitchCountWarning(event)
+        }
+    }
+
+    @Nested
+    @DisplayName("onTimeLimitWarning - 시간 제한 경고 이벤트")
+    inner class OnTimeLimitWarning {
+
+        @Test
+        @DisplayName("LIMIT_REACHED 시 broadcastWarning 호출")
+        fun `시간 제한 도달 시 경고 브로드캐스트`() {
+            // given
+            val event =
+                TimeLimitWarningEvent(
+                    gameId = GAME_ID,
+                    startedAt = Instant.now().minusSeconds(7200),
+                    timeLimitMinutes = 120,
+                    elapsedMinutes = 125,
+                    warningType = TimeLimitWarningType.LIMIT_REACHED,
+                )
+
+            // when
+            listener.onTimeLimitWarning(event)
+
+            // then
+            verify(exactly = 1) { gameBroadcastService.broadcastWarning(eq(GAME_ID), any()) }
+        }
+
+        @Test
+        @DisplayName("APPROACHING_LIMIT 시 broadcastWarning 호출")
+        fun `시간 제한 임박 시 경고 브로드캐스트`() {
+            // given
+            val event =
+                TimeLimitWarningEvent(
+                    gameId = GAME_ID,
+                    startedAt = Instant.now().minusSeconds(6600),
+                    timeLimitMinutes = 120,
+                    elapsedMinutes = 112,
+                    warningType = TimeLimitWarningType.APPROACHING_LIMIT,
+                )
+
+            // when
+            listener.onTimeLimitWarning(event)
+
+            // then
+            verify(exactly = 1) { gameBroadcastService.broadcastWarning(eq(GAME_ID), any()) }
+        }
+
+        @Test
+        @DisplayName("broadcastWarning 실패 시 예외를 삼킴")
+        fun `브로드캐스트 실패 시 예외 전파 없음`() {
+            // given
+            every {
+                gameBroadcastService.broadcastWarning(any(), any())
+            } throws RuntimeException("WebSocket 전송 실패")
+
+            val event =
+                TimeLimitWarningEvent(
+                    gameId = GAME_ID,
+                    startedAt = Instant.now().minusSeconds(7200),
+                    timeLimitMinutes = 120,
+                    elapsedMinutes = 125,
+                    warningType = TimeLimitWarningType.LIMIT_REACHED,
+                )
+
+            // when & then - 예외가 전파되지 않음
+            listener.onTimeLimitWarning(event)
         }
     }
 }

--- a/nextup-scorer/src/test/kotlin/com/nextup/scorer/service/websocket/GameBroadcastServiceTest.kt
+++ b/nextup-scorer/src/test/kotlin/com/nextup/scorer/service/websocket/GameBroadcastServiceTest.kt
@@ -96,4 +96,36 @@ class GameBroadcastServiceTest {
             messagingTemplate.convertAndSend("/topic/games/$gameId/state", state)
         }
     }
+
+    @Test
+    fun `should broadcast warning to correct topic`() {
+        // given
+        val gameId = 1L
+        val warning =
+            WarningMessage(
+                gameId = gameId,
+                warningType = WarningType.PITCH_COUNT,
+                severity = WarningSeverity.CRITICAL,
+                title = "투구 수 제한 도달",
+                message = "투수가 투구 수 제한(100구)에 도달했습니다(현재 102구). 투수 교체를 권고합니다.",
+                details =
+                    mapOf(
+                        "gamePlayerId" to 5L,
+                        "playerId" to 10L,
+                        "pitchesThrown" to 102,
+                        "pitchCountLimit" to 100,
+                        "remainingPitches" to -2,
+                        "isSubstitutionRecommended" to true,
+                    ),
+                timestamp = Instant.now(),
+            )
+
+        // when
+        service.broadcastWarning(gameId, warning)
+
+        // then
+        verify(exactly = 1) {
+            messagingTemplate.convertAndSend("/topic/games/$gameId/warnings", warning)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

>- Close #393

경기 시간 제한(timeLimitMinutes) 및 투구수 제한(pitchCountLimit) 도달 시 기록원에게 WebSocket 경고 알림을 발송하는 기능을 구현합니다.

기존에 `TimeLimitWarningEvent`와 `PitchCountWarningEvent` 도메인 이벤트 클래스는 존재했지만, 시간 제한 이벤트는 발행되지 않았고 투구수 제한 이벤트는 발행만 되고 WebSocket으로 전파되지 않았습니다. 이번 PR에서 두 경고 모두 타석 기록 시점에 감지하여 WebSocket으로 브로드캐스트합니다.

## Tasks

- [x] M-5: `PlateAppearanceRecordServiceImpl`에 `detectTimeLimitWarning()` 추가 — 경기 시작 시각 기반 시간 제한 체크 후 `TimeLimitWarningEvent` 발행
- [x] M-8: `GameBroadcastEventListener`에 `onPitchCountWarning()`, `onTimeLimitWarning()` 핸들러 추가
- [x] `GameBroadcastService`에 `broadcastWarning()` 메서드 추가 (`/topic/games/{gameId}/warnings`)
- [x] `WarningMessage` DTO 신규 생성 (`WarningType`, `WarningSeverity` enum 포함)
- [x] 투구수 제한 도달 시 투수 교체 권고 메시지 포함
- [x] 단위 테스트 추가 (시간 제한 경고 4건, 브로드캐스트 리스너 6건, broadcastWarning 1건)
- [x] `./gradlew clean build` 성공

## To Reviewer

### 아키텍처 결정
- 경고 전용 WebSocket 토픽(`/topic/games/{gameId}/warnings`)을 분리하여 기존 이벤트/상태/스코어보드 토픽과 혼선을 방지했습니다.
- 경고 이벤트 리스너는 DB 재조회가 필요 없으므로 `@Transactional(propagation = REQUIRES_NEW)` 없이 `@TransactionalEventListener(AFTER_COMMIT)`만 적용했습니다.
- `WarningMessage`의 `details` 필드를 `Map<String, Any?>`로 설계하여 경고 유형별 상세 정보를 유연하게 전달합니다.

### 시간 제한 경고 동작
- 매 타석 기록 시점에 `Game.checkTimeLimitStatus()`를 호출하여 경과 시간을 체크합니다.
- 제한 10분 전 임박 경고(WARNING), 제한 도달 시 위험 경고(CRITICAL)를 발송합니다.
- `startedAt`이 `LocalDateTime`이므로 `Instant` 변환 시 시스템 타임존을 사용합니다.

## Screenshot

_(백엔드 작업이므로 삭제)_