### PR TITLE
feat(#405): HTTP 캐싱 전략 — Spring Cache 확장 + Cache-Control 헤더

### DIFF
--- a/nextup-api/src/main/kotlin/com/nextup/api/config/CacheControlConfig.kt
+++ b/nextup-api/src/main/kotlin/com/nextup/api/config/CacheControlConfig.kt
@@ -1,0 +1,93 @@
+package com.nextup.api.config
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.CacheControl
+import org.springframework.http.HttpHeaders
+import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import java.util.concurrent.TimeUnit
+
+/**
+ * HTTP Cache-Control 설정
+ *
+ * GET 조회 API 응답에 Cache-Control 헤더를 자동 추가합니다.
+ * URL 패턴에 따라 적절한 max-age를 설정하여 클라이언트 측 캐싱을 유도합니다.
+ *
+ * | URL 패턴                  | max-age | scope   | 근거                     |
+ * |--------------------------|---------|---------|-------------------------|
+ * | /standings               | 300초   | public  | 순위표 (변경 빈도 낮음)    |
+ * | /leaderboard             | 300초   | public  | 리더보드 (변경 빈도 낮음)  |
+ * | /stats                   | 600초   | public  | 선수/팀 통계             |
+ * | /competitions            | 1800초  | public  | 대회 기본 정보            |
+ * | /leagues                 | 1800초  | public  | 리그 기본 정보            |
+ * | /stadiums (GET only)     | 3600초  | public  | 구장 정보 (정적 데이터)    |
+ */
+@Configuration
+class CacheControlConfig : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(CacheControlInterceptor())
+            .addPathPatterns("/api/v1/**")
+    }
+}
+
+/**
+ * GET 요청에 Cache-Control 헤더를 추가하는 인터셉터
+ *
+ * POST/PUT/PATCH/DELETE 요청에는 적용하지 않습니다.
+ * 응답에 이미 Cache-Control 헤더가 있으면 덮어쓰지 않습니다.
+ */
+class CacheControlInterceptor : HandlerInterceptor {
+
+    companion object {
+        private val CACHE_RULES: List<CacheRule> =
+            listOf(
+                CacheRule("/standings", 300, false),
+                CacheRule("/leaderboard", 300, false),
+                CacheRule("/stats", 600, false),
+                CacheRule("/competitions", 1800, false),
+                CacheRule("/leagues", 1800, false),
+                CacheRule("/associations", 1800, false),
+                CacheRule("/stadiums", 3600, false),
+            )
+    }
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?,
+    ) {
+        // GET 요청만 대상
+        if (request.method != "GET") return
+
+        // 이미 Cache-Control 헤더가 설정되어 있으면 건너뜀
+        if (response.containsHeader(HttpHeaders.CACHE_CONTROL)) return
+
+        // 에러 응답에는 캐시 적용하지 않음
+        if (response.status >= 400) return
+
+        val uri = request.requestURI
+        val rule = CACHE_RULES.firstOrNull { uri.contains(it.pathPattern) } ?: return
+
+        val cacheControl =
+            if (rule.isPrivate) {
+                CacheControl.maxAge(rule.maxAgeSec.toLong(), TimeUnit.SECONDS)
+                    .cachePrivate()
+            } else {
+                CacheControl.maxAge(rule.maxAgeSec.toLong(), TimeUnit.SECONDS)
+                    .cachePublic()
+            }
+
+        response.setHeader(HttpHeaders.CACHE_CONTROL, cacheControl.headerValue)
+    }
+
+    private data class CacheRule(
+        val pathPattern: String,
+        val maxAgeSec: Int,
+        val isPrivate: Boolean,
+    )
+}

--- a/nextup-api/src/test/kotlin/com/nextup/api/config/CacheControlInterceptorTest.kt
+++ b/nextup-api/src/test/kotlin/com/nextup/api/config/CacheControlInterceptorTest.kt
@@ -1,0 +1,168 @@
+package com.nextup.api.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+@DisplayName("CacheControlInterceptor")
+class CacheControlInterceptorTest {
+
+    private lateinit var interceptor: CacheControlInterceptor
+
+    @BeforeEach
+    fun setUp() {
+        interceptor = CacheControlInterceptor()
+    }
+
+    @Nested
+    @DisplayName("GET 요청에 Cache-Control 헤더 추가")
+    inner class GetRequestCacheControl {
+
+        @Test
+        @DisplayName("순위표 URL에 max-age=300, public 헤더가 추가된다")
+        fun standingsUrl() {
+            val request = MockHttpServletRequest("GET", "/api/v1/competitions/1/standings")
+            val response = MockHttpServletResponse()
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            val header = response.getHeader(HttpHeaders.CACHE_CONTROL)
+            assertThat(header).contains("max-age=300")
+            assertThat(header).contains("public")
+        }
+
+        @Test
+        @DisplayName("리더보드 URL에 max-age=300, public 헤더가 추가된다")
+        fun leaderboardUrl() {
+            val request = MockHttpServletRequest("GET", "/api/v1/competitions/1/leaderboard/batting")
+            val response = MockHttpServletResponse()
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            val header = response.getHeader(HttpHeaders.CACHE_CONTROL)
+            assertThat(header).contains("max-age=300")
+            assertThat(header).contains("public")
+        }
+
+        @Test
+        @DisplayName("통계 URL에 max-age=600, public 헤더가 추가된다")
+        fun statsUrl() {
+            val request = MockHttpServletRequest("GET", "/api/v1/players/1/stats/batting/season/2025")
+            val response = MockHttpServletResponse()
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            val header = response.getHeader(HttpHeaders.CACHE_CONTROL)
+            assertThat(header).contains("max-age=600")
+            assertThat(header).contains("public")
+        }
+
+        @Test
+        @DisplayName("대회 URL에 max-age=1800, public 헤더가 추가된다")
+        fun competitionsUrl() {
+            val request = MockHttpServletRequest("GET", "/api/v1/competitions")
+            val response = MockHttpServletResponse()
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            val header = response.getHeader(HttpHeaders.CACHE_CONTROL)
+            assertThat(header).contains("max-age=1800")
+            assertThat(header).contains("public")
+        }
+
+        @Test
+        @DisplayName("리그 URL에 max-age=1800, public 헤더가 추가된다")
+        fun leaguesUrl() {
+            val request = MockHttpServletRequest("GET", "/api/v1/leagues")
+            val response = MockHttpServletResponse()
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            val header = response.getHeader(HttpHeaders.CACHE_CONTROL)
+            assertThat(header).contains("max-age=1800")
+            assertThat(header).contains("public")
+        }
+
+        @Test
+        @DisplayName("구장 URL에 max-age=3600, public 헤더가 추가된다")
+        fun stadiumsUrl() {
+            val request = MockHttpServletRequest("GET", "/api/v1/stadiums/1")
+            val response = MockHttpServletResponse()
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            val header = response.getHeader(HttpHeaders.CACHE_CONTROL)
+            assertThat(header).contains("max-age=3600")
+            assertThat(header).contains("public")
+        }
+
+        @Test
+        @DisplayName("팀 통계 URL에 max-age=600 헤더가 추가된다")
+        fun teamStatsUrl() {
+            val request = MockHttpServletRequest("GET", "/api/v1/teams/1/stats")
+            val response = MockHttpServletResponse()
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            val header = response.getHeader(HttpHeaders.CACHE_CONTROL)
+            assertThat(header).contains("max-age=600")
+            assertThat(header).contains("public")
+        }
+    }
+
+    @Nested
+    @DisplayName("Cache-Control 헤더가 추가되지 않는 경우")
+    inner class NoCacheControl {
+
+        @Test
+        @DisplayName("POST 요청에는 헤더가 추가되지 않는다")
+        fun postRequest() {
+            val request = MockHttpServletRequest("POST", "/api/v1/competitions")
+            val response = MockHttpServletResponse()
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL)).isNull()
+        }
+
+        @Test
+        @DisplayName("매칭되지 않는 URL에는 헤더가 추가되지 않는다")
+        fun unmatchedUrl() {
+            val request = MockHttpServletRequest("GET", "/api/v1/auth/login")
+            val response = MockHttpServletResponse()
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL)).isNull()
+        }
+
+        @Test
+        @DisplayName("4xx 에러 응답에는 헤더가 추가되지 않는다")
+        fun errorResponse() {
+            val request = MockHttpServletRequest("GET", "/api/v1/competitions/1/standings")
+            val response = MockHttpServletResponse()
+            response.status = 404
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL)).isNull()
+        }
+
+        @Test
+        @DisplayName("이미 Cache-Control 헤더가 있으면 덮어쓰지 않는다")
+        fun existingHeader() {
+            val request = MockHttpServletRequest("GET", "/api/v1/competitions/1/standings")
+            val response = MockHttpServletResponse()
+            response.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache")
+
+            interceptor.afterCompletion(request, response, Any(), null)
+
+            assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL)).isEqualTo("no-cache")
+        }
+    }
+}

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/CacheConfig.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/config/CacheConfig.kt
@@ -3,7 +3,8 @@ package com.nextup.infrastructure.config
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.concurrent.TimeUnit
@@ -11,8 +12,15 @@ import java.util.concurrent.TimeUnit
 /**
  * Spring Cache 설정
  *
- * Caffeine 기반 인메모리 캐시를 구성합니다.
- * - standings: 대회 순위표 캐시 (10분 TTL)
+ * Caffeine 기반 인메모리 캐시를 캐시별 TTL로 구성합니다.
+ *
+ * | 캐시명           | TTL   | 최대 크기 | 용도                           |
+ * |-----------------|-------|----------|-------------------------------|
+ * | standings       | 5분   | 200      | 대회 순위표                     |
+ * | leaderboard     | 5분   | 500      | 개인 타이틀 리더보드              |
+ * | teamStats       | 10분  | 500      | 팀 통계                        |
+ * | competitionInfo | 30분  | 200      | 대회 기본 정보 (목록/상세)        |
+ * | leagueInfo      | 30분  | 100      | 리그 기본 정보 (목록/상세)        |
  */
 @Configuration
 @EnableCaching
@@ -20,16 +28,38 @@ class CacheConfig {
 
     companion object {
         const val STANDINGS_CACHE = "standings"
+        const val LEADERBOARD_CACHE = "leaderboard"
+        const val TEAM_STATS_CACHE = "teamStats"
+        const val COMPETITION_INFO_CACHE = "competitionInfo"
+        const val LEAGUE_INFO_CACHE = "leagueInfo"
     }
 
     @Bean
     fun cacheManager(): CacheManager {
-        val cacheManager = CaffeineCacheManager(STANDINGS_CACHE)
-        cacheManager.setCaffeine(
-            Caffeine.newBuilder()
-                .expireAfterWrite(10, TimeUnit.MINUTES)
-                .maximumSize(200),
-        )
-        return cacheManager
+        val caches =
+            listOf(
+                buildCache(STANDINGS_CACHE, 5, TimeUnit.MINUTES, 200),
+                buildCache(LEADERBOARD_CACHE, 5, TimeUnit.MINUTES, 500),
+                buildCache(TEAM_STATS_CACHE, 10, TimeUnit.MINUTES, 500),
+                buildCache(COMPETITION_INFO_CACHE, 30, TimeUnit.MINUTES, 200),
+                buildCache(LEAGUE_INFO_CACHE, 30, TimeUnit.MINUTES, 100),
+            )
+        val manager = SimpleCacheManager()
+        manager.setCaches(caches)
+        return manager
     }
+
+    private fun buildCache(
+        name: String,
+        ttl: Long,
+        unit: TimeUnit,
+        maxSize: Long,
+    ): CaffeineCache =
+        CaffeineCache(
+            name,
+            Caffeine.newBuilder()
+                .expireAfterWrite(ttl, unit)
+                .maximumSize(maxSize)
+                .build(),
+        )
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameCancelEventListener.kt
@@ -250,9 +250,11 @@ class GameCancelEventListener(
 
         val competitionId = game.competition.id
         cacheManager.getCache(CacheConfig.STANDINGS_CACHE)?.evict(competitionId)
+        cacheManager.getCache(CacheConfig.LEADERBOARD_CACHE)?.clear()
+        cacheManager.getCache(CacheConfig.TEAM_STATS_CACHE)?.clear()
 
         logger.debug(
-            "경기 취소 후 순위 캐시 무효화 완료 (competitionId={}, gameId={})",
+            "경기 취소 후 캐시 무효화 완료 (competitionId={}, gameId={})",
             competitionId,
             gameId,
         )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameResultEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/GameResultEventListener.kt
@@ -98,12 +98,21 @@ class GameResultEventListener(
                 }
 
         val competitionId = game.competition.id
-        cacheManager.getCache(CacheConfig.STANDINGS_CACHE)?.evict(competitionId)
+        evictStatsCaches(competitionId)
 
         logger.debug(
-            "순위 캐시 무효화 완료 (competitionId={}, gameId={})",
+            "캐시 무효화 완료 (competitionId={}, gameId={})",
             competitionId,
             event.gameId,
         )
+    }
+
+    /**
+     * 순위, 리더보드, 팀 통계 캐시를 일괄 무효화합니다.
+     */
+    private fun evictStatsCaches(competitionId: Long) {
+        cacheManager.getCache(CacheConfig.STANDINGS_CACHE)?.evict(competitionId)
+        cacheManager.getCache(CacheConfig.LEADERBOARD_CACHE)?.clear()
+        cacheManager.getCache(CacheConfig.TEAM_STATS_CACHE)?.clear()
     }
 }

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListener.kt
@@ -312,8 +312,10 @@ class RecordCorrectionEventListener(
         val game = gameRepository.findByIdOrNull(gameId) ?: return
         val competitionId = game.competition.id
         cacheManager.getCache(CacheConfig.STANDINGS_CACHE)?.evict(competitionId)
+        cacheManager.getCache(CacheConfig.LEADERBOARD_CACHE)?.clear()
+        cacheManager.getCache(CacheConfig.TEAM_STATS_CACHE)?.clear()
         logger.debug(
-            "기록 정정으로 순위 캐시 무효화 (competitionId={}, gameId={})",
+            "기록 정정으로 캐시 무효화 (competitionId={}, gameId={})",
             competitionId,
             gameId,
         )

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/IndividualRankingServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/IndividualRankingServiceImpl.kt
@@ -12,6 +12,8 @@ import com.nextup.core.service.stats.dto.BattingCategory
 import com.nextup.core.service.stats.dto.BattingLeaderDto
 import com.nextup.core.service.stats.dto.PitchingCategory
 import com.nextup.core.service.stats.dto.PitchingLeaderDto
+import com.nextup.infrastructure.config.CacheConfig
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -34,6 +36,10 @@ class IndividualRankingServiceImpl(
         const val DEFAULT_TEAM_GAMES = 10
     }
 
+    @Cacheable(
+        cacheNames = [CacheConfig.LEADERBOARD_CACHE],
+        key = "'batting:' + #competitionId + ':' + #category + ':' + #limit",
+    )
     override fun getBattingLeaders(
         competitionId: Long,
         category: BattingCategory,
@@ -73,6 +79,10 @@ class IndividualRankingServiceImpl(
         }
     }
 
+    @Cacheable(
+        cacheNames = [CacheConfig.LEADERBOARD_CACHE],
+        key = "'pitching:' + #competitionId + ':' + #category + ':' + #limit",
+    )
     override fun getPitchingLeaders(
         competitionId: Long,
         category: PitchingCategory,

--- a/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/TeamStatsServiceImpl.kt
+++ b/nextup-infrastructure/src/main/kotlin/com/nextup/infrastructure/service/stats/TeamStatsServiceImpl.kt
@@ -11,6 +11,8 @@ import com.nextup.core.service.stats.dto.TeamBattingStatsDto
 import com.nextup.core.service.stats.dto.TeamPitchingStatsDto
 import com.nextup.core.service.stats.dto.TeamRecordDto
 import com.nextup.core.service.stats.dto.TeamStatsDto
+import com.nextup.infrastructure.config.CacheConfig
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -24,6 +26,10 @@ class TeamStatsServiceImpl(
     private val battingRecordRepositoryPort: BattingRecordRepositoryPort,
     private val pitchingRecordRepositoryPort: PitchingRecordRepositoryPort,
 ) : TeamStatsService {
+    @Cacheable(
+        cacheNames = [CacheConfig.TEAM_STATS_CACHE],
+        key = "#teamId + ':' + #year + ':' + #competitionId",
+    )
     override fun getTeamStats(
         teamId: Long,
         year: Int?,

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/config/CacheConfigTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/config/CacheConfigTest.kt
@@ -1,0 +1,101 @@
+package com.nextup.infrastructure.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.cache.CacheManager
+import org.springframework.cache.support.SimpleCacheManager
+
+@DisplayName("CacheConfig")
+class CacheConfigTest {
+
+    private lateinit var cacheManager: CacheManager
+
+    @BeforeEach
+    fun setUp() {
+        val config = CacheConfig()
+        val manager = config.cacheManager() as SimpleCacheManager
+        manager.afterPropertiesSet()
+        cacheManager = manager
+    }
+
+    @Nested
+    @DisplayName("cacheManager()")
+    inner class CacheManagerTest {
+
+        @Test
+        @DisplayName("모든 캐시 이름이 등록되어 있어야 한다")
+        fun shouldRegisterAllCacheNames() {
+            assertThat(cacheManager.cacheNames).containsExactlyInAnyOrder(
+                CacheConfig.STANDINGS_CACHE,
+                CacheConfig.LEADERBOARD_CACHE,
+                CacheConfig.TEAM_STATS_CACHE,
+                CacheConfig.COMPETITION_INFO_CACHE,
+                CacheConfig.LEAGUE_INFO_CACHE,
+            )
+        }
+
+        @Test
+        @DisplayName("standings 캐시가 존재해야 한다")
+        fun shouldHaveStandingsCache() {
+            assertThat(cacheManager.getCache(CacheConfig.STANDINGS_CACHE)).isNotNull
+        }
+
+        @Test
+        @DisplayName("leaderboard 캐시가 존재해야 한다")
+        fun shouldHaveLeaderboardCache() {
+            assertThat(cacheManager.getCache(CacheConfig.LEADERBOARD_CACHE)).isNotNull
+        }
+
+        @Test
+        @DisplayName("teamStats 캐시가 존재해야 한다")
+        fun shouldHaveTeamStatsCache() {
+            assertThat(cacheManager.getCache(CacheConfig.TEAM_STATS_CACHE)).isNotNull
+        }
+
+        @Test
+        @DisplayName("competitionInfo 캐시가 존재해야 한다")
+        fun shouldHaveCompetitionInfoCache() {
+            assertThat(cacheManager.getCache(CacheConfig.COMPETITION_INFO_CACHE)).isNotNull
+        }
+
+        @Test
+        @DisplayName("leagueInfo 캐시가 존재해야 한다")
+        fun shouldHaveLeagueInfoCache() {
+            assertThat(cacheManager.getCache(CacheConfig.LEAGUE_INFO_CACHE)).isNotNull
+        }
+
+        @Test
+        @DisplayName("캐시에 값을 넣고 꺼낼 수 있어야 한다")
+        fun shouldPutAndGetCacheValue() {
+            val cache = cacheManager.getCache(CacheConfig.STANDINGS_CACHE)!!
+
+            cache.put("key1", "value1")
+            assertThat(cache.get("key1")?.get()).isEqualTo("value1")
+        }
+
+        @Test
+        @DisplayName("캐시 evict 후 값이 제거되어야 한다")
+        fun shouldEvictCacheValue() {
+            val cache = cacheManager.getCache(CacheConfig.STANDINGS_CACHE)!!
+
+            cache.put("key1", "value1")
+            cache.evict("key1")
+            assertThat(cache.get("key1")).isNull()
+        }
+
+        @Test
+        @DisplayName("캐시 clear 후 모든 값이 제거되어야 한다")
+        fun shouldClearAllValues() {
+            val cache = cacheManager.getCache(CacheConfig.LEADERBOARD_CACHE)!!
+
+            cache.put("key1", "value1")
+            cache.put("key2", "value2")
+            cache.clear()
+            assertThat(cache.get("key1")).isNull()
+            assertThat(cache.get("key2")).isNull()
+        }
+    }
+}

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameCancelEventListenerTest.kt
@@ -113,6 +113,8 @@ class GameCancelEventListenerTest {
         every { mockGame.competition } returns mockCompetition
         every { mockCompetition.id } returns 200L
         every { cacheManager.getCache(CacheConfig.STANDINGS_CACHE) } returns standingsCache
+        every { cacheManager.getCache(CacheConfig.LEADERBOARD_CACHE) } returns mockk(relaxed = true)
+        every { cacheManager.getCache(CacheConfig.TEAM_STATS_CACHE) } returns mockk(relaxed = true)
     }
 
     @Nested

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameResultEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/GameResultEventListenerTest.kt
@@ -49,6 +49,8 @@ class GameResultEventListenerTest {
         game = createGame(10L, competition, GameStatus.FINISHED)
 
         every { cacheManager.getCache(CacheConfig.STANDINGS_CACHE) } returns standingsCache
+        every { cacheManager.getCache(CacheConfig.LEADERBOARD_CACHE) } returns mockk(relaxed = true)
+        every { cacheManager.getCache(CacheConfig.TEAM_STATS_CACHE) } returns mockk(relaxed = true)
         every { standingsCache.evict(any<Long>()) } returns Unit
     }
 

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerCoverageTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerCoverageTest.kt
@@ -135,6 +135,6 @@ class RecordCorrectionEventListenerCoverageTest {
         listener.onRecordCorrected(event)
 
         // then
-        verify(exactly = 1) { cacheManager.getCache(any()) }
+        verify(exactly = 3) { cacheManager.getCache(any()) }
     }
 }

--- a/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
+++ b/nextup-infrastructure/src/test/kotlin/com/nextup/infrastructure/listener/RecordCorrectionEventListenerTest.kt
@@ -30,6 +30,7 @@ import com.nextup.core.port.repository.GameTeamRepositoryPort
 import com.nextup.core.port.repository.SeasonBattingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonFieldingStatsRepositoryPort
 import com.nextup.core.port.repository.SeasonPitchingStatsRepositoryPort
+import com.nextup.infrastructure.config.CacheConfig
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -369,7 +370,9 @@ class RecordCorrectionEventListenerTest {
             listener.onRecordCorrected(event)
 
             // then
-            verify(exactly = 1) { cacheManager.getCache("standings") }
+            verify(exactly = 1) { cacheManager.getCache(CacheConfig.STANDINGS_CACHE) }
+            verify(exactly = 1) { cacheManager.getCache(CacheConfig.LEADERBOARD_CACHE) }
+            verify(exactly = 1) { cacheManager.getCache(CacheConfig.TEAM_STATS_CACHE) }
             verify(exactly = 1) { mockCache.evict(100L) }
         }
 


### PR DESCRIPTION
## Summary

>- Close #405

HTTP 캐싱 전략을 도입하여 API 응답 성능을 개선합니다. 서버 측 Spring Cache(Caffeine)와 클라이언트 측 Cache-Control 헤더를 함께 적용합니다.

## Tasks

- [x] CacheConfig를 캐시별 TTL로 확장 (SimpleCacheManager + CaffeineCache)
  - standings: 5분, leaderboard: 5분, teamStats: 10분, competitionInfo: 30분, leagueInfo: 30분
- [x] IndividualRankingServiceImpl에 @Cacheable 적용 (리더보드 캐싱)
- [x] TeamStatsServiceImpl에 @Cacheable 적용 (팀 통계 캐싱)
- [x] CacheControlInterceptor 추가 — GET API에 URL 패턴별 Cache-Control 헤더 자동 부여
  - standings/leaderboard: max-age=300, stats: max-age=600, competitions/leagues: max-age=1800, stadiums: max-age=3600
- [x] 경기 결과/취소/기록정정 이벤트 리스너에 leaderboard·teamStats 캐시 evict 추가
- [x] CacheConfigTest 추가 (캐시 등록, put/get/evict/clear 검증)
- [x] CacheControlInterceptorTest 추가 (URL 패턴별 헤더 검증, POST/에러/미매칭 URL 제외 검증)
- [x] 기존 이벤트 리스너 테스트의 캐시 mock 보완
- [x] `./gradlew clean build` 성공

## To Reviewer

### 아키텍처 결정

1. **SimpleCacheManager로 전환**: 기존 CaffeineCacheManager는 모든 캐시에 동일 TTL을 적용했습니다. SimpleCacheManager + 개별 CaffeineCache 조합으로 캐시별 TTL/크기를 독립 설정할 수 있도록 변경했습니다.

2. **Cache-Control은 Interceptor 방식**: Controller마다 ResponseEntity로 헤더를 설정하는 대신, URL 패턴 기반 HandlerInterceptor로 횡단 관심사를 분리했습니다.

3. **캐시 evict 전략**: leaderboard와 teamStats 캐시는 키 구조가 복합적(competitionId + category + limit 등)이므로 개별 evict 대신 `clear()`로 전체 무효화합니다. TTL이 5~10분으로 짧아 성능 영향은 미미합니다.

4. **Core 모듈 서비스(PlayerStatsService 등)에는 @Cacheable 미적용**: Core 모듈은 Spring Cache에 의존하지 않아야 하므로, Infrastructure ServiceImpl에만 캐싱을 적용했습니다.