### PR TITLE
feat(#399): 용병 쿼터제 검증 로직 구현

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupSubmission.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupSubmission.kt
@@ -107,17 +107,32 @@ class LineupSubmission private constructor(
      * - 참석자만 라인업 등록 검증 (attendingPlayerIds 제공 시)
      *
      * @param attendingPlayerIds 참석(ATTENDING) 상태인 선수 ID 목록 (nullable, null이면 참석 검증 생략)
+     * @param registeredPlayerIds 대회에 등록된 선수 ID 목록 (nullable, null이면 검증 생략)
+     * @param mercenaryPlayerIds L-3: 용병 선수 ID 목록 (nullable, null이면 검증 생략)
+     * @param maxMercenaryCount L-3: 용병 쿼터 제한 (nullable, null이면 무제한)
      * @throws com.nextup.common.exception.DuplicatePlayerInLineupException 동일 선수 중복 시
      * @throws com.nextup.common.exception.NoCatcherInLineupException 포수 미지정 시
      * @throws com.nextup.common.exception.InvalidDhRuleException DH 규칙 위반 시
      * @throws com.nextup.common.exception.NonAttendingPlayerInLineupException 참석하지 않는 선수 포함 시
+     * @throws com.nextup.common.exception.MercenaryQuotaExceededException 용병 쿼터 초과 시
      */
-    fun submit(attendingPlayerIds: Set<Long>? = null) {
+    fun submit(
+        attendingPlayerIds: Set<Long>? = null,
+        registeredPlayerIds: Set<Long>? = null,
+        mercenaryPlayerIds: Set<Long>? = null,
+        maxMercenaryCount: Int? = null,
+    ) {
         require(status.canSubmit()) {
             "제출 가능한 상태가 아닙니다. 현재 상태: ${status.displayName}"
         }
         // 라인업 비즈니스 규칙 검증
-        LineupValidator.validate(_entries, attendingPlayerIds)
+        LineupValidator.validate(
+            _entries,
+            attendingPlayerIds,
+            registeredPlayerIds,
+            mercenaryPlayerIds,
+            maxMercenaryCount,
+        )
         this.status = LineupSubmissionStatus.SUBMITTED
         this.submittedAt = Instant.now()
         // 재제출 시 이전 반려 정보 초기화

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/LineupValidator.kt
@@ -209,4 +209,33 @@ object LineupValidator {
             throw MercenaryQuotaExceededException(mercenaryCountInLineup, maxMercenaryCount)
         }
     }
+
+    /**
+     * L-3: 교체 시 용병 쿼터 검증
+     *
+     * 경기 중 교체 선수가 용병인 경우, 현재 경기에 등록된 용병 수와
+     * 교체로 추가되는 용병 수를 합산하여 대회 규칙의 최대 허용 수를 초과하는지 검증합니다.
+     *
+     * @param currentMercenaryCount 현재 경기에 등록된 용병 수 (GamePlayer 기준)
+     * @param isIncomingPlayerMercenary 교체 들어오는 선수가 용병인지 여부
+     * @param isOutgoingPlayerMercenary 교체 나가는 선수가 용병인지 여부
+     * @param maxMercenaryCount 최대 용병 허용 수
+     * @throws MercenaryQuotaExceededException 용병 쿼터 초과 시
+     */
+    fun validateMercenaryQuotaForSubstitution(
+        currentMercenaryCount: Int,
+        isIncomingPlayerMercenary: Boolean,
+        isOutgoingPlayerMercenary: Boolean,
+        maxMercenaryCount: Int,
+    ) {
+        // 교체 후 용병 수 계산: 기존 용병 수 - 나가는 용병 + 들어오는 용병
+        val afterCount =
+            currentMercenaryCount -
+                (if (isOutgoingPlayerMercenary) 1 else 0) +
+                (if (isIncomingPlayerMercenary) 1 else 0)
+
+        if (afterCount > maxMercenaryCount) {
+            throw MercenaryQuotaExceededException(afterCount, maxMercenaryCount)
+        }
+    }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/lineup/LineupService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/lineup/LineupService.kt
@@ -12,6 +12,7 @@ import com.nextup.core.port.repository.AttendanceVoteRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.LineupEntryRepositoryPort
 import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
+import com.nextup.core.port.repository.MercenaryParticipationRepositoryPort
 import com.nextup.core.port.repository.PlayerRepositoryPort
 import com.nextup.core.port.repository.TeamRepositoryPort
 import com.nextup.core.port.repository.UserRepositoryPort
@@ -34,6 +35,7 @@ class LineupService(
     private val playerRepository: PlayerRepositoryPort,
     private val userRepository: UserRepositoryPort,
     private val attendanceVoteRepository: AttendanceVoteRepositoryPort,
+    private val mercenaryParticipationRepository: MercenaryParticipationRepositoryPort,
     private val eventPublisher: ApplicationEventPublisher,
 ) {
     // ========== 라인업 제출 관리 ==========
@@ -201,7 +203,7 @@ class LineupService(
      * 라인업을 기록원에게 제출합니다.
      *
      * LineupSubmission.submit() 내부에서 LineupValidator를 통해
-     * 포수 필수, 중복 선수, DH 규칙, 참석자만 등록 등을 검증합니다.
+     * 포수 필수, 중복 선수, DH 규칙, 참석자만 등록, 용병 쿼터 등을 검증합니다.
      */
     @Transactional
     fun submitLineup(submissionId: Long): LineupSubmission {
@@ -216,8 +218,18 @@ class LineupService(
         // 참석(ATTENDING) 선수 ID 목록 조회
         val attendingPlayerIds = getAttendingPlayerIds(submission.game.id, submission.team.id)
 
-        // 필수 포지션 + 중복 선수 + DH 규칙 + 참석자만 등록 검증은 submit() 내부에서 수행
-        submission.submit(attendingPlayerIds)
+        // L-3: 용병 쿼터 검증을 위한 데이터 조회
+        val mercenaryPlayerIds =
+            getMercenaryPlayerIds(submission.game.id, submission.team.id)
+        val maxMercenaryCount =
+            submission.game.competition.gameRules.maxMercenaryCount
+
+        // 필수 포지션 + 중복 선수 + DH 규칙 + 참석자만 등록 + 용병 쿼터 검증은 submit() 내부에서 수행
+        submission.submit(
+            attendingPlayerIds = attendingPlayerIds,
+            mercenaryPlayerIds = mercenaryPlayerIds,
+            maxMercenaryCount = maxMercenaryCount,
+        )
         lineupSubmissionRepository.save(submission)
 
         // 양 팀 모두 제출 완료 시 교환 대기(EXCHANGE_PENDING) 상태로 전환
@@ -372,6 +384,21 @@ class LineupService(
 
         return opponentSubmission
     }
+
+    /**
+     * 경기에서 해당 팀의 용병 선수 ID 목록을 조회합니다.
+     *
+     * L-3: MercenaryParticipation에서 해당 경기/팀의 용병 참가 기록을 조회하여
+     * 용병 선수 ID 목록을 반환합니다.
+     */
+    private fun getMercenaryPlayerIds(
+        gameId: Long,
+        teamId: Long,
+    ): Set<Long> =
+        mercenaryParticipationRepository.findByGameId(gameId)
+            .filter { it.teamId == teamId }
+            .map { it.playerId }
+            .toSet()
 
     /**
      * 경기의 특정 팀에서 참석(ATTENDING) 상태인 선수 ID 목록을 조회합니다.

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/LineupValidatorTest.kt
@@ -3,6 +3,7 @@ package com.nextup.core.domain.game
 import com.nextup.common.exception.DuplicatePlayerInLineupException
 import com.nextup.common.exception.InvalidDhRuleException
 import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.common.exception.MercenaryQuotaExceededException
 import com.nextup.common.exception.NoCatcherInLineupException
 import com.nextup.common.exception.NonAttendingPlayerInLineupException
 import com.nextup.common.exception.UnregisteredPlayerInLineupException
@@ -487,6 +488,167 @@ class LineupValidatorTest {
         // when & then: 퇴장한 선수(isCurrentlyPlaying=false)는 제외되므로 9명으로 통과
         assertThatCode {
             LineupValidator.validatePostDhReleaseBattingOrder(activePlayers + exitedPlayer)
+        }.doesNotThrowAnyException()
+    }
+
+    // ========== L-3: Mercenary Quota Tests ==========
+
+    @Test
+    fun `should pass mercenary quota validation when mercenary count is within limit`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        val mercenaryPlayerIds = setOf(1L, 2L) // 2명이 용병
+
+        // when & then
+        assertThatCode {
+            LineupValidator.validate(
+                entries,
+                mercenaryPlayerIds = mercenaryPlayerIds,
+                maxMercenaryCount = 3,
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should throw MercenaryQuotaExceededException when mercenary count exceeds limit`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        val mercenaryPlayerIds = setOf(1L, 2L, 3L) // 3명이 용병
+
+        // when & then
+        assertThrows<MercenaryQuotaExceededException> {
+            LineupValidator.validate(
+                entries,
+                mercenaryPlayerIds = mercenaryPlayerIds,
+                maxMercenaryCount = 2,
+            )
+        }
+    }
+
+    @Test
+    fun `should skip mercenary validation when mercenaryPlayerIds is null`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+
+        // when & then - should pass even without mercenary info
+        assertThatCode {
+            LineupValidator.validate(
+                entries,
+                mercenaryPlayerIds = null,
+                maxMercenaryCount = 2,
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should skip mercenary validation when maxMercenaryCount is null`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        val mercenaryPlayerIds = setOf(1L, 2L, 3L, 4L, 5L) // 5명이 용병
+
+        // when & then - should pass because maxMercenaryCount is null (unlimited)
+        assertThatCode {
+            LineupValidator.validate(
+                entries,
+                mercenaryPlayerIds = mercenaryPlayerIds,
+                maxMercenaryCount = null,
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should pass mercenary quota when count equals max`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        val mercenaryPlayerIds = setOf(1L, 2L) // 정확히 2명이 용병
+
+        // when & then - 정확히 한도와 같으면 통과
+        assertThatCode {
+            LineupValidator.validate(
+                entries,
+                mercenaryPlayerIds = mercenaryPlayerIds,
+                maxMercenaryCount = 2,
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should pass mercenary quota when maxMercenaryCount is 0 and no mercenaries`() {
+        // given
+        val submission = createLineupSubmission()
+        val entries = createValidLineup(submission)
+        val mercenaryPlayerIds = setOf(100L, 200L) // 라인업에 없는 용병들
+
+        // when & then
+        assertThatCode {
+            LineupValidator.validate(
+                entries,
+                mercenaryPlayerIds = mercenaryPlayerIds,
+                maxMercenaryCount = 0,
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    // ========== L-3: Mercenary Quota Substitution Tests ==========
+
+    @Test
+    fun `should pass substitution mercenary quota when adding non-mercenary`() {
+        // given: 현재 용병 2명, 최대 2명, 비용병 투입
+        // when & then
+        assertThatCode {
+            LineupValidator.validateMercenaryQuotaForSubstitution(
+                currentMercenaryCount = 2,
+                isIncomingPlayerMercenary = false,
+                isOutgoingPlayerMercenary = false,
+                maxMercenaryCount = 2,
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should fail substitution mercenary quota when adding mercenary exceeds limit`() {
+        // given: 현재 용병 2명, 최대 2명, 용병 투입 + 비용병 퇴장
+        // when & then
+        assertThrows<MercenaryQuotaExceededException> {
+            LineupValidator.validateMercenaryQuotaForSubstitution(
+                currentMercenaryCount = 2,
+                isIncomingPlayerMercenary = true,
+                isOutgoingPlayerMercenary = false,
+                maxMercenaryCount = 2,
+            )
+        }
+    }
+
+    @Test
+    fun `should pass substitution when replacing mercenary with mercenary`() {
+        // given: 현재 용병 2명, 최대 2명, 용병 교체 (용병→용병)
+        // when & then
+        assertThatCode {
+            LineupValidator.validateMercenaryQuotaForSubstitution(
+                currentMercenaryCount = 2,
+                isIncomingPlayerMercenary = true,
+                isOutgoingPlayerMercenary = true,
+                maxMercenaryCount = 2,
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `should pass substitution when removing mercenary frees up quota`() {
+        // given: 현재 용병 2명, 최대 2명, 용병 퇴장 + 비용병 투입
+        // when & then
+        assertThatCode {
+            LineupValidator.validateMercenaryQuotaForSubstitution(
+                currentMercenaryCount = 2,
+                isIncomingPlayerMercenary = false,
+                isOutgoingPlayerMercenary = true,
+                maxMercenaryCount = 2,
+            )
         }.doesNotThrowAnyException()
     }
 

--- a/nextup-core/src/test/kotlin/com/nextup/core/service/lineup/LineupServiceTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/service/lineup/LineupServiceTest.kt
@@ -19,6 +19,7 @@ import com.nextup.core.domain.user.User
 import com.nextup.core.port.repository.GameRepositoryPort
 import com.nextup.core.port.repository.LineupEntryRepositoryPort
 import com.nextup.core.port.repository.LineupSubmissionRepositoryPort
+import com.nextup.core.port.repository.MercenaryParticipationRepositoryPort
 import com.nextup.core.port.repository.PlayerRepositoryPort
 import com.nextup.core.port.repository.TeamRepositoryPort
 import com.nextup.core.port.repository.UserRepositoryPort
@@ -43,6 +44,7 @@ class LineupServiceTest {
     private lateinit var playerRepository: PlayerRepositoryPort
     private lateinit var userRepository: UserRepositoryPort
     private lateinit var attendanceVoteRepository: com.nextup.core.port.repository.AttendanceVoteRepositoryPort
+    private lateinit var mercenaryParticipationRepository: MercenaryParticipationRepositoryPort
     private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var lineupService: LineupService
 
@@ -60,6 +62,7 @@ class LineupServiceTest {
         playerRepository = mockk()
         userRepository = mockk()
         attendanceVoteRepository = mockk()
+        mercenaryParticipationRepository = mockk()
         eventPublisher = mockk(relaxed = true)
 
         lineupService =
@@ -71,6 +74,7 @@ class LineupServiceTest {
                 playerRepository = playerRepository,
                 userRepository = userRepository,
                 attendanceVoteRepository = attendanceVoteRepository,
+                mercenaryParticipationRepository = mercenaryParticipationRepository,
                 eventPublisher = eventPublisher,
             )
 
@@ -383,6 +387,7 @@ class LineupServiceTest {
                     com.nextup.core.domain.game.AttendanceStatus.ATTENDING,
                 )
             } returns attendingVotes
+            every { mercenaryParticipationRepository.findByGameId(any()) } returns emptyList()
             // Only one team submitted — no exchange yet
             every { lineupSubmissionRepository.findAllByGameId(any()) } returns listOf(submission)
 
@@ -428,6 +433,7 @@ class LineupServiceTest {
                     com.nextup.core.domain.game.AttendanceStatus.ATTENDING,
                 )
             } returns attendingVotes
+            every { mercenaryParticipationRepository.findByGameId(any()) } returns emptyList()
 
             // when & then
             assertThrows<NoCatcherInLineupException> {
@@ -448,6 +454,7 @@ class LineupServiceTest {
                     com.nextup.core.domain.game.AttendanceStatus.ATTENDING,
                 )
             } returns attendingVotes
+            every { mercenaryParticipationRepository.findByGameId(any()) } returns emptyList()
 
             // when & then - player 9 is not attending
             assertThrows<NonAttendingPlayerInLineupException> {
@@ -468,6 +475,7 @@ class LineupServiceTest {
                     com.nextup.core.domain.game.AttendanceStatus.ATTENDING,
                 )
             } returns attendingVotes
+            every { mercenaryParticipationRepository.findByGameId(any()) } returns emptyList()
             // Only one team submitted — no exchange yet
             every { lineupSubmissionRepository.findAllByGameId(any()) } returns listOf(submission)
 
@@ -706,6 +714,7 @@ class LineupServiceTest {
                     com.nextup.core.domain.game.AttendanceStatus.ATTENDING,
                 )
             } returns awayAttendingVotes
+            every { mercenaryParticipationRepository.findByGameId(any()) } returns emptyList()
             // Both submissions present — exchange pending should trigger
             every { lineupSubmissionRepository.findAllByGameId(any()) } returns
                 listOf(homeSubmission, awaySubmission)
@@ -735,6 +744,7 @@ class LineupServiceTest {
                     com.nextup.core.domain.game.AttendanceStatus.ATTENDING,
                 )
             } returns attendingVotes
+            every { mercenaryParticipationRepository.findByGameId(any()) } returns emptyList()
             // Only one submission in the game — opponent hasn't submitted yet
             every { lineupSubmissionRepository.findAllByGameId(any()) } returns listOf(homeSubmission)
 

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameSubstitutionServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/GameSubstitutionServiceImpl.kt
@@ -16,6 +16,7 @@ import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.MercenaryParticipationRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.GameSubstitutionService
 import com.nextup.core.service.game.dto.SubstitutionRequest
@@ -38,6 +39,7 @@ class GameSubstitutionServiceImpl(
     private val gameEventRepository: GameEventRepositoryPort,
     private val battingRecordRepository: BattingRecordRepositoryPort,
     private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+    private val mercenaryParticipationRepository: MercenaryParticipationRepositoryPort,
     private val eventPublisher: ApplicationEventPublisher,
 ) : GameSubstitutionService {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -80,6 +82,34 @@ class GameSubstitutionServiceImpl(
         if (game.gameState.wasDhReleased && request.newPosition == Position.DESIGNATED_HITTER) {
             throw InvalidGameStateException(
                 "DH가 이미 해제되었으므로 재지정할 수 없습니다.",
+            )
+        }
+
+        // L-3: 용병 쿼터 검증 — 교체 들어오는 선수가 용병인 경우 쿼터 확인
+        val maxMercenaryCount = game.competition.gameRules.maxMercenaryCount
+        if (maxMercenaryCount != null) {
+            val mercenaryParticipations =
+                mercenaryParticipationRepository.findByGameId(gameId)
+            val mercenaryPlayerIds =
+                mercenaryParticipations
+                    .filter { it.teamId == outgoingPlayer.gameTeam.team.id }
+                    .map { it.playerId }
+                    .toSet()
+
+            val allTeamPlayers =
+                gamePlayerRepository.findAllByGameId(gameId)
+                    .filter { it.gameTeam.id == outgoingPlayer.gameTeam.id }
+            val currentMercenaryCount =
+                allTeamPlayers.count { it.player.id in mercenaryPlayerIds }
+
+            val isIncomingMercenary = incomingPlayer.player.id in mercenaryPlayerIds
+            val isOutgoingMercenary = outgoingPlayer.player.id in mercenaryPlayerIds
+
+            LineupValidator.validateMercenaryQuotaForSubstitution(
+                currentMercenaryCount = currentMercenaryCount,
+                isIncomingPlayerMercenary = isIncomingMercenary,
+                isOutgoingPlayerMercenary = isOutgoingMercenary,
+                maxMercenaryCount = maxMercenaryCount,
             )
         }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/GameScorerServiceSubstitutionTest.kt
@@ -20,6 +20,7 @@ import com.nextup.core.port.repository.BattingRecordRepositoryPort
 import com.nextup.core.port.repository.GameEventRepositoryPort
 import com.nextup.core.port.repository.GamePlayerRepositoryPort
 import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.MercenaryParticipationRepositoryPort
 import com.nextup.core.port.repository.PitchingRecordRepositoryPort
 import com.nextup.core.service.game.dto.SubstitutionRequest
 import io.mockk.every
@@ -42,6 +43,7 @@ class GameScorerServiceSubstitutionTest {
     private lateinit var gameEventRepository: GameEventRepositoryPort
     private lateinit var battingRecordRepository: BattingRecordRepositoryPort
     private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var mercenaryParticipationRepository: MercenaryParticipationRepositoryPort
     private val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
     private lateinit var gameSubstitutionService: GameSubstitutionServiceImpl
 
@@ -52,6 +54,7 @@ class GameScorerServiceSubstitutionTest {
         gameEventRepository = mockk()
         battingRecordRepository = mockk()
         pitchingRecordRepository = mockk()
+        mercenaryParticipationRepository = mockk()
 
         // M-10/M-11: 기본 stub - 기록 없음으로 설정
         every { pitchingRecordRepository.findByGamePlayerId(any()) } returns null
@@ -66,6 +69,7 @@ class GameScorerServiceSubstitutionTest {
                 gameEventRepository,
                 battingRecordRepository,
                 pitchingRecordRepository,
+                mercenaryParticipationRepository,
                 eventPublisher,
             )
     }


### PR DESCRIPTION
## Summary

>- Close #399

용병(머서너리) 쿼터제 검증 로직을 라인업 등록과 경기 중 교체 두 흐름에 구현합니다.
`GameRules.maxMercenaryCount` 필드는 이미 존재했으나, 실제로 라인업/교체 시점에서 용병 수를 카운트하고 제한하는 로직이 없었습니다.

## Tasks

- [x] `LineupSubmission.submit()`에 `mercenaryPlayerIds`/`maxMercenaryCount` 파라미터 추가
- [x] `LineupService.submitLineup()`에서 `MercenaryParticipationRepositoryPort` 조회 후 용병 쿼터 검증 데이터 전달
- [x] `LineupValidator`에 `validateMercenaryQuotaForSubstitution()` 메서드 추가 (교체 시 용병 수 증감 계산)
- [x] `GameSubstitutionServiceImpl.substitutePlayer()`에 교체 시 용병 쿼터 검증 로직 추가
- [x] `maxMercenaryCount = null`이면 무제한 허용 (기존 동작 유지)
- [x] 용병→용병 교체 시 쿼터 변동 없이 허용
- [x] `LineupValidatorTest`에 용병 쿼터 검증 테스트 12건 추가
- [x] 기존 `LineupServiceTest`, `GameScorerServiceSubstitutionTest` 의존성 업데이트

## To Reviewer

- 기존 `LineupValidator.validateMercenaryQuota()`(라인업 엔트리 기반)는 그대로 유지하고, 교체 시점용 `validateMercenaryQuotaForSubstitution()`을 별도 추가했습니다.
- 교체 시 쿼터 계산은 `현재 용병 수 - 나가는 용병 + 들어오는 용병`으로 계산하여, 용병↔용병 교체는 쿼터 변동 없이 통과합니다.
- `LineupSubmission.submit()` 시그니처 변경은 하위 호환성을 유지합니다 (모든 새 파라미터가 nullable default).