### PR TITLE
feat(#385): 부상 퇴장 및 긴급 교체 API

### DIFF
--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/EjectionReason.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/EjectionReason.kt
@@ -1,0 +1,20 @@
+package com.nextup.core.domain.game
+
+/**
+ * 퇴장 사유
+ *
+ * 부상 퇴장과 심판 판정에 의한 퇴장, 기타 사유를 구분합니다.
+ * 사회인 야구에서 부상 퇴장은 빈번하며, 긴급 교체와 연계됩니다.
+ */
+enum class EjectionReason(
+    val displayName: String,
+) {
+    /** 부상으로 인한 퇴장 */
+    INJURY("부상"),
+
+    /** 심판 판정에 의한 퇴장 (퇴장 명령) */
+    EJECTION_BY_UMPIRE("심판 퇴장"),
+
+    /** 기타 사유 */
+    OTHER("기타"),
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEvent.kt
@@ -286,5 +286,36 @@ class GameEvent(
                 description = description,
                 batter = ejectedPlayer,
             )
+
+        /**
+         * 긴급 교체 이벤트를 생성합니다.
+         *
+         * 퇴장(부상/심판 퇴장 등)으로 인한 긴급 교체를 기록합니다.
+         * 일반 교체(SUBSTITUTION)와 구분되며, 퇴장 사유를 포함합니다.
+         *
+         * @param game 경기
+         * @param incomingPlayer 교체 들어오는 선수
+         * @param outgoingPlayer 퇴장하는 선수
+         * @param reason 퇴장 사유
+         * @param description 긴급 교체 설명
+         */
+        fun createEmergencySubstitution(
+            game: Game,
+            incomingPlayer: GamePlayer,
+            outgoingPlayer: GamePlayer,
+            reason: EjectionReason,
+            description: String,
+        ): GameEvent =
+            GameEvent(
+                game = game,
+                inning = game.currentInning,
+                isTopInning = game.isTopInning,
+                outCountBefore = game.gameState.outs,
+                outCountAfter = game.gameState.outs,
+                eventType = GameEventType.EMERGENCY_SUBSTITUTION,
+                description = description,
+                batter = incomingPlayer,
+                pitcher = outgoingPlayer,
+            )
     }
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GameEventType.kt
@@ -14,6 +14,7 @@ enum class GameEventType(
     GAME_STATUS("경기 상태 변경"),
     POSITION_CHANGE("포지션 변경"),
     EJECTION("퇴장"),
+    EMERGENCY_SUBSTITUTION("긴급 교체"),
     NO_HITTER("노히트노런"),
     PERFECT_GAME("퍼펙트게임"),
 }

--- a/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GamePlayer.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/domain/game/GamePlayer.kt
@@ -70,6 +70,15 @@ class GamePlayer(
         protected set
 
     /**
+     * 퇴장 사유 (부상/심판 퇴장/기타)
+     * null이면 퇴장이 아닌 일반 교체로 퇴장한 경우입니다.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ejection_reason", length = 30)
+    var ejectionReason: EjectionReason? = null
+        protected set
+
+    /**
      * 포지션 변경 이력
      * DB에는 CSV 형식("이닝:포지션,이닝:포지션,...")으로 저장됩니다.
      */
@@ -131,6 +140,32 @@ class GamePlayer(
         this.isCurrentlyPlaying = false
         this.exitInning = inning
     }
+
+    /**
+     * 부상/퇴장 사유와 함께 경기에서 퇴장합니다.
+     *
+     * 일반 교체(exitGame)와 달리 퇴장 사유를 기록합니다.
+     * 부상 퇴장, 심판 퇴장 명령 등의 사유를 구분하여 추적합니다.
+     *
+     * @param inning 퇴장 이닝
+     * @param reason 퇴장 사유
+     */
+    fun eject(
+        inning: Int,
+        reason: EjectionReason,
+    ) {
+        require(inning >= 1) { "이닝은 1 이상이어야 합니다." }
+        require(isCurrentlyPlaying) { "현재 출전 중인 선수만 퇴장할 수 있습니다." }
+        this.isCurrentlyPlaying = false
+        this.exitInning = inning
+        this.ejectionReason = reason
+    }
+
+    /**
+     * 퇴장된 선수인지 확인합니다 (퇴장 사유가 있는 경우).
+     */
+    val isEjected: Boolean
+        get() = ejectionReason != null
 
     /**
      * 포지션을 변경합니다.

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/EmergencySubstitutionService.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/EmergencySubstitutionService.kt
@@ -1,0 +1,51 @@
+package com.nextup.core.service.game
+
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.service.game.dto.EjectAndSubstituteRequest
+import com.nextup.core.service.game.dto.EjectionRequest
+
+/**
+ * 긴급 교체 서비스 인터페이스 (Port)
+ *
+ * 부상 퇴장 및 긴급 교체를 처리합니다.
+ * - 퇴장만 처리 (교체 선수 없는 경우)
+ * - 퇴장 + 교체를 원자적으로 처리
+ * - 주자 상태 선수 퇴장 시 베이스 계승
+ * - 투수 부상 퇴장 시 currentPitcherId 갱신
+ */
+interface EmergencySubstitutionService {
+    /**
+     * 선수를 퇴장 처리합니다 (교체 없음).
+     *
+     * 교체 선수가 없는 경우 (벤치 소진 등) 퇴장만 처리합니다.
+     * 해당 타순은 이후 자동 아웃으로 처리됩니다.
+     *
+     * @param gameId 경기 ID
+     * @param request 퇴장 요청
+     * @param scorerId 기록원 ID
+     * @return 퇴장 이벤트
+     */
+    fun ejectPlayer(
+        gameId: Long,
+        request: EjectionRequest,
+        scorerId: Long,
+    ): GameEvent
+
+    /**
+     * 선수를 퇴장시키고 교체 선수를 투입합니다.
+     *
+     * 퇴장과 교체를 원자적으로 처리합니다.
+     * 주자 상태인 선수가 퇴장하면 교체 선수가 해당 베이스를 계승합니다.
+     * 투수가 부상 퇴장하면 교체 투수로 currentPitcherId를 갱신합니다.
+     *
+     * @param gameId 경기 ID
+     * @param request 퇴장 + 교체 요청
+     * @param scorerId 기록원 ID
+     * @return 긴급 교체 이벤트
+     */
+    fun ejectAndSubstitute(
+        gameId: Long,
+        request: EjectAndSubstituteRequest,
+        scorerId: Long,
+    ): GameEvent
+}

--- a/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/EmergencySubstitutionRequest.kt
+++ b/nextup-core/src/main/kotlin/com/nextup/core/service/game/dto/EmergencySubstitutionRequest.kt
@@ -1,0 +1,35 @@
+package com.nextup.core.service.game.dto
+
+import com.nextup.core.domain.game.EjectionReason
+import com.nextup.core.domain.player.Position
+
+/**
+ * 퇴장 처리 요청 도메인 DTO
+ *
+ * 교체 없이 퇴장만 처리하는 경우에 사용합니다.
+ *
+ * @param ejectedPlayerId 퇴장할 선수의 GamePlayer ID
+ * @param reason 퇴장 사유
+ */
+data class EjectionRequest(
+    val ejectedPlayerId: Long,
+    val reason: EjectionReason,
+)
+
+/**
+ * 퇴장 + 긴급 교체 요청 도메인 DTO
+ *
+ * 퇴장과 교체를 원자적으로 처리하는 경우에 사용합니다.
+ * 주자 상태인 선수 퇴장 시 교체 선수가 해당 베이스를 계승합니다.
+ *
+ * @param ejectedPlayerId 퇴장할 선수의 GamePlayer ID
+ * @param replacementPlayerId 교체 투입할 선수의 GamePlayer ID
+ * @param reason 퇴장 사유
+ * @param newPosition 교체 선수의 포지션
+ */
+data class EjectAndSubstituteRequest(
+    val ejectedPlayerId: Long,
+    val replacementPlayerId: Long,
+    val reason: EjectionReason,
+    val newPosition: Position,
+)

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/EmergencySubstitutionEventTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/EmergencySubstitutionEventTest.kt
@@ -1,0 +1,145 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.association.Association
+import com.nextup.core.domain.competition.Competition
+import com.nextup.core.domain.competition.CompetitionStatus
+import com.nextup.core.domain.competition.CompetitionType
+import com.nextup.core.domain.league.League
+import com.nextup.core.domain.team.Team
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@DisplayName("GameEvent - 긴급 교체")
+class EmergencySubstitutionEventTest {
+    private lateinit var game: Game
+    private lateinit var ejectedPlayer: GamePlayer
+    private lateinit var replacementPlayer: GamePlayer
+
+    @BeforeEach
+    fun setUp() {
+        game = createGame()
+        ejectedPlayer = mockk(relaxed = true)
+        replacementPlayer = mockk(relaxed = true)
+    }
+
+    @Nested
+    @DisplayName("createEmergencySubstitution")
+    inner class CreateEmergencySubstitution {
+        @Test
+        fun `부상으로 인한 긴급 교체 이벤트를 생성한다`() {
+            // when
+            val event =
+                GameEvent.createEmergencySubstitution(
+                    game = game,
+                    incomingPlayer = replacementPlayer,
+                    outgoingPlayer = ejectedPlayer,
+                    reason = EjectionReason.INJURY,
+                    description = "1회초: 홍길동 퇴장 (부상) → 김철수 긴급 교체 (유격수)",
+                )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.EMERGENCY_SUBSTITUTION)
+            assertThat(event.description).isEqualTo("1회초: 홍길동 퇴장 (부상) → 김철수 긴급 교체 (유격수)")
+            assertThat(event.inning).isEqualTo(game.currentInning)
+            assertThat(event.isTopInning).isEqualTo(game.isTopInning)
+            assertThat(event.outCountBefore).isEqualTo(game.gameState.outs)
+            assertThat(event.outCountAfter).isEqualTo(game.gameState.outs)
+            assertThat(event.batter).isEqualTo(replacementPlayer)
+            assertThat(event.pitcher).isEqualTo(ejectedPlayer)
+            assertThat(event.plateAppearanceResult).isNull()
+            assertThat(event.runsScored).isEqualTo(0)
+        }
+
+        @Test
+        fun `심판 퇴장으로 인한 긴급 교체 이벤트를 생성한다`() {
+            // when
+            val event =
+                GameEvent.createEmergencySubstitution(
+                    game = game,
+                    incomingPlayer = replacementPlayer,
+                    outgoingPlayer = ejectedPlayer,
+                    reason = EjectionReason.EJECTION_BY_UMPIRE,
+                    description = "3회말: 박선수 퇴장 (심판 퇴장) → 이대타 긴급 교체 (좌익수)",
+                )
+
+            // then
+            assertThat(event.eventType).isEqualTo(GameEventType.EMERGENCY_SUBSTITUTION)
+            assertThat(event.batter).isEqualTo(replacementPlayer)
+            assertThat(event.pitcher).isEqualTo(ejectedPlayer)
+        }
+    }
+
+    private fun createGame(): Game {
+        val association =
+            Association(
+                name = "서울시야구협회",
+                abbreviation = null,
+                region = "서울",
+                description = null,
+                logoUrl = null,
+                websiteUrl = null,
+            ).apply {
+                val idField = Association::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
+
+        val league =
+            League(
+                association = association,
+                name = "1부 리그",
+                abbreviation = null,
+                foundedYear = 2020,
+                divisionLevel = 1,
+                description = null,
+                logoUrl = null,
+            ).apply {
+                val idField = League::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
+
+        val competition =
+            Competition(
+                league = league,
+                name = "2025 춘계대회",
+                year = 2025,
+                season = 1,
+                type = CompetitionType.LEAGUE,
+                startDate = LocalDate.of(2025, 3, 1),
+                endDate = LocalDate.of(2025, 6, 30),
+                status = CompetitionStatus.IN_PROGRESS,
+                description = null,
+                maxTeams = null,
+            ).apply {
+                val idField = Competition::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
+
+        val homeTeam = Team(league = league, name = "홈팀", city = "서울", foundedYear = 2020, id = 10L)
+        val awayTeam = Team(league = league, name = "원정팀", city = "부산", foundedYear = 2020, id = 20L)
+
+        return Game.createForTest(
+            competition = competition,
+            homeTeam = homeTeam,
+            awayTeam = awayTeam,
+            scheduledAt = LocalDateTime.of(2025, 4, 15, 14, 0),
+            location = "잠실구장",
+            fieldName = "1구장",
+            gameNumber = 1,
+            status = GameStatus.IN_PROGRESS,
+            currentInning = 1,
+            isTopInning = true,
+            totalInnings = 9,
+            gameState = GameState(),
+            id = 1L,
+        )
+    }
+}

--- a/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GamePlayerEjectTest.kt
+++ b/nextup-core/src/test/kotlin/com/nextup/core/domain/game/GamePlayerEjectTest.kt
@@ -1,0 +1,170 @@
+package com.nextup.core.domain.game
+
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("GamePlayer 퇴장 (eject)")
+class GamePlayerEjectTest {
+    private lateinit var gameTeam: GameTeam
+    private lateinit var player: Player
+
+    @BeforeEach
+    fun setup() {
+        gameTeam = mockk<GameTeam>(relaxed = true)
+        player = mockk<Player>(relaxed = true)
+    }
+
+    @Nested
+    @DisplayName("eject()")
+    inner class EjectTest {
+        @Test
+        fun `부상 사유로 퇴장할 수 있다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.SHORTSTOP,
+                    battingOrder = 3,
+                )
+
+            gamePlayer.eject(5, EjectionReason.INJURY)
+
+            assertThat(gamePlayer.isCurrentlyPlaying).isFalse()
+            assertThat(gamePlayer.exitInning).isEqualTo(5)
+            assertThat(gamePlayer.ejectionReason).isEqualTo(EjectionReason.INJURY)
+            assertThat(gamePlayer.isEjected).isTrue()
+        }
+
+        @Test
+        fun `심판 퇴장 사유로 퇴장할 수 있다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.CATCHER,
+                    battingOrder = 5,
+                )
+
+            gamePlayer.eject(3, EjectionReason.EJECTION_BY_UMPIRE)
+
+            assertThat(gamePlayer.isCurrentlyPlaying).isFalse()
+            assertThat(gamePlayer.ejectionReason).isEqualTo(EjectionReason.EJECTION_BY_UMPIRE)
+            assertThat(gamePlayer.isEjected).isTrue()
+        }
+
+        @Test
+        fun `기타 사유로 퇴장할 수 있다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.LEFT_FIELD,
+                    battingOrder = 7,
+                )
+
+            gamePlayer.eject(4, EjectionReason.OTHER)
+
+            assertThat(gamePlayer.ejectionReason).isEqualTo(EjectionReason.OTHER)
+        }
+
+        @Test
+        fun `이닝이 0이면 예외가 발생한다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.THIRD_BASE,
+                    battingOrder = 5,
+                )
+
+            assertThatThrownBy {
+                gamePlayer.eject(0, EjectionReason.INJURY)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("이닝은 1 이상")
+        }
+
+        @Test
+        fun `출전 중이 아닌 선수는 퇴장할 수 없다`() {
+            val gamePlayer =
+                GamePlayer.createBench(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.LEFT_FIELD,
+                )
+
+            assertThatThrownBy {
+                gamePlayer.eject(5, EjectionReason.INJURY)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("현재 출전 중인 선수만")
+        }
+
+        @Test
+        fun `퇴장하지 않은 선수의 isEjected는 false이다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.CENTER_FIELD,
+                    battingOrder = 8,
+                )
+
+            assertThat(gamePlayer.isEjected).isFalse()
+            assertThat(gamePlayer.ejectionReason).isNull()
+        }
+
+        @Test
+        fun `일반 교체로 퇴장한 선수의 isEjected는 false이다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.RIGHT_FIELD,
+                    battingOrder = 9,
+                )
+
+            gamePlayer.exitGame(6)
+
+            assertThat(gamePlayer.hasExited).isTrue()
+            assertThat(gamePlayer.isEjected).isFalse()
+            assertThat(gamePlayer.ejectionReason).isNull()
+        }
+
+        @Test
+        fun `퇴장 후 hasExited가 true이다`() {
+            val gamePlayer =
+                GamePlayer.createStarter(
+                    gameTeam = gameTeam,
+                    player = player,
+                    position = Position.SECOND_BASE,
+                    battingOrder = 4,
+                )
+
+            gamePlayer.eject(7, EjectionReason.INJURY)
+
+            assertThat(gamePlayer.hasExited).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("EjectionReason enum")
+    inner class EjectionReasonEnumTest {
+        @Test
+        fun `EjectionReason 값이 올바르다`() {
+            assertThat(EjectionReason.INJURY.displayName).isEqualTo("부상")
+            assertThat(EjectionReason.EJECTION_BY_UMPIRE.displayName).isEqualTo("심판 퇴장")
+            assertThat(EjectionReason.OTHER.displayName).isEqualTo("기타")
+        }
+
+        @Test
+        fun `EjectionReason enum 값이 3개이다`() {
+            assertThat(EjectionReason.entries).hasSize(3)
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/EmergencySubstitutionServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/game/EmergencySubstitutionServiceImpl.kt
@@ -1,0 +1,314 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.game.Base
+import com.nextup.core.domain.game.BattingRecord
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.game.PitchingRecord
+import com.nextup.core.domain.player.PositionCategory
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.service.game.EmergencySubstitutionService
+import com.nextup.core.service.game.dto.EjectAndSubstituteRequest
+import com.nextup.core.service.game.dto.EjectionRequest
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 긴급 교체 서비스 구현
+ *
+ * 부상 퇴장 및 긴급 교체를 처리합니다.
+ * - 퇴장만 처리 (교체 선수 없는 경우)
+ * - 퇴장 + 교체를 원자적으로 처리
+ * - 주자 상태 선수 퇴장 시 베이스 계승
+ * - 투수 부상 퇴장 시 currentPitcherId 갱신
+ */
+@Service
+@Transactional(readOnly = true)
+class EmergencySubstitutionServiceImpl(
+    private val gameRepository: GameRepositoryPort,
+    private val gamePlayerRepository: GamePlayerRepositoryPort,
+    private val gameEventRepository: GameEventRepositoryPort,
+    private val battingRecordRepository: BattingRecordRepositoryPort,
+    private val pitchingRecordRepository: PitchingRecordRepositoryPort,
+) : EmergencySubstitutionService {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    override fun ejectPlayer(
+        gameId: Long,
+        request: EjectionRequest,
+        scorerId: Long,
+    ): GameEvent {
+        val game = findGame(gameId)
+        game.validateScorer(scorerId)
+        validateGameInProgress(game)
+
+        val ejectedPlayer =
+            gamePlayerRepository.findByIdOrNull(request.ejectedPlayerId)
+                ?: throw GamePlayerNotFoundException(request.ejectedPlayerId)
+
+        if (!ejectedPlayer.isCurrentlyPlaying) {
+            throw InvalidGameStateException(
+                "현재 출전 중인 선수만 퇴장할 수 있습니다. (GamePlayer ID: ${request.ejectedPlayerId})",
+            )
+        }
+
+        // 주자 상태인 선수 퇴장 시 베이스 비움
+        clearRunnerBase(game, ejectedPlayer.id)
+
+        // 투수 퇴장 시 이닝 마감 처리
+        if (ejectedPlayer.isPitcher) {
+            closePitcherInning(ejectedPlayer, game)
+            game.gameState.currentPitcherId = null
+            gameRepository.save(game)
+        }
+
+        // 퇴장 처리
+        ejectedPlayer.eject(game.currentInning, request.reason)
+        gamePlayerRepository.save(ejectedPlayer)
+
+        val halfInning = if (game.isTopInning) "초" else "말"
+        val description =
+            "${game.currentInning}회$halfInning: ${ejectedPlayer.player.name} 퇴장 (${request.reason.displayName})"
+
+        val ejectionEvent =
+            GameEvent.createEjection(
+                game = game,
+                ejectedPlayer = ejectedPlayer,
+                description = description,
+            )
+
+        val savedEvent = gameEventRepository.save(ejectionEvent)
+        log.info(
+            "선수 퇴장 처리 완료 (gameId={}, gamePlayerId={}, reason={})",
+            gameId,
+            request.ejectedPlayerId,
+            request.reason,
+        )
+        return savedEvent
+    }
+
+    @Transactional
+    override fun ejectAndSubstitute(
+        gameId: Long,
+        request: EjectAndSubstituteRequest,
+        scorerId: Long,
+    ): GameEvent {
+        val game = findGame(gameId)
+        game.validateScorer(scorerId)
+        validateGameInProgress(game)
+
+        val ejectedPlayer =
+            gamePlayerRepository.findByIdOrNull(request.ejectedPlayerId)
+                ?: throw GamePlayerNotFoundException(request.ejectedPlayerId)
+
+        val replacementPlayer =
+            gamePlayerRepository.findByIdOrNull(request.replacementPlayerId)
+                ?: throw GamePlayerNotFoundException(request.replacementPlayerId)
+
+        if (!ejectedPlayer.isCurrentlyPlaying) {
+            throw InvalidGameStateException(
+                "현재 출전 중인 선수만 퇴장할 수 있습니다. (GamePlayer ID: ${request.ejectedPlayerId})",
+            )
+        }
+
+        if (replacementPlayer.hasExited) {
+            throw InvalidGameStateException(
+                "이미 퇴장한 선수는 재출전할 수 없습니다. (GamePlayer ID: ${request.replacementPlayerId})",
+            )
+        }
+
+        if (replacementPlayer.isCurrentlyPlaying) {
+            throw InvalidGameStateException(
+                "이미 출전 중인 선수는 교체 투입할 수 없습니다. (GamePlayer ID: ${request.replacementPlayerId})",
+            )
+        }
+
+        // 주자 베이스 계승: 퇴장 선수가 주자이면 교체 선수가 같은 베이스를 계승
+        inheritRunnerBase(game, ejectedPlayer.id, replacementPlayer.id)
+
+        // 투수 퇴장 시 이닝 마감 처리
+        if (ejectedPlayer.isPitcher) {
+            closePitcherInning(ejectedPlayer, game)
+        }
+
+        // 퇴장 처리
+        ejectedPlayer.eject(game.currentInning, request.reason)
+        gamePlayerRepository.save(ejectedPlayer)
+
+        // 교체 선수 투입
+        replacementPlayer.enterAsSubstitute(
+            inning = game.currentInning,
+            newPosition = request.newPosition,
+            newBattingOrder = ejectedPlayer.battingOrder,
+        )
+        gamePlayerRepository.save(replacementPlayer)
+
+        // 교체 선수 기록 자동 생성
+        createRecordsForSubstitute(replacementPlayer)
+
+        // 투수 교체 시 currentPitcherId 갱신
+        if (request.newPosition.category == PositionCategory.PITCHER) {
+            game.gameState.currentPitcherId = replacementPlayer.id
+            gameRepository.save(game)
+            log.debug(
+                "투수 긴급 교체 - currentPitcherId 갱신 (gameId={}, newPitcherId={})",
+                game.id,
+                replacementPlayer.id,
+            )
+        }
+
+        val halfInning = if (game.isTopInning) "초" else "말"
+        val description =
+            "${game.currentInning}회$halfInning: ${ejectedPlayer.player.name} 퇴장 (${request.reason.displayName}) → ${replacementPlayer.player.name} 긴급 교체 (${request.newPosition.displayName})"
+
+        val emergencySubstitutionEvent =
+            GameEvent.createEmergencySubstitution(
+                game = game,
+                incomingPlayer = replacementPlayer,
+                outgoingPlayer = ejectedPlayer,
+                reason = request.reason,
+                description = description,
+            )
+
+        val savedEvent = gameEventRepository.save(emergencySubstitutionEvent)
+        log.info(
+            "긴급 교체 처리 완료 (gameId={}, ejectedPlayerId={}, replacementPlayerId={}, reason={})",
+            gameId,
+            request.ejectedPlayerId,
+            request.replacementPlayerId,
+            request.reason,
+        )
+        return savedEvent
+    }
+
+    /**
+     * 퇴장 선수가 주자인 경우 베이스를 비웁니다.
+     */
+    private fun clearRunnerBase(
+        game: Game,
+        ejectedPlayerId: Long,
+    ) {
+        for (base in listOf(Base.FIRST, Base.SECOND, Base.THIRD)) {
+            if (game.gameState.getRunner(base) == ejectedPlayerId) {
+                game.gameState.setRunner(base, null)
+                gameRepository.save(game)
+                log.debug(
+                    "퇴장 선수 베이스 비움 (gameId={}, playerId={}, base={})",
+                    game.id,
+                    ejectedPlayerId,
+                    base,
+                )
+                break
+            }
+        }
+    }
+
+    /**
+     * 퇴장 선수가 주자인 경우 교체 선수가 해당 베이스를 계승합니다.
+     * 담당 투수(책임투수) ID는 기존 값을 유지합니다.
+     */
+    private fun inheritRunnerBase(
+        game: Game,
+        ejectedPlayerId: Long,
+        replacementPlayerId: Long,
+    ) {
+        for (base in listOf(Base.FIRST, Base.SECOND, Base.THIRD)) {
+            if (game.gameState.getRunner(base) == ejectedPlayerId) {
+                val existingPitcherId = game.gameState.getRunnerPitcherId(base)
+                game.gameState.setRunner(base, replacementPlayerId, existingPitcherId)
+                gameRepository.save(game)
+                log.debug(
+                    "주자 베이스 계승 (gameId={}, base={}, ejected={}, replacement={}, pitcherId={})",
+                    game.id,
+                    base,
+                    ejectedPlayerId,
+                    replacementPlayerId,
+                    existingPitcherId,
+                )
+                break
+            }
+        }
+    }
+
+    /**
+     * 투수 퇴장 시 이전 투수의 이닝 마감 처리를 수행합니다.
+     */
+    private fun closePitcherInning(
+        pitcher: GamePlayer,
+        game: Game,
+    ) {
+        val pitchingRecord =
+            pitchingRecordRepository.findByGamePlayerId(pitcher.id)
+        pitchingRecord?.closeInning(
+            currentInning = game.currentInning,
+            currentOuts = game.gameState.outs,
+        )
+        if (pitchingRecord != null) {
+            pitchingRecordRepository.save(pitchingRecord)
+            log.debug(
+                "투수 퇴장 - 이닝 마감 처리 완료 (gamePlayerId={}, inning={}, outs={})",
+                pitcher.id,
+                game.currentInning,
+                game.gameState.outs,
+            )
+        }
+    }
+
+    /**
+     * 교체 선수의 BattingRecord 및 PitchingRecord를 자동 생성합니다.
+     */
+    private fun createRecordsForSubstitute(incomingPlayer: GamePlayer) {
+        if (incomingPlayer.battingOrder != null) {
+            val existingBattingRecord =
+                battingRecordRepository.findByGamePlayerId(incomingPlayer.id)
+            if (existingBattingRecord == null) {
+                val battingRecord = BattingRecord.create(gamePlayer = incomingPlayer)
+                battingRecordRepository.save(battingRecord)
+                log.debug(
+                    "긴급 교체 선수 BattingRecord 자동 생성 (gamePlayerId={})",
+                    incomingPlayer.id,
+                )
+            }
+        }
+
+        if (incomingPlayer.isPitcher) {
+            val existingPitchingRecord =
+                pitchingRecordRepository.findByGamePlayerId(incomingPlayer.id)
+            if (existingPitchingRecord == null) {
+                val pitchingRecord =
+                    PitchingRecord.create(
+                        gamePlayer = incomingPlayer,
+                        isStartingPitcher = false,
+                    )
+                pitchingRecordRepository.save(pitchingRecord)
+                log.debug(
+                    "긴급 교체 투수 PitchingRecord 자동 생성 (gamePlayerId={})",
+                    incomingPlayer.id,
+                )
+            }
+        }
+    }
+
+    private fun findGame(id: Long): Game =
+        gameRepository.findByIdOrNull(id)
+            ?: throw GameNotFoundException(id)
+
+    private fun validateGameInProgress(game: Game) {
+        if (game.status != GameStatus.IN_PROGRESS) {
+            throw InvalidGameStateException(
+                "진행 중인 경기만 퇴장/긴급 교체를 할 수 있습니다. 현재 상태: ${game.status.displayName}",
+            )
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/resources/db/migration/V048__add_ejection_reason_to_game_players.sql
+++ b/nextup-infrastructure/src/main/resources/db/migration/V048__add_ejection_reason_to_game_players.sql
@@ -1,0 +1,8 @@
+-- V048: 부상 퇴장 사유 컬럼 추가 (#385)
+-- game_players 테이블에 ejection_reason 컬럼을 추가합니다.
+-- INJURY: 부상, EJECTION_BY_UMPIRE: 심판 퇴장, OTHER: 기타
+
+ALTER TABLE game_players
+    ADD COLUMN ejection_reason VARCHAR(30) DEFAULT NULL;
+
+COMMENT ON COLUMN game_players.ejection_reason IS '퇴장 사유 (INJURY, EJECTION_BY_UMPIRE, OTHER). NULL이면 일반 교체.';

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/EmergencySubstitutionServiceImplTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/service/game/EmergencySubstitutionServiceImplTest.kt
@@ -1,0 +1,361 @@
+package com.nextup.infrastructure.service.game
+
+import com.nextup.common.exception.GameNotFoundException
+import com.nextup.common.exception.GamePlayerNotFoundException
+import com.nextup.common.exception.InvalidGameStateException
+import com.nextup.core.domain.game.Base
+import com.nextup.core.domain.game.EjectionReason
+import com.nextup.core.domain.game.Game
+import com.nextup.core.domain.game.GameEvent
+import com.nextup.core.domain.game.GameEventType
+import com.nextup.core.domain.game.GamePlayer
+import com.nextup.core.domain.game.GameState
+import com.nextup.core.domain.game.GameStatus
+import com.nextup.core.domain.player.Player
+import com.nextup.core.domain.player.Position
+import com.nextup.core.domain.player.PositionCategory
+import com.nextup.core.port.repository.BattingRecordRepositoryPort
+import com.nextup.core.port.repository.GameEventRepositoryPort
+import com.nextup.core.port.repository.GamePlayerRepositoryPort
+import com.nextup.core.port.repository.GameRepositoryPort
+import com.nextup.core.port.repository.PitchingRecordRepositoryPort
+import com.nextup.core.service.game.dto.EjectAndSubstituteRequest
+import com.nextup.core.service.game.dto.EjectionRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmergencySubstitutionServiceImpl")
+class EmergencySubstitutionServiceImplTest {
+    private lateinit var gameRepository: GameRepositoryPort
+    private lateinit var gamePlayerRepository: GamePlayerRepositoryPort
+    private lateinit var gameEventRepository: GameEventRepositoryPort
+    private lateinit var battingRecordRepository: BattingRecordRepositoryPort
+    private lateinit var pitchingRecordRepository: PitchingRecordRepositoryPort
+    private lateinit var service: EmergencySubstitutionServiceImpl
+
+    private val scorerId = 99L
+    private val gameId = 1L
+
+    @BeforeEach
+    fun setUp() {
+        gameRepository = mockk(relaxed = true)
+        gamePlayerRepository = mockk(relaxed = true)
+        gameEventRepository = mockk(relaxed = true)
+        battingRecordRepository = mockk(relaxed = true)
+        pitchingRecordRepository = mockk(relaxed = true)
+
+        service =
+            EmergencySubstitutionServiceImpl(
+                gameRepository = gameRepository,
+                gamePlayerRepository = gamePlayerRepository,
+                gameEventRepository = gameEventRepository,
+                battingRecordRepository = battingRecordRepository,
+                pitchingRecordRepository = pitchingRecordRepository,
+            )
+    }
+
+    @Nested
+    @DisplayName("ejectPlayer()")
+    inner class EjectPlayerTest {
+        @Test
+        fun `부상 퇴장을 처리한다`() {
+            // given
+            val game = createMockGame(GameStatus.IN_PROGRESS)
+            val ejectedPlayer = createMockPlayer(10L, isPlaying = true, position = Position.SHORTSTOP)
+            val request = EjectionRequest(ejectedPlayerId = 10L, reason = EjectionReason.INJURY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns ejectedPlayer
+            val eventSlot = slot<GameEvent>()
+            every { gameEventRepository.save(capture(eventSlot)) } answers { eventSlot.captured }
+
+            // when
+            val result = service.ejectPlayer(gameId, request, scorerId)
+
+            // then
+            assertThat(result.eventType).isEqualTo(GameEventType.EJECTION)
+            verify { gamePlayerRepository.save(ejectedPlayer) }
+        }
+
+        @Test
+        fun `경기가 진행 중이 아니면 예외가 발생한다`() {
+            // given
+            val game = createMockGame(GameStatus.SCHEDULED)
+            val request = EjectionRequest(ejectedPlayerId = 10L, reason = EjectionReason.INJURY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+
+            // when/then
+            assertThatThrownBy {
+                service.ejectPlayer(gameId, request, scorerId)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("진행 중인 경기만")
+        }
+
+        @Test
+        fun `선수를 찾을 수 없으면 예외가 발생한다`() {
+            // given
+            val game = createMockGame(GameStatus.IN_PROGRESS)
+            val request = EjectionRequest(ejectedPlayerId = 999L, reason = EjectionReason.INJURY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gamePlayerRepository.findByIdOrNull(999L) } returns null
+
+            // when/then
+            assertThatThrownBy {
+                service.ejectPlayer(gameId, request, scorerId)
+            }.isInstanceOf(GamePlayerNotFoundException::class.java)
+        }
+
+        @Test
+        fun `출전 중이 아닌 선수 퇴장 시 예외가 발생한다`() {
+            // given
+            val game = createMockGame(GameStatus.IN_PROGRESS)
+            val benchPlayer = createMockPlayer(10L, isPlaying = false, position = Position.LEFT_FIELD)
+            val request = EjectionRequest(ejectedPlayerId = 10L, reason = EjectionReason.INJURY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns benchPlayer
+
+            // when/then
+            assertThatThrownBy {
+                service.ejectPlayer(gameId, request, scorerId)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("현재 출전 중인 선수만")
+        }
+
+        @Test
+        fun `주자 상태인 선수 퇴장 시 베이스를 비운다`() {
+            // given
+            val gameState = GameState()
+            gameState.setRunner(Base.SECOND, 10L, 50L)
+            val game = createMockGame(GameStatus.IN_PROGRESS, gameState = gameState)
+            val ejectedPlayer = createMockPlayer(10L, isPlaying = true, position = Position.SHORTSTOP)
+            val request = EjectionRequest(ejectedPlayerId = 10L, reason = EjectionReason.INJURY)
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns ejectedPlayer
+            val eventSlot = slot<GameEvent>()
+            every { gameEventRepository.save(capture(eventSlot)) } answers { eventSlot.captured }
+
+            // when
+            service.ejectPlayer(gameId, request, scorerId)
+
+            // then
+            assertThat(game.gameState.getRunner(Base.SECOND)).isNull()
+        }
+
+        @Test
+        fun `경기를 찾을 수 없으면 예외가 발생한다`() {
+            // given
+            val request = EjectionRequest(ejectedPlayerId = 10L, reason = EjectionReason.INJURY)
+            every { gameRepository.findByIdOrNull(gameId) } returns null
+
+            // when/then
+            assertThatThrownBy {
+                service.ejectPlayer(gameId, request, scorerId)
+            }.isInstanceOf(GameNotFoundException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("ejectAndSubstitute()")
+    inner class EjectAndSubstituteTest {
+        @Test
+        fun `퇴장과 교체를 원자적으로 처리한다`() {
+            // given
+            val game = createMockGame(GameStatus.IN_PROGRESS)
+            val ejectedPlayer =
+                createMockPlayer(10L, isPlaying = true, position = Position.SHORTSTOP, battingOrder = 6)
+            val replacementPlayer =
+                createMockPlayer(20L, isPlaying = false, position = Position.SHORTSTOP, hasExited = false)
+            val request =
+                EjectAndSubstituteRequest(
+                    ejectedPlayerId = 10L,
+                    replacementPlayerId = 20L,
+                    reason = EjectionReason.INJURY,
+                    newPosition = Position.SHORTSTOP,
+                )
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns ejectedPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns replacementPlayer
+            every { battingRecordRepository.findByGamePlayerId(any()) } returns null
+            every { pitchingRecordRepository.findByGamePlayerId(any()) } returns null
+            val eventSlot = slot<GameEvent>()
+            every { gameEventRepository.save(capture(eventSlot)) } answers { eventSlot.captured }
+
+            // when
+            val result = service.ejectAndSubstitute(gameId, request, scorerId)
+
+            // then
+            assertThat(result.eventType).isEqualTo(GameEventType.EMERGENCY_SUBSTITUTION)
+            verify { gamePlayerRepository.save(ejectedPlayer) }
+            verify { gamePlayerRepository.save(replacementPlayer) }
+        }
+
+        @Test
+        fun `주자 상태 선수 퇴장 시 교체 선수가 베이스를 계승한다`() {
+            // given
+            val gameState = GameState()
+            gameState.setRunner(Base.FIRST, 10L, 50L)
+            val game = createMockGame(GameStatus.IN_PROGRESS, gameState = gameState)
+            val ejectedPlayer =
+                createMockPlayer(10L, isPlaying = true, position = Position.LEFT_FIELD, battingOrder = 7)
+            val replacementPlayer =
+                createMockPlayer(20L, isPlaying = false, position = Position.LEFT_FIELD, hasExited = false)
+            val request =
+                EjectAndSubstituteRequest(
+                    ejectedPlayerId = 10L,
+                    replacementPlayerId = 20L,
+                    reason = EjectionReason.INJURY,
+                    newPosition = Position.LEFT_FIELD,
+                )
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns ejectedPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns replacementPlayer
+            every { battingRecordRepository.findByGamePlayerId(any()) } returns null
+            every { pitchingRecordRepository.findByGamePlayerId(any()) } returns null
+            val eventSlot = slot<GameEvent>()
+            every { gameEventRepository.save(capture(eventSlot)) } answers { eventSlot.captured }
+
+            // when
+            service.ejectAndSubstitute(gameId, request, scorerId)
+
+            // then — 교체 선수가 1루 주자를 계승, 담당 투수 ID 유지
+            assertThat(game.gameState.getRunner(Base.FIRST)).isEqualTo(20L)
+            assertThat(game.gameState.getRunnerPitcherId(Base.FIRST)).isEqualTo(50L)
+        }
+
+        @Test
+        fun `투수 부상 퇴장 시 교체 투수로 currentPitcherId를 갱신한다`() {
+            // given
+            val gameState = GameState()
+            gameState.currentPitcherId = 10L
+            val game = createMockGame(GameStatus.IN_PROGRESS, gameState = gameState)
+            val ejectedPitcher =
+                createMockPlayer(10L, isPlaying = true, position = Position.STARTING_PITCHER, battingOrder = null)
+            val replacementPitcher =
+                createMockPlayer(20L, isPlaying = false, position = Position.RELIEF_PITCHER, hasExited = false)
+            val request =
+                EjectAndSubstituteRequest(
+                    ejectedPlayerId = 10L,
+                    replacementPlayerId = 20L,
+                    reason = EjectionReason.INJURY,
+                    newPosition = Position.RELIEF_PITCHER,
+                )
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns ejectedPitcher
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns replacementPitcher
+            every { battingRecordRepository.findByGamePlayerId(any()) } returns null
+            every { pitchingRecordRepository.findByGamePlayerId(any()) } returns null
+            val eventSlot = slot<GameEvent>()
+            every { gameEventRepository.save(capture(eventSlot)) } answers { eventSlot.captured }
+
+            // when
+            service.ejectAndSubstitute(gameId, request, scorerId)
+
+            // then
+            assertThat(game.gameState.currentPitcherId).isEqualTo(20L)
+        }
+
+        @Test
+        fun `이미 퇴장한 선수를 교체 투입하면 예외가 발생한다`() {
+            // given
+            val game = createMockGame(GameStatus.IN_PROGRESS)
+            val ejectedPlayer =
+                createMockPlayer(10L, isPlaying = true, position = Position.SHORTSTOP, battingOrder = 6)
+            val alreadyExitedPlayer =
+                createMockPlayer(20L, isPlaying = false, position = Position.SHORTSTOP, hasExited = true)
+            val request =
+                EjectAndSubstituteRequest(
+                    ejectedPlayerId = 10L,
+                    replacementPlayerId = 20L,
+                    reason = EjectionReason.INJURY,
+                    newPosition = Position.SHORTSTOP,
+                )
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns ejectedPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns alreadyExitedPlayer
+
+            // when/then
+            assertThatThrownBy {
+                service.ejectAndSubstitute(gameId, request, scorerId)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("이미 퇴장한 선수")
+        }
+
+        @Test
+        fun `이미 출전 중인 선수를 교체 투입하면 예외가 발생한다`() {
+            // given
+            val game = createMockGame(GameStatus.IN_PROGRESS)
+            val ejectedPlayer =
+                createMockPlayer(10L, isPlaying = true, position = Position.SHORTSTOP, battingOrder = 6)
+            val alreadyPlayingPlayer =
+                createMockPlayer(20L, isPlaying = true, position = Position.LEFT_FIELD, hasExited = false)
+            val request =
+                EjectAndSubstituteRequest(
+                    ejectedPlayerId = 10L,
+                    replacementPlayerId = 20L,
+                    reason = EjectionReason.INJURY,
+                    newPosition = Position.SHORTSTOP,
+                )
+
+            every { gameRepository.findByIdOrNull(gameId) } returns game
+            every { gamePlayerRepository.findByIdOrNull(10L) } returns ejectedPlayer
+            every { gamePlayerRepository.findByIdOrNull(20L) } returns alreadyPlayingPlayer
+
+            // when/then
+            assertThatThrownBy {
+                service.ejectAndSubstitute(gameId, request, scorerId)
+            }.isInstanceOf(InvalidGameStateException::class.java)
+                .hasMessageContaining("이미 출전 중인 선수")
+        }
+    }
+
+    private fun createMockGame(
+        status: GameStatus,
+        gameState: GameState = GameState(),
+    ): Game {
+        val game = mockk<Game>(relaxed = true)
+        every { game.id } returns gameId
+        every { game.status } returns status
+        every { game.gameState } returns gameState
+        every { game.currentInning } returns 3
+        every { game.isTopInning } returns true
+        every { game.scorerId } returns scorerId
+        every { game.validateScorer(scorerId) } returns Unit
+        return game
+    }
+
+    private fun createMockPlayer(
+        id: Long,
+        isPlaying: Boolean,
+        position: Position,
+        battingOrder: Int? = null,
+        hasExited: Boolean = false,
+    ): GamePlayer {
+        val player = mockk<GamePlayer>(relaxed = true)
+        val playerEntity = mockk<Player>(relaxed = true)
+        every { player.id } returns id
+        every { player.isCurrentlyPlaying } returns isPlaying
+        every { player.position } returns position
+        every { player.battingOrder } returns battingOrder
+        every { player.hasExited } returns hasExited
+        every { player.isPitcher } returns (position.category == PositionCategory.PITCHER)
+        every { player.player } returns playerEntity
+        every { playerEntity.name } returns "테스트선수$id"
+        return player
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/EmergencySubstitutionScorerController.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/controller/game/EmergencySubstitutionScorerController.kt
@@ -1,0 +1,83 @@
+package com.nextup.scorer.controller.game
+
+import com.nextup.common.dto.ApiResponse
+import com.nextup.core.service.game.EmergencySubstitutionService
+import com.nextup.scorer.dto.game.EjectAndSubstituteRequestDto
+import com.nextup.scorer.dto.game.EjectPlayerRequestDto
+import com.nextup.scorer.dto.game.EjectionResponse
+import com.nextup.scorer.dto.game.EmergencySubstitutionResponse
+import com.nextup.scorer.dto.game.toDomain
+import com.nextup.scorer.dto.game.toEjectionResponse
+import com.nextup.scorer.dto.game.toEmergencySubstitutionResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 기록원 전용 부상 퇴장 및 긴급 교체 컨트롤러
+ *
+ * 부상, 심판 퇴장 등의 사유로 선수를 퇴장시키고,
+ * 필요 시 교체 선수를 긴급 투입하는 API를 제공합니다.
+ * 주자 상태인 선수 퇴장 시 교체 선수가 해당 베이스를 계승합니다.
+ */
+@PreAuthorize("isAuthenticated()")
+@RestController
+@RequestMapping("/api/v1/scorer/games")
+class EmergencySubstitutionScorerController(
+    private val emergencySubstitutionService: EmergencySubstitutionService,
+) {
+    /**
+     * 선수를 퇴장 처리합니다 (교체 없음).
+     *
+     * 교체 선수가 없는 경우 (벤치 소진 등) 퇴장만 처리합니다.
+     * 주자 상태인 선수 퇴장 시 해당 베이스를 비웁니다.
+     * 투수 퇴장 시 currentPitcherId를 null로 설정합니다.
+     */
+    @PostMapping("/{gameId}/players/{playerId}/eject")
+    @ResponseStatus(HttpStatus.OK)
+    fun ejectPlayer(
+        @PathVariable gameId: Long,
+        @PathVariable playerId: Long,
+        @AuthenticationPrincipal scorerId: Long,
+        @RequestBody @Valid request: EjectPlayerRequestDto,
+    ): ApiResponse<EjectionResponse> {
+        val event =
+            emergencySubstitutionService.ejectPlayer(
+                gameId = gameId,
+                request = request.toDomain(playerId),
+                scorerId = scorerId,
+            )
+        return ApiResponse.success(event.toEjectionResponse())
+    }
+
+    /**
+     * 선수를 퇴장시키고 교체 선수를 긴급 투입합니다.
+     *
+     * 퇴장과 교체를 원자적으로 처리합니다.
+     * 주자 상태인 선수 퇴장 시 교체 선수가 해당 베이스를 계승합니다.
+     * 투수 부상 퇴장 시 교체 투수로 currentPitcherId를 갱신합니다.
+     */
+    @PostMapping("/{gameId}/players/{playerId}/eject-and-substitute")
+    @ResponseStatus(HttpStatus.OK)
+    fun ejectAndSubstitute(
+        @PathVariable gameId: Long,
+        @PathVariable playerId: Long,
+        @AuthenticationPrincipal scorerId: Long,
+        @RequestBody @Valid request: EjectAndSubstituteRequestDto,
+    ): ApiResponse<EmergencySubstitutionResponse> {
+        val event =
+            emergencySubstitutionService.ejectAndSubstitute(
+                gameId = gameId,
+                request = request.toDomain(playerId),
+                scorerId = scorerId,
+            )
+        return ApiResponse.success(event.toEmergencySubstitutionResponse())
+    }
+}

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/EjectionRequestDto.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/EjectionRequestDto.kt
@@ -1,0 +1,47 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.game.EjectionReason
+import com.nextup.core.domain.player.Position
+import com.nextup.core.service.game.dto.EjectAndSubstituteRequest
+import com.nextup.core.service.game.dto.EjectionRequest
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 퇴장 처리 요청 DTO (교체 없음)
+ */
+data class EjectPlayerRequestDto(
+    @field:NotNull(message = "퇴장 사유는 필수입니다")
+    val reason: EjectionReason?,
+)
+
+/**
+ * EjectPlayerRequestDto를 EjectionRequest 도메인 DTO로 변환합니다.
+ */
+fun EjectPlayerRequestDto.toDomain(ejectedPlayerId: Long): EjectionRequest =
+    EjectionRequest(
+        ejectedPlayerId = ejectedPlayerId,
+        reason = this.reason!!,
+    )
+
+/**
+ * 퇴장 + 긴급 교체 요청 DTO
+ */
+data class EjectAndSubstituteRequestDto(
+    @field:NotNull(message = "퇴장 사유는 필수입니다")
+    val reason: EjectionReason?,
+    @field:NotNull(message = "교체 선수 ID는 필수입니다")
+    val replacementPlayerId: Long?,
+    @field:NotNull(message = "포지션은 필수입니다")
+    val position: Position?,
+)
+
+/**
+ * EjectAndSubstituteRequestDto를 EjectAndSubstituteRequest 도메인 DTO로 변환합니다.
+ */
+fun EjectAndSubstituteRequestDto.toDomain(ejectedPlayerId: Long): EjectAndSubstituteRequest =
+    EjectAndSubstituteRequest(
+        ejectedPlayerId = ejectedPlayerId,
+        replacementPlayerId = this.replacementPlayerId!!,
+        reason = this.reason!!,
+        newPosition = this.position!!,
+    )

--- a/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/EjectionResponse.kt
+++ b/nextup-scorer/src/main/kotlin/com/nextup/scorer/dto/game/EjectionResponse.kt
@@ -1,0 +1,51 @@
+package com.nextup.scorer.dto.game
+
+import com.nextup.core.domain.game.GameEvent
+
+/**
+ * 퇴장 처리 응답 DTO
+ */
+data class EjectionResponse(
+    val eventId: Long,
+    val inning: Int,
+    val isTopInning: Boolean,
+    val ejectedPlayerId: Long?,
+    val description: String,
+)
+
+/**
+ * GameEvent(EJECTION)를 EjectionResponse로 변환합니다.
+ */
+fun GameEvent.toEjectionResponse(): EjectionResponse =
+    EjectionResponse(
+        eventId = this.id,
+        inning = this.inning,
+        isTopInning = this.isTopInning,
+        ejectedPlayerId = this.batter?.id,
+        description = this.description,
+    )
+
+/**
+ * 긴급 교체 응답 DTO
+ */
+data class EmergencySubstitutionResponse(
+    val eventId: Long,
+    val inning: Int,
+    val isTopInning: Boolean,
+    val ejectedPlayerId: Long?,
+    val replacementPlayerId: Long?,
+    val description: String,
+)
+
+/**
+ * GameEvent(EMERGENCY_SUBSTITUTION)를 EmergencySubstitutionResponse로 변환합니다.
+ */
+fun GameEvent.toEmergencySubstitutionResponse(): EmergencySubstitutionResponse =
+    EmergencySubstitutionResponse(
+        eventId = this.id,
+        inning = this.inning,
+        isTopInning = this.isTopInning,
+        ejectedPlayerId = this.pitcher?.id,
+        replacementPlayerId = this.batter?.id,
+        description = this.description,
+    )


### PR DESCRIPTION
## Summary

>- Close #385

부상 퇴장 및 긴급 교체 API를 구현합니다. `GameEvent.createEjection()` 팩토리만 존재하던 상태에서, 실제 부상 퇴장/긴급 교체 Service와 Scorer API 엔드포인트를 추가합니다.

## Tasks

- [x] `EjectionReason` enum 추가 (INJURY, EJECTION_BY_UMPIRE, OTHER)
- [x] `GamePlayer.eject(inning, reason)` 도메인 메서드 추가 (ejectionReason 필드 포함)
- [x] `GameEvent.createEmergencySubstitution()` 팩토리 메서드 추가
- [x] `EMERGENCY_SUBSTITUTION` GameEventType 추가
- [x] `EmergencySubstitutionService` 포트 인터페이스 (core)
- [x] `EmergencySubstitutionServiceImpl` 구현체 (infrastructure)
  - 퇴장만 처리 (벤치 소진 시 교체 선수 없는 케이스)
  - 퇴장 + 교체 원자적 처리
  - 주자 상태 선수 퇴장 시 교체 선수가 베이스 계승 (담당 투수 ID 유지)
  - 투수 부상 퇴장 시 이닝 마감 + currentPitcherId 갱신
  - 교체 선수 BattingRecord/PitchingRecord 자동 생성
- [x] Scorer API 엔드포인트 2개 추가
  - `POST /api/v1/scorer/games/{gameId}/players/{playerId}/eject`
  - `POST /api/v1/scorer/games/{gameId}/players/{playerId}/eject-and-substitute`
- [x] V048 DB 마이그레이션 (`ejection_reason` 컬럼 추가)
- [x] 단위 테스트 작성 (GamePlayer eject, GameEvent 긴급 교체, ServiceImpl)
- [x] `./gradlew clean build` 성공

## To Reviewer

### 아키텍처 결정

1. **EjectionReason enum**: 기존 `createEjection`의 `description` 문자열 기반 사유 구분을 enum으로 정형화했습니다. 부상(INJURY), 심판 퇴장(EJECTION_BY_UMPIRE), 기타(OTHER) 3가지 사유를 구분합니다.

2. **GamePlayer.eject vs exitGame 분리**: 기존 `exitGame`은 일반 교체용으로 유지하고, 사유가 있는 퇴장은 `eject(inning, reason)`로 분리했습니다. `ejectionReason` 필드로 퇴장 여부를 추적할 수 있습니다.

3. **주자 베이스 계승**: 퇴장 선수가 주자일 때 교체 선수가 동일 베이스를 계승합니다. 담당 투수(책임투수) ID는 기존 값을 유지하여 자책점 추적이 정확합니다.

4. **Controller 클래스 레벨 @PreAuthorize**: `@PreAuthorize("isAuthenticated()")` 를 컨트롤러 클래스 레벨에 적용했습니다. 기록원 잠금 검증은 기존 패턴대로 Service 내에서 `game.validateScorer(scorerId)`로 수행합니다.

5. **이슈 작업 내용 #6 (알림 연동)**: 알림 시스템은 별도 이슈에서 다룰 예정이므로 이번 PR에는 포함하지 않았습니다.