### PR TITLE
feat(#395): 운영 자동화 — OWNER 강퇴 선거 + SUSPENDED 타임아웃 + 구장 폐업 처리

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/team/TeamMember.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/team/TeamMember.kt
@@ -189,6 +189,23 @@ class TeamMember private constructor(
     }
 
     /**
+     * L-10: 관리자/시스템에 의한 강제 강퇴입니다.
+     *
+     * OWNER를 포함한 모든 역할의 멤버를 강제로 강퇴할 수 있습니다.
+     * 일반 강퇴([kick])와 달리 역할 제한이 없으며, 요청자 권한 검증도 수행하지 않습니다.
+     *
+     * @param reason 강퇴 사유
+     * @return 강퇴된 멤버가 OWNER였는지 여부 (선거 트리거 판단용)
+     */
+    fun forceKick(reason: String? = null): Boolean {
+        val wasOwner = this.role == TeamMemberRole.OWNER
+        this.status = TeamMemberStatus.KICKED
+        this.leftAt = LocalDateTime.now()
+        this.memo = reason
+        return wasOwner
+    }
+
+    /**
      * 자진 탈퇴합니다.
      *
      * @throws IllegalStateException OWNER이거나 상태가 부적절한 경우

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/GameRepositoryPort.kt
@@ -82,4 +82,9 @@ interface GameRepositoryPort {
         status: GameStatus?,
         pageCommand: PageCommand,
     ): PageResult<Game>
+
+    /**
+     * L-11: 특정 상태의 경기 목록을 조회합니다. (SUSPENDED 타임아웃 스케줄러용)
+     */
+    fun findByStatus(status: GameStatus): List<Game>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumBookingRepositoryPort.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/port/repository/StadiumBookingRepositoryPort.kt
@@ -24,4 +24,13 @@ interface StadiumBookingRepositoryPort {
         slotId: Long,
         status: BookingStatus,
     ): Boolean
+
+    /**
+     * L-12: 구장 ID와 예약 상태로 예약 목록을 조회합니다.
+     * StadiumBooking → StadiumSlot → Stadium 관계를 통해 조회합니다.
+     */
+    fun findByStadiumIdAndStatus(
+        stadiumId: Long,
+        status: BookingStatus,
+    ): List<StadiumBooking>
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/team/TeamMembershipService.kt
@@ -285,4 +285,21 @@ interface TeamMembershipService {
      * @param memberId 멤버 ID
      */
     fun deleteMemberByAdmin(memberId: Long)
+
+    /**
+     * L-10: 관리자에 의한 강제 강퇴입니다.
+     *
+     * OWNER를 포함한 모든 역할의 멤버를 강제로 강퇴할 수 있습니다.
+     * OWNER가 강퇴되면 OwnerKickedEvent를 발행하여 자동 선거를 트리거합니다.
+     *
+     * @param memberId 강퇴 대상 멤버 ID
+     * @param reason 강퇴 사유
+     * @param addToBlacklist 블랙리스트 추가 여부
+     * @throws TeamMemberNotFoundException 멤버를 찾을 수 없는 경우
+     */
+    fun forceKickMember(
+        memberId: Long,
+        reason: String,
+        addToBlacklist: Boolean,
+    )
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamMemberTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/team/TeamMemberTest.kt
@@ -164,6 +164,61 @@ class TeamMemberTest {
     }
 
     @Nested
+    @DisplayName("L-10: 강제 강퇴")
+    inner class ForceKick {
+        @Test
+        fun `일반 멤버를 강제 강퇴하면 wasOwner가 false이다`() {
+            // when
+            val wasOwner = member.forceKick("관리자 강퇴")
+
+            // then
+            assertThat(wasOwner).isFalse()
+            assertThat(member.status).isEqualTo(TeamMemberStatus.KICKED)
+            assertThat(member.leftAt).isNotNull()
+            assertThat(member.memo).isEqualTo("관리자 강퇴")
+        }
+
+        @Test
+        fun `OWNER를 강제 강퇴하면 wasOwner가 true이다`() {
+            // when
+            val wasOwner = owner.forceKick("관리자에 의한 OWNER 강퇴")
+
+            // then
+            assertThat(wasOwner).isTrue()
+            assertThat(owner.status).isEqualTo(TeamMemberStatus.KICKED)
+            assertThat(owner.leftAt).isNotNull()
+            assertThat(owner.memo).isEqualTo("관리자에 의한 OWNER 강퇴")
+        }
+
+        @Test
+        fun `MANAGER를 강제 강퇴하면 wasOwner가 false이다`() {
+            // given
+            val managerUser = User.createLocalUser("manager@example.com", "password", "매니저")
+            val managerPlayer = Player(name = "매니저", primaryPosition = Position.CATCHER)
+            val manager = TeamMember.create(team, managerUser, managerPlayer, 5, TeamMemberRole.MANAGER)
+            setTeamMemberId(manager, 3L)
+
+            // when
+            val wasOwner = manager.forceKick("관리자 강퇴")
+
+            // then
+            assertThat(wasOwner).isFalse()
+            assertThat(manager.status).isEqualTo(TeamMemberStatus.KICKED)
+        }
+
+        @Test
+        fun `사유 없이 강제 강퇴할 수 있다`() {
+            // when
+            val wasOwner = member.forceKick()
+
+            // then
+            assertThat(wasOwner).isFalse()
+            assertThat(member.status).isEqualTo(TeamMemberStatus.KICKED)
+            assertThat(member.memo).isNull()
+        }
+    }
+
+    @Nested
     @DisplayName("탈퇴")
     inner class Leave {
         @Test

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/OwnerKickedEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/OwnerKickedEventListener.kt
@@ -1,0 +1,95 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.core.domain.election.Election
+import com.nextup.core.domain.election.ElectionType
+import com.nextup.core.domain.event.OwnerKickedEvent
+import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.port.repository.ElectionRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * L-10: OWNER 강퇴 이벤트 리스너
+ *
+ * OWNER가 강제 강퇴되었을 때 자동으로 긴급 선거(EMERGENCY)를 생성합니다.
+ * 팀에 MANAGER가 있으면 해당 MANAGER가 임시 구단주로 지정됩니다.
+ */
+@Component
+class OwnerKickedEventListener(
+    private val electionRepository: ElectionRepositoryPort,
+    private val teamMemberRepository: TeamMemberRepositoryPort,
+) {
+    private val logger = LoggerFactory.getLogger(OwnerKickedEventListener::class.java)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleOwnerKicked(event: OwnerKickedEvent) {
+        logger.info(
+            "OWNER 강퇴 이벤트 수신 - teamId={}, kickedMemberId={}",
+            event.teamId,
+            event.kickedMemberId,
+        )
+
+        // 팀에 다른 OWNER가 이미 있는지 확인 (이양 후 강퇴된 경우)
+        val currentOwnerCount = teamMemberRepository.countOwnersByTeamId(event.teamId)
+        if (currentOwnerCount > 0) {
+            logger.info(
+                "팀에 이미 OWNER 존재, 선거 생성 생략 - teamId={}, ownerCount={}",
+                event.teamId,
+                currentOwnerCount,
+            )
+            return
+        }
+
+        // 긴급 선거 생성
+        val now = Instant.now()
+        val electionEnd = now.plus(ELECTION_DURATION_DAYS, ChronoUnit.DAYS)
+
+        // MANAGER를 트리거 멤버로 지정 (없으면 시스템 발동)
+        val managers =
+            teamMemberRepository.findByTeamId(event.teamId)
+                .filter { it.role == TeamMemberRole.MANAGER && it.isActive }
+        val triggerMemberId = managers.firstOrNull()?.id ?: 0L
+
+        val election =
+            if (triggerMemberId > 0L) {
+                Election.createEmergency(
+                    teamId = event.teamId,
+                    triggeredByMemberId = triggerMemberId,
+                    title = "OWNER 강퇴에 따른 긴급 구단주 선거",
+                    description = "기존 구단주가 강퇴되어 긴급 구단주 선거가 자동 개시되었습니다.",
+                    startAt = now,
+                    endAt = electionEnd,
+                )
+            } else {
+                Election.create(
+                    teamId = event.teamId,
+                    title = "OWNER 강퇴에 따른 구단주 선거",
+                    description = "기존 구단주가 강퇴되어 구단주 선거가 자동 개시되었습니다.",
+                    electionType = ElectionType.OWNER_ELECTION,
+                    startAt = now,
+                    endAt = electionEnd,
+                )
+            }
+
+        val savedElection = electionRepository.save(election)
+        logger.info(
+            "자동 선거 생성 완료 - teamId={}, electionId={}, type={}",
+            event.teamId,
+            savedElection.id,
+            savedElection.electionType,
+        )
+    }
+
+    companion object {
+        /** 긴급 선거 기간 (일) */
+        const val ELECTION_DURATION_DAYS = 7L
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StadiumClosedEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/StadiumClosedEventListener.kt
@@ -1,0 +1,61 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.core.domain.event.StadiumClosedEvent
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.port.repository.StadiumBookingRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * L-12: 구장 폐업 이벤트 리스너
+ *
+ * 구장이 폐업(비활성화)되었을 때 해당 구장의 CONFIRMED 상태 예약을 일괄 취소합니다.
+ * AFTER_COMMIT 단계에서 실행되어 구장 비활성화 트랜잭션 롤백에 영향을 주지 않습니다.
+ */
+@Component
+class StadiumClosedEventListener(
+    private val stadiumBookingRepository: StadiumBookingRepositoryPort,
+) {
+    private val logger = LoggerFactory.getLogger(StadiumClosedEventListener::class.java)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleStadiumClosed(event: StadiumClosedEvent) {
+        logger.info(
+            "구장 폐업 이벤트 수신 - stadiumId={}, stadiumName={}",
+            event.stadiumId,
+            event.stadiumName,
+        )
+
+        val confirmedBookings =
+            stadiumBookingRepository.findByStadiumIdAndStatus(
+                event.stadiumId,
+                BookingStatus.CONFIRMED,
+            )
+
+        if (confirmedBookings.isEmpty()) {
+            logger.info("취소 대상 예약 없음 - stadiumId={}", event.stadiumId)
+            return
+        }
+
+        confirmedBookings.forEach { booking ->
+            booking.cancel()
+            stadiumBookingRepository.save(booking)
+            logger.info(
+                "구장 폐업으로 예약 취소 - bookingId={}, teamId={}",
+                booking.id,
+                booking.teamId,
+            )
+        }
+
+        logger.info(
+            "구장 폐업 예약 일괄 취소 완료 - stadiumId={}, 취소건수={}",
+            event.stadiumId,
+            confirmedBookings.size,
+        )
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumBookingJpaRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumBookingJpaRepository.kt
@@ -19,10 +19,18 @@ interface StadiumBookingJpaRepository : JpaRepository<StadiumBooking, Long> {
     ): List<StadiumBooking>
 
     @Query(
-        "SELECT CASE WHEN COUNT(b) > 0 THEN true ELSE false END FROM StadiumBooking b WHERE b.slot.id = :slotId AND b.status = :status"
+        "SELECT CASE WHEN COUNT(b) > 0 THEN true ELSE false END FROM StadiumBooking b WHERE b.slot.id = :slotId AND b.status = :status",
     )
     fun existsBySlotIdAndStatus(
         slotId: Long,
         status: BookingStatus,
     ): Boolean
+
+    @Query(
+        "SELECT b FROM StadiumBooking b JOIN b.slot s WHERE s.stadium.id = :stadiumId AND b.status = :status",
+    )
+    fun findByStadiumIdAndStatus(
+        stadiumId: Long,
+        status: BookingStatus,
+    ): List<StadiumBooking>
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumBookingRepositoryAdapter.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/persistence/stadium/StadiumBookingRepositoryAdapter.kt
@@ -27,4 +27,9 @@ class StadiumBookingRepositoryAdapter(
         slotId: Long,
         status: BookingStatus,
     ): Boolean = jpaRepository.existsBySlotIdAndStatus(slotId, status)
+
+    override fun findByStadiumIdAndStatus(
+        stadiumId: Long,
+        status: BookingStatus,
+    ): List<StadiumBooking> = jpaRepository.findByStadiumIdAndStatus(stadiumId, status)
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/repository/game/GameRepository.kt
@@ -88,6 +88,11 @@ interface GameRepository :
         @Param("threshold") threshold: LocalDateTime,
     ): List<Game>
 
+    @Query("SELECT g FROM Game g WHERE g.status = :status")
+    override fun findByStatus(
+        @Param("status") status: GameStatus,
+    ): List<Game>
+
     // ---- 페이징용 내부 쿼리 메서드 (Spring Data Pageable은 Infra 레이어에서만 사용) ----
 
     @Query(

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/scheduler/SuspendedGameTimeoutScheduler.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/scheduler/SuspendedGameTimeoutScheduler.kt
@@ -1,0 +1,61 @@
+package com.nextup.infrastructure.scheduler
+
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.port.repository.GameRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+/**
+ * L-11: SUSPENDED 경기 자동 타임아웃 스케줄러
+ *
+ * 1시간마다 실행되어 SUSPENDED 상태가 48시간 이상 경과한 경기를 자동으로 CANCELLED 전환합니다.
+ * Game 엔티티의 isSuspendedTimeout()과 cancelByTimeout() 메서드를 활용합니다.
+ */
+@Component
+class SuspendedGameTimeoutScheduler(
+    private val gameRepository: GameRepositoryPort,
+) {
+    private val logger = LoggerFactory.getLogger(SuspendedGameTimeoutScheduler::class.java)
+
+    @Scheduled(fixedRate = CHECK_INTERVAL_MS)
+    @Transactional
+    fun cancelTimedOutSuspendedGames() {
+        val suspendedGames = gameRepository.findByStatus(GameStatus.SUSPENDED)
+
+        if (suspendedGames.isEmpty()) {
+            logger.debug("SUSPENDED 상태 경기 없음")
+            return
+        }
+
+        val now = Instant.now()
+        var cancelledCount = 0
+
+        suspendedGames.forEach { game ->
+            if (game.isSuspendedTimeout(SUSPENDED_TIMEOUT_HOURS, now)) {
+                logger.info(
+                    "SUSPENDED 경기 타임아웃 자동 취소: gameId={}, updatedAt={}",
+                    game.id,
+                    game.updatedAt,
+                )
+                game.cancelByTimeout()
+                gameRepository.save(game)
+                cancelledCount++
+            }
+        }
+
+        if (cancelledCount > 0) {
+            logger.info("총 {}건의 SUSPENDED 경기가 타임아웃으로 자동 취소됨", cancelledCount)
+        }
+    }
+
+    companion object {
+        /** 타임아웃 기준 시간 (48시간) */
+        const val SUSPENDED_TIMEOUT_HOURS = 48L
+
+        /** 스케줄러 실행 주기 (1시간 = 3,600,000ms) */
+        const val CHECK_INTERVAL_MS = 3_600_000L
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/team/TeamMembershipServiceImpl.kt
@@ -3,6 +3,7 @@ package com.nextup.infrastructure.service.team
 import com.nextup.common.exception.*
 import com.nextup.core.common.PageCommand
 import com.nextup.core.common.PageResult
+import com.nextup.core.domain.event.OwnerKickedEvent
 import com.nextup.core.domain.event.TeamJoinApprovedEvent
 import com.nextup.core.domain.event.TeamJoinRejectedEvent
 import com.nextup.core.domain.event.TeamMemberKickedEvent
@@ -486,5 +487,55 @@ class TeamMembershipServiceImpl(
     @Transactional
     override fun deleteMemberByAdmin(memberId: Long) {
         teamMemberRepository.deleteById(memberId)
+    }
+
+    @Transactional
+    override fun forceKickMember(
+        memberId: Long,
+        reason: String,
+        addToBlacklist: Boolean,
+    ) {
+        val member =
+            teamMemberRepository.findByIdOrNull(memberId)
+                ?: throw TeamMemberNotFoundException(memberId)
+
+        // L-10: 강제 강퇴 (OWNER 포함 가능)
+        val wasOwner = member.forceKick(reason)
+        teamMemberRepository.save(member)
+
+        // 블랙리스트 추가 옵션
+        if (addToBlacklist) {
+            val blacklist =
+                TeamBlacklist.createPermanent(
+                    team = member.team,
+                    user = member.user,
+                    player = member.player,
+                    reason = reason,
+                    registeredBy = member.user,
+                )
+            teamBlacklistRepository.save(blacklist)
+        }
+
+        // 일반 강퇴 이벤트 발행
+        eventPublisher.publishEvent(
+            TeamMemberKickedEvent(
+                teamId = member.team.id,
+                userId = member.user.id,
+                playerId = member.player.id,
+                memberId = member.id,
+                teamName = member.team.name,
+            ),
+        )
+
+        // L-10: OWNER가 강퇴된 경우 자동 선거 트리거 이벤트 발행
+        if (wasOwner) {
+            eventPublisher.publishEvent(
+                OwnerKickedEvent(
+                    teamId = member.team.id,
+                    kickedPlayerId = member.player.id,
+                    kickedMemberId = member.id,
+                ),
+            )
+        }
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/OwnerKickedEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/OwnerKickedEventListenerTest.kt
@@ -1,0 +1,118 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.core.domain.election.Election
+import com.nextup.core.domain.event.OwnerKickedEvent
+import com.nextup.core.domain.team.TeamMember
+import com.nextup.core.domain.team.TeamMemberRole
+import com.nextup.core.port.repository.ElectionRepositoryPort
+import com.nextup.core.port.repository.TeamMemberRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("OwnerKickedEventListener 테스트")
+class OwnerKickedEventListenerTest {
+    private val electionRepository: ElectionRepositoryPort = mockk()
+    private val teamMemberRepository: TeamMemberRepositoryPort = mockk()
+
+    private lateinit var listener: OwnerKickedEventListener
+
+    @BeforeEach
+    fun setUp() {
+        listener =
+            OwnerKickedEventListener(
+                electionRepository = electionRepository,
+                teamMemberRepository = teamMemberRepository,
+            )
+    }
+
+    @Test
+    fun `OWNER가 이미 존재하면 선거를 생성하지 않는다`() {
+        // given
+        val event = OwnerKickedEvent(teamId = 1L, kickedPlayerId = 100L, kickedMemberId = 200L)
+        every { teamMemberRepository.countOwnersByTeamId(1L) } returns 1L
+
+        // when
+        listener.handleOwnerKicked(event)
+
+        // then
+        verify(exactly = 0) { electionRepository.save(any()) }
+    }
+
+    @Test
+    fun `OWNER 부재 시 MANAGER가 있으면 긴급 선거를 생성한다`() {
+        // given
+        val event = OwnerKickedEvent(teamId = 1L, kickedPlayerId = 100L, kickedMemberId = 200L)
+        val manager: TeamMember =
+            mockk {
+                every { id } returns 300L
+                every { role } returns TeamMemberRole.MANAGER
+                every { isActive } returns true
+            }
+        every { teamMemberRepository.countOwnersByTeamId(1L) } returns 0L
+        every { teamMemberRepository.findByTeamId(1L) } returns listOf(manager)
+
+        val electionSlot = slot<Election>()
+        every { electionRepository.save(capture(electionSlot)) } answers { firstArg() }
+
+        // when
+        listener.handleOwnerKicked(event)
+
+        // then
+        verify(exactly = 1) { electionRepository.save(any()) }
+        val savedElection = electionSlot.captured
+        assertThat(savedElection.teamId).isEqualTo(1L)
+        assertThat(savedElection.electionType.name).isEqualTo("EMERGENCY")
+        assertThat(savedElection.title).contains("긴급")
+    }
+
+    @Test
+    fun `OWNER 부재 시 MANAGER가 없으면 일반 OWNER_ELECTION을 생성한다`() {
+        // given
+        val event = OwnerKickedEvent(teamId = 1L, kickedPlayerId = 100L, kickedMemberId = 200L)
+        val member: TeamMember =
+            mockk {
+                every { id } returns 300L
+                every { role } returns TeamMemberRole.MEMBER
+                every { isActive } returns true
+            }
+        every { teamMemberRepository.countOwnersByTeamId(1L) } returns 0L
+        every { teamMemberRepository.findByTeamId(1L) } returns listOf(member)
+
+        val electionSlot = slot<Election>()
+        every { electionRepository.save(capture(electionSlot)) } answers { firstArg() }
+
+        // when
+        listener.handleOwnerKicked(event)
+
+        // then
+        verify(exactly = 1) { electionRepository.save(any()) }
+        val savedElection = electionSlot.captured
+        assertThat(savedElection.teamId).isEqualTo(1L)
+        assertThat(savedElection.electionType.name).isEqualTo("OWNER_ELECTION")
+    }
+
+    @Test
+    fun `OWNER 부재 시 팀원이 아무도 없어도 일반 선거를 생성한다`() {
+        // given
+        val event = OwnerKickedEvent(teamId = 1L, kickedPlayerId = 100L, kickedMemberId = 200L)
+        every { teamMemberRepository.countOwnersByTeamId(1L) } returns 0L
+        every { teamMemberRepository.findByTeamId(1L) } returns emptyList()
+
+        val electionSlot = slot<Election>()
+        every { electionRepository.save(capture(electionSlot)) } answers { firstArg() }
+
+        // when
+        listener.handleOwnerKicked(event)
+
+        // then
+        verify(exactly = 1) { electionRepository.save(any()) }
+        val savedElection = electionSlot.captured
+        assertThat(savedElection.electionType.name).isEqualTo("OWNER_ELECTION")
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StadiumClosedEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/StadiumClosedEventListenerTest.kt
@@ -1,0 +1,91 @@
+package com.nextup.infrastructure.listener
+
+import com.nextup.core.domain.event.StadiumClosedEvent
+import com.nextup.core.domain.stadium.BookingStatus
+import com.nextup.core.domain.stadium.StadiumBooking
+import com.nextup.core.port.repository.StadiumBookingRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("StadiumClosedEventListener 테스트")
+class StadiumClosedEventListenerTest {
+    private val stadiumBookingRepository: StadiumBookingRepositoryPort = mockk()
+
+    private lateinit var listener: StadiumClosedEventListener
+
+    @BeforeEach
+    fun setUp() {
+        listener =
+            StadiumClosedEventListener(
+                stadiumBookingRepository = stadiumBookingRepository,
+            )
+    }
+
+    @Test
+    fun `구장 폐업 시 CONFIRMED 예약을 일괄 취소한다`() {
+        // given
+        val event = StadiumClosedEvent(stadiumId = 1L, stadiumName = "잠실 야구장")
+        val booking1 = mockk<StadiumBooking>(relaxed = true)
+        every { booking1.id } returns 10L
+        every { booking1.teamId } returns 100L
+        val booking2 = mockk<StadiumBooking>(relaxed = true)
+        every { booking2.id } returns 20L
+        every { booking2.teamId } returns 200L
+
+        every {
+            stadiumBookingRepository.findByStadiumIdAndStatus(1L, BookingStatus.CONFIRMED)
+        } returns listOf(booking1, booking2)
+        every { stadiumBookingRepository.save(any()) } answers { firstArg() }
+
+        // when
+        listener.handleStadiumClosed(event)
+
+        // then
+        verify(exactly = 1) { booking1.cancel() }
+        verify(exactly = 1) { booking2.cancel() }
+        verify(exactly = 2) { stadiumBookingRepository.save(any()) }
+    }
+
+    @Test
+    fun `구장 폐업 시 취소 대상 예약이 없으면 아무 작업도 하지 않는다`() {
+        // given
+        val event = StadiumClosedEvent(stadiumId = 1L, stadiumName = "잠실 야구장")
+        every {
+            stadiumBookingRepository.findByStadiumIdAndStatus(1L, BookingStatus.CONFIRMED)
+        } returns emptyList()
+
+        // when
+        listener.handleStadiumClosed(event)
+
+        // then
+        verify(exactly = 0) { stadiumBookingRepository.save(any()) }
+    }
+
+    @Test
+    fun `구장 폐업 시 CONFIRMED 상태 예약만 대상으로 한다`() {
+        // given
+        val event = StadiumClosedEvent(stadiumId = 1L, stadiumName = "잠실 야구장")
+        val confirmedBooking = mockk<StadiumBooking>(relaxed = true)
+        every { confirmedBooking.id } returns 10L
+        every { confirmedBooking.teamId } returns 100L
+
+        every {
+            stadiumBookingRepository.findByStadiumIdAndStatus(1L, BookingStatus.CONFIRMED)
+        } returns listOf(confirmedBooking)
+        every { stadiumBookingRepository.save(any()) } answers { firstArg() }
+
+        // when
+        listener.handleStadiumClosed(event)
+
+        // then
+        verify(exactly = 1) {
+            stadiumBookingRepository.findByStadiumIdAndStatus(1L, BookingStatus.CONFIRMED)
+        }
+        verify(exactly = 1) { confirmedBooking.cancel() }
+        verify(exactly = 1) { stadiumBookingRepository.save(confirmedBooking) }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/scheduler/SuspendedGameTimeoutSchedulerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/scheduler/SuspendedGameTimeoutSchedulerTest.kt
@@ -1,0 +1,97 @@
+package com.nextup.infrastructure.scheduler
+
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.port.repository.GameRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("SuspendedGameTimeoutScheduler 테스트")
+class SuspendedGameTimeoutSchedulerTest {
+    private val gameRepository = mockk<GameRepositoryPort>()
+
+    private val scheduler =
+        SuspendedGameTimeoutScheduler(
+            gameRepository = gameRepository,
+        )
+
+    @Nested
+    @DisplayName("SUSPENDED 경기 타임아웃 처리")
+    inner class CancelTimedOutSuspendedGames {
+        @Test
+        fun `SUSPENDED 경기가 없으면 아무 작업도 하지 않는다`() {
+            // given
+            every { gameRepository.findByStatus(GameStatus.SUSPENDED) } returns emptyList()
+
+            // when
+            scheduler.cancelTimedOutSuspendedGames()
+
+            // then
+            verify(exactly = 0) { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `타임아웃된 SUSPENDED 경기를 자동 취소한다`() {
+            // given
+            val timedOutGame = mockk<Game>(relaxed = true)
+            every { timedOutGame.id } returns 1L
+            every { timedOutGame.isSuspendedTimeout(any(), any()) } returns true
+
+            every { gameRepository.findByStatus(GameStatus.SUSPENDED) } returns listOf(timedOutGame)
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            scheduler.cancelTimedOutSuspendedGames()
+
+            // then
+            verify(exactly = 1) { timedOutGame.cancelByTimeout() }
+            verify(exactly = 1) { gameRepository.save(timedOutGame) }
+        }
+
+        @Test
+        fun `타임아웃되지 않은 SUSPENDED 경기는 취소하지 않는다`() {
+            // given
+            val recentGame = mockk<Game>(relaxed = true)
+            every { recentGame.id } returns 1L
+            every { recentGame.isSuspendedTimeout(any(), any()) } returns false
+
+            every { gameRepository.findByStatus(GameStatus.SUSPENDED) } returns listOf(recentGame)
+
+            // when
+            scheduler.cancelTimedOutSuspendedGames()
+
+            // then
+            verify(exactly = 0) { recentGame.cancelByTimeout() }
+            verify(exactly = 0) { gameRepository.save(any()) }
+        }
+
+        @Test
+        fun `여러 SUSPENDED 경기 중 타임아웃된 것만 취소한다`() {
+            // given
+            val timedOutGame = mockk<Game>(relaxed = true)
+            every { timedOutGame.id } returns 1L
+            every { timedOutGame.isSuspendedTimeout(any(), any()) } returns true
+
+            val recentGame = mockk<Game>(relaxed = true)
+            every { recentGame.id } returns 2L
+            every { recentGame.isSuspendedTimeout(any(), any()) } returns false
+
+            every {
+                gameRepository.findByStatus(GameStatus.SUSPENDED)
+            } returns listOf(timedOutGame, recentGame)
+            every { gameRepository.save(any()) } answers { firstArg() }
+
+            // when
+            scheduler.cancelTimedOutSuspendedGames()
+
+            // then
+            verify(exactly = 1) { timedOutGame.cancelByTimeout() }
+            verify(exactly = 0) { recentGame.cancelByTimeout() }
+            verify(exactly = 1) { gameRepository.save(timedOutGame) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

>- Close #395

운영 자동화 3건(L-10, L-11, L-12) 구현. OWNER 강퇴 시 자동 선거 트리거, SUSPENDED 경기 자동 타임아웃, 구장 폐업 시 기존 예약 일괄 취소 기능을 추가합니다.

## Tasks

- [x] **L-10**: `TeamMember.forceKick()` 도메인 메서드 추가 (OWNER 포함 강제 강퇴)
- [x] **L-10**: `TeamMembershipService.forceKickMember()` 서비스 인터페이스 + 구현체 추가
- [x] **L-10**: `OwnerKickedEventListener` — OWNER 강퇴 시 긴급 선거(EMERGENCY) 또는 일반 OWNER_ELECTION 자동 생성
- [x] **L-11**: `GameRepositoryPort.findByStatus()` 포트 + JPA 구현 추가
- [x] **L-11**: `SuspendedGameTimeoutScheduler` — 1시간마다 실행, 48시간 초과 SUSPENDED 경기 자동 CANCELLED 전환
- [x] **L-12**: `StadiumBookingRepositoryPort.findByStadiumIdAndStatus()` 포트 + JPA/Adapter 구현 추가
- [x] **L-12**: `StadiumClosedEventListener` — 구장 폐업 이벤트 수신 시 CONFIRMED 예약 일괄 취소
- [x] 각 기능에 대한 단위 테스트 작성 (총 15개 테스트)
- [x] `./gradlew clean build` 성공

## To Reviewer

### L-10: OWNER 강퇴 → 자동 선거
- `TeamMember.forceKick()`은 기존 `kick()`과 달리 역할 제한 없이 OWNER도 강퇴 가능합니다 (관리자/시스템용).
- 반환값 `wasOwner: Boolean`으로 선거 트리거 여부를 판단합니다.
- MANAGER가 있으면 `EMERGENCY` 선거, 없으면 `OWNER_ELECTION` 선거를 생성합니다.
- 기존 `kick()` 메서드는 변경 없이 유지됩니다 (OWNER 강퇴 불가 규칙 유지).

### L-11: SUSPENDED 타임아웃
- `Game.isSuspendedTimeout()`, `Game.cancelByTimeout()`은 이미 도메인에 구현되어 있었고, 이번에 스케줄러만 추가했습니다.
- 기본 타임아웃: 48시간, 스케줄러 주기: 1시간.

### L-12: 구장 폐업 예약 취소
- `StadiumClosedEvent`는 이미 core에 정의되어 있었고, 이번에 리스너만 추가했습니다.
- `StadiumBooking → StadiumSlot → Stadium` 관계를 JOIN으로 추적하여 예약을 조회합니다.