### PR TITLE
fix(#396): 교체 선수 기록 자동 생성 및 이닝 마감 테스트 추가

### DIFF
--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/BattingRecordTest.kt
@@ -2019,4 +2019,66 @@ class BattingRecordTest {
                 .hasMessageContaining("정정 값은 정수여야 합니다")
         }
     }
+
+    @Nested
+    @DisplayName("create - 팩토리 메서드")
+    inner class CreateTest {
+        @Test
+        fun `교체 선수용 BattingRecord를 생성하면 모든 기록이 0이다`() {
+            // when
+            val record = BattingRecord.create(gamePlayer = gamePlayer)
+
+            // then
+            assertThat(record.gamePlayer).isEqualTo(gamePlayer)
+            assertThat(record.plateAppearances).isEqualTo(0)
+            assertThat(record.atBats).isEqualTo(0)
+            assertThat(record.hits).isEqualTo(0)
+            assertThat(record.doubles).isEqualTo(0)
+            assertThat(record.triples).isEqualTo(0)
+            assertThat(record.homeRuns).isEqualTo(0)
+            assertThat(record.runs).isEqualTo(0)
+            assertThat(record.runsBattedIn).isEqualTo(0)
+            assertThat(record.walks).isEqualTo(0)
+            assertThat(record.intentionalWalks).isEqualTo(0)
+            assertThat(record.hitByPitch).isEqualTo(0)
+            assertThat(record.strikeouts).isEqualTo(0)
+            assertThat(record.sacrificeBunts).isEqualTo(0)
+            assertThat(record.sacrificeFlies).isEqualTo(0)
+            assertThat(record.stolenBases).isEqualTo(0)
+            assertThat(record.caughtStealing).isEqualTo(0)
+            assertThat(record.groundedIntoDoublePlays).isEqualTo(0)
+            assertThat(record.triplePlays).isEqualTo(0)
+        }
+
+        @Test
+        fun `생성 직후 계산 속성이 올바르다`() {
+            // when
+            val record = BattingRecord.create(gamePlayer = gamePlayer)
+
+            // then
+            assertThat(record.singles).isEqualTo(0)
+            assertThat(record.totalBases).isEqualTo(0)
+            assertThat(record.extraBaseHits).isEqualTo(0)
+            assertThat(record.sacrifices).isEqualTo(0)
+            assertThat(record.totalWalks).isEqualTo(0)
+            assertThat(record.battingAverage).isEqualByComparingTo(BigDecimal.ZERO)
+            assertThat(record.onBasePercentage).isEqualByComparingTo(BigDecimal.ZERO)
+            assertThat(record.sluggingPercentage).isEqualByComparingTo(BigDecimal.ZERO)
+            assertThat(record.ops).isEqualByComparingTo(BigDecimal.ZERO)
+        }
+
+        @Test
+        fun `생성 후 즉시 타석 결과를 기록할 수 있다`() {
+            // given
+            val record = BattingRecord.create(gamePlayer = gamePlayer)
+
+            // when
+            record.applyPlateAppearanceResult(PlateAppearanceResult.SINGLE, rbis = 1)
+
+            // then
+            assertThat(record.plateAppearances).isEqualTo(1)
+            assertThat(record.hits).isEqualTo(1)
+            assertThat(record.runsBattedIn).isEqualTo(1)
+        }
+    }
 }

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/PitchingRecordTest.kt
@@ -2005,4 +2005,110 @@ class PitchingRecordTest {
             pitchingRecord.validateInningReduction(5) // 5이닝 = 15아웃이 최대
         }
     }
+
+    @Nested
+    @DisplayName("closeInning - 투수 교체 시 이닝 마감")
+    inner class CloseInningTest {
+        @Test
+        fun `정상적인 이닝과 아웃 카운트로 이닝을 마감할 수 있다`() {
+            // given
+            repeat(5) { pitchingRecord.recordOut() } // 1.2이닝 소화
+
+            // when & then (예외 없이 정상 수행)
+            pitchingRecord.closeInning(currentInning = 3, currentOuts = 2)
+        }
+
+        @Test
+        fun `1이닝 0아웃에서 이닝 마감이 가능하다`() {
+            // when & then
+            pitchingRecord.closeInning(currentInning = 1, currentOuts = 0)
+        }
+
+        @Test
+        fun `9이닝 2아웃에서 이닝 마감이 가능하다`() {
+            // given
+            repeat(26) { pitchingRecord.recordOut() } // 8.2이닝 소화
+
+            // when & then
+            pitchingRecord.closeInning(currentInning = 9, currentOuts = 2)
+        }
+
+        @Test
+        fun `이닝이 0 이하이면 예외가 발생한다`() {
+            assertThatThrownBy {
+                pitchingRecord.closeInning(currentInning = 0, currentOuts = 1)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이닝은 1 이상이어야 합니다")
+        }
+
+        @Test
+        fun `아웃 카운트가 음수이면 예외가 발생한다`() {
+            assertThatThrownBy {
+                pitchingRecord.closeInning(currentInning = 3, currentOuts = -1)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("아웃 카운트는 0-2 사이여야 합니다")
+        }
+
+        @Test
+        fun `아웃 카운트가 3 이상이면 예외가 발생한다`() {
+            assertThatThrownBy {
+                pitchingRecord.closeInning(currentInning = 3, currentOuts = 3)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("아웃 카운트는 0-2 사이여야 합니다")
+        }
+
+        @Test
+        fun `이닝 마감 후에도 기존 기록(inningsPitchedOuts)은 유지된다`() {
+            // given
+            repeat(6) { pitchingRecord.recordOut() } // 2.0이닝 소화
+            val beforeOuts = pitchingRecord.inningsPitchedOuts
+
+            // when
+            pitchingRecord.closeInning(currentInning = 3, currentOuts = 0)
+
+            // then - BoxScore 실시간 기록이므로 추가 갱신 없음
+            assertThat(pitchingRecord.inningsPitchedOuts).isEqualTo(beforeOuts)
+        }
+    }
+
+    @Nested
+    @DisplayName("create - 팩토리 메서드")
+    inner class CreateTest {
+        @Test
+        fun `선발 투수로 생성하면 isStartingPitcher가 true이다`() {
+            // when
+            val record = PitchingRecord.create(gamePlayer, isStartingPitcher = true)
+
+            // then
+            assertThat(record.isStartingPitcher).isTrue()
+            assertThat(record.inningsPitchedOuts).isEqualTo(0)
+            assertThat(record.decision).isEqualTo(PitchingDecision.NONE)
+        }
+
+        @Test
+        fun `구원 투수로 생성하면 isStartingPitcher가 false이다`() {
+            // when
+            val record = PitchingRecord.create(gamePlayer, isStartingPitcher = false)
+
+            // then
+            assertThat(record.isStartingPitcher).isFalse()
+            assertThat(record.inningsPitchedOuts).isEqualTo(0)
+            assertThat(record.battersFaced).isEqualTo(0)
+            assertThat(record.earnedRuns).isEqualTo(0)
+            assertThat(record.runsAllowed).isEqualTo(0)
+            assertThat(record.hitsAllowed).isEqualTo(0)
+            assertThat(record.walksAllowed).isEqualTo(0)
+            assertThat(record.strikeouts).isEqualTo(0)
+            assertThat(record.homeRunsAllowed).isEqualTo(0)
+        }
+
+        @Test
+        fun `기본값으로 생성하면 선발 투수가 아니다`() {
+            // when
+            val record = PitchingRecord.create(gamePlayer)
+
+            // then
+            assertThat(record.isStartingPitcher).isFalse()
+        }
+    }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
@@ -7,12 +7,14 @@ import com.nextup.core.domain.association.Association
 import com.nextup.core.domain.competition.Competition
 import com.nextup.core.domain.competition.CompetitionStatus
 import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.game.BattingRecord
 import com.nextup.core.domain.game.Game
 import com.nextup.core.domain.game.GameEvent
 import com.nextup.core.domain.game.GameEventType
 import com.nextup.core.domain.game.GamePlayer
 import com.nextup.core.domain.game.GameState
 import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.PitchingRecord
 import com.nextup.core.domain.league.League
 import com.nextup.core.domain.player.Position
 import com.nextup.core.domain.team.Team
@@ -435,6 +437,367 @@ class GameScorerServiceSubstitutionTest {
                 gameSubstitutionService.substitutePlayer(1L, request, 999L)
             }.isInstanceOf(InvalidGameStateException::class.java)
                 .hasMessageContaining("DH 타순")
+        }
+    }
+
+    @Nested
+    @DisplayName("M-10: 투수 교체 시 이닝 마감 처리")
+    inner class PitcherInningClose {
+        @Test
+        fun `투수 교체 시 이전 투수의 PitchingRecord에 closeInning이 호출된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPitcher = createStartingPlayer(10L, Position.STARTING_PITCHER, 1)
+            val incomingPitcher = createBenchPlayer(20L, Position.RELIEF_PITCHER)
+
+            val existingPitchingRecord = PitchingRecord.create(outgoingPitcher, isStartingPitcher = true)
+            // 3아웃 기록 (1이닝 소화)
+            repeat(3) { existingPitchingRecord.recordOut() }
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPitcher
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPitcher
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayerId(10L) } returns existingPitchingRecord
+            every { pitchingRecordRepository.findByGamePlayerId(20L) } returns null
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RELIEF_PITCHER,
+                    newBattingOrder = 1,
+                )
+
+            // when
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
+
+            // then - PitchingRecord가 저장됨 (closeInning 후)
+            verify { pitchingRecordRepository.save(existingPitchingRecord) }
+        }
+
+        @Test
+        fun `투수 교체 시 PitchingRecord가 없으면 저장을 건너뛴다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPitcher = createStartingPlayer(10L, Position.STARTING_PITCHER, 1)
+            val incomingPitcher = createBenchPlayer(20L, Position.RELIEF_PITCHER)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPitcher
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPitcher
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayerId(10L) } returns null
+            every { pitchingRecordRepository.findByGamePlayerId(20L) } returns null
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RELIEF_PITCHER,
+                    newBattingOrder = 1,
+                )
+
+            // when
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
+
+            // then - pitchingRecordRepository.save는 incomingPitcher 기록 생성 1회만 호출
+            verify(exactly = 1) { pitchingRecordRepository.save(any()) }
+        }
+
+        @Test
+        fun `비투수 교체 시에는 closeInning이 호출되지 않는다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPlayer = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            val incomingPlayer = createBenchPlayer(20L, Position.CENTER_FIELD)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPlayer
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
+
+            // then - 투수가 아니므로 pitchingRecordRepository.findByGamePlayerId(outgoing)는 호출되지 않음
+            verify(exactly = 0) { pitchingRecordRepository.findByGamePlayerId(10L) }
+        }
+
+        @Test
+        fun `투수 교체 시 currentPitcherId가 갱신된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPitcher = createStartingPlayer(10L, Position.STARTING_PITCHER, 1)
+            val incomingPitcher = createBenchPlayer(20L, Position.RELIEF_PITCHER)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPitcher
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPitcher
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayerId(20L) } returns null
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RELIEF_PITCHER,
+                    newBattingOrder = 1,
+                )
+
+            // when
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
+
+            // then
+            assertThat(game.gameState.currentPitcherId).isEqualTo(20L)
+            verify { gameRepository.save(game) }
+        }
+    }
+
+    @Nested
+    @DisplayName("M-11: 교체 선수 기록 자동 생성")
+    inner class SubstituteRecordAutoCreation {
+        @Test
+        fun `대타 투입 시 BattingRecord가 자동 생성된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPlayer = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            val incomingPlayer = createBenchPlayer(20L, Position.LEFT_FIELD)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPlayer
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
+
+            // then - BattingRecord가 생성 및 저장됨
+            verify { battingRecordRepository.save(any()) }
+        }
+
+        @Test
+        fun `구원 투수 투입 시 PitchingRecord가 자동 생성된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPitcher = createStartingPlayer(10L, Position.STARTING_PITCHER, 1)
+            val incomingPitcher = createBenchPlayer(20L, Position.RELIEF_PITCHER)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPitcher
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPitcher
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayerId(20L) } returns null
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RELIEF_PITCHER,
+                    newBattingOrder = 1,
+                )
+
+            // when
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
+
+            // then - 구원투수 PitchingRecord가 생성됨
+            verify { pitchingRecordRepository.save(match { !it.isStartingPitcher }) }
+        }
+
+        @Test
+        fun `이미 BattingRecord가 존재하면 중복 생성하지 않는다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPlayer = createStartingPlayer(10L, Position.LEFT_FIELD, 5)
+            val incomingPlayer = createBenchPlayer(20L, Position.LEFT_FIELD)
+
+            val existingBattingRecord = mockk<BattingRecord>(relaxed = true)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPlayer
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { battingRecordRepository.findByGamePlayerId(20L) } returns existingBattingRecord
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.LEFT_FIELD,
+                    newBattingOrder = 5,
+                )
+
+            // when
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
+
+            // then - 이미 존재하므로 save 호출 안 됨
+            verify(exactly = 0) { battingRecordRepository.save(any()) }
+        }
+
+        @Test
+        fun `이미 PitchingRecord가 존재하면 중복 생성하지 않는다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPitcher = createStartingPlayer(10L, Position.STARTING_PITCHER, 1)
+            val incomingPitcher = createBenchPlayer(20L, Position.RELIEF_PITCHER)
+
+            val outgoingPitchingRecord =
+                PitchingRecord.create(outgoingPitcher, isStartingPitcher = true)
+            val existingIncomingPitchingRecord = mockk<PitchingRecord>(relaxed = true)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPitcher
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPitcher
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayerId(10L) } returns outgoingPitchingRecord
+            every { pitchingRecordRepository.findByGamePlayerId(20L) } returns existingIncomingPitchingRecord
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RELIEF_PITCHER,
+                    newBattingOrder = 1,
+                )
+
+            // when
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
+
+            // then - outgoing의 closeInning save(1회) + incoming은 기존 존재하므로 save 안 됨
+            verify(exactly = 1) { pitchingRecordRepository.save(outgoingPitchingRecord) }
+            verify(exactly = 0) { pitchingRecordRepository.save(existingIncomingPitchingRecord) }
+        }
+
+        @Test
+        fun `타순 없는 교체 선수는 BattingRecord가 생성되지 않는다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPitcher = createStartingPlayer(10L, Position.STARTING_PITCHER, 1)
+            val incomingPitcher = createBenchPlayer(20L, Position.RELIEF_PITCHER)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPitcher
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPitcher
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayerId(20L) } returns null
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RELIEF_PITCHER,
+                    newBattingOrder = null, // 타순 없음 (DH 사용 시 투수는 타순에 안 들어감)
+                )
+
+            // when
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
+
+            // then - 타순이 null이므로 BattingRecord 조회/생성 안 함
+            verify(exactly = 0) { battingRecordRepository.findByGamePlayerId(20L) }
+            verify(exactly = 0) { battingRecordRepository.save(any()) }
+        }
+
+        @Test
+        fun `구원투수에게 타순이 있으면 BattingRecord와 PitchingRecord가 모두 생성된다`() {
+            // given
+            val game = createGame(1L, GameStatus.IN_PROGRESS)
+            val outgoingPitcher = createStartingPlayer(10L, Position.STARTING_PITCHER, 1)
+            val incomingPitcher = createBenchPlayer(20L, Position.RELIEF_PITCHER)
+
+            every { gameRepository.findByIdOrNull(1L) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns outgoingPitcher
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns incomingPitcher
+            every { gamePlayerRepository.save(any()) } answers { firstArg() }
+            every { gameRepository.save(any()) } answers { firstArg() }
+            every { pitchingRecordRepository.findByGamePlayerId(20L) } returns null
+            every { battingRecordRepository.findByGamePlayerId(20L) } returns null
+
+            val savedEvent = mockk<GameEvent>(relaxed = true)
+            every { savedEvent.eventType } returns GameEventType.SUBSTITUTION
+            every { gameEventRepository.save(any()) } returns savedEvent
+
+            val request =
+                SubstitutionRequest(
+                    gameTeamId = 1L,
+                    outgoingPlayerId = 10L,
+                    incomingPlayerId = 20L,
+                    newPosition = Position.RELIEF_PITCHER,
+                    newBattingOrder = 1, // DH 미사용 시 투수도 타순에 포함
+                )
+
+            // when
+            gameSubstitutionService.substitutePlayer(1L, request, 999L)
+
+            // then - BattingRecord + PitchingRecord 모두 생성
+            verify { battingRecordRepository.save(any()) }
+            verify { pitchingRecordRepository.save(match { !it.isStartingPitcher }) }
         }
     }
 


### PR DESCRIPTION
## Summary

>- Close #396

교체 선수 기록 자동 생성 및 이닝 마감 처리(M-10, M-11)에 대한 단위 테스트를 추가합니다.
프로덕션 코드는 이미 구현되어 있으나, 해당 기능의 정확성을 검증하는 테스트가 누락되어 있어 이를 보완합니다.

## Tasks

- [x] PitchingRecord.closeInning() 검증 테스트 추가 (정상/경계값/예외 6개)
- [x] PitchingRecord.create() 팩토리 메서드 테스트 추가 (선발/구원/기본값 3개)
- [x] BattingRecord.create() 팩토리 메서드 테스트 추가 (초기값/계산속성/즉시기록 3개)
- [x] M-10 투수 교체 시 이닝 마감 처리 통합 테스트 추가 (closeInning 호출/미호출/비투수 교체/currentPitcherId 갱신 4개)
- [x] M-11 교체 선수 Record 자동 생성 통합 테스트 추가 (대타 BattingRecord/구원 PitchingRecord/중복방지/타순없음/투수+타순 6개)
- [x] `./gradlew clean build` 성공

## To Reviewer

- 프로덕션 코드(GameSubstitutionServiceImpl, PitchingRecord, BattingRecord)는 변경 없이 테스트만 추가했습니다.
- M-10(투수 교체 시 이닝 마감): `closeInning()`은 BoxScore에서 실시간으로 `inningsPitchedOuts`를 추적하므로 교체 시점의 유효성 검증 역할만 수행합니다 (의도적 설계).
- M-11(교체 선수 기록 생성): `createRecordsForSubstitute()`에서 기존 기록 존재 여부를 확인한 뒤에만 생성하여 중복 방지가 보장됩니다.
- 총 22개 테스트 (기존 12개 + 신규 10개 M-10/M-11 관련) 모두 통과 확인.